### PR TITLE
feat: add root accessor to SubSchema for enhanced flexibility

### DIFF
--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -145,6 +145,12 @@ pub struct RootSchema {
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubSchema {
+    /// # The accessors to apply the sub schema.
+    #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
+    #[cfg_attr(feature = "jsonschema", schemars(example = "tools.tombi"))]
+    #[cfg_attr(feature = "jsonschema", schemars(example = "items[0].name"))]
+    pub root: Option<String>,
+
     /// # The sub schema path.
     pub path: String,
 
@@ -154,12 +160,6 @@ pub struct SubSchema {
     /// Supports glob pattern.
     #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
     pub include: Vec<String>,
-
-    /// # The accessors to apply the sub schema.
-    #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
-    #[cfg_attr(feature = "jsonschema", schemars(example = "tools.tombi"))]
-    #[cfg_attr(feature = "jsonschema", schemars(example = "items[0].name"))]
-    pub root: Option<String>,
 }
 
 /// # The schema for the old sub value.

--- a/docs/src/routes/docs/configuration/index.mdx
+++ b/docs/src/routes/docs/configuration/index.mdx
@@ -49,7 +49,7 @@ include = ["example.toml"]
 
 # Sub Schema
 [[schemas]]
+root = "tool.taskipy"
 path = "schemas/partial-taskipy.schema.json"
 include = ["pyproject.toml"]
-root = "tool.taskipy"
 ```

--- a/tombi.schema.json
+++ b/tombi.schema.json
@@ -470,6 +470,18 @@
       "title": "The schema for the sub value.",
       "type": "object",
       "properties": {
+        "root": {
+          "title": "The accessors to apply the sub schema.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "tools.tombi",
+            "items[0].name"
+          ],
+          "minLength": 1
+        },
         "path": {
           "title": "The sub schema path.",
           "type": "string"
@@ -482,18 +494,6 @@
             "type": "string"
           },
           "minItems": 1
-        },
-        "root": {
-          "title": "The accessors to apply the sub schema.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "examples": [
-            "tools.tombi",
-            "items[0].name"
-          ],
-          "minLength": 1
         }
       },
       "additionalProperties": false,

--- a/tombi.toml
+++ b/tombi.toml
@@ -34,6 +34,6 @@ path = "schemas/type-test.schema.json"
 include = ["type-test.toml"]
 
 [[schemas]]
+root = "tool.taskipy"
 path = "schemas/partial-taskipy.schema.json"
 include = ["pyproject.toml"]
-root = "tool.taskipy"


### PR DESCRIPTION
- Introduced a new optional `root` field in the SubSchema struct to allow specifying accessors for applying the sub schema.
- Updated related documentation and schema files to reflect this change.