### PR TITLE
refactor: prevent the printer from requesting a Copy and make it use &mut

### DIFF
--- a/crates/tombi-diagnostic/examples/diagnostics.rs
+++ b/crates/tombi-diagnostic/examples/diagnostics.rs
@@ -41,10 +41,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let warning = Diagnostic::new_warning("Some warning occured.".to_owned(), ((2, 1), (2, 3)));
     let error = Diagnostic::new_error("Some error occured.".to_owned(), ((2, 1), (2, 3)));
 
-    warning.print(Pretty);
-    warning.with_source_file(&source_file).print(Pretty);
-    error.print(Pretty);
-    error.with_source_file(&source_file).print(Pretty);
+    warning.print(&mut Pretty);
+    warning.with_source_file(&source_file).print(&mut Pretty);
+    error.print(&mut Pretty);
+    error.with_source_file(&source_file).print(&mut Pretty);
 
     Ok(())
 }

--- a/crates/tombi-diagnostic/src/printer.rs
+++ b/crates/tombi-diagnostic/src/printer.rs
@@ -6,15 +6,14 @@ pub use simple::Simple;
 
 pub trait Print<Printer> {
     /// Formats the object using the given formatter.
-    fn print(&self, printer: Printer);
+    fn print(&self, printer: &mut Printer);
 }
 
 impl<T, P> Print<P> for Vec<T>
 where
     T: Print<P>,
-    P: Copy,
 {
-    fn print(&self, printer: P) {
+    fn print(&self, printer: &mut P) {
         for item in self {
             item.print(printer);
         }

--- a/crates/tombi-diagnostic/src/printer/pretty.rs
+++ b/crates/tombi-diagnostic/src/printer/pretty.rs
@@ -6,13 +6,13 @@ use crate::{printer::Simple, Diagnostic, Level, Print};
 pub struct Pretty;
 
 impl Print<Pretty> for Level {
-    fn print(&self, _printer: Pretty) {
-        self.print(Simple);
+    fn print(&self, _printer: &mut Pretty) {
+        self.print(&mut Simple);
     }
 }
 
 impl Print<Pretty> for Diagnostic {
-    fn print(&self, printer: Pretty) {
+    fn print(&self, printer: &mut Pretty) {
         self.level().print(printer);
         println!(": {}", Style::new().bold().paint(self.message()));
 

--- a/crates/tombi-diagnostic/src/printer/simple.rs
+++ b/crates/tombi-diagnostic/src/printer/simple.rs
@@ -6,13 +6,13 @@ use crate::{Diagnostic, Level, Print};
 pub struct Simple;
 
 impl Print<Simple> for Level {
-    fn print(&self, _printer: Simple) {
+    fn print(&self, _printer: &mut Simple) {
         print!("{}", self.color().bold().paint(self.as_padded_str()));
     }
 }
 
 impl Print<Simple> for Diagnostic {
-    fn print(&self, printer: Simple) {
+    fn print(&self, printer: &mut Simple) {
         self.level().print(printer);
         println!(": {}", Style::new().bold().paint(self.message()));
     }

--- a/rust/tombi-cli/src/error.rs
+++ b/rust/tombi-cli/src/error.rs
@@ -62,13 +62,13 @@ impl std::fmt::Display for NotFormattedError {
 }
 
 impl Print<Pretty> for Error {
-    fn print(&self, _printer: Pretty) {
-        self.print(Simple);
+    fn print(&self, _printer: &mut Pretty) {
+        self.print(&mut Simple);
     }
 }
 
 impl Print<Simple> for Error {
-    fn print(&self, printer: Simple) {
+    fn print(&self, printer: &mut Simple) {
         Level::ERROR.print(printer);
         println!(": {}", Style::new().bold().paint(self.to_string()));
     }


### PR DESCRIPTION
## Summary

Change `diagnostic::Print` to require `&mut`, removing the need for `Copy`.

## Details

The current design, which requires the `Copy` trait, is sufficient for implementations that write exclusively to stdout.

However, this approach makes it impossible to implement a printer that internally buffers outputs for later retrieval.
(I am developing a plugin for a tool that integrates with tombi, which requires this functionality.)

This PR changes the API to use `&mut` references for writing, thereby removing the requirement for `Copy`. For parallel implementations involving multiple threads, a `Clone` trait is required instead.