### PR TITLE
chore: update package versions to 0.0.0

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-      - run: cargo xtask set-version >> $GITHUB_ENV
+      - run: cargo xtask set-version
       - run: uv python install
       - run: python python/set_version.py >> $GITHUB_ENV
       - name: Get TOMBI_VERSION

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "serde_tombi"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "chrono",
  "futures",

--- a/crates/tombi-ast-editor/Cargo.toml
+++ b/crates/tombi-ast-editor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-ast-editor"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-date-time/Cargo.toml
+++ b/crates/tombi-date-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-date-time"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-extension/Cargo.toml
+++ b/crates/tombi-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-extension"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-json-lexer/Cargo.toml
+++ b/crates/tombi-json-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-json-lexer"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-json-syntax/Cargo.toml
+++ b/crates/tombi-json-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-json-syntax"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-json-value/Cargo.toml
+++ b/crates/tombi-json-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-json-value"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-json"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-lexer/Cargo.toml
+++ b/crates/tombi-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-lexer"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/tombi-linter/Cargo.toml
+++ b/crates/tombi-linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-linter"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/tombi-schema-store/Cargo.toml
+++ b/crates/tombi-schema-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-schema-store"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-toml-text/Cargo.toml
+++ b/crates/tombi-toml-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-toml-text"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/tombi-validator/Cargo.toml
+++ b/crates/tombi-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-validator"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/tombi-cargo-extension/Cargo.toml
+++ b/extensions/tombi-cargo-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-cargo-extension"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 description = "Tombi extension for Cargo.toml"

--- a/extensions/tombi-uv-extension/Cargo.toml
+++ b/extensions/tombi-uv-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tombi-uv-extension"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 description = "Tombi extension for uv Python project management"

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_tombi"
-version = "0.0.1"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 description = "A TOML serialization file format using Tombi."


### PR DESCRIPTION
Set all package versions to 0.0.0 in Cargo.toml files and adjust GitHub Actions workflow to remove unnecessary output redirection.