### PR TITLE
fix: zed tombi extension.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "zed-tombi"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 typed-builder = "0.21.0"
 unicode-segmentation = "1.12.0"
 url = { version = "2.5.4", features = ["serde"] }
+zed_extension_api = "0.1.0"

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-zed_extension_api = "0.1.0"
+zed_extension_api.workspace = true

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-tombi"
-version = "0.1.0"
+version = "0.1.2"
 authors.workspace = true
 edition.workspace = true
 description = "🦅  TOML Language Server  🦅 "

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "tombi"
 name = "Tombi | TOML Toolkit"
-version = "0.1.1"
+version = "0.1.2"
 description = "🦅  TOML Language Server  🦅 "
 schema_version = 1
 authors = ["tombi-toml <tombi-toml@outlook.com>"]

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -60,10 +60,13 @@ impl TombiExtension {
         )?;
 
         let (platform, arch) = zed::current_platform();
+        let version = release
+            .version
+            .strip_prefix("v")
+            .unwrap_or(&release.version);
 
         let asset_stem = format!(
             "tombi-cli-{version}-{arch}-{os}",
-            version = release.version,
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
                 zed::Architecture::X86 => "x86",
@@ -79,7 +82,7 @@ impl TombiExtension {
             "{asset_stem}.{suffix}",
             suffix = match platform {
                 zed::Os::Windows => "zip",
-                _ => "tar.gz",
+                _ => "gz",
             }
         );
 
@@ -89,10 +92,12 @@ impl TombiExtension {
             .find(|asset| asset.name == asset_name)
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
-        let version_dir = format!("tombi-{}", release.version);
+        let version_dir = format!("tombi-{version}");
+        fs::create_dir_all(&version_dir)
+            .map_err(|err| format!("failed to create directory '{version_dir}': {err}"))?;
         let binary_path = match platform {
             zed::Os::Windows => format!("{version_dir}/tombi.exe"),
-            _ => format!("{version_dir}/{asset_stem}/tombi"),
+            _ => format!("{version_dir}/tombi"),
         };
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
@@ -102,15 +107,17 @@ impl TombiExtension {
             );
             let file_kind = match platform {
                 zed::Os::Windows => zed::DownloadedFileType::Zip,
-                _ => zed::DownloadedFileType::GzipTar,
+                _ => zed::DownloadedFileType::Gzip,
             };
-            zed::download_file(&asset.download_url, &version_dir, file_kind)
+            zed::download_file(&asset.download_url, &binary_path, file_kind)
                 .map_err(|e| format!("failed to download file: {e}"))?;
 
-            let entries =
-                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            zed::make_file_executable(&binary_path)?;
+
+            let entries = fs::read_dir(".")
+                .map_err(|err| format!("failed to list working directory {err}"))?;
             for entry in entries {
-                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                let entry = entry.map_err(|err| format!("failed to load directory entry {err}"))?;
                 if entry.file_name().to_str() != Some(&version_dir) {
                     fs::remove_dir_all(entry.path()).ok();
                 }


### PR DESCRIPTION
Updated the asset naming logic to strip the prefix from the release version and improved the format for version directories. This enhances clarity and consistency in the generated asset names.