### PR TITLE
refactor: implement Default trait for SchemaStore and Deserializer

### DIFF
--- a/crates/tombi-config/src/types/schema_catalog_path.rs
+++ b/crates/tombi-config/src/types/schema_catalog_path.rs
@@ -19,7 +19,7 @@ impl SchemaCatalogPath {
         match self.0.parse() {
             Ok(url) => Ok(url),
             Err(err) => match base_dirpath {
-                Some(base_dirpath) => url::Url::from_file_path(&base_dirpath.join(&self.0)),
+                Some(base_dirpath) => url::Url::from_file_path(base_dirpath.join(&self.0)),
                 None => url::Url::from_file_path(&self.0),
             }
             .map_err(|_| err),

--- a/crates/tombi-extension/src/definition.rs
+++ b/crates/tombi-extension/src/definition.rs
@@ -21,30 +21,30 @@ impl From<DefinitionLocation> for tower_lsp::lsp_types::Location {
     }
 }
 
-impl Into<GotoDeclarationResponse> for DefinitionLocation {
-    fn into(self) -> GotoDeclarationResponse {
-        GotoDeclarationResponse::Scalar(self.into())
+impl From<DefinitionLocation> for GotoDeclarationResponse {
+    fn from(val: DefinitionLocation) -> Self {
+        GotoDeclarationResponse::Scalar(val.into())
     }
 }
 
-impl Into<DefinitionLocations> for DefinitionLocation {
-    fn into(self) -> DefinitionLocations {
-        DefinitionLocations(vec![self])
+impl From<DefinitionLocation> for DefinitionLocations {
+    fn from(val: DefinitionLocation) -> Self {
+        DefinitionLocations(vec![val])
     }
 }
 
 #[derive(Debug)]
 pub struct DefinitionLocations(pub Vec<DefinitionLocation>);
 
-impl Into<Option<GotoDeclarationResponse>> for DefinitionLocations {
-    fn into(self) -> Option<GotoDeclarationResponse> {
-        match self.0.len() {
+impl From<DefinitionLocations> for Option<GotoDeclarationResponse> {
+    fn from(val: DefinitionLocations) -> Self {
+        match val.0.len() {
             0 => None,
             1 => Some(GotoDeclarationResponse::Scalar(
-                self.0.into_iter().next().unwrap().into(),
+                val.0.into_iter().next().unwrap().into(),
             )),
             _ => Some(GotoDeclarationResponse::Array(
-                self.0.into_iter().map(|location| location.into()).collect(),
+                val.0.into_iter().map(|location| location.into()).collect(),
             )),
         }
     }

--- a/crates/tombi-json-lexer/src/cursor.rs
+++ b/crates/tombi-json-lexer/src/cursor.rs
@@ -33,13 +33,13 @@ impl<'a> Cursor<'a> {
     pub fn peek(&self, i: usize) -> char {
         assert!(i != 0, "peek(0) is invalid");
 
-        let peeked_char = self
+        
+
+        self
             .chars
             .clone()
             .nth(i.saturating_sub(1))
-            .unwrap_or(EOF_CHAR);
-
-        peeked_char
+            .unwrap_or(EOF_CHAR)
     }
 
     pub fn peek_with_current_while(&self, mut predicate: impl FnMut(char) -> bool) -> String {

--- a/crates/tombi-json-value/src/lib.rs
+++ b/crates/tombi-json-value/src/lib.rs
@@ -16,8 +16,10 @@ pub use object::Object;
 
 /// Enum representing a JSON value
 #[derive(Debug, Clone, PartialEq)]
+#[derive(Default)]
 pub enum Value {
     /// `null` value
+    #[default]
     Null,
     /// Boolean value
     Bool(bool),
@@ -151,11 +153,6 @@ impl Value {
     }
 }
 
-impl Default for Value {
-    fn default() -> Self {
-        Value::Null
-    }
-}
 
 impl From<bool> for Value {
     fn from(b: bool) -> Self {

--- a/crates/tombi-json-value/src/number.rs
+++ b/crates/tombi-json-value/src/number.rs
@@ -17,7 +17,7 @@ impl Number {
 
     /// Creates a Number from a u64 value
     pub fn from_u64(value: u64) -> Self {
-        assert!(value < 0 as u64);
+        assert!(value < 0_u64);
         assert!(value <= i64::MAX as u64);
 
         Number::Integer(value as i64)
@@ -173,7 +173,7 @@ impl<'de> serde::Deserialize<'de> for Number {
     {
         struct NumberVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for NumberVisitor {
+        impl serde::de::Visitor<'_> for NumberVisitor {
             type Value = Number;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/tombi-json/src/lib.rs
+++ b/crates/tombi-json/src/lib.rs
@@ -63,7 +63,7 @@ pub struct ValueNodeDeserializer<'de> {
     _marker: PhantomData<&'de ()>,
 }
 
-impl<'de> ValueNodeDeserializer<'de> {
+impl ValueNodeDeserializer<'_> {
     pub fn new(node: ValueNode) -> Self {
         ValueNodeDeserializer {
             node,
@@ -298,7 +298,7 @@ impl<'de> SerdeDeserializer<'de> for ValueNodeDeserializer<'de> {
                     match item {
                         ValueNode::Number(n) => {
                             if let Some(i) = n.value.as_i64() {
-                                if i >= 0 && i <= 255 {
+                                if (0..=255).contains(&i) {
                                     bytes.push(i as u8);
                                 } else {
                                     return Err(Error::Custom(format!(
@@ -544,7 +544,7 @@ impl<'de> serde::de::MapAccess<'de> for MapAccess {
     where
         V: de::DeserializeSeed<'de>,
     {
-        if let Some(value_node) = std::mem::replace(&mut self.value, None) {
+        if let Some(value_node) = self.value.take() {
             seed.deserialize(ValueNodeDeserializer::new(value_node))
         } else {
             Err(Error::Custom(format!("no value for key: {:?}", self.key)))

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -19,6 +19,12 @@ pub struct SchemaStore {
     options: crate::Options,
 }
 
+impl Default for SchemaStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SchemaStore {
     /// New with default options
     ///

--- a/crates/tombi-server/src/backend.rs
+++ b/crates/tombi-server/src/backend.rs
@@ -128,7 +128,7 @@ impl Backend {
 
         let source_schema = self
             .schema_store
-            .try_get_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))
+            .try_get_source_schema_from_ast(&root, Some(Either::Left(text_document_uri)))
             .await
             .ok()
             .flatten();
@@ -153,11 +153,11 @@ impl Backend {
         &self,
         text_document_uri: &Url,
     ) -> Option<tombi_document_tree::DocumentTree> {
-        let root = self.get_incomplete_ast(&text_document_uri).await?;
+        let root = self.get_incomplete_ast(text_document_uri).await?;
 
         let source_schema = self
             .schema_store
-            .try_get_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))
+            .try_get_source_schema_from_ast(&root, Some(Either::Left(text_document_uri)))
             .await
             .ok()
             .flatten();

--- a/crates/tombi-server/src/handler/goto_type_definition.rs
+++ b/crates/tombi-server/src/handler/goto_type_definition.rs
@@ -59,7 +59,7 @@ pub async fn handle_goto_type_definition(
         .flatten();
 
     let (toml_version, _) = backend.source_toml_version(source_schema.as_ref()).await;
-    let position = position.into();
+    let position = position;
 
     let Some((keys, range)) = get_hover_keys_and_range(&root, position, toml_version).await else {
         return Ok(None);

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -31,7 +31,9 @@ print_success() {
 while [[ $# -gt 0 ]]; do
     case $1 in
     --version)
-        SPECIFIED_VERSION="$2"
+        if [[ "$2" != "latest" ]]; then
+            SPECIFIED_VERSION="$2"
+        fi
         shift 2
         ;;
     *)

--- a/extensions/tombi-cargo-extension/src/lib.rs
+++ b/extensions/tombi-cargo-extension/src/lib.rs
@@ -1,7 +1,6 @@
 mod goto_declaration;
 mod goto_definition;
 
-use glob;
 pub use goto_declaration::goto_declaration;
 pub use goto_definition::goto_definition;
 use itertools::Itertools;
@@ -183,7 +182,7 @@ fn goto_workspace(
 
     Ok(Some(tombi_extension::DefinitionLocation::new(
         workspace_cargo_toml_uri,
-        key.range().into(),
+        key.range(),
     )))
 }
 
@@ -208,7 +207,7 @@ fn goto_dependency_crates(
     );
 
     let Some((tombi_schema_store::Accessor::Key(crate_name), crate_value)) =
-        tombi_schema_store::dig_accessors(&workspace_document_tree, accessors)
+        tombi_schema_store::dig_accessors(workspace_document_tree, accessors)
     else {
         return Ok(Vec::with_capacity(0));
     };
@@ -219,7 +218,7 @@ fn goto_dependency_crates(
         if let Some(tombi_document_tree::Value::String(subcrate_path)) = table.get("path") {
             if let Some((subcrate_cargo_toml_path, subcrate_document_tree)) =
                 get_subcrate_cargo_toml(
-                    &workspace_cargo_toml_path,
+                    workspace_cargo_toml_path,
                     std::path::Path::new(subcrate_path.value()),
                     toml_version,
                 )
@@ -275,7 +274,7 @@ fn goto_dependency_crates(
             for dependency_key in ["dependencies", "dev-dependencies", "build-dependencies"] {
                 if let Some((crate_key, _)) = tombi_document_tree::dig_keys(
                     &crate_document_tree,
-                    &[dependency_key, &crate_name],
+                    &[dependency_key, crate_name],
                 ) {
                     if let Some(mut definition_location) =
                         Option::<tombi_extension::DefinitionLocation>::from(crate_location.clone())
@@ -310,7 +309,7 @@ fn goto_crate_package(
             || match_accessors!(accessors, ["build-dependencies", _, "path"])
     );
 
-    let Some((_, value)) = tombi_schema_store::dig_accessors(&workspace_document_tree, accessors)
+    let Some((_, value)) = tombi_schema_store::dig_accessors(workspace_document_tree, accessors)
     else {
         return Ok(None);
     };
@@ -322,7 +321,7 @@ fn goto_crate_package(
         };
 
         if let Some((subcrate_cargo_toml_path, subcrate_document_tree)) = get_subcrate_cargo_toml(
-            &workspace_cargo_toml_path,
+            workspace_cargo_toml_path,
             std::path::Path::new(subcrate_path.value()),
             toml_version,
         ) {

--- a/extensions/tombi-uv-extension/src/goto_declaration.rs
+++ b/extensions/tombi-uv-extension/src/goto_declaration.rs
@@ -22,7 +22,7 @@ pub async fn goto_declaration(
     let locations = if match_accessors!(accessors[..3], ["tool", "uv", "sources"]) {
         goto_definition_for_member_pyproject_toml(
             document_tree,
-            &accessors,
+            accessors,
             &pyproject_toml_path,
             toml_version,
             false,

--- a/extensions/tombi-uv-extension/src/lib.rs
+++ b/extensions/tombi-uv-extension/src/lib.rs
@@ -1,7 +1,6 @@
 mod goto_declaration;
 mod goto_definition;
 
-use glob;
 pub use goto_declaration::goto_declaration;
 pub use goto_definition::goto_definition;
 use itertools::Itertools;
@@ -67,10 +66,10 @@ fn find_workspace_pyproject_toml(
 
             // Check if this pyproject.toml has a [tool.uv.workspace] section
 
-            if let Some(_) = tombi_document_tree::dig_keys(
+            if tombi_document_tree::dig_keys(
                 &package_pyproject_toml_document_tree,
                 &["tool", "uv", "workspace"],
-            ) {
+            ).is_some() {
                 return Some((
                     workspace_pyproject_toml_path,
                     package_pyproject_toml_document_tree,
@@ -157,7 +156,7 @@ fn goto_definition_for_member_pyproject_toml(
         match goto_workspace_member(
             document_tree,
             accessors,
-            &pyproject_toml_path,
+            pyproject_toml_path,
             toml_version,
             jump_to_package,
         )? {
@@ -181,7 +180,7 @@ fn goto_definition_for_workspace_pyproject_toml(
         goto_member_pyprojects(
             workspace_document_tree,
             accessors,
-            &workspace_pyproject_toml_path,
+            workspace_pyproject_toml_path,
             toml_version,
         )
         .map(|locations| locations.into_iter().filter_map(Into::into).collect_vec())
@@ -250,7 +249,7 @@ fn goto_workspace_member(
 
         Ok(Some(tombi_extension::DefinitionLocation::new(
             package_pyproject_toml_uri,
-            tombi_text::Range::default().into(),
+            tombi_text::Range::default(),
         )))
     } else {
         let Ok(workspace_pyproject_toml_uri) = Url::from_file_path(&workspace_pyproject_toml_path)
@@ -260,7 +259,7 @@ fn goto_workspace_member(
 
         Ok(Some(tombi_extension::DefinitionLocation::new(
             workspace_pyproject_toml_uri,
-            member_range.into(),
+            member_range,
         )))
     }
 }
@@ -359,7 +358,7 @@ fn find_member_project_toml(
     };
 
     let member_patterns = match tombi_document_tree::dig_keys(
-        &workspace_pyproject_toml_document_tree,
+        workspace_pyproject_toml_document_tree,
         &[&"tool", &"uv", &"workspace", &"members"],
     ) {
         Some((_, tombi_document_tree::Value::Array(members))) => members
@@ -373,7 +372,7 @@ fn find_member_project_toml(
     };
 
     let exclude_patterns = match tombi_document_tree::dig_keys(
-        &workspace_pyproject_toml_document_tree,
+        workspace_pyproject_toml_document_tree,
         &[&"tool", &"uv", &"workspace", &"exclude"],
     ) {
         Some((_, tombi_document_tree::Value::Array(exclude))) => exclude

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -71,7 +71,13 @@ pub struct Deserializer<'de> {
     schema_store: Option<&'de tombi_schema_store::SchemaStore>,
 }
 
-impl<'de> Deserializer<'de> {
+impl Default for Deserializer<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deserializer<'_> {
     pub fn new() -> Self {
         Self {
             config: None,

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -68,7 +68,13 @@ pub struct Serializer<'a> {
     schema_store: Option<&'a tombi_schema_store::SchemaStore>,
 }
 
-impl<'a> Serializer<'a> {
+impl Default for Serializer<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Serializer<'_> {
     pub const fn new() -> Self {
         Self {
             config: None,
@@ -135,7 +141,7 @@ impl<'a> Serializer<'a> {
             format_definitions,
             &format_options,
             self.source_path
-                .map(|source_path| Either::Right(source_path)),
+                .map(Either::Right),
             schema_store,
         );
 


### PR DESCRIPTION
- Added Default implementations for SchemaStore and Deserializer structs to simplify instantiation.
- Updated related code to utilize the new Default trait where applicable.