### PR TITLE
docs: clarify TOML references in documentation

### DIFF
--- a/docs/src/routes/docs/index.mdx
+++ b/docs/src/routes/docs/index.mdx
@@ -11,7 +11,7 @@ Visit our [Quick Start Guide](/docs/installation) to begin using Tombi in your p
 
 ## Why Tombi?
 
-TOML has become a popular configuration format used in many modern development tools, including [pyproject](https://peps.python.org/pep-0621/) for Python and [cargo](https://doc.rust-lang.org/cargo/reference/manifest.html) for Rust.
+TOML has become a popular configuration format used in many modern development tools, including [pyproject.toml](https://peps.python.org/pep-0621/) for Python and [Cargo.toml](https://doc.rust-lang.org/cargo/reference/manifest.html) for Rust.
 
 While TOML offers several advantages over other configuration formats:
 - Unlike JSON, it supports comments and has a more human-readable syntax


### PR DESCRIPTION
Updated the documentation to specify 'pyproject.toml' and 'Cargo.toml' for better clarity on TOML usage in modern development tools.