### PR TITLE
ci: add workflow_dispatch trigger for NPM release workflow

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -25,6 +25,6 @@ jobs:
         run: cd typescript/tombi && npm run build
 
       - name: Publish to NPM
-        run: cd typescript/tombi && npm publish --access public
+        run: cd typescript/tombi && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/typescript/tombi/package.json
+++ b/typescript/tombi/package.json
@@ -28,5 +28,8 @@
     "axios": "^1.9.0",
     "tar": "^6.2.1",
     "adm-zip": "^0.5.16"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This change allows manual triggering of the NPM release workflow in addition to the existing tag-based triggers.