### PR TITLE
docs: add alternative installation command for tombi

### DIFF
--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -18,6 +18,12 @@ curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --version 0.
 pipx install tombi
 ```
 
+Or
+
+```bash
+uvx tombi
+```
+
 ## VSCode/Cursor
 
 <LinkCard


### PR DESCRIPTION
Added a new installation command using 'uvx' for easier setup of tombi in the documentation.