### PR TITLE
ci: add continue-on-error to workflow jobs

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -57,6 +57,7 @@ jobs:
             vscode_target: darwin-arm64
     name: dist (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     env:
       TOMBI_TARGET: ${{ matrix.target }}
       VSCODE_TARGET: ${{ matrix.vscode_target }}

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -37,6 +37,7 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -78,6 +79,7 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -109,6 +111,7 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -139,6 +142,7 @@ jobs:
             target: x86_64
           - runner: macos-14
             target: aarch64
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/.github/workflows/toml-test.yml
+++ b/.github/workflows/toml-test.yml
@@ -15,7 +15,7 @@ jobs:
         toml-version:
           - v1.0.0
           - v1.1.0-preview
-
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Add continue-on-error: true to multiple workflow jobs to ensure that the workflows continue executing even if some steps fail.