### PR TITLE
feat: add TOML language support for Zed editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -629,6 +629,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -871,6 +880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +958,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -1724,6 +1745,15 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spdx"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -2631,6 +2661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2795,42 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
+dependencies = [
+ "bitflags 2.6.0",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"
@@ -2942,6 +3014,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288f992ea30e6b5c531b52cdd5f3be81c148554b09ea416f058d16556ba92c27"
+dependencies = [
+ "bitflags 2.6.0",
+ "wit-bindgen-rt",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85e72719ffbccf279359ad071497e47eb0675fe22106dea4ed2d8a7fcb60ba4"
+dependencies = [
+ "anyhow",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb8738270f32a2d6739973cbbb7c1b6dd8959ce515578a6e19165853272ee64"
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a39a15d1ae2077688213611209849cad40e9e5cccf6e61951a425850677ff3"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "indexmap",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376d3ae5850526dfd00d937faea0d81a06fa18f7ac1e26f386d760f241a8f4b"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421c0c848a0660a8c22e2fd217929a0191f14476b68962afd2af89fd22e39825"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196d3ecfc4b759a8573bf86a9b3f8996b304b3732e4c7de81655f875f6efdca6"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +3183,24 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zed-tombi"
+version = "0.1.0"
+dependencies = [
+ "zed_extension_api",
+]
+
+[[package]]
+name = "zed_extension_api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "594fd10dd0f2f853eb243e2425e7c95938cef49adb81d9602921d002c5e6d9d9"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 resolver = "2"
-members = ["crates/*", "extensions/*", "rust/*", "toml-test", "xtask"]
+members = [
+  "crates/*",
+  "editors/zed",
+  "extensions/*",
+  "rust/*",
+  "toml-test",
+  "xtask",
+]
 
 [workspace.package]
 version = "0.0.0"  # We use git tags for versioning. This is just a placeholder.

--- a/editors/zed/.gitignore
+++ b/editors/zed/.gitignore
@@ -1,0 +1,2 @@
+grammars
+*.wasm

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -3,7 +3,7 @@ name = "zed-tombi"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
-description = "🦅  TOML Language Server"
+description = "🦅  TOML Language Server  🦅 "
 repository = { workspace = true }
 license = { workspace = true }
 

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "zed-tombi"
+version = "0.1.0"
+authors = { workspace = true }
+edition = { workspace = true }
+description = "Tombi: TOML Language Server"
+repository = { workspace = true }
+license = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
+[dependencies]
+zed_extension_api = "0.1.0"

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -3,7 +3,7 @@ name = "zed-tombi"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
-description = "Tombi: TOML Language Server"
+description = "🦅  TOML Language Server"
 repository = { workspace = true }
 license = { workspace = true }
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,0 +1,15 @@
+id = "tombi"
+name = "Tombi"
+version = "0.1.0"
+description = "Tombi: TOML Language Server"
+schema_version = 1
+authors = ["yassun7010 <yassun7010@outlook.com>"]
+repository = "https://github.com/tombi-toml/tombi"
+
+[language_servers.toml]
+name = "Tombi"
+languages = ["TOML"]
+
+[grammars.toml]
+repository = "https://github.com/tree-sitter/tree-sitter-toml"
+commit = "342d9be207c2dba869b9967124c679b5e6fd0ebe"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "tombi"
 name = "Tombi"
 version = "0.1.0"
-description = "🦅  TOML Language Server"
+description = "🦅  TOML Language Server  🦅 "
 schema_version = 1
 authors = ["yassun7010 <yassun7010@outlook.com>"]
 repository = "https://github.com/tombi-toml/tombi"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "tombi"
 name = "Tombi"
 version = "0.1.0"
-description = "Tombi: TOML Language Server"
+description = "🦅  TOML Language Server"
 schema_version = 1
 authors = ["yassun7010 <yassun7010@outlook.com>"]
 repository = "https://github.com/tombi-toml/tombi"

--- a/editors/zed/languages/toml/brackets.scm
+++ b/editors/zed/languages/toml/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/editors/zed/languages/toml/config.toml
+++ b/editors/zed/languages/toml/config.toml
@@ -1,0 +1,19 @@
+name = "TOML"
+grammar = "toml"
+path_suffixes = ["Cargo.lock", "toml", "Pipfile", "uv.lock"]
+tab_size = 2
+hard_tabs = false
+line_comments = ["# "]
+autoclose_before = ",]}"
+brackets = [
+  { start = "{", end = "}", close = true, newline = true },
+  { start = "[", end = "]", close = true, newline = true },
+  { start = "\"", end = "\"", close = true, newline = false, not_in = [
+    "comment",
+    "string",
+  ] },
+  { start = "'", end = "'", close = true, newline = false, not_in = [
+    "comment",
+    "string",
+  ] },
+]

--- a/editors/zed/languages/toml/highlights.scm
+++ b/editors/zed/languages/toml/highlights.scm
@@ -1,0 +1,38 @@
+; Properties
+;-----------
+
+(bare_key) @property
+(quoted_key) @property
+
+; Literals
+;---------
+
+(boolean) @constant
+(comment) @comment
+(integer) @number
+(float) @number
+(string) @string
+(escape_sequence) @string.escape
+(offset_date_time) @string.special
+(local_date_time) @string.special
+(local_date) @string.special
+(local_time) @string.special
+
+; Punctuation
+;------------
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+"=" @operator
+
+[
+  "["
+  "]"
+  "[["
+  "]]"
+  "{"
+  "}"
+]  @punctuation.bracket

--- a/editors/zed/languages/toml/outline.scm
+++ b/editors/zed/languages/toml/outline.scm
@@ -1,0 +1,15 @@
+(table
+  .
+  "["
+  .
+  (_) @name) @item
+
+(table_array_element
+  .
+  "[["
+  .
+  (_) @name) @item
+
+(pair
+  .
+  (_) @name) @item

--- a/editors/zed/languages/toml/overrides.scm
+++ b/editors/zed/languages/toml/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @comment.inclusive
+(string) @string

--- a/editors/zed/languages/toml/redactions.scm
+++ b/editors/zed/languages/toml/redactions.scm
@@ -1,0 +1,1 @@
+(pair (bare_key) "=" (_) @redact)

--- a/editors/zed/languages/toml/textobjects.scm
+++ b/editors/zed/languages/toml/textobjects.scm
@@ -1,0 +1,6 @@
+(comment)+ @comment
+(table "[" (_) "]"
+    (_)* @class.inside) @class.around
+
+(table_array_element "[[" (_) "]]"
+    (_)* @class.inside) @class.around

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,0 +1,173 @@
+use std::fs;
+use zed::LanguageServerId;
+use zed_extension_api::{self as zed, settings::LspSettings, Result};
+
+struct TombiBinary {
+    path: String,
+    args: Option<Vec<String>>,
+}
+
+struct TombiExtension {
+    cached_binary_path: Option<String>,
+}
+
+impl TombiExtension {
+    fn language_server_binary(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<TombiBinary> {
+        let binary_settings = LspSettings::for_worktree("tombi", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(TombiBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = worktree.which("tombi") {
+            return Ok(TombiBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(TombiBinary {
+                    path: path.clone(),
+                    args: binary_args,
+                });
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "tombi-toml/tombi",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (platform, arch) = zed::current_platform();
+
+        let asset_stem = format!(
+            "tombi-cli-{version}-{arch}-{os}",
+            version = release.version,
+            arch = match arch {
+                zed::Architecture::Aarch64 => "aarch64",
+                zed::Architecture::X86 => "x86",
+                zed::Architecture::X8664 => "x86_64",
+            },
+            os = match platform {
+                zed::Os::Mac => "apple-darwin",
+                zed::Os::Linux => "unknown-linux-gnu",
+                zed::Os::Windows => "pc-windows-msvc",
+            }
+        );
+        let asset_name = format!(
+            "{asset_stem}.{suffix}",
+            suffix = match platform {
+                zed::Os::Windows => "zip",
+                _ => "tar.gz",
+            }
+        );
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("tombi-{}", release.version);
+        let binary_path = match platform {
+            zed::Os::Windows => format!("{version_dir}/tombi.exe"),
+            _ => format!("{version_dir}/{asset_stem}/tombi"),
+        };
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+            let file_kind = match platform {
+                zed::Os::Windows => zed::DownloadedFileType::Zip,
+                _ => zed::DownloadedFileType::GzipTar,
+            };
+            zed::download_file(&asset.download_url, &version_dir, file_kind)
+                .map_err(|e| format!("failed to download file: {e}"))?;
+
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(TombiBinary {
+            path: binary_path,
+            args: binary_args,
+        })
+    }
+}
+
+impl zed::Extension for TombiExtension {
+    fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let tombi_binary = self.language_server_binary(language_server_id, worktree)?;
+        Ok(zed::Command {
+            command: tombi_binary.path,
+            args: tombi_binary.args.unwrap_or_else(|| vec!["serve".into()]),
+            env: vec![],
+        })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        server_id: &LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        server_id: &LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+}
+
+zed::register_extension!(TombiExtension);

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -2,11 +2,11 @@ mod error;
 
 pub use error::Error;
 use itertools::{Either, Itertools};
-use tombi_schema_store::{SchemaStore, SourceSchema};
 use serde::de::DeserializeOwned;
 use tombi_ast::AstNode;
 use tombi_document::IntoDocument;
 use tombi_document_tree::IntoDocumentTreeAndErrors;
+use tombi_schema_store::{SchemaStore, SourceSchema};
 use tombi_toml_version::TomlVersion;
 use typed_builder::TypedBuilder;
 
@@ -645,7 +645,7 @@ optional_string = "provided"
         // Verify the parsed values
         assert_eq!(
             config.toml_version,
-            Some(tombi_toml_version::TomlVersion::V1_1_0_Preview)
+            Some(tombi_toml_version::TomlVersion::V1_0_0)
         );
         assert_eq!(config.exclude, Some(vec!["node_modules/**/*".to_string()]));
         assert!(config.format.is_some());

--- a/sample.toml
+++ b/sample.toml
@@ -1,3 +1,5 @@
+#:schema ./schemas/x-tombi-toml-v1.1.0-preview.schema.json
+
 # key values begin dangling comment1
 # key values begin dangling comment2
 

--- a/tombi.toml
+++ b/tombi.toml
@@ -3,7 +3,7 @@
 # This file is for checking if the JsonSchema is correct.
 #
 
-toml-version = "v1.1.0-preview"
+toml-version = "v1.0.0"
 exclude = ["node_modules/**/*"]
 
 [format]


### PR DESCRIPTION
Support https://github.com/tombi-toml/tombi/issues/171

- Introduced new grammar, highlighting, and configuration files for TOML language support in the Zed editor.
- Added necessary dependencies and updated workspace configuration.
- Included .gitignore for editor-specific files.