### PR TITLE
docs: update link to JSON Schema Store in documentation

### DIFF
--- a/docs/src/routes/docs/json-schema.mdx
+++ b/docs/src/routes/docs/json-schema.mdx
@@ -12,7 +12,7 @@ This section explains how Tombi prioritizes the application of `x-tombi-*` keys 
 
 1. `#:schema` directive in the TOML file's top comment (compatible with [Taplo](https://taplo.tamasfe.dev/configuration/directives.html#the-schema-directive))
 2. JSON Schema specified in [the Tombi configuration file](/docs/configuration#search-priority)
-3. JSON Schema from the JSON Schema Store
+3. JSON Schema from the [JSON Schema Store](https://www.schemastore.org/json/)
 
 ## Formatting
 ### x-tombi-toml-version


### PR DESCRIPTION
Replaced the plain text reference to the JSON Schema Store with a formatted link for better accessibility and clarity in the documentation.