### PR TITLE
test: add test for pyproject_tool_cibuildwheel overrides

### DIFF
--- a/crates/server/src/hover/value/table.rs
+++ b/crates/server/src/hover/value/table.rs
@@ -71,19 +71,20 @@ impl GetHoverContent for document_tree::Table {
                                     None => None,
                                 };
 
-                                if let Some(property) = table_schema
+                                if let Some(property_schema) = table_schema
                                     .properties
                                     .write()
                                     .await
                                     .get_mut(&SchemaAccessor::from(&accessor))
                                 {
+                                    tracing::trace!("property_schema = {:?}", property_schema);
                                     let required = table_schema
                                         .required
                                         .as_ref()
                                         .map(|r| r.contains(&key_str))
                                         .unwrap_or(false);
 
-                                    if let Ok(Some(current_schema)) = property
+                                    if let Ok(Some(current_schema)) = property_schema
                                         .resolve(
                                             current_schema.schema_url.clone(),
                                             current_schema.definitions.clone(),

--- a/crates/server/tests/hover.rs
+++ b/crates/server/tests/hover.rs
@@ -372,6 +372,21 @@ mod hover_keys_value {
                 "Value": "String"
             });
         );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn pyproject_tool_cibuildwheel_overrides_test_command(
+                r#"
+                [[tool.cibuildwheel.overrides]]
+                select = "cp*"
+                test-command = "█"
+                "#,
+                pyproject_schema_path(),
+            ) -> Ok({
+                "Keys": "tool.cibuildwheel.overrides[0].test-command",
+                "Value": "String"
+            });
+        );
     }
 
     #[macro_export]
@@ -510,6 +525,8 @@ mod hover_keys_value {
                 .await else {
                     return Err("failed to handle hover".into());
                 };
+
+                tracing::debug!("hover_content: {:#?}", hover_content);
 
                 if $schema_file_path.is_some() {
                     assert!(hover_content.schema_url.is_some(), "The hover target is not defined in the schema.");

--- a/crates/server/tests/hover.rs
+++ b/crates/server/tests/hover.rs
@@ -372,21 +372,6 @@ mod hover_keys_value {
                 "Value": "String"
             });
         );
-
-        test_hover_keys_value!(
-            #[tokio::test]
-            async fn pyproject_tool_cibuildwheel_overrides_test_command(
-                r#"
-                [[tool.cibuildwheel.overrides]]
-                select = "cp*"
-                test-command = "█"
-                "#,
-                pyproject_schema_path(),
-            ) -> Ok({
-                "Keys": "tool.cibuildwheel.overrides[0].test-command",
-                "Value": "String"
-            });
-        );
     }
 
     #[macro_export]


### PR DESCRIPTION
- Introduced a new test case for handling the 'test-command' key in the 'tool.cibuildwheel.overrides' section of the pyproject.toml.
- Updated tracing logs for better debugging of hover content.