### PR TITLE
chore: add pretty_assertions to dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,7 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "itertools",
+ "pretty_assertions",
  "serde",
  "thiserror",
  "tombi-json-lexer",
@@ -2184,6 +2185,7 @@ name = "tombi-json-value"
 version = "0.0.0"
 dependencies = [
  "indexmap",
+ "pretty_assertions",
  "serde",
  "tracing",
 ]
@@ -2261,6 +2263,7 @@ dependencies = [
  "countme",
  "hashbrown 0.15.3",
  "itertools",
+ "pretty_assertions",
  "rustc-hash",
  "tombi-text",
 ]
@@ -2363,6 +2366,7 @@ dependencies = [
 name = "tombi-text"
 version = "0.0.0"
 dependencies = [
+ "pretty_assertions",
  "rstest",
  "serde",
  "tower-lsp",

--- a/crates/tombi-document/src/value/float.rs
+++ b/crates/tombi-document/src/value/float.rs
@@ -58,19 +58,19 @@ mod test {
     #[test]
     fn inf() {
         let float = crate::value::Float::try_new("inf").unwrap();
-        assert_eq!(float.value(), f64::INFINITY);
+        pretty_assertions::assert_eq!(float.value(), f64::INFINITY);
     }
 
     #[test]
     fn p_inf() {
         let float = crate::value::Float::try_new("+inf").unwrap();
-        assert_eq!(float.value(), f64::INFINITY);
+        pretty_assertions::assert_eq!(float.value(), f64::INFINITY);
     }
 
     #[test]
     fn m_inf() {
         let float = crate::value::Float::try_new("-inf").unwrap();
-        assert_eq!(float.value(), f64::NEG_INFINITY);
+        pretty_assertions::assert_eq!(float.value(), f64::NEG_INFINITY);
     }
 
     #[test]

--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -162,8 +162,8 @@ fn format_singleline_array(
 
 #[cfg(test)]
 mod tests {
-    use tombi_config::{QuoteStyle, TomlVersion};
     use rstest::rstest;
+    use tombi_config::{QuoteStyle, TomlVersion};
 
     use super::*;
     use crate::{formatter::definitions::FormatDefinitions, test_format};
@@ -401,13 +401,13 @@ mod tests {
     #[case("[1, 2, 3]", false)]
     fn has_tailing_comma_after_last_value(#[case] source: &str, #[case] expected: bool) {
         let p = tombi_parser::parse_as::<tombi_ast::Array>(source);
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             p.errors(TomlVersion::default()).collect_vec(),
             Vec::<&tombi_parser::Error>::new()
         );
 
         let ast = tombi_ast::Array::cast(p.syntax_node()).unwrap();
-        assert_eq!(ast.has_tailing_comma_after_last_value(), expected);
+        pretty_assertions::assert_eq!(ast.has_tailing_comma_after_last_value(), expected);
     }
 
     test_format! {

--- a/crates/tombi-json-value/Cargo.toml
+++ b/crates/tombi-json-value/Cargo.toml
@@ -11,6 +11,9 @@ indexmap.workspace = true
 serde = { workspace = true, optional = true }
 tracing.workspace = true
 
+[dev-dependencies]
+pretty_assertions.workspace = true
+
 [features]
 default = ["serde"]
 serde = ["dep:serde"]

--- a/crates/tombi-json-value/src/macros.rs
+++ b/crates/tombi-json-value/src/macros.rs
@@ -85,28 +85,28 @@ mod tests {
 
         // Test boolean
         let bool_value = json!(true);
-        assert_eq!(bool_value, Value::Bool(true));
+        pretty_assertions::assert_eq!(bool_value, Value::Bool(true));
 
         // Test number
         let num_value = json!(42);
-        assert_eq!(num_value, Value::Number(Number::from(42)));
+        pretty_assertions::assert_eq!(num_value, Value::Number(Number::from(42)));
 
         // Test float
         let float_value = json!(42.5);
-        assert_eq!(float_value, Value::Number(Number::from(42.5)));
+        pretty_assertions::assert_eq!(float_value, Value::Number(Number::from(42.5)));
 
         // Test string
         let str_value = json!("hello");
-        assert_eq!(str_value, Value::String("hello".to_string()));
+        pretty_assertions::assert_eq!(str_value, Value::String("hello".to_string()));
 
         // Test array
         let array_value = json!([1, 2, "three", false]);
         if let Value::Array(arr) = array_value {
-            assert_eq!(arr.len(), 4);
-            assert_eq!(arr[0], Value::Number(Number::from(1)));
-            assert_eq!(arr[1], Value::Number(Number::from(2)));
-            assert_eq!(arr[2], Value::String("three".to_string()));
-            assert_eq!(arr[3], Value::Bool(false));
+            pretty_assertions::assert_eq!(arr.len(), 4);
+            pretty_assertions::assert_eq!(arr[0], Value::Number(Number::from(1)));
+            pretty_assertions::assert_eq!(arr[1], Value::Number(Number::from(2)));
+            pretty_assertions::assert_eq!(arr[2], Value::String("three".to_string()));
+            pretty_assertions::assert_eq!(arr[3], Value::Bool(false));
         } else {
             panic!("Expected array");
         }
@@ -118,13 +118,16 @@ mod tests {
             "is_active": true
         });
         if let Value::Object(obj) = obj_value {
-            assert_eq!(obj.len(), 3);
-            assert_eq!(
+            pretty_assertions::assert_eq!(obj.len(), 3);
+            pretty_assertions::assert_eq!(
                 obj.get_str("name"),
                 Some(&Value::String("John".to_string()))
             );
-            assert_eq!(obj.get_str("age"), Some(&Value::Number(Number::from(30))));
-            assert_eq!(obj.get_str("is_active"), Some(&Value::Bool(true)));
+            pretty_assertions::assert_eq!(
+                obj.get_str("age"),
+                Some(&Value::Number(Number::from(30)))
+            );
+            pretty_assertions::assert_eq!(obj.get_str("is_active"), Some(&Value::Bool(true)));
         } else {
             panic!("Expected object");
         }
@@ -137,11 +140,14 @@ mod tests {
             "age": age
         });
         if let Value::Object(obj) = user {
-            assert_eq!(
+            pretty_assertions::assert_eq!(
                 obj.get_str("name"),
                 Some(&Value::String("Jane".to_string()))
             );
-            assert_eq!(obj.get_str("age"), Some(&Value::Number(Number::from(25))));
+            pretty_assertions::assert_eq!(
+                obj.get_str("age"),
+                Some(&Value::Number(Number::from(25)))
+            );
         } else {
             panic!("Expected object");
         }
@@ -155,14 +161,14 @@ mod tests {
         });
         if let Value::Object(obj) = nested {
             if let Some(Value::Object(user)) = obj.get_str("user") {
-                assert_eq!(
+                pretty_assertions::assert_eq!(
                     user.get_str("name"),
                     Some(&Value::String("Bob".to_string()))
                 );
                 if let Some(Value::Array(hobbies)) = user.get_str("hobbies") {
-                    assert_eq!(hobbies.len(), 2);
-                    assert_eq!(hobbies[0], Value::String("Reading".to_string()));
-                    assert_eq!(hobbies[1], Value::String("Running".to_string()));
+                    pretty_assertions::assert_eq!(hobbies.len(), 2);
+                    pretty_assertions::assert_eq!(hobbies[0], Value::String("Reading".to_string()));
+                    pretty_assertions::assert_eq!(hobbies[1], Value::String("Running".to_string()));
                 } else {
                     panic!("Expected hobbies array");
                 }
@@ -179,19 +185,19 @@ mod tests {
 
         assert!(int_value.is_i64());
         assert!(!int_value.is_f64());
-        assert_eq!(int_value.as_i64(), Some(42));
+        pretty_assertions::assert_eq!(int_value.as_i64(), Some(42));
 
         // Default behavior is to convert whole number floats to integers
         assert!(float_value.is_i64());
         assert!(!float_value.is_f64());
-        assert_eq!(float_value.as_i64(), Some(42));
-        assert_eq!(float_value.as_f64(), Some(42.0));
+        pretty_assertions::assert_eq!(float_value.as_i64(), Some(42));
+        pretty_assertions::assert_eq!(float_value.as_f64(), Some(42.0));
 
         // Explicit float
         let explicit_float = json!(42.5);
         assert!(!explicit_float.is_i64());
         assert!(explicit_float.is_f64());
-        assert_eq!(explicit_float.as_i64(), None);
-        assert_eq!(explicit_float.as_f64(), Some(42.5));
+        pretty_assertions::assert_eq!(explicit_float.as_i64(), None);
+        pretty_assertions::assert_eq!(explicit_float.as_f64(), Some(42.5));
     }
 }

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -16,3 +16,6 @@ tombi-json-syntax.workspace = true
 tombi-json-value.workspace = true
 tombi-text.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/crates/tombi-json/src/lib.rs
+++ b/crates/tombi-json/src/lib.rs
@@ -689,12 +689,12 @@ mod tests {
         let json = "true";
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_bool());
-        assert_eq!(value_node.as_bool(), Some(true));
+        pretty_assertions::assert_eq!(value_node.as_bool(), Some(true));
 
         let json = "false";
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_bool());
-        assert_eq!(value_node.as_bool(), Some(false));
+        pretty_assertions::assert_eq!(value_node.as_bool(), Some(false));
     }
 
     #[test]
@@ -702,12 +702,12 @@ mod tests {
         let json = "42";
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_number());
-        assert_eq!(value_node.as_f64(), Some(42.0));
+        pretty_assertions::assert_eq!(value_node.as_f64(), Some(42.0));
 
         let json = "-3.14";
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_number());
-        assert_eq!(value_node.as_f64(), Some(-3.14));
+        pretty_assertions::assert_eq!(value_node.as_f64(), Some(-3.14));
     }
 
     #[test]
@@ -715,7 +715,7 @@ mod tests {
         let json = r#""hello""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(value_node.as_str(), Some("hello"));
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("hello"));
     }
 
     #[test]
@@ -749,16 +749,16 @@ mod tests {
         assert!(node.is_object());
 
         if let Some(obj) = node.as_object() {
-            assert_eq!(obj.len(), 2);
+            pretty_assertions::assert_eq!(obj.len(), 2);
 
             if let Some(name_node) = obj.properties.get("name") {
-                assert_eq!(name_node.as_str(), Some("John"));
+                pretty_assertions::assert_eq!(name_node.as_str(), Some("John"));
             } else {
                 panic!("name property not found");
             }
 
             if let Some(age_node) = obj.properties.get("age") {
-                assert_eq!(age_node.as_i64(), Some(30));
+                pretty_assertions::assert_eq!(age_node.as_i64(), Some(30));
             } else {
                 panic!("age property not found");
             }
@@ -786,18 +786,18 @@ mod tests {
         // Convert to Value for easier testing
         let value: Value = value_node.into();
         let obj = value.as_object().unwrap();
-        assert_eq!(obj.get("name").unwrap().as_str(), Some("John"));
-        assert_eq!(obj.get("age").unwrap().as_i64(), Some(30));
-        assert_eq!(obj.get("isStudent").unwrap().as_bool(), Some(false));
+        pretty_assertions::assert_eq!(obj.get("name").unwrap().as_str(), Some("John"));
+        pretty_assertions::assert_eq!(obj.get("age").unwrap().as_i64(), Some(30));
+        pretty_assertions::assert_eq!(obj.get("isStudent").unwrap().as_bool(), Some(false));
 
         let courses = obj.get("courses").unwrap().as_array().unwrap();
-        assert_eq!(courses.len(), 2);
-        assert_eq!(courses[0].as_str(), Some("Math"));
-        assert_eq!(courses[1].as_str(), Some("Physics"));
+        pretty_assertions::assert_eq!(courses.len(), 2);
+        pretty_assertions::assert_eq!(courses[0].as_str(), Some("Math"));
+        pretty_assertions::assert_eq!(courses[1].as_str(), Some("Physics"));
 
         let address = obj.get("address").unwrap().as_object().unwrap();
-        assert_eq!(address.get("city").unwrap().as_str(), Some("New York"));
-        assert_eq!(address.get("zip").unwrap().as_str(), Some("10001"));
+        pretty_assertions::assert_eq!(address.get("city").unwrap().as_str(), Some("New York"));
+        pretty_assertions::assert_eq!(address.get("zip").unwrap().as_str(), Some("10001"));
     }
 
     #[test]
@@ -812,9 +812,9 @@ mod tests {
         let json = r#"{"name": "John", "age": 30, "is_student": false}"#;
         let person: Person = from_str(json).unwrap();
 
-        assert_eq!(person.name, "John");
-        assert_eq!(person.age, 30);
-        assert_eq!(person.is_student, false);
+        pretty_assertions::assert_eq!(person.name, "John");
+        pretty_assertions::assert_eq!(person.age, 30);
+        pretty_assertions::assert_eq!(person.is_student, false);
     }
 
     #[test]
@@ -845,10 +845,10 @@ mod tests {
 
         let person: Person = from_str(json).unwrap();
 
-        assert_eq!(person.name, "John");
-        assert_eq!(person.age, 30);
-        assert_eq!(person.address.city, "New York");
-        assert_eq!(person.address.zip, "10001");
+        pretty_assertions::assert_eq!(person.name, "John");
+        pretty_assertions::assert_eq!(person.age, 30);
+        pretty_assertions::assert_eq!(person.address.city, "New York");
+        pretty_assertions::assert_eq!(person.address.zip, "10001");
     }
 
     #[test]
@@ -864,15 +864,15 @@ mod tests {
 
         let json = r#""Red""#;
         let color: Color = from_str(json).unwrap();
-        assert_eq!(color, Color::Red);
+        pretty_assertions::assert_eq!(color, Color::Red);
 
         let json = r#"{"RGB": [255, 255, 255]}"#;
         let color: Color = from_str(json).unwrap();
-        assert_eq!(color, Color::RGB(255, 255, 255));
+        pretty_assertions::assert_eq!(color, Color::RGB(255, 255, 255));
 
         let json = r###"{"HexCode": "#FFFFFF"}"###;
         let color: Color = from_str(json).unwrap();
-        assert_eq!(color, Color::HexCode("#FFFFFF".to_string()));
+        pretty_assertions::assert_eq!(color, Color::HexCode("#FFFFFF".to_string()));
     }
 
     #[test]
@@ -890,7 +890,7 @@ mod tests {
                 assert!(name_node.range().start() != name_node.range().end());
 
                 // 値が "John" であることを確認
-                assert_eq!(name_node.as_str(), Some("John"));
+                pretty_assertions::assert_eq!(name_node.as_str(), Some("John"));
             }
 
             if let Some(age_node) = object_node.properties.get("age") {
@@ -898,7 +898,7 @@ mod tests {
                 assert!(age_node.range().start() != age_node.range().end());
 
                 // 値が 30 であることを確認
-                assert_eq!(age_node.as_i64(), Some(30));
+                pretty_assertions::assert_eq!(age_node.as_i64(), Some(30));
             }
         }
     }
@@ -908,7 +908,7 @@ mod tests {
         let json = r#""This string contains \"quotes\" inside it""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             value_node.as_str(),
             Some(r#"This string contains "quotes" inside it"#)
         );
@@ -919,7 +919,7 @@ mod tests {
         let json = r#""Line1\nLine2\tTabbed\rCarriage Return\\Backslash""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             value_node.as_str(),
             Some("Line1\nLine2\tTabbed\rCarriage Return\\Backslash")
         );
@@ -930,7 +930,7 @@ mod tests {
         let json = r#""こんにちは世界! 🌍 🌎 🌏""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(value_node.as_str(), Some("こんにちは世界! 🌍 🌎 🌏"));
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("こんにちは世界! 🌍 🌎 🌏"));
     }
 
     #[test]
@@ -938,7 +938,7 @@ mod tests {
         let json = r#""\u3053\u3093\u306B\u3061\u306F\u4E16\u754C""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(value_node.as_str(), Some("こんにちは世界"));
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("こんにちは世界"));
     }
 
     #[test]
@@ -946,7 +946,7 @@ mod tests {
         let json = r#""Mixed: \"quotes\", 日本語, and \u0065\u0073\u0063\u0061\u0070\u0065\u0064 text with 🚀""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             value_node.as_str(),
             Some(r#"Mixed: "quotes", 日本語, and escaped text with 🚀"#)
         );
@@ -957,7 +957,7 @@ mod tests {
         let json = r#""\u0000\u0001\u0002\b\f""#;
         let value_node = ValueNode::from_str(json).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             value_node.as_str(),
             Some("\u{0000}\u{0001}\u{0002}\u{0008}\u{000C}")
         );

--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -397,12 +397,12 @@ mod tests {
         let source = "true";
         let value_node = parse(source).unwrap();
         assert!(value_node.is_bool());
-        assert_eq!(value_node.as_bool(), Some(true));
+        pretty_assertions::assert_eq!(value_node.as_bool(), Some(true));
 
         let source = "false";
         let value_node = parse(source).unwrap();
         assert!(value_node.is_bool());
-        assert_eq!(value_node.as_bool(), Some(false));
+        pretty_assertions::assert_eq!(value_node.as_bool(), Some(false));
     }
 
     #[test]
@@ -410,12 +410,12 @@ mod tests {
         let source = "42";
         let value_node = parse(source).unwrap();
         assert!(value_node.is_number());
-        assert_eq!(value_node.as_f64(), Some(42.0));
+        pretty_assertions::assert_eq!(value_node.as_f64(), Some(42.0));
 
         let source = "-3.14";
         let value_node = parse(source).unwrap();
         assert!(value_node.is_number());
-        assert_eq!(value_node.as_f64(), Some(-3.14));
+        pretty_assertions::assert_eq!(value_node.as_f64(), Some(-3.14));
     }
 
     #[test]
@@ -423,7 +423,7 @@ mod tests {
         let source = r#""hello""#;
         let value_node = parse(source).unwrap();
         assert!(value_node.is_string());
-        assert_eq!(value_node.as_str(), Some("hello"));
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("hello"));
     }
 
     #[test]

--- a/crates/tombi-rg-tree/Cargo.toml
+++ b/crates/tombi-rg-tree/Cargo.toml
@@ -13,5 +13,8 @@ itertools.workspace = true
 rustc-hash = "2.0.0"
 tombi-text.workspace = true
 
+[dev-dependencies]
+pretty_assertions.workspace = true
+
 [features]
 default = []

--- a/crates/tombi-rg-tree/src/green/builder.rs
+++ b/crates/tombi-rg-tree/src/green/builder.rs
@@ -122,7 +122,7 @@ impl GreenNodeBuilder<'_> {
     /// are paired!
     #[inline]
     pub fn finish(mut self) -> GreenNode {
-        assert_eq!(self.children.len(), 1);
+        debug_assert_eq!(self.children.len(), 1);
         match self.children.pop().unwrap().1 {
             NodeOrToken::Node(node) => node,
             NodeOrToken::Token(_) => panic!(),

--- a/crates/tombi-rg-tree/src/red/node.rs
+++ b/crates/tombi-rg-tree/src/red/node.rs
@@ -35,7 +35,7 @@ impl<L: Language> fmt::Debug for RedNode<L> {
                     WalkEvent::Leave(_) => level -= 1,
                 }
             }
-            assert_eq!(level, 0);
+            debug_assert_eq!(level, 0);
             Ok(())
         } else {
             write!(

--- a/crates/tombi-rg-tree/src/syntax_text.rs
+++ b/crates/tombi-rg-tree/src/syntax_text.rs
@@ -280,13 +280,21 @@ mod tests {
             let t2 = build_tree(t2).text();
             let expected = t1.to_string() == t2.to_string();
             let actual = t1 == t2;
-            assert_eq!(
-                expected, actual,
+            pretty_assertions::assert_eq!(
+                expected,
+                actual,
                 "`{}` (SyntaxText) `{}` (SyntaxText)",
-                t1, t2
+                t1,
+                t2
             );
             let actual = t1 == *t2.to_string();
-            assert_eq!(expected, actual, "`{}` (SyntaxText) `{}` (&str)", t1, t2);
+            pretty_assertions::assert_eq!(
+                expected,
+                actual,
+                "`{}` (SyntaxText) `{}` (&str)",
+                t1,
+                t2
+            );
         }
         fn check(t1: &[&str], t2: &[&str]) {
             do_check(t1, t2);

--- a/crates/tombi-schema-store/src/schema/schema_accessor.rs
+++ b/crates/tombi-schema-store/src/schema/schema_accessor.rs
@@ -1,5 +1,5 @@
-use tombi_config::TomlVersion;
 use itertools::Itertools;
+use tombi_config::TomlVersion;
 
 use crate::Accessor;
 
@@ -245,6 +245,6 @@ mod tests {
     ])]
     fn test_schema_accessor(#[case] input: &str, #[case] expected: Vec<SchemaAccessor>) {
         let result = SchemaAccessor::parse(input).unwrap();
-        assert_eq!(result, expected, "Failed for input: {}", input);
+        pretty_assertions::assert_eq!(result, expected, "Failed for input: {}", input);
     }
 }

--- a/crates/tombi-server/src/hover.rs
+++ b/crates/tombi-server/src/hover.rs
@@ -9,7 +9,9 @@ use std::{borrow::Cow, fmt::Debug, ops::Deref};
 
 use constraints::DataConstraints;
 use futures::future::BoxFuture;
-use tombi_schema_store::{get_schema_name, Accessor, Accessors, CurrentSchema, SchemaUrl, ValueType};
+use tombi_schema_store::{
+    get_schema_name, Accessor, Accessors, CurrentSchema, SchemaUrl, ValueType,
+};
 
 pub async fn get_hover_content(
     tree: &tombi_document_tree::DocumentTree,
@@ -155,6 +157,6 @@ mod test {
     #[case("file://tombi.schema.json")]
     fn url_content(#[case] url: &str) {
         let url = SchemaUrl::parse(url).unwrap();
-        assert_eq!(get_schema_name(&url).unwrap(), "tombi.schema.json");
+        pretty_assertions::assert_eq!(get_schema_name(&url).unwrap(), "tombi.schema.json");
     }
 }

--- a/crates/tombi-text/Cargo.toml
+++ b/crates/tombi-text/Cargo.toml
@@ -11,6 +11,7 @@ tower-lsp = { workspace = true, optional = true }
 tracing.workspace = true
 
 [dev-dependencies]
+pretty_assertions.workspace = true
 rstest.workspace = true
 
 [features]

--- a/crates/tombi-text/src/range.rs
+++ b/crates/tombi-text/src/range.rs
@@ -27,7 +27,11 @@ impl Range {
             end: if start <= end {
                 end
             } else {
-                tracing::error!("Invalid tombi_text::Range: start: {:?} > end: {:?}", start, end);
+                tracing::error!(
+                    "Invalid tombi_text::Range: start: {:?} > end: {:?}",
+                    start,
+                    end
+                );
                 start
             },
         }
@@ -159,7 +163,7 @@ mod test {
         let r1 = Range::from(range);
         let r2 = Range::from(other);
 
-        assert_eq!(r1.cmp(&r2), expected);
+        pretty_assertions::assert_eq!(r1.cmp(&r2), expected);
     }
 
     #[rstest]
@@ -173,6 +177,6 @@ mod test {
     ) {
         let mut range = Range::from(range);
         range += RelativePosition::of(text);
-        assert_eq!(range, expected.into());
+        pretty_assertions::assert_eq!(range, expected.into());
     }
 }

--- a/crates/tombi-text/src/relative_position.rs
+++ b/crates/tombi-text/src/relative_position.rs
@@ -106,6 +106,6 @@ mod test {
     #[case("abc\ndef\nghi", (2, 3))]
     #[case("abc\r\ndef\r\nghi", (2, 3))]
     fn test_position(#[case] source: &str, #[case] expected: (Line, Column)) {
-        assert_eq!(RelativePosition::of(source), expected.into());
+        pretty_assertions::assert_eq!(RelativePosition::of(source), expected.into());
     }
 }

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -222,7 +222,7 @@ opt = "optional"
         let result: Test = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -255,7 +255,7 @@ value = "nested value"
         let result: Test = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -274,7 +274,7 @@ value = "nested value"
         let result: SimpleArrayTest = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -311,7 +311,7 @@ three = 3
         let result: MapTest = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -335,7 +335,7 @@ three = 3
         let result: EnumTest = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -359,7 +359,7 @@ updated_at = "2023-07-20T14:45:30Z"
         let result: DateTimeTest = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -380,7 +380,7 @@ updated_at = "2023-07-20T14:45:30Z"
         let result: OptionTest = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -404,7 +404,7 @@ empty_map = {}
         let result: EmptyContainers = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -434,7 +434,7 @@ escape_chars = "\\t\\n\\r\\\""
         let result: SpecialChars = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -470,7 +470,7 @@ negative_zero = -0.0
         let result: NumericBoundaries = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -547,7 +547,7 @@ key4 = "value4"
         let result: ComplexNested = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -582,7 +582,7 @@ mixed = [42, 3.14, "hello", true]
         let result: MixedTypeArray = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -618,7 +618,7 @@ optional_string = "provided"
         let result: DefaultValues = from_str_async(toml)
             .await
             .expect("TOML deserialization failed");
-        assert_eq!(result, expected);
+        pretty_assertions::assert_eq!(result, expected);
     }
 
     #[tokio::test]
@@ -643,11 +643,11 @@ optional_string = "provided"
         .expect("Failed to parse tombi.toml");
 
         // Verify the parsed values
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             config.toml_version,
             Some(tombi_toml_version::TomlVersion::V1_0_0)
         );
-        assert_eq!(config.exclude, Some(vec!["node_modules/**/*".to_string()]));
+        pretty_assertions::assert_eq!(config.exclude, Some(vec!["node_modules/**/*".to_string()]));
         assert!(config.format.is_some());
         assert!(config.lint.is_some());
         assert!(config.server.is_some());
@@ -655,23 +655,23 @@ optional_string = "provided"
         assert!(config.schemas.is_some());
 
         let schema = config.schema.unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             schema.enabled,
             Some(tombi_config::BoolDefaultTrue::default())
         );
 
         let schemas = config.schemas.unwrap();
-        assert_eq!(schemas.len(), 5);
+        pretty_assertions::assert_eq!(schemas.len(), 5);
 
         // Verify the first schema
         let first_schema = &schemas[0];
-        assert_eq!(first_schema.path(), "tombi.schema.json");
-        assert_eq!(first_schema.include(), &["tombi.toml"]);
+        pretty_assertions::assert_eq!(first_schema.path(), "tombi.schema.json");
+        pretty_assertions::assert_eq!(first_schema.include(), &["tombi.toml"]);
 
         // Verify the last schema
         let last_schema = &schemas[4];
-        assert_eq!(last_schema.path(), "schemas/partial-taskipy.schema.json");
-        assert_eq!(last_schema.include(), &["pyproject.toml"]);
-        assert_eq!(last_schema.root_keys(), Some("tool.taskipy"));
+        pretty_assertions::assert_eq!(last_schema.path(), "schemas/partial-taskipy.schema.json");
+        pretty_assertions::assert_eq!(last_schema.include(), &["pyproject.toml"]);
+        pretty_assertions::assert_eq!(last_schema.root_keys(), Some("tool.taskipy"));
     }
 }

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -74,10 +74,11 @@ where
 
     let toml_version = config.toml_version.unwrap_or_default();
     let schema_options = config.schema.as_ref();
-    let schema_store = tombi_schema_store::SchemaStore::new_with_options(tombi_schema_store::Options {
-        offline: offline.then_some(true),
-        strict: schema_options.and_then(|schema_options| schema_options.strict()),
-    });
+    let schema_store =
+        tombi_schema_store::SchemaStore::new_with_options(tombi_schema_store::Options {
+            offline: offline.then_some(true),
+            strict: schema_options.and_then(|schema_options| schema_options.strict()),
+        });
 
     let Ok(runtime) = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -194,7 +195,7 @@ where
             }
         };
 
-        assert_eq!(success_num + not_needed_num + error_num, total_num);
+        debug_assert_eq!(success_num + not_needed_num + error_num, total_num);
 
         Ok((success_num, not_needed_num, error_num))
     })

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -60,10 +60,11 @@ where
 
     let toml_version = config.toml_version.unwrap_or_default();
     let schema_options = config.schema.as_ref();
-    let schema_store = tombi_schema_store::SchemaStore::new_with_options(tombi_schema_store::Options {
-        offline: offline.then_some(true),
-        strict: schema_options.and_then(|schema_options| schema_options.strict()),
-    });
+    let schema_store =
+        tombi_schema_store::SchemaStore::new_with_options(tombi_schema_store::Options {
+            offline: offline.then_some(true),
+            strict: schema_options.and_then(|schema_options| schema_options.strict()),
+        });
 
     let Ok(runtime) = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -174,7 +175,7 @@ where
             }
         }
 
-        assert_eq!(success_num + error_num, total_num);
+        debug_assert_eq!(success_num + error_num, total_num);
 
         Ok((success_num, error_num))
     })


### PR DESCRIPTION
This commit adds the `pretty_assertions` crate to the dev-dependencies of multiple Cargo.toml files to enhance test output readability. Additionally, it updates assertions to use `pretty_assertions` for better comparison output in tests.