### PR TITLE
refactor: improve validation handling in hover content

### DIFF
--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -78,7 +78,7 @@ where
                     hover_content.value_type = value_type.clone();
                 }
 
-                if value
+                match value
                     .validate(
                         &accessors
                             .iter()
@@ -88,9 +88,16 @@ where
                         schema_context,
                     )
                     .await
-                    .is_ok()
                 {
-                    valid_hover_contents.push(hover_content.clone());
+                    Ok(()) => valid_hover_contents.push(hover_content.clone()),
+                    Err(errors)
+                        if errors
+                            .iter()
+                            .all(|error| error.level() == tombi_diagnostic::Level::WARNING) =>
+                    {
+                        valid_hover_contents.push(hover_content.clone());
+                    }
+                    _ => {}
                 }
 
                 any_hover_contents.push(hover_content);

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -79,13 +79,14 @@ where
                     hover_content.value_type = value_type.clone();
                 }
 
-                if current_schema.value_schema.value_type().await == tombi_schema_store::ValueType::Array
+                if current_schema.value_schema.value_type().await
+                    == tombi_schema_store::ValueType::Array
                     && hover_content.value_type != tombi_schema_store::ValueType::Array
                 {
                     return Some(hover_content);
                 }
 
-                if value
+                match value
                     .validate(
                         &accessors
                             .iter()
@@ -95,9 +96,18 @@ where
                         schema_context,
                     )
                     .await
-                    .is_ok()
                 {
-                    valid_hover_contents.insert(hover_content.clone());
+                    Ok(()) => {
+                        valid_hover_contents.insert(hover_content.clone());
+                    }
+                    Err(errors)
+                        if errors
+                            .iter()
+                            .all(|error| error.level() == tombi_diagnostic::Level::WARNING) =>
+                    {
+                        valid_hover_contents.insert(hover_content.clone());
+                    }
+                    _ => {}
                 }
 
                 one_hover_contents.insert(hover_content);


### PR DESCRIPTION
Updated validation logic in `any_of.rs` and `one_of.rs` to handle errors more gracefully, allowing hover contents to be added when validation returns warnings.