### PR TITLE
feat: enhance TOML version retrieval from documents

### DIFF
--- a/crates/server/src/handler/completion.rs
+++ b/crates/server/src/handler/completion.rs
@@ -49,7 +49,7 @@ pub async fn handle_completion(
         return Ok(None);
     }
 
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
     let Some(root) = backend.get_incomplete_ast(&text_document.uri).await else {
         return Ok(None);
     };

--- a/crates/server/src/handler/diagnostic.rs
+++ b/crates/server/src/handler/diagnostic.rs
@@ -32,10 +32,11 @@ pub async fn handle_diagnostic(
         ));
     }
 
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
     let document_sources = backend.document_sources.read().await;
     let diagnostics = match document_sources.get(&text_document.uri) {
         Some(document) => linter::Linter::new(
-            backend.toml_version().await.unwrap_or_default(),
+            toml_version,
             backend
                 .config()
                 .await

--- a/crates/server/src/handler/document_link.rs
+++ b/crates/server/src/handler/document_link.rs
@@ -10,7 +10,7 @@ pub async fn handle_document_link(
     tracing::trace!(?params);
 
     let DocumentLinkParams { text_document, .. } = params;
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
 
     let Some(Ok(root)) = backend.try_get_ast(&text_document.uri, toml_version).await else {
         return Ok(None);

--- a/crates/server/src/handler/document_symbol.rs
+++ b/crates/server/src/handler/document_symbol.rs
@@ -14,7 +14,7 @@ pub async fn handle_document_symbol(
 
     let DocumentSymbolParams { text_document, .. } = params;
 
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
 
     let Some(tree) = backend
         .get_incomplete_document_tree(&text_document.uri, toml_version)

--- a/crates/server/src/handler/folding_range.rs
+++ b/crates/server/src/handler/folding_range.rs
@@ -13,7 +13,7 @@ pub async fn handle_folding_range(
 
     let FoldingRangeParams { text_document, .. } = params;
 
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
 
     let Some(Ok(root)) = backend.try_get_ast(&text_document.uri, toml_version).await else {
         return Ok(None);

--- a/crates/server/src/handler/formatting.rs
+++ b/crates/server/src/handler/formatting.rs
@@ -29,7 +29,7 @@ pub async fn handle_formatting(
         return Ok(None);
     }
 
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
     let mut document_sources = backend.document_sources.write().await;
     let Some(document_source) = document_sources.get_mut(&text_document.uri) else {
         return Ok(None);

--- a/crates/server/src/handler/get_toml_version.rs
+++ b/crates/server/src/handler/get_toml_version.rs
@@ -13,25 +13,7 @@ pub async fn handle_get_toml_version(
 
     let TextDocumentIdentifier { uri } = params;
 
-    let source_schema = backend
-        .schema_store
-        .try_get_source_schema_from_url(&uri)
-        .await
-        .ok()
-        .flatten();
-
-    let (toml_version, source) = source_schema
-        .as_ref()
-        .and_then(|source_schema| source_schema.root_schema.as_ref())
-        .and_then(|document_schema| {
-            document_schema
-                .toml_version()
-                .map(|toml_version| (toml_version, "schema"))
-        })
-        .unwrap_or(match backend.toml_version().await {
-            Some(toml_version) => (toml_version, "config"),
-            None => (TomlVersion::default(), "default"),
-        });
+    let (toml_version, source) = backend.text_document_toml_version(&uri).await;
 
     Ok(GetTomlVersionResponse {
         toml_version,

--- a/crates/server/src/handler/hover.rs
+++ b/crates/server/src/handler/hover.rs
@@ -40,7 +40,7 @@ pub async fn handle_hover(
     }
 
     let position = position.into();
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
     let Some(root) = backend.get_incomplete_ast(&text_document.uri).await else {
         return Ok(None);
     };

--- a/crates/server/src/handler/semantic_tokens_full.rs
+++ b/crates/server/src/handler/semantic_tokens_full.rs
@@ -15,7 +15,7 @@ pub async fn handle_semantic_tokens_full(
 
     let SemanticTokensParams { text_document, .. } = params;
 
-    let toml_version = backend.toml_version().await.unwrap_or_default();
+    let (toml_version, _) = backend.text_document_toml_version(&text_document.uri).await;
     let Some(Ok(root)) = backend.try_get_ast(&text_document.uri, toml_version).await else {
         return Ok(None);
     };


### PR DESCRIPTION
Updated the backend to provide TOML version based on the document's schema or configuration. This change improves the handling of TOML versioning in various document-related operations.