### PR TITLE
refactor: replace constructor with struct initialization for DefinitionLocation

### DIFF
--- a/crates/tombi-extension/src/definition.rs
+++ b/crates/tombi-extension/src/definition.rs
@@ -6,12 +6,6 @@ pub struct DefinitionLocation {
     pub range: tombi_text::Range,
 }
 
-impl DefinitionLocation {
-    pub fn new(uri: tower_lsp::lsp_types::Url, range: tombi_text::Range) -> Self {
-        Self { uri, range }
-    }
-}
-
 impl From<DefinitionLocation> for tower_lsp::lsp_types::Location {
     fn from(definition_location: DefinitionLocation) -> Self {
         tower_lsp::lsp_types::Location::new(

--- a/extensions/tombi-extension-cargo/src/lib.rs
+++ b/extensions/tombi-extension-cargo/src/lib.rs
@@ -173,10 +173,10 @@ fn goto_workspace(
                     if let Some((_, tombi_document_tree::Value::String(package_name))) =
                         tombi_document_tree::dig_keys(&subcrate_document_tree, &["package", "name"])
                     {
-                        return Ok(Some(tombi_extension::DefinitionLocation::new(
-                            Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
-                            package_name.range(),
-                        )));
+                        return Ok(Some(tombi_extension::DefinitionLocation {
+                            uri: Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
+                            range: package_name.range(),
+                        }));
                     }
                 }
             }
@@ -187,10 +187,10 @@ fn goto_workspace(
         return Ok(None);
     };
 
-    Ok(Some(tombi_extension::DefinitionLocation::new(
-        workspace_cargo_toml_uri,
-        key.range(),
-    )))
+    Ok(Some(tombi_extension::DefinitionLocation {
+        uri: workspace_cargo_toml_uri,
+        range: key.range(),
+    }))
 }
 
 /// Get the location of the crate path in the workspace.
@@ -233,10 +233,10 @@ fn goto_dependency_crates(
                 if let Some((_, tombi_document_tree::Value::String(package_name))) =
                     tombi_document_tree::dig_keys(&subcrate_document_tree, &["package", "name"])
                 {
-                    locations.push(tombi_extension::DefinitionLocation::new(
-                        Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
-                        package_name.range(),
-                    ));
+                    locations.push(tombi_extension::DefinitionLocation {
+                        uri: Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
+                        range: package_name.range(),
+                    });
                 }
             }
         } else if let Some(tombi_document_tree::Value::Boolean(has_workspace)) =
@@ -335,10 +335,10 @@ fn goto_crate_package(
             if let Some((_, tombi_document_tree::Value::String(package_name))) =
                 tombi_document_tree::dig_keys(&subcrate_document_tree, &["package", "name"])
             {
-                return Ok(Some(tombi_extension::DefinitionLocation::new(
-                    Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
-                    package_name.range(),
-                )));
+                return Ok(Some(tombi_extension::DefinitionLocation {
+                    uri: Url::from_file_path(subcrate_cargo_toml_path).unwrap(),
+                    range: package_name.range(),
+                }));
             }
         }
     }

--- a/extensions/tombi-extension-uv/src/lib.rs
+++ b/extensions/tombi-extension-uv/src/lib.rs
@@ -250,20 +250,20 @@ fn goto_workspace_member(
             return Ok(None);
         };
 
-        Ok(Some(tombi_extension::DefinitionLocation::new(
-            package_pyproject_toml_uri,
-            tombi_text::Range::default(),
-        )))
+        Ok(Some(tombi_extension::DefinitionLocation {
+            uri: package_pyproject_toml_uri,
+            range: tombi_text::Range::default(),
+        }))
     } else {
         let Ok(workspace_pyproject_toml_uri) = Url::from_file_path(&workspace_pyproject_toml_path)
         else {
             return Ok(None);
         };
 
-        Ok(Some(tombi_extension::DefinitionLocation::new(
-            workspace_pyproject_toml_uri,
-            member_range,
-        )))
+        Ok(Some(tombi_extension::DefinitionLocation {
+            uri: workspace_pyproject_toml_uri,
+            range: member_range,
+        }))
     }
 }
 


### PR DESCRIPTION
Updated DefinitionLocation instantiation to use struct initialization instead of a constructor for improved clarity and consistency across the codebase.