### PR TITLE
refactor: remove unnecessary option wrapping for toml_version

### DIFF
--- a/crates/tombi-ast-editor/src/node.rs
+++ b/crates/tombi-ast-editor/src/node.rs
@@ -1,12 +1,16 @@
 use tombi_parser::parse_as;
+use tombi_toml_version::TomlVersion;
 
 pub fn make_comma() -> tombi_syntax::SyntaxNode {
-    parse_as::<tombi_ast::Comma>(",", None).into_syntax_node_mut()
+    parse_as::<tombi_ast::Comma>(",", TomlVersion::default()).into_syntax_node_mut()
 }
 
 pub fn make_comma_with_tailing_comment(
     tailing_comment: &tombi_ast::TailingComment,
 ) -> tombi_syntax::SyntaxNode {
-    parse_as::<tombi_ast::Comma>(&format!(",{}", tailing_comment.syntax().text()), None)
-        .into_syntax_node_mut()
+    parse_as::<tombi_ast::Comma>(
+        &format!(",{}", tailing_comment.syntax().text()),
+        TomlVersion::default(),
+    )
+    .into_syntax_node_mut()
 }

--- a/crates/tombi-document/src/lib.rs
+++ b/crates/tombi-document/src/lib.rs
@@ -120,7 +120,7 @@ macro_rules! test_deserialize {
             tombi_test_lib::init_tracing();
 
             let source = textwrap::dedent($source);
-            let p = tombi_parser::parse(&source.trim(), Some($toml_version));
+            let p = tombi_parser::parse(&source.trim(), $toml_version);
             pretty_assertions::assert_eq!(p.errors, Vec::<tombi_parser::Error>::new());
             let root = tombi_ast::Root::cast(p.into_syntax_node()).unwrap();
             let (document_tree, errors) = root.into_document_tree_and_errors($toml_version).into();
@@ -144,7 +144,7 @@ macro_rules! test_deserialize {
             use tombi_document_tree::IntoDocumentTreeAndErrors;
 
             let source = textwrap::dedent($source);
-            let p = tombi_parser::parse(&source.trim(), Some($toml_version));
+            let p = tombi_parser::parse(&source.trim(), $toml_version);
             let expected_errors = $errors
                 .into_iter()
                 .map(|(m, r)| (m.to_string(), tombi_text::Range::from(r)))

--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -400,7 +400,7 @@ mod tests {
     #[case("[1, 2, 3,]", true)]
     #[case("[1, 2, 3]", false)]
     fn has_tailing_comma_after_last_value(#[case] source: &str, #[case] expected: bool) {
-        let p = tombi_parser::parse_as::<tombi_ast::Array>(source, None);
+        let p = tombi_parser::parse_as::<tombi_ast::Array>(source, TomlVersion::default());
         pretty_assertions::assert_eq!(p.errors, Vec::<tombi_parser::Error>::new());
 
         let ast = tombi_ast::Array::cast(p.syntax_node()).unwrap();

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -67,7 +67,7 @@ impl<'a> Formatter<'a> {
             })
             .unwrap_or(self.toml_version);
 
-        let root = tombi_parser::parse(source, Some(self.toml_version))
+        let root = tombi_parser::parse(source, self.toml_version)
             .try_into_root()
             .map_err(|errors| {
                 let mut diagnostics = vec![];

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -33,24 +33,25 @@ impl<'a> Linter<'a> {
     }
 
     pub async fn lint(mut self, source: &str) -> Result<(), Vec<Diagnostic>> {
-        let source_schema =
-            if let Some(parsed) = tombi_parser::parse_document_header_comments(source).cast::<tombi_ast::Root>() {
-                match self
-                    .schema_store
-                    .try_get_source_schema_from_ast(&parsed.tree(), self.source_url_or_path)
-                    .await
-                {
-                    Ok(Some(schema)) => Some(schema),
-                    Ok(None) => None,
-                    Err((err, range)) => {
-                        self.diagnostics
-                            .push(Diagnostic::new_error(err.to_string(), range));
-                        None
-                    }
+        let source_schema = if let Some(parsed) =
+            tombi_parser::parse_document_header_comments(source).cast::<tombi_ast::Root>()
+        {
+            match self
+                .schema_store
+                .try_get_source_schema_from_ast(&parsed.tree(), self.source_url_or_path)
+                .await
+            {
+                Ok(Some(schema)) => Some(schema),
+                Ok(None) => None,
+                Err((err, range)) => {
+                    self.diagnostics
+                        .push(Diagnostic::new_error(err.to_string(), range));
+                    None
                 }
-            } else {
-                None
-            };
+            }
+        } else {
+            None
+        };
 
         let toml_version = source_schema
             .as_ref()
@@ -62,7 +63,7 @@ impl<'a> Linter<'a> {
             })
             .unwrap_or(self.toml_version);
 
-        let (root, errors) = tombi_parser::parse(source, Some(toml_version)).into_root_and_errors();
+        let (root, errors) = tombi_parser::parse(source, toml_version).into_root_and_errors();
         for error in errors {
             error.set_diagnostics(&mut self.diagnostics);
         }

--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -121,10 +121,7 @@ impl Backend {
             })
             .unwrap_or(self.config.read().await.toml_version.unwrap_or_default());
 
-        Some(tombi_parser::parse(
-            &document_info.source,
-            Some(toml_version),
-        ))
+        Some(tombi_parser::parse(&document_info.source, toml_version))
     }
 
     #[inline]

--- a/crates/tombi-parser/src/lib.rs
+++ b/crates/tombi-parser/src/lib.rs
@@ -15,7 +15,7 @@ use parse::Parse;
 pub use parsed::Parsed;
 pub use tombi_syntax::{SyntaxKind, SyntaxNode, SyntaxToken};
 
-pub fn parse(source: &str, toml_version: Option<tombi_config::TomlVersion>) -> Parsed<SyntaxNode> {
+pub fn parse(source: &str, toml_version: tombi_config::TomlVersion) -> Parsed<SyntaxNode> {
     parse_as::<tombi_ast::Root>(source, toml_version)
 }
 
@@ -45,10 +45,10 @@ pub fn parse_document_header_comments(source: &str) -> Parsed<SyntaxNode> {
 #[allow(private_bounds)]
 pub fn parse_as<P: Parse>(
     source: &str,
-    toml_version: Option<tombi_config::TomlVersion>,
+    toml_version: tombi_config::TomlVersion,
 ) -> Parsed<SyntaxNode> {
     let lexed = tombi_lexer::lex(source);
-    let mut p = crate::parser::Parser::new(source, toml_version, &lexed.tokens);
+    let mut p = crate::parser::Parser::new(source, Some(toml_version), &lexed.tokens);
 
     P::parse(&mut p);
 
@@ -99,7 +99,7 @@ macro_rules! test_parser {
     {#[test] fn $name:ident($source:expr, $toml_version:expr) -> Ok(_)} => {
         #[test]
         fn $name() {
-            let p = $crate::parse(textwrap::dedent($source).trim(), Some($toml_version));
+            let p = $crate::parse(textwrap::dedent($source).trim(), $toml_version);
             pretty_assertions::assert_eq!(
                 p.errors,
                 Vec::<$crate::Error>::new()
@@ -132,7 +132,7 @@ macro_rules! test_parser {
     )} => {
         #[test]
         fn $name() {
-            let p = $crate::parse(textwrap::dedent($source).trim(), Some($toml_version));
+            let p = $crate::parse(textwrap::dedent($source).trim(), $toml_version);
 
             pretty_assertions::assert_eq!(
                 p.errors,

--- a/crates/tombi-parser/src/parse/root.rs
+++ b/crates/tombi-parser/src/parse/root.rs
@@ -65,6 +65,8 @@ fn unknwon_line(p: &mut Parser<'_>) {
 
 #[cfg(test)]
 mod test {
+    use tombi_config::TomlVersion;
+
     #[test]
     fn test_begin_dangling_comments() {
         let input = r#"
@@ -76,7 +78,7 @@ mod test {
 [table]
         "#
         .trim();
-        let p = crate::parse(input, None);
+        let p = crate::parse(input, TomlVersion::default());
 
         assert_eq!(p.errors, vec![]);
     }

--- a/extensions/tombi-cargo-extension/src/lib.rs
+++ b/extensions/tombi-cargo-extension/src/lib.rs
@@ -39,9 +39,9 @@ fn load_cargo_toml(
         return None;
     };
 
-    let Some(root) = tombi_ast::Root::cast(
-        tombi_parser::parse(&toml_text, Some(toml_version)).into_syntax_node(),
-    ) else {
+    let Some(root) =
+        tombi_ast::Root::cast(tombi_parser::parse(&toml_text, toml_version).into_syntax_node())
+    else {
         return None;
     };
 

--- a/extensions/tombi-uv-extension/src/lib.rs
+++ b/extensions/tombi-uv-extension/src/lib.rs
@@ -37,9 +37,9 @@ fn load_pyproject_toml(
         return None;
     };
 
-    let Some(root) = tombi_ast::Root::cast(
-        tombi_parser::parse(&toml_text, Some(toml_version)).into_syntax_node(),
-    ) else {
+    let Some(root) =
+        tombi_ast::Root::cast(tombi_parser::parse(&toml_text, toml_version).into_syntax_node())
+    else {
         return None;
     };
 

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -19,7 +19,7 @@ pub(crate) fn from_str(
         .build();
 
     let toml_version = TOMBI_CONFIG_TOML_VERSION;
-    let parsed = tombi_parser::parse(toml_text, Some(toml_version));
+    let parsed = tombi_parser::parse(toml_text, toml_version);
     let root = tombi_ast::Root::cast(parsed.syntax_node()).expect("AST Root must be present");
     // Check if there are any parsing errors
     if !parsed.errors.is_empty() {
@@ -42,7 +42,7 @@ impl PyProjectToml {
             .build();
 
         let toml_version = TOMBI_CONFIG_TOML_VERSION;
-        let parsed = tombi_parser::parse(toml_text, Some(toml_version));
+        let parsed = tombi_parser::parse(toml_text, toml_version);
         let root = tombi_ast::Root::cast(parsed.syntax_node()).expect("AST Root must be present");
         // Check if there are any parsing errors
         if !parsed.errors.is_empty() {

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -92,7 +92,7 @@ impl Deserializer<'_> {
         T: DeserializeOwned,
     {
         let toml_version = self.get_toml_version(&toml_text).await?;
-        let parsed = tombi_parser::parse(toml_text, Some(toml_version));
+        let parsed = tombi_parser::parse(toml_text, toml_version);
         let root = tombi_ast::Root::cast(parsed.syntax_node()).expect("AST Root must be present");
         // Check if there are any parsing errors
         if !parsed.errors.is_empty() {

--- a/toml-test/bin/decode.rs
+++ b/toml-test/bin/decode.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 fn decode(source: &str, toml_version: TomlVersion) -> Result<Value, anyhow::Error> {
-    let p = tombi_parser::parse(source, Some(toml_version));
+    let p = tombi_parser::parse(source, toml_version);
 
     if !p.errors.is_empty() {
         for error in p.errors {


### PR DESCRIPTION
Updated parsing functions to directly use toml_version instead of wrapping it in an Option. This simplifies the code and improves clarity across multiple modules.