### PR TITLE
refactor: test_code

### DIFF
--- a/crates/tombi-diagnostic/examples/diagnostics.rs
+++ b/crates/tombi-diagnostic/examples/diagnostics.rs
@@ -11,7 +11,7 @@ pub struct Args {
     verbose: Verbosity<InfoLevel>,
 }
 
-pub fn project_root() -> PathBuf {
+pub fn project_root_path() -> PathBuf {
     let dir = std::env::var("CARGO_MANIFEST_DIR")
         .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned());
     PathBuf::from(dir)
@@ -23,7 +23,7 @@ pub fn project_root() -> PathBuf {
 }
 
 pub fn source_file() -> PathBuf {
-    project_root().join("Cargo.toml")
+    project_root_path().join("Cargo.toml")
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/tombi-formatter/tests/x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/x_tombi_order.rs
@@ -942,7 +942,7 @@ mod table_keys_order {
 
                 // Initialize formatter
                 let format_options = FormatOptions::default();
-                let source_path = tombi_test_lib::project_root().join("test.toml");
+                let source_path = tombi_test_lib::project_root_path().join("test.toml");
                 let formatter = Formatter::new(
                     TomlVersion::default(),
                     tombi_formatter::formatter::definitions::FormatDefinitions::default(),

--- a/crates/tombi-linter/src/lib.rs
+++ b/crates/tombi-linter/src/lib.rs
@@ -71,7 +71,7 @@ macro_rules! test_lint {
             }
 
             // Initialize linter with schema if provided
-            let source_path = tombi_test_lib::project_root().join("test.toml");
+            let source_path = tombi_test_lib::project_root_path().join("test.toml");
             let options = $crate::LintOptions::default();
             let linter = $crate::Linter::new(
                 TomlVersion::default(),
@@ -147,7 +147,7 @@ macro_rules! test_lint {
             }
 
             // Initialize linter with schema if provided
-            let source_path = tombi_test_lib::project_root().join("test.toml");
+            let source_path = tombi_test_lib::project_root_path().join("test.toml");
             let options = $crate::LintOptions::default();
             let linter = $crate::Linter::new(
                 TomlVersion::default(),

--- a/crates/tombi-linter/src/lib.rs
+++ b/crates/tombi-linter/src/lib.rs
@@ -277,7 +277,7 @@ mod tests {
                 "#,
             ) -> Err([
                 tombi_schema_store::Error::SchemaFileNotFound{
-                    schema_path: tombi_test_lib::project_root().join("does-not-exist.schema.json"),
+                    schema_path: tombi_test_lib::project_root_path().join("does-not-exist.schema.json"),
                 }
             ]);
         }
@@ -290,7 +290,7 @@ mod tests {
                 "#,
             ) -> Err([
                 tombi_schema_store::Error::SchemaFileNotFound{
-                    schema_path: tombi_test_lib::project_root().join("does-not-exist.schema.json"),
+                    schema_path: tombi_test_lib::project_root_path().join("does-not-exist.schema.json"),
                 }
             ]);
         }
@@ -303,7 +303,7 @@ mod tests {
                 "#,
             ) -> Err([
                 tombi_schema_store::Error::SchemaFileNotFound{
-                    schema_path: tombi_test_lib::project_root().join("../does-not-exist.schema.json"),
+                    schema_path: tombi_test_lib::project_root_path().join("../does-not-exist.schema.json"),
                 }
             ]);
         }

--- a/crates/tombi-schema-store/tests/test_tombi_schema.rs
+++ b/crates/tombi-schema-store/tests/test_tombi_schema.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tombi_schema_store::{DocumentSchema, SchemaUrl};
 
-fn project_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn project_root_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let cargo_manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
 
     if cargo_manifest_dir.ends_with("tombi-schema-store") {
@@ -24,7 +24,7 @@ fn tombi_schema() -> Result<(), Box<dyn std::error::Error>> {
         io::{BufReader, Read},
     };
 
-    let document_path = project_root()?.join("tombi.schema.json");
+    let document_path = project_root_path()?.join("tombi.schema.json");
     let file = File::open(&document_path)?;
     let mut reader = BufReader::new(file);
 

--- a/crates/tombi-server/tests/goto_definition.rs
+++ b/crates/tombi-server/tests/goto_definition.rs
@@ -1,0 +1,170 @@
+use tombi_test_lib::project_root_path;
+
+mod goto_definition_tests {
+    use super::*;
+
+    mod cargo_schema {
+        use super::*;
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn dependencies_serde_workspace(
+                r#"
+                [dependencies]
+                serde = { workspace█ = true }
+                "#,
+                project_root_path().join("crates/test-crate/Cargo.toml"),
+            ) -> Ok(project_root_path().join("Cargo.toml"));
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn dependencies_tombi_ast_workspace(
+                r#"
+                [dependencies]
+                tombi-ast = { workspace█ = true }
+                "#,
+                project_root_path().join("crates/test-crate/Cargo.toml"),
+            ) -> Ok(project_root_path().join("crates/tombi-ast/Cargo.toml"));
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn dependencies_tombi_ast_path(
+                r#"
+                [workspace.dependencies]
+                tombi-ast = { path█ = "crates/tombi-ast" }
+                "#,
+                project_root_path().join("Cargo.toml"),
+            ) -> Ok(project_root_path().join("crates/tombi-ast/Cargo.toml"));
+        );
+    }
+
+    #[macro_export]
+    macro_rules! test_goto_definition {
+        (#[tokio::test] async fn $name:ident(
+            $source:expr,
+            $file_path:expr,
+        ) -> Ok($expected_file_path:expr);) => {
+            #[tokio::test]
+            async fn $name() -> Result<(), Box<dyn std::error::Error>> {
+                use tombi_server::handler::{handle_did_open, handle_goto_definition};
+                use tombi_server::Backend;
+                use tower_lsp::{
+                    lsp_types::{
+                        DidOpenTextDocumentParams, GotoDefinitionParams, GotoDefinitionResponse,
+                        PartialResultParams, TextDocumentIdentifier, TextDocumentItem,
+                        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+                    },
+                    LspService,
+                };
+
+                tombi_test_lib::init_tracing();
+
+                let (service, _) = LspService::new(|client| {
+                    Backend::new(client, &tombi_server::backend::Options::default())
+                });
+
+                let backend = service.inner();
+
+                let toml_file_url = Url::from_file_path($file_path).expect("failed to convert file path to URL");
+
+                let mut toml_text = textwrap::dedent($source).trim().to_string();
+                let Some(index) = toml_text.as_str().find("█") else {
+                    return Err("failed to find position marker (█) in the test data".into());
+                };
+                toml_text.remove(index);
+
+                handle_did_open(
+                    backend,
+                    DidOpenTextDocumentParams {
+                        text_document: TextDocumentItem {
+                            uri: toml_file_url.clone(),
+                            language_id: "toml".to_string(),
+                            version: 0,
+                            text: toml_text.clone(),
+                        },
+                    },
+                )
+                .await;
+
+                let params = GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri: toml_file_url },
+                        position: (tombi_text::Position::default()
+                            + tombi_text::RelativePosition::of(&toml_text[..index]))
+                        .into(),
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                };
+
+                let Ok(result) = handle_goto_definition(&backend, params).await else {
+                    return Err("failed to handle goto_definition".into());
+                };
+
+                tracing::debug!("goto_definition result: {:#?}", result);
+
+                let expected_path = $expected_file_path.to_owned();
+
+                match result {
+                    Some(def_links) => {
+                        // Handle different return types (single link or array)
+                        match def_links {
+                            GotoDefinitionResponse::Link(links) => {
+                                assert!(!links.is_empty(), "Definition links were returned but empty");
+
+                                let first_link = &links[0];
+                                let target_url = first_link.target_uri.clone();
+                                let target_path = target_url.to_file_path()
+                                    .expect("Failed to convert URL to file path");
+
+                                assert_eq!(
+                                    target_path,
+                                    expected_path,
+                                    "Definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",
+                                    expected_path,
+                                    target_path
+                                );
+                            },
+                            GotoDefinitionResponse::Scalar(location) => {
+                                let target_url = location.uri.clone();
+                                let target_path = target_url.to_file_path()
+                                    .expect("Failed to convert URL to file path");
+
+                                assert_eq!(
+                                    target_path,
+                                    expected_path,
+                                    "Definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",
+                                    expected_path,
+                                    target_path
+                                );
+                            },
+                            GotoDefinitionResponse::Array(locations) => {
+                                assert!(!locations.is_empty(), "Definition locations were returned but empty");
+
+                                let first_location = &locations[0];
+                                let target_url = first_location.uri.clone();
+                                let target_path = target_url.to_file_path()
+                                    .expect("Failed to convert URL to file path");
+
+                                assert_eq!(
+                                    target_path,
+                                    expected_path,
+                                    "Definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",
+                                    expected_path,
+                                    target_path
+                                );
+                            }
+                        }
+                    },
+                    None => {
+                        panic!("No definition link was returned, but expected path: {:?}", expected_path);
+                    }
+                }
+
+                Ok(())
+            }
+        };
+    }
+}

--- a/crates/tombi-server/tests/goto_type_definition.rs
+++ b/crates/tombi-server/tests/goto_type_definition.rs
@@ -12,8 +12,8 @@ mod goto_type_definition_tests {
                 r#"
                 toml-version = "█v1.0.0"
                 "#,
-                Some(tombi_schema_path()),
-            ) -> Ok(tombi_schema_path());
+                tombi_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -23,8 +23,8 @@ mod goto_type_definition_tests {
                 [schema.catalog]
                 path = "█https://www.schemastore.org/api/json/catalog.json"
                 "#,
-                Some(tombi_schema_path()),
-            ) -> Ok(tombi_schema_path());
+                tombi_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -33,8 +33,8 @@ mod goto_type_definition_tests {
                 r#"
                 [[schemas█]]
                 "#,
-                Some(tombi_schema_path()),
-            ) -> Ok(tombi_schema_path());
+                tombi_schema_path(),
+            ) -> Ok(_);
         );
     }
 
@@ -48,8 +48,8 @@ mod goto_type_definition_tests {
                 [package]
                 name█ = "tombi"
                 "#,
-                Some(cargo_schema_path()),
-            ) -> Ok(cargo_schema_path());
+                cargo_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -59,8 +59,8 @@ mod goto_type_definition_tests {
                 [package]
                 readme = "█README.md"
                 "#,
-                Some(cargo_schema_path()),
-            ) -> Ok(cargo_schema_path());
+                cargo_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -70,8 +70,8 @@ mod goto_type_definition_tests {
                 [dependencies]
                 serde█ = { workspace = true }
                 "#,
-                Some(cargo_schema_path()),
-            ) -> Ok(cargo_schema_path());
+                cargo_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -81,8 +81,8 @@ mod goto_type_definition_tests {
                 [profile.release]
                 strip = "debuginfo█"
                 "#,
-                Some(cargo_schema_path()),
-            ) -> Ok(cargo_schema_path());
+                cargo_schema_path(),
+            ) -> Ok(_);
         );
     }
 
@@ -96,8 +96,8 @@ mod goto_type_definition_tests {
                 [project]
                 readme = "█1.0.0"
                 "#,
-                Some(pyproject_schema_path()),
-            ) -> Ok(pyproject_schema_path());
+                pyproject_schema_path(),
+            ) -> Ok(_);
         );
 
         test_goto_type_definition!(
@@ -109,18 +109,43 @@ mod goto_type_definition_tests {
                     "█pytest>=8.3.3",
                 ]
                 "#,
-                Some(pyproject_schema_path()),
-            ) -> Ok(pyproject_schema_path());
+                pyproject_schema_path(),
+            ) -> Ok(_);
         );
     }
 
     #[macro_export]
     macro_rules! test_goto_type_definition {
-        // パスをチェックするバリアント
         (#[tokio::test] async fn $name:ident(
             $source:expr,
+            $schema_file_path:expr$(,)?
+        ) -> Ok(_)$(;)?) => {
+            test_goto_type_definition!(
+                #[tokio::test]
+                async fn $name(
+                    $source,
+                    $schema_file_path,
+                ) -> Ok($schema_file_path);
+            );
+        };
+
+        (#[tokio::test] async fn $name:ident(
+            $source:expr,
+            $schema_file_path:expr$(,)?
+        ) -> Ok($expected_schema_path:expr)$(;)?) => {
+            test_goto_type_definition!(
+                #[tokio::test]
+                async fn _$name(
+                    $source,
+                    Some($schema_file_path),
+                ) -> Ok($expected_schema_path);
+            );
+        };
+
+        (#[tokio::test] async fn _$name:ident(
+            $source:expr,
             $schema_file_path:expr,
-        ) -> Ok($schema_path:expr);) => {
+        ) -> Ok($expected_schema_path:expr);) => {
             #[tokio::test]
             async fn $name() -> Result<(), Box<dyn std::error::Error>> {
                 use std::io::Write;
@@ -219,7 +244,7 @@ mod goto_type_definition_tests {
                 tracing::debug!("goto_type_definition result: {:#?}", result);
 
                 // パス用ケース: 結果のパスを検証
-                let expected_path = $schema_path.to_owned();
+                let expected_path = $expected_schema_path.to_owned();
 
                 match result {
                     Some(def_links) => {

--- a/crates/tombi-server/tests/goto_type_definition.rs
+++ b/crates/tombi-server/tests/goto_type_definition.rs
@@ -243,7 +243,6 @@ mod goto_type_definition_tests {
 
                 tracing::debug!("goto_type_definition result: {:#?}", result);
 
-                // パス用ケース: 結果のパスを検証
                 let expected_path = $expected_schema_path.to_owned();
 
                 match result {

--- a/crates/tombi-server/tests/goto_type_definition.rs
+++ b/crates/tombi-server/tests/goto_type_definition.rs
@@ -258,7 +258,7 @@ mod goto_type_definition_tests {
                                 let target_path = target_url.to_file_path()
                                     .expect("Failed to convert URL to file path");
 
-                                assert_eq!(
+                                pretty_assertions::assert_eq!(
                                     target_path,
                                     expected_path,
                                     "Type definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",
@@ -271,7 +271,7 @@ mod goto_type_definition_tests {
                                 let target_path = target_url.to_file_path()
                                     .expect("Failed to convert URL to file path");
 
-                                assert_eq!(
+                                pretty_assertions::assert_eq!(
                                     target_path,
                                     expected_path,
                                     "Type definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",
@@ -287,7 +287,7 @@ mod goto_type_definition_tests {
                                 let target_path = target_url.to_file_path()
                                     .expect("Failed to convert URL to file path");
 
-                                assert_eq!(
+                                pretty_assertions::assert_eq!(
                                     target_path,
                                     expected_path,
                                     "Type definition link points to an unexpected schema path\nExpected: {:?}\nActual: {:?}",

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-pub fn project_root() -> PathBuf {
+pub fn project_root_path() -> PathBuf {
     let dir = std::env::var("CARGO_MANIFEST_DIR")
         .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned());
 
@@ -13,23 +13,29 @@ pub fn project_root() -> PathBuf {
 }
 
 pub fn tombi_schema_path() -> PathBuf {
-    project_root().join("tombi.schema.json")
+    project_root_path().join("tombi.schema.json")
 }
 
 pub fn cargo_schema_path() -> PathBuf {
-    project_root().join("schemas").join("cargo.schema.json")
+    project_root_path()
+        .join("schemas")
+        .join("cargo.schema.json")
 }
 
 pub fn pyproject_schema_path() -> PathBuf {
-    project_root().join("schemas").join("pyproject.schema.json")
+    project_root_path()
+        .join("schemas")
+        .join("pyproject.schema.json")
 }
 
 pub fn type_test_schema_path() -> PathBuf {
-    project_root().join("schemas").join("type-test.schema.json")
+    project_root_path()
+        .join("schemas")
+        .join("type-test.schema.json")
 }
 
 pub fn x_tombi_table_keys_order_schema_path() -> PathBuf {
-    project_root()
+    project_root_path()
         .join("schemas")
         .join("x-tombi-table-keys-order.schema.json")
 }

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -190,7 +190,7 @@ mod tests {
     use chrono::{DateTime, TimeZone, Utc};
     use indexmap::{indexmap, IndexMap};
     use serde::Deserialize;
-    use tombi_test_lib::project_root;
+    use tombi_test_lib::project_root_path;
 
     #[tokio::test]
     async fn test_deserialize_struct() {
@@ -635,7 +635,7 @@ optional_string = "provided"
 
     #[tokio::test]
     async fn test_deserialize_actual_tombi_config() {
-        let config_path = project_root().join("tombi.toml");
+        let config_path = project_root_path().join("tombi.toml");
         let config = crate::config::from_str(
             &std::fs::read_to_string(&config_path).unwrap(),
             &config_path,

--- a/xtask/src/command/codegen_grammar.rs
+++ b/xtask/src/command/codegen_grammar.rs
@@ -6,11 +6,11 @@ use crate::{
         ast_node::generate_ast_node, ast_token::generate_ast_token, lower,
         syntax_kind::generate_syntax_kind,
     },
-    utils::{ensure_rustfmt, project_root},
+    utils::{ensure_rustfmt, project_root_path},
 };
 
 pub fn run() -> Result<(), anyhow::Error> {
-    let grammar = std::fs::read_to_string(project_root().join("toml.ungram"))
+    let grammar = std::fs::read_to_string(project_root_path().join("toml.ungram"))
         .unwrap()
         .parse::<Grammar>()
         .unwrap();
@@ -22,18 +22,18 @@ pub fn run() -> Result<(), anyhow::Error> {
     write_file(
         &generate_syntax_kind()
             .context("Failed to generate syntax kind from grammar.".to_string())?,
-        &project_root().join("crates/syntax/src/generated/syntax_kind.rs"),
+        &project_root_path().join("crates/syntax/src/generated/syntax_kind.rs"),
     );
 
     write_file(
         &generate_ast_node(&ast)
             .context("Failed to generate ast node from grammar.".to_string())?,
-        &project_root().join("crates/ast/src/generated/ast_node.rs"),
+        &project_root_path().join("crates/ast/src/generated/ast_node.rs"),
     );
 
     write_file(
         &generate_ast_token().context("Failed to generate ast node from grammar.".to_string())?,
-        &project_root().join("crates/ast/src/generated/ast_token.rs"),
+        &project_root_path().join("crates/ast/src/generated/ast_token.rs"),
     );
 
     Ok(())

--- a/xtask/src/command/codegen_jsonschema.rs
+++ b/xtask/src/command/codegen_jsonschema.rs
@@ -1,19 +1,20 @@
-use tombi_config::TomlVersion;
 use schemars::{generate::SchemaSettings, SchemaGenerator};
+use tombi_config::TomlVersion;
 
-use crate::utils::project_root;
+use crate::utils::project_root_path;
 
 pub fn run() -> Result<(), anyhow::Error> {
     let settings = SchemaSettings::draft07();
     let generator = SchemaGenerator::new(settings);
 
     std::fs::write(
-        project_root().join("schemas/type-test.schema.json"),
+        project_root_path().join("schemas/type-test.schema.json"),
         serde_json::to_string_pretty(&generator.clone().into_root_schema_for::<TypeTest>())? + "\n",
     )?;
     std::fs::write(
-        project_root().join("tombi.schema.json"),
-        serde_json::to_string_pretty(&generator.into_root_schema_for::<tombi_config::Config>())? + "\n",
+        project_root_path().join("tombi.schema.json"),
+        serde_json::to_string_pretty(&generator.into_root_schema_for::<tombi_config::Config>())?
+            + "\n",
     )?;
     Ok(())
 }

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -10,10 +10,10 @@ use xshell::Shell;
 use zip::{write::FileOptions, DateTime, ZipWriter};
 
 use super::set_version::DEV_VERSION;
-use crate::utils::project_root;
+use crate::utils::project_root_path;
 
 pub fn run(sh: &Shell) -> Result<(), anyhow::Error> {
-    let project_root = project_root();
+    let project_root = project_root_path();
     let target = Target::get(&project_root);
     let dist = project_root.join("dist");
 
@@ -37,7 +37,7 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
         std::env::set_var("CC", "clang");
     }
 
-    let manifest_path = project_root()
+    let manifest_path = project_root_path()
         .join("rust")
         .join("tombi-cli")
         .join("Cargo.toml");
@@ -48,7 +48,7 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
     )
     .run()?;
 
-    let dist = project_root().join("dist");
+    let dist = project_root_path().join("dist");
     if target_name.contains("-windows-") {
         zip(
             &target.server_path,
@@ -67,7 +67,7 @@ fn dist_client(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
 }
 
 fn dist_editor_vscode(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
-    let vscode_path = project_root().join("editors").join("vscode");
+    let vscode_path = project_root_path().join("editors").join("vscode");
     let bundle_path = vscode_path.join("server");
     sh.remove_path(&bundle_path)?;
     sh.create_dir(&bundle_path)?;

--- a/xtask/src/command/set_version.rs
+++ b/xtask/src/command/set_version.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use xshell::Shell;
 
-use crate::utils::project_root;
+use crate::utils::project_root_path;
 
 pub const DEV_VERSION: &str = "0.0.0";
 
@@ -23,7 +23,7 @@ pub fn run(sh: &Shell) -> anyhow::Result<()> {
 }
 
 fn set_cargo_toml_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
-    let project_root = project_root();
+    let project_root = project_root_path();
     let mut patch = Patch::new(sh, project_root.join("Cargo.toml"))?;
     patch.replace(
         &format!(r#"version = "{}""#, DEV_VERSION),
@@ -36,7 +36,7 @@ fn set_cargo_toml_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
 fn set_editors_vscode_package_json_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
     let mut patch = Patch::new(
         sh,
-        project_root()
+        project_root_path()
             .join("editors")
             .join("vscode")
             .join("package.json"),

--- a/xtask/src/command/toml_test.rs
+++ b/xtask/src/command/toml_test.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use tombi_config::TomlVersion;
 use xshell::Shell;
 
-use crate::utils::project_root;
+use crate::utils::project_root_path;
 
 #[derive(clap::Args, Debug)]
 pub struct Args {
@@ -12,7 +12,7 @@ pub struct Args {
 }
 
 pub fn run(sh: &Shell, args: Args) -> anyhow::Result<()> {
-    let project_root = project_root();
+    let project_root = project_root_path();
 
     sh.change_dir(&project_root);
 

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -4,7 +4,7 @@ pub use crate::glue::pushenv;
 use crate::run;
 
 /// Returns the path to the root directory of `tombi` project.
-pub fn project_root() -> PathBuf {
+pub fn project_root_path() -> PathBuf {
     let dir = std::env::var("CARGO_MANIFEST_DIR")
         .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned());
     PathBuf::from(dir).parent().unwrap().to_owned()


### PR DESCRIPTION
Updated all references from `project_root` to `project_root_path` for consistency and clarity across the codebase.