### PR TITLE
chore: update Cargo.toml dependencies to use workspace syntax

### DIFF
--- a/crates/tombi-ast-editor/Cargo.toml
+++ b/crates/tombi-ast-editor/Cargo.toml
@@ -7,19 +7,19 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash = { workspace = true }
-futures = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
-regex = { workspace = true }
-thiserror = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tombi-toml-version = { workspace = true }
-tombi-validator = { workspace = true }
-tombi-x-keyword = { workspace = true }
-tracing = { workspace = true }
+ahash.workspace = true
+futures.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+regex.workspace = true
+thiserror.workspace = true
+tombi-ast.workspace = true
+tombi-document-tree.workspace = true
+tombi-parser.workspace = true
+tombi-schema-store.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tombi-toml-version.workspace = true
+tombi-validator.workspace = true
+tombi-x-keyword.workspace = true
+tracing.workspace = true

--- a/crates/tombi-ast/Cargo.toml
+++ b/crates/tombi-ast/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "tombi-ast"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-itertools = { workspace = true }
-thiserror = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tombi-toml-text = { workspace = true }
-tombi-toml-version = { workspace = true }
-tracing = { workspace = true }
-url = { workspace = true }
+itertools.workspace = true
+thiserror.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tombi-toml-text.workspace = true
+tombi-toml-version.workspace = true
+tracing.workspace = true
+url.workspace = true

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -10,14 +10,14 @@ license.workspace = true
 clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-thiserror = { workspace = true }
-tombi-toml-version = { workspace = true }
-tombi-x-keyword = { workspace = true }
-tracing = { workspace = true }
-url = { workspace = true }
+thiserror.workspace = true
+tombi-toml-version.workspace = true
+tombi-x-keyword.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-assert_matches = { workspace = true }
+assert_matches.workspace = true
 
 [features]
 clap = ["dep:clap"]

--- a/crates/tombi-date-time/Cargo.toml
+++ b/crates/tombi-date-time/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 chrono = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/tombi-diagnostic/Cargo.toml
+++ b/crates/tombi-diagnostic/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "tombi-diagnostic"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-nu-ansi-term = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
-tombi-text = { workspace = true }
+nu-ansi-term.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tombi-text.workspace = true
 tower-lsp = { workspace = true, optional = true }
-tracing = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
-clap = { workspace = true }
+clap.workspace = true
 clap-verbosity-flag.workspace = true
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 
 [features]
 default = ["lsp"]

--- a/crates/tombi-document-tree/Cargo.toml
+++ b/crates/tombi-document-tree/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "tombi-document-tree"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-chrono = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
-thiserror = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-date-time = { workspace = true }
+chrono.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+thiserror.workspace = true
+tombi-ast.workspace = true
+tombi-date-time.workspace = true
 tombi-diagnostic = { workspace = true, optional = true }
-tombi-text = { workspace = true }
-tombi-toml-text = { workspace = true }
-tombi-toml-version = { workspace = true }
-tracing = { workspace = true }
+tombi-text.workspace = true
+tombi-toml-text.workspace = true
+tombi-toml-version.workspace = true
+tracing.workspace = true
 
 [features]
 default = ["diagnostic"]

--- a/crates/tombi-document/Cargo.toml
+++ b/crates/tombi-document/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "tombi-document"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-chrono = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
+chrono.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
 serde = { workspace = true, optional = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-date-time = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-text = { workspace = true }
-tombi-toml-text = { workspace = true }
-tombi-toml-version = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true
+tombi-ast.workspace = true
+tombi-date-time.workspace = true
+tombi-document-tree.workspace = true
+tombi-parser.workspace = true
+tombi-text.workspace = true
+tombi-toml-text.workspace = true
+tombi-toml-version.workspace = true
 tower-lsp = { workspace = true, optional = true }
-tracing = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
-serde_json = { workspace = true }
-textwrap = { workspace = true }
-tombi-test-lib = { workspace = true }
+pretty_assertions.workspace = true
+serde_json.workspace = true
+textwrap.workspace = true
+tombi-test-lib.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/tombi-extension/Cargo.toml
+++ b/crates/tombi-extension/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-tombi-text = { workspace = true }
-tower-lsp = { workspace = true }
+tombi-text.workspace = true
+tower-lsp.workspace = true

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
 name = "tombi-formatter"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-itertools = { workspace = true }
+itertools.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-tokio = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-ast-editor = { workspace = true }
-tombi-config = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-json = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
-unicode-segmentation = { workspace = true }
-url = { workspace = true }
+tokio.workspace = true
+tombi-ast.workspace = true
+tombi-ast-editor.workspace = true
+tombi-config.workspace = true
+tombi-diagnostic.workspace = true
+tombi-document-tree.workspace = true
+tombi-json.workspace = true
+tombi-parser.workspace = true
+tombi-schema-store.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tracing.workspace = true
+unicode-segmentation.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-assert_matches = { workspace = true }
-pretty_assertions = { workspace = true }
-rstest = { workspace = true }
-textwrap = { workspace = true }
+assert_matches.workspace = true
+pretty_assertions.workspace = true
+rstest.workspace = true
+textwrap.workspace = true
 tokio = { workspace = true, features = ["macros"] }
-tombi-test-lib = { workspace = true }
-tracing-subscriber = { workspace = true }
+tombi-test-lib.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 jsonschema = ["dep:schemars", "serde"]

--- a/crates/tombi-json-lexer/Cargo.toml
+++ b/crates/tombi-json-lexer/Cargo.toml
@@ -7,15 +7,15 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-itertools = { workspace = true }
-regex = { workspace = true }
-thiserror = { workspace = true }
+itertools.workspace = true
+regex.workspace = true
+thiserror.workspace = true
 tombi-json-syntax = { path = "../tombi-json-syntax" }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
+tombi-text.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
-rstest = { workspace = true }
-textwrap = { workspace = true }
+pretty_assertions.workspace = true
+rstest.workspace = true
+textwrap.workspace = true
 tombi-test-lib.workspace = true

--- a/crates/tombi-json-syntax/Cargo.toml
+++ b/crates/tombi-json-syntax/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pretty_assertions = { workspace = true }
-tombi-rg-tree = { workspace = true }
+pretty_assertions.workspace = true
+tombi-rg-tree.workspace = true

--- a/crates/tombi-json-value/Cargo.toml
+++ b/crates/tombi-json-value/Cargo.toml
@@ -7,9 +7,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-indexmap = { workspace = true }
+indexmap.workspace = true
 serde = { workspace = true, optional = true }
-tracing = { workspace = true }
+tracing.workspace = true
 
 [features]
 default = ["serde"]

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -7,12 +7,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-indexmap = { workspace = true }
-itertools = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
-tombi-json-lexer = { workspace = true }
-tombi-json-syntax = { workspace = true }
-tombi-json-value = { workspace = true }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
+indexmap.workspace = true
+itertools.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tombi-json-lexer.workspace = true
+tombi-json-syntax.workspace = true
+tombi-json-value.workspace = true
+tombi-text.workspace = true
+tracing.workspace = true

--- a/crates/tombi-lexer/Cargo.toml
+++ b/crates/tombi-lexer/Cargo.toml
@@ -6,15 +6,15 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-itertools = { workspace = true }
-regex = { workspace = true }
-thiserror = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
+itertools.workspace = true
+regex.workspace = true
+thiserror.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
-rstest = { workspace = true }
-textwrap = { workspace = true }
-tombi-test-lib = { workspace = true }
+pretty_assertions.workspace = true
+rstest.workspace = true
+textwrap.workspace = true
+tombi-test-lib.workspace = true

--- a/crates/tombi-linter/Cargo.toml
+++ b/crates/tombi-linter/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "tombi-linter"
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-futures = { workspace = true }
-itertools = { workspace = true }
-regex = { workspace = true }
-schemars = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tombi-validator = { workspace = true }
-tracing = { workspace = true }
-url = { workspace = true }
+futures.workspace = true
+itertools.workspace = true
+regex.workspace = true
+schemars.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-diagnostic.workspace = true
+tombi-document-tree.workspace = true
+tombi-parser.workspace = true
+tombi-schema-store.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tombi-validator.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-assert_matches = { workspace = true }
-pretty_assertions = { workspace = true }
+assert_matches.workspace = true
+pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["macros"] }
-tombi-test-lib = { workspace = true }
-tracing-subscriber = { workspace = true }
+tombi-test-lib.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/tombi-parser/Cargo.toml
+++ b/crates/tombi-parser/Cargo.toml
@@ -7,23 +7,23 @@ license.workspace = true
 
 [dependencies]
 drop_bomb = "0.1.5"
-itertools = { workspace = true }
-thiserror = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
+itertools.workspace = true
+thiserror.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
 tombi-diagnostic = { workspace = true, optional = true }
-tombi-document-tree = { workspace = true }
-tombi-lexer = { workspace = true }
-tombi-rg-tree = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
+tombi-document-tree.workspace = true
+tombi-lexer.workspace = true
+tombi-rg-tree.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-rstest = { workspace = true }
-textwrap = { workspace = true }
-tracing-subscriber = { workspace = true }
+rstest.workspace = true
+textwrap.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 default = ["diagnostic"]

--- a/crates/tombi-rg-tree/Cargo.toml
+++ b/crates/tombi-rg-tree/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 [dependencies]
 countme = "3.0.1"
 hashbrown = "0.15.0"
-itertools = { workspace = true }
+itertools.workspace = true
 rustc-hash = "2.0.0"
-tombi-text = { workspace = true }
+tombi-text.workspace = true
 
 [features]
 default = []

--- a/crates/tombi-schema-store/Cargo.toml
+++ b/crates/tombi-schema-store/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "tombi-schema-store"
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-ahash = { workspace = true }
-futures = { workspace = true }
-glob = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
-regex = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-tokio = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
-tombi-document = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-json = { workspace = true }
-tombi-text = { workspace = true }
-tombi-x-keyword = { workspace = true }
-tracing = { workspace = true }
-url = { workspace = true }
+ahash.workspace = true
+futures.workspace = true
+glob.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+regex.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-document.workspace = true
+tombi-document-tree.workspace = true
+tombi-json.workspace = true
+tombi-text.workspace = true
+tombi-x-keyword.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
+pretty_assertions.workspace = true
 rstest.workspace = true

--- a/crates/tombi-server/Cargo.toml
+++ b/crates/tombi-server/Cargo.toml
@@ -1,55 +1,55 @@
 [package]
 name = "tombi-server"
 version = "0.0.0"
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 ahash.workspace = true
-camino = { workspace = true }
+camino.workspace = true
 chrono.workspace = true
 clap = { workspace = true, optional = true }
-futures = { workspace = true }
-futures-util = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
+futures.workspace = true
+futures-util.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
 regex.workspace = true
-reqwest = { workspace = true }
-rustc-hash = { workspace = true }
-semver = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-serde_tombi = { workspace = true }
-thiserror = { workspace = true }
-tokio = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-cargo-extension = { workspace = true }
-tombi-config = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-document = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-formatter = { workspace = true }
-tombi-json = { workspace = true }
-tombi-linter = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-syntax = { workspace = true }
-tombi-text = { workspace = true }
-tombi-uv-extension = { workspace = true }
-tombi-validator = { workspace = true }
-tombi-x-keyword = { workspace = true }
-tower-lsp = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+reqwest.workspace = true
+rustc-hash.workspace = true
+semver.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_tombi.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tombi-ast.workspace = true
+tombi-cargo-extension.workspace = true
+tombi-config.workspace = true
+tombi-diagnostic.workspace = true
+tombi-document.workspace = true
+tombi-document-tree.workspace = true
+tombi-formatter.workspace = true
+tombi-json.workspace = true
+tombi-linter.workspace = true
+tombi-parser.workspace = true
+tombi-schema-store.workspace = true
+tombi-syntax.workspace = true
+tombi-text.workspace = true
+tombi-uv-extension.workspace = true
+tombi-validator.workspace = true
+tombi-x-keyword.workspace = true
+tower-lsp.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
-rstest = { workspace = true }
+pretty_assertions.workspace = true
+rstest.workspace = true
 tempfile = { version = "3.15.0" }
-textwrap = { workspace = true }
+textwrap.workspace = true
 tokio = { workspace = true, features = ["macros"] }
-tombi-test-lib = { workspace = true }
+tombi-test-lib.workspace = true
 
 [features]
 clap = ["dep:clap"]

--- a/crates/tombi-syntax/Cargo.toml
+++ b/crates/tombi-syntax/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-rstest = { workspace = true }
-thiserror = { workspace = true }
-tombi-rg-tree = { workspace = true }
-tombi-text = { workspace = true }
+rstest.workspace = true
+thiserror.workspace = true
+tombi-rg-tree.workspace = true
+tombi-text.workspace = true

--- a/crates/tombi-toml-text/Cargo.toml
+++ b/crates/tombi-toml-text/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-thiserror = { workspace = true }
-tombi-toml-version = { workspace = true }
+thiserror.workspace = true
+tombi-toml-version.workspace = true

--- a/crates/tombi-validator/Cargo.toml
+++ b/crates/tombi-validator/Cargo.toml
@@ -7,12 +7,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures = { workspace = true }
-itertools = { workspace = true }
-regex = { workspace = true }
-thiserror = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-text = { workspace = true }
-tracing = { workspace = true }
+futures.workspace = true
+itertools.workspace = true
+regex.workspace = true
+thiserror.workspace = true
+tombi-diagnostic.workspace = true
+tombi-document-tree.workspace = true
+tombi-schema-store.workspace = true
+tombi-text.workspace = true
+tracing.workspace = true

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "zed-tombi"
 version = "0.1.0"
-authors = { workspace = true }
-edition = { workspace = true }
+authors.workspace = true
+edition.workspace = true
 description = "🦅  TOML Language Server  🦅 "
-repository = { workspace = true }
-license = { workspace = true }
+repository.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/extensions/tombi-cargo-extension/Cargo.toml
+++ b/extensions/tombi-cargo-extension/Cargo.toml
@@ -8,13 +8,13 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-cargo_metadata = { workspace = true }
-itertools = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-extension = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-text = { workspace = true }
-tower-lsp = { workspace = true }
-tracing = { workspace = true }
+cargo_metadata.workspace = true
+itertools.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-document-tree.workspace = true
+tombi-extension.workspace = true
+tombi-parser.workspace = true
+tombi-text.workspace = true
+tower-lsp.workspace = true
+tracing.workspace = true

--- a/extensions/tombi-uv-extension/Cargo.toml
+++ b/extensions/tombi-uv-extension/Cargo.toml
@@ -8,16 +8,16 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-glob = { workspace = true }
-itertools = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-extension = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-text = { workspace = true }
-tower-lsp = { workspace = true }
-tracing = { workspace = true }
+glob.workspace = true
+itertools.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-document-tree.workspace = true
+tombi-extension.workspace = true
+tombi-parser.workspace = true
+tombi-text.workspace = true
+tower-lsp.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tombi-test-lib = { workspace = true }
+tombi-test-lib.workspace = true

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -8,32 +8,32 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-chrono = { workspace = true }
-futures = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
-serde = { workspace = true }
-textwrap = { workspace = true }
-thiserror = { workspace = true }
-tokio = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-config = { workspace = true }
-tombi-date-time = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-document = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-formatter = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-text = { workspace = true }
-tombi-toml-text = { workspace = true }
-tombi-toml-version = { workspace = true }
-tracing = { workspace = true }
-typed-builder = { workspace = true }
-url = { workspace = true }
+chrono.workspace = true
+futures.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+serde.workspace = true
+textwrap.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-date-time.workspace = true
+tombi-diagnostic.workspace = true
+tombi-document.workspace = true
+tombi-document-tree.workspace = true
+tombi-formatter.workspace = true
+tombi-parser.workspace = true
+tombi-schema-store.workspace = true
+tombi-text.workspace = true
+tombi-toml-text.workspace = true
+tombi-toml-version.workspace = true
+tracing.workspace = true
+typed-builder.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-maplit = { workspace = true }
-pretty_assertions = { workspace = true }
+maplit.workspace = true
+pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["macros"] }
-tombi-test-lib = { workspace = true }
+tombi-test-lib.workspace = true

--- a/rust/tombi-cli/Cargo.toml
+++ b/rust/tombi-cli/Cargo.toml
@@ -12,20 +12,20 @@ name = "tombi"
 path = "src/main.rs"
 
 [dependencies]
-clap = { workspace = true }
-clap-verbosity-flag = { workspace = true }
-glob = { workspace = true }
-itertools = { workspace = true }
-nu-ansi-term = { workspace = true }
-serde_tombi = { workspace = true }
-thiserror = { workspace = true }
-tokio = { workspace = true }
-tombi-config = { workspace = true }
-tombi-diagnostic = { workspace = true }
-tombi-formatter = { workspace = true }
-tombi-linter = { workspace = true }
-tombi-schema-store = { workspace = true }
-tombi-server = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-url = { workspace = true }
+clap.workspace = true
+clap-verbosity-flag.workspace = true
+glob.workspace = true
+itertools.workspace = true
+nu-ansi-term.workspace = true
+serde_tombi.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tombi-config.workspace = true
+tombi-diagnostic.workspace = true
+tombi-formatter.workspace = true
+tombi-linter.workspace = true
+tombi-schema-store.workspace = true
+tombi-server.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+url.workspace = true

--- a/toml-test/Cargo.toml
+++ b/toml-test/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "toml-test"
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "decode"
 path = "bin/decode.rs"
 
 [dependencies]
-anyhow = { workspace = true }
-chrono = { workspace = true }
-clap = { workspace = true }
-indexmap = { workspace = true }
-itertools = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-tombi-ast = { workspace = true }
-tombi-document-tree = { workspace = true }
-tombi-parser = { workspace = true }
-tombi-text = { workspace = true }
-tombi-toml-version = { workspace = true }
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tombi-ast.workspace = true
+tombi-document-tree.workspace = true
+tombi-parser.workspace = true
+tombi-text.workspace = true
+tombi-toml-version.workspace = true
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
-textwrap = { workspace = true }
+pretty_assertions.workspace = true
+textwrap.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "xtask"
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 chrono.workspace = true
-clap = { workspace = true }
+clap.workspace = true
 convert_case = "0.6.0"
 flate2 = "1.0.35"
-itertools = { workspace = true }
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
+itertools.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
 schemars = { workspace = true, features = ["chrono04"] }
 serde.workspace = true
 serde_json.workspace = true
-thiserror = { workspace = true }
+thiserror.workspace = true
 time = { version = "0.3.36", default-features = false }
 tombi-config = { workspace = true, features = ["jsonschema"] }
 ungrammar = "1.16.1"


### PR DESCRIPTION
Refactor all Cargo.toml files to replace the old dependency syntax with the new workspace syntax for better consistency and clarity.