### PR TITLE
feat: rename [server] to [lsp] in configuration and handlers

### DIFF
--- a/crates/tombi-config/src/lib.rs
+++ b/crates/tombi-config/src/lib.rs
@@ -10,7 +10,7 @@ pub use format::FormatOptions;
 pub use lint::LintOptions;
 pub use schema::SchemaOptions;
 pub use schema::{RootSchema, Schema, SubSchema};
-pub use server::{ServerCompletion, ServerOptions};
+pub use server::{LspCompletion, LspOptions};
 pub use tombi_toml_version::TomlVersion;
 pub use types::*;
 
@@ -58,12 +58,23 @@ pub struct Config {
     /// # Linter options.
     pub lint: Option<LintOptions>,
 
-    /// # Language server options.
-    pub server: Option<ServerOptions>,
+    /// # Language Server Protocol options.
+    lsp: Option<LspOptions>,
+
+    /// # Deprecated. Use `lsp` instead.
+    #[cfg_attr(feature = "jsonschema", deprecated)]
+    server: Option<LspOptions>,
 
     /// # Schema options.
     pub schema: Option<SchemaOptions>,
 
     /// # Schema catalog items.
     pub schemas: Option<Vec<Schema>>,
+}
+
+impl Config {
+    pub fn lsp(&self) -> Option<&LspOptions> {
+        #[allow(deprecated)]
+        self.lsp.as_ref().or_else(|| self.server.as_ref())
+    }
 }

--- a/crates/tombi-config/src/server.rs
+++ b/crates/tombi-config/src/server.rs
@@ -1,36 +1,35 @@
 use crate::BoolDefaultTrue;
 
-/// # Language Server options.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerOptions {
+pub struct LspOptions {
     /// # Hover Feature options.
-    pub hover: Option<ServerHover>,
+    pub hover: Option<LspHover>,
 
     /// # Completion Feature options.
-    pub completion: Option<ServerCompletion>,
+    pub completion: Option<LspCompletion>,
 
     /// # Formatting Feature options.
-    pub formatting: Option<ServerFormatting>,
+    pub formatting: Option<LspFormatting>,
 
     /// # Diagnostics Feature options.
-    pub diagnostics: Option<ServerDiagnostics>,
+    pub diagnostics: Option<LspDiagnostics>,
 
     /// # Goto Declaration Feature options.
-    pub goto_declaration: Option<ServerGotoDefinition>,
+    pub goto_declaration: Option<LspGotoDefinition>,
 
     /// # Goto Definition Feature options.
-    pub goto_definition: Option<ServerGotoDefinition>,
+    pub goto_definition: Option<LspGotoDefinition>,
 
     /// # Goto Type Definition Feature options.
-    pub goto_type_definition: Option<ServerGotoDefinition>,
+    pub goto_type_definition: Option<LspGotoDefinition>,
 }
 
-impl ServerOptions {
+impl LspOptions {
     pub const fn default() -> Self {
         Self {
             hover: None,
@@ -49,7 +48,7 @@ impl ServerOptions {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerHover {
+pub struct LspHover {
     /// # Enable hover feature.
     ///
     /// Whether to enable hover.
@@ -61,7 +60,7 @@ pub struct ServerHover {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerCompletion {
+pub struct LspCompletion {
     /// # Enable completion feature.
     ///
     /// Whether to enable completion.
@@ -73,7 +72,7 @@ pub struct ServerCompletion {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerFormatting {
+pub struct LspFormatting {
     /// # Enable formatting feature.
     ///
     /// Whether to enable formatting.
@@ -85,14 +84,14 @@ pub struct ServerFormatting {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerDiagnostics {
+pub struct LspDiagnostics {
     /// # Enable diagnostics feature.
     ///
     /// Whether to enable diagnostics.
     pub enabled: Option<BoolDefaultTrue>,
 }
 
-impl ServerCompletion {
+impl LspCompletion {
     pub const fn default() -> Self {
         Self { enabled: None }
     }
@@ -103,7 +102,7 @@ impl ServerCompletion {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ServerGotoDefinition {
+pub struct LspGotoDefinition {
     /// # Enable goto definition feature.
     ///
     /// Whether to enable goto definition.

--- a/crates/tombi-server/src/handler/completion.rs
+++ b/crates/tombi-server/src/handler/completion.rs
@@ -29,8 +29,8 @@ pub async fn handle_completion(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.completion)
+        .lsp()
+        .and_then(|server| server.completion.as_ref())
         .and_then(|completion| completion.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/diagnostic.rs
+++ b/crates/tombi-server/src/handler/diagnostic.rs
@@ -20,8 +20,8 @@ pub async fn handle_diagnostic(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.diagnostics)
+        .lsp()
+        .and_then(|server| server.diagnostics.as_ref())
         .and_then(|diagnostics| diagnostics.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/formatting.rs
+++ b/crates/tombi-server/src/handler/formatting.rs
@@ -19,8 +19,8 @@ pub async fn handle_formatting(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.formatting)
+        .lsp()
+        .and_then(|server| server.formatting.as_ref())
         .and_then(|formatting| formatting.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/goto_declaration.rs
+++ b/crates/tombi-server/src/handler/goto_declaration.rs
@@ -26,8 +26,8 @@ pub async fn handle_goto_declaration(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.goto_declaration)
+        .lsp()
+        .and_then(|server| server.goto_declaration.as_ref())
         .and_then(|goto_declaration| goto_declaration.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/goto_definition.rs
+++ b/crates/tombi-server/src/handler/goto_definition.rs
@@ -27,8 +27,8 @@ pub async fn handle_goto_definition(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.goto_definition)
+        .lsp()
+        .and_then(|server| server.goto_definition.as_ref())
         .and_then(|goto_definition| goto_definition.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/goto_type_definition.rs
+++ b/crates/tombi-server/src/handler/goto_type_definition.rs
@@ -36,8 +36,8 @@ pub async fn handle_goto_type_definition(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.goto_type_definition)
+        .lsp()
+        .and_then(|server| server.goto_type_definition.as_ref())
         .and_then(|goto_type_definition| goto_type_definition.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/src/handler/hover.rs
+++ b/crates/tombi-server/src/handler/hover.rs
@@ -29,8 +29,8 @@ pub async fn handle_hover(
     let config = backend.config().await;
 
     if !config
-        .server
-        .and_then(|server| server.hover)
+        .lsp()
+        .and_then(|server| server.hover.as_ref())
         .and_then(|hover| hover.enabled)
         .unwrap_or_default()
         .value()

--- a/crates/tombi-server/tests/completion_edit.rs
+++ b/crates/tombi-server/tests/completion_edit.rs
@@ -1,4 +1,6 @@
-use tombi_test_lib::{today_local_date, today_local_date_time, today_local_time, today_offset_date_time};
+use tombi_test_lib::{
+    today_local_date, today_local_date_time, today_local_time, today_offset_date_time,
+};
 
 struct Select<T>(T);
 mod completion_edit {
@@ -13,14 +15,14 @@ mod completion_edit {
             #[tokio::test]
             async fn tombi_server_completion_dot(
                 r#"
-                [server]
+                [lsp]
                 completion.█
                 "#,
                 Select("enabled"),
                 tombi_schema_path(),
             ) -> Ok(
                 r#"
-                [server]
+                [lsp]
                 completion.enabled
                 "#
             );
@@ -30,14 +32,14 @@ mod completion_edit {
             #[tokio::test]
             async fn tombi_server_completion_equal(
                 r#"
-                [server]
+                [lsp]
                 completion=█
                 "#,
                 Select("enabled"),
                 tombi_schema_path(),
             ) -> Ok(
                 r#"
-                [server]
+                [lsp]
                 completion = { enabled$1 }$0
                 "#
             );

--- a/crates/tombi-server/tests/completion_labels.rs
+++ b/crates/tombi-server/tests/completion_labels.rs
@@ -21,6 +21,7 @@ mod completion_labels {
                 "format",
                 "include",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -73,6 +74,7 @@ mod completion_labels {
                 "format",
                 "include",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -95,6 +97,7 @@ mod completion_labels {
                 "format",
                 "include",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -110,6 +113,7 @@ mod completion_labels {
             ) -> Ok([
                 "format",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -128,6 +132,7 @@ mod completion_labels {
             ) -> Ok([
                 "format",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -148,6 +153,7 @@ mod completion_labels {
             ) -> Ok([
                 "format",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",
@@ -162,6 +168,7 @@ mod completion_labels {
             ) -> Ok([
                 "format",
                 "lint",
+                "lsp",
                 "schema",
                 "schemas",
                 "server",

--- a/crates/tombi-server/tests/completion_labels.rs
+++ b/crates/tombi-server/tests/completion_labels.rs
@@ -87,7 +87,7 @@ mod completion_labels {
                 toml-version = "v1.0.0"
                 █
 
-                [server]
+                [lsp]
                 "#,
                 tombi_schema_path(),
             ) -> Ok([
@@ -214,7 +214,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_completion_dot(
                 r#"
-                [server]
+                [lsp]
                 completion.█
                 "#,
                 tombi_schema_path(),
@@ -228,7 +228,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_completion_equal(
                 r#"
-                [server]
+                [lsp]
                 completion=█
                 "#,
                 tombi_schema_path(),
@@ -289,7 +289,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server2(
                 r#"
-                [server]
+                [lsp]
                 █
                 completion.enabled = true
                 "#,
@@ -309,7 +309,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server3(
                 r#"
-                [server]
+                [lsp]
                 formatting.enabled = true
                 █
                 completion.enabled = true
@@ -330,7 +330,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_completion(
                 r#"
-                [server]
+                [lsp]
                 completion.enabled = █
                 "#,
                 tombi_schema_path(),
@@ -344,7 +344,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_comp(
                 r#"
-                [server]
+                [lsp]
                 comp█
                 "#,
                 tombi_schema_path(),
@@ -357,7 +357,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_comp2(
                 r#"
-                [server.comp█]
+                [lsp.comp█]
                 "#,
                 tombi_schema_path(),
             ) -> Ok([
@@ -369,7 +369,7 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_server_comp3(
                 r#"
-                [server]
+                [lsp]
                 comp█
 
                 [schema]

--- a/docs/src/routes/docs/configuration/index.mdx
+++ b/docs/src/routes/docs/configuration/index.mdx
@@ -24,7 +24,7 @@ exclude = []
 
 [lint]
 
-[server]
+[lsp]
 formatting.enabled = true
 diagnostics.enabled = true
 hover.enabled = true

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -656,7 +656,7 @@ optional_string = "provided"
         pretty_assertions::assert_eq!(config.exclude, Some(vec!["node_modules/**/*".to_string()]));
         assert!(config.format.is_some());
         assert!(config.lint.is_some());
-        assert!(config.server.is_some());
+        assert!(config.lsp().is_some());
         assert!(config.schema.is_some());
         assert!(config.schemas.is_some());
 

--- a/tombi.schema.json
+++ b/tombi.schema.json
@@ -64,16 +64,28 @@
         }
       ]
     },
-    "server": {
-      "title": "Language server options.",
+    "lsp": {
+      "title": "Language Server Protocol options.",
       "anyOf": [
         {
-          "$ref": "#/definitions/ServerOptions"
+          "$ref": "#/definitions/LspOptions"
         },
         {
           "type": "null"
         }
       ]
+    },
+    "server": {
+      "title": "Deprecated. Use `lsp` instead.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LspOptions"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "deprecated": true
     },
     "schema": {
       "title": "Schema options.",
@@ -121,15 +133,14 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "schema"
     },
-    "ServerOptions": {
-      "title": "Language Server options.",
+    "LspOptions": {
       "type": "object",
       "properties": {
         "hover": {
           "title": "Hover Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerHover"
+              "$ref": "#/definitions/LspHover"
             },
             {
               "type": "null"
@@ -140,7 +151,7 @@
           "title": "Completion Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerCompletion"
+              "$ref": "#/definitions/LspCompletion"
             },
             {
               "type": "null"
@@ -151,7 +162,7 @@
           "title": "Formatting Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerFormatting"
+              "$ref": "#/definitions/LspFormatting"
             },
             {
               "type": "null"
@@ -162,7 +173,7 @@
           "title": "Diagnostics Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerDiagnostics"
+              "$ref": "#/definitions/LspDiagnostics"
             },
             {
               "type": "null"
@@ -173,7 +184,7 @@
           "title": "Goto Declaration Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerGotoDefinition"
+              "$ref": "#/definitions/LspGotoDefinition"
             },
             {
               "type": "null"
@@ -184,7 +195,7 @@
           "title": "Goto Definition Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerGotoDefinition"
+              "$ref": "#/definitions/LspGotoDefinition"
             },
             {
               "type": "null"
@@ -195,7 +206,7 @@
           "title": "Goto Type Definition Feature options.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ServerGotoDefinition"
+              "$ref": "#/definitions/LspGotoDefinition"
             },
             {
               "type": "null"
@@ -206,7 +217,7 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "schema"
     },
-    "ServerHover": {
+    "LspHover": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -228,7 +239,7 @@
       "type": "boolean",
       "default": true
     },
-    "ServerCompletion": {
+    "LspCompletion": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -246,7 +257,7 @@
       },
       "additionalProperties": false
     },
-    "ServerFormatting": {
+    "LspFormatting": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -264,7 +275,7 @@
       },
       "additionalProperties": false
     },
-    "ServerDiagnostics": {
+    "LspDiagnostics": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -282,7 +293,7 @@
       },
       "additionalProperties": false
     },
-    "ServerGotoDefinition": {
+    "LspGotoDefinition": {
       "type": "object",
       "properties": {
         "enabled": {

--- a/tombi.toml
+++ b/tombi.toml
@@ -10,7 +10,7 @@ exclude = ["node_modules/**/*"]
 
 [lint]
 
-[server]
+[lsp]
 
 [schema]
 enabled = true


### PR DESCRIPTION
Updated configuration and handler files to replace 'server' references with 'lsp' for improved clarity and consistency in the codebase.