### PR TITLE
ci: update Ubuntu version in CI workflow

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -36,13 +36,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             vscode_target: linux-x64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             vscode_target: linux-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: arm-unknown-linux-gnueabihf
             vscode_target: linux-armhf
           - os: windows-latest


### PR DESCRIPTION
Updated the CI workflow to use Ubuntu 24.04 for all relevant jobs to ensure compatibility with the latest dependencies and features.