### PR TITLE
style: reorder imports and clean up code formatting

### DIFF
--- a/crates/tombi-ast-editor/src/edit/array_of_table.rs
+++ b/crates/tombi-ast-editor/src/edit/array_of_table.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
-use tombi_document_tree::IntoDocumentTreeAndErrors;
 use futures::FutureExt;
 use itertools::Itertools;
+use tombi_document_tree::IntoDocumentTreeAndErrors;
 use tombi_schema_store::{CurrentSchema, GetHeaderSchemarAccessors, SchemaAccessor};
 
 use crate::{edit::get_schema, rule::table_keys_order};
@@ -31,7 +31,9 @@ impl crate::Edit for tombi_ast::ArrayOfTable {
             );
 
             let current_schema = if let Some(current_schema) = current_schema {
-                get_schema(value, &header_accessors, current_schema, schema_context).await.map(|value_schema| CurrentSchema {
+                get_schema(value, &header_accessors, current_schema, schema_context)
+                    .await
+                    .map(|value_schema| CurrentSchema {
                         value_schema: Cow::Owned(value_schema),
                         schema_url: current_schema.schema_url.clone(),
                         definitions: current_schema.definitions.clone(),

--- a/crates/tombi-ast-editor/src/edit/key_value.rs
+++ b/crates/tombi-ast-editor/src/edit/key_value.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
-use tombi_document_tree::TryIntoDocumentTree;
 use futures::FutureExt;
 use itertools::Itertools;
+use tombi_document_tree::TryIntoDocumentTree;
 use tombi_schema_store::{CurrentSchema, SchemaAccessor};
 
 use super::get_schema;

--- a/crates/tombi-ast-editor/src/edit/table.rs
+++ b/crates/tombi-ast-editor/src/edit/table.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
-use tombi_document_tree::IntoDocumentTreeAndErrors;
 use futures::FutureExt;
 use itertools::Itertools;
+use tombi_document_tree::IntoDocumentTreeAndErrors;
 use tombi_schema_store::{GetHeaderSchemarAccessors, SchemaAccessor};
 
 use crate::{edit::get_schema, rule::table_keys_order};
@@ -31,7 +31,9 @@ impl crate::Edit for tombi_ast::Table {
             );
 
             let current_schema = if let Some(current_schema) = current_schema {
-                get_schema(value, &header_accessors, current_schema, schema_context).await.map(|value_schema| tombi_schema_store::CurrentSchema {
+                get_schema(value, &header_accessors, current_schema, schema_context)
+                    .await
+                    .map(|value_schema| tombi_schema_store::CurrentSchema {
                         value_schema: Cow::Owned(value_schema),
                         schema_url: current_schema.schema_url.clone(),
                         definitions: current_schema.definitions.clone(),

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
-use tombi_syntax::SyntaxElement;
 use tombi_ast::AstNode;
 use tombi_document_tree::IntoDocumentTreeAndErrors;
 use tombi_schema_store::{CurrentSchema, SchemaAccessor, SchemaContext};
+use tombi_syntax::SyntaxElement;
 
 use crate::rule::table_keys_order::{sorted_accessors, table_keys_order};
 

--- a/crates/tombi-ast/src/support/node.rs
+++ b/crates/tombi-ast/src/support/node.rs
@@ -14,7 +14,10 @@ pub fn children<N: AstNode>(parent: &tombi_syntax::SyntaxNode) -> AstChildren<N>
 }
 
 #[inline]
-pub fn token(parent: &tombi_syntax::SyntaxNode, kind: tombi_syntax::SyntaxKind) -> Option<tombi_syntax::SyntaxToken> {
+pub fn token(
+    parent: &tombi_syntax::SyntaxNode,
+    kind: tombi_syntax::SyntaxKind,
+) -> Option<tombi_syntax::SyntaxToken> {
     parent
         .children_with_tokens()
         .filter_map(|it| it.into_token())

--- a/crates/tombi-date-time/tests/deserialize.rs
+++ b/crates/tombi-date-time/tests/deserialize.rs
@@ -1,6 +1,6 @@
-use tombi_date_time::{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, TimeZoneOffset};
 use rstest::rstest;
 use serde_json::json;
+use tombi_date_time::{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, TimeZoneOffset};
 
 #[test]
 fn test_local_date_deserialization() {

--- a/crates/tombi-date-time/tests/serialize.rs
+++ b/crates/tombi-date-time/tests/serialize.rs
@@ -1,6 +1,6 @@
-use tombi_date_time::{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, TimeZoneOffset};
 use rstest::rstest;
 use serde_json::json;
+use tombi_date_time::{LocalDate, LocalDateTime, LocalTime, OffsetDateTime, TimeZoneOffset};
 
 #[test]
 fn test_local_date_serialization() {

--- a/crates/tombi-document/src/value.rs
+++ b/crates/tombi-document/src/value.rs
@@ -148,12 +148,18 @@ impl IntoDocument<Value> for tombi_document_tree::Value {
             tombi_document_tree::Value::Integer(value) => Value::Integer(value.into()),
             tombi_document_tree::Value::Float(value) => Value::Float(value.into()),
             tombi_document_tree::Value::String(value) => Value::String(value.into()),
-            tombi_document_tree::Value::OffsetDateTime(value) => Value::OffsetDateTime(value.into()),
+            tombi_document_tree::Value::OffsetDateTime(value) => {
+                Value::OffsetDateTime(value.into())
+            }
             tombi_document_tree::Value::LocalDateTime(value) => Value::LocalDateTime(value.into()),
             tombi_document_tree::Value::LocalDate(value) => Value::LocalDate(value.into()),
             tombi_document_tree::Value::LocalTime(value) => Value::LocalTime(value.into()),
-            tombi_document_tree::Value::Array(value) => Value::Array(value.into_document(toml_version)),
-            tombi_document_tree::Value::Table(value) => Value::Table(value.into_document(toml_version)),
+            tombi_document_tree::Value::Array(value) => {
+                Value::Array(value.into_document(toml_version))
+            }
+            tombi_document_tree::Value::Table(value) => {
+                Value::Table(value.into_document(toml_version))
+            }
             tombi_document_tree::Value::Incomplete { .. } => {
                 unreachable!("Incomplete value should not be converted to document")
             }

--- a/crates/tombi-document/src/value/table.rs
+++ b/crates/tombi-document/src/value/table.rs
@@ -62,15 +62,16 @@ impl Table {
 impl IntoDocument<Table> for tombi_document_tree::Table {
     fn into_document(self, toml_version: crate::TomlVersion) -> Table {
         let kind = self.kind().into();
-        let key_values = IndexMap::<tombi_document_tree::Key, tombi_document_tree::Value>::from(self)
-            .into_iter()
-            .map(|(key, value)| {
-                (
-                    key.into_document(toml_version),
-                    value.into_document(toml_version),
-                )
-            })
-            .collect();
+        let key_values =
+            IndexMap::<tombi_document_tree::Key, tombi_document_tree::Value>::from(self)
+                .into_iter()
+                .map(|(key, value)| {
+                    (
+                        key.into_document(toml_version),
+                        value.into_document(toml_version),
+                    )
+                })
+                .collect();
 
         Table { kind, key_values }
     }

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -1,8 +1,8 @@
 use std::fmt::Write;
 
-use tombi_config::TomlVersion;
 use itertools::Itertools;
 use tombi_ast::AstNode;
+use tombi_config::TomlVersion;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::Format;

--- a/crates/tombi-formatter/src/format/value/string.rs
+++ b/crates/tombi-formatter/src/format/value/string.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
-use tombi_config::QuoteStyle;
 use tombi_ast::AstNode;
+use tombi_config::QuoteStyle;
 
 use super::LiteralNode;
 use crate::format::Format;

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -1,4 +1,6 @@
-use tombi_config::{DateTimeDelimiter, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle};
+use tombi_config::{
+    DateTimeDelimiter, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+};
 
 /// FormatDefinitions provides the definition of the format that does not have the freedom set by [`FormatOptions`][crate::FormatOptions].
 ///

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -1,10 +1,10 @@
 mod format;
 pub mod formatter;
 
-pub use tombi_config::FormatOptions;
 use format::Format;
 use formatter::definitions::FormatDefinitions;
 pub use formatter::Formatter;
+pub use tombi_config::FormatOptions;
 
 #[cfg(test)]
 #[macro_export]

--- a/crates/tombi-json-lexer/src/cursor.rs
+++ b/crates/tombi-json-lexer/src/cursor.rs
@@ -33,10 +33,7 @@ impl<'a> Cursor<'a> {
     pub fn peek(&self, i: usize) -> char {
         assert!(i != 0, "peek(0) is invalid");
 
-        
-
-        self
-            .chars
+        self.chars
             .clone()
             .nth(i.saturating_sub(1))
             .unwrap_or(EOF_CHAR)

--- a/crates/tombi-json-value/src/lib.rs
+++ b/crates/tombi-json-value/src/lib.rs
@@ -15,8 +15,7 @@ pub use number::Number;
 pub use object::Object;
 
 /// Enum representing a JSON value
-#[derive(Debug, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum Value {
     /// `null` value
     #[default]
@@ -152,7 +151,6 @@ impl Value {
         }
     }
 }
-
 
 impl From<bool> for Value {
     fn from(b: bool) -> Self {

--- a/crates/tombi-lsp/src/handler/get_toml_version.rs
+++ b/crates/tombi-lsp/src/handler/get_toml_version.rs
@@ -1,5 +1,5 @@
-use tombi_config::TomlVersion;
 use itertools::Either;
+use tombi_config::TomlVersion;
 use tower_lsp::lsp_types::TextDocumentIdentifier;
 
 use crate::backend::Backend;
@@ -24,9 +24,7 @@ pub async fn handle_get_toml_version(
         None => None,
     };
 
-    let (toml_version, source) = backend
-        .source_toml_version(source_schema.as_ref())
-        .await;
+    let (toml_version, source) = backend.source_toml_version(source_schema.as_ref()).await;
 
     Ok(GetTomlVersionResponse {
         toml_version,

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -83,7 +83,8 @@ impl GetHoverContent for tombi_document_tree::Array {
                                             .await?;
 
                                         if keys.is_empty()
-                                            && self.kind() == tombi_document_tree::ArrayKind::ArrayOfTable
+                                            && self.kind()
+                                                == tombi_document_tree::ArrayKind::ArrayOfTable
                                         {
                                             if let Some(constraints) =
                                                 &mut hover_content.constraints

--- a/crates/tombi-parser/src/error.rs
+++ b/crates/tombi-parser/src/error.rs
@@ -105,9 +105,7 @@ impl std::fmt::Display for Error {
         write!(
             f,
             "{} in {}..{}",
-            self.kind,
-            self.range.start,
-            self.range.end
+            self.kind, self.range.start, self.range.end
         )
     }
 }

--- a/crates/tombi-validator/src/validate/boolean.rs
+++ b/crates/tombi-validator/src/validate/boolean.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::ValueImpl;
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::{ValueSchema, ValueType};
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/crates/tombi-validator/src/validate/float.rs
+++ b/crates/tombi-validator/src/validate/float.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::ValueImpl;
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/crates/tombi-validator/src/validate/integer.rs
+++ b/crates/tombi-validator/src/validate/integer.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::ValueImpl;
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/crates/tombi-validator/src/validate/local_date.rs
+++ b/crates/tombi-validator/src/validate/local_date.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::{LocalDate, ValueImpl};
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};
@@ -37,7 +37,9 @@ impl Validate for LocalDate {
                 }
 
                 let local_date_schema = match current_schema.value_schema.as_ref() {
-                    tombi_schema_store::ValueSchema::LocalDate(local_date_schema) => local_date_schema,
+                    tombi_schema_store::ValueSchema::LocalDate(local_date_schema) => {
+                        local_date_schema
+                    }
                     tombi_schema_store::ValueSchema::OneOf(one_of_schema) => {
                         return validate_one_of(
                             self,

--- a/crates/tombi-validator/src/validate/local_date_time.rs
+++ b/crates/tombi-validator/src/validate/local_date_time.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::{LocalDateTime, ValueImpl};
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/crates/tombi-validator/src/validate/local_time.rs
+++ b/crates/tombi-validator/src/validate/local_time.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::{LocalTime, ValueImpl};
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};
@@ -37,7 +37,9 @@ impl Validate for LocalTime {
                 }
 
                 let local_time_schema = match current_schema.value_schema.as_ref() {
-                    tombi_schema_store::ValueSchema::LocalTime(local_time_schema) => local_time_schema,
+                    tombi_schema_store::ValueSchema::LocalTime(local_time_schema) => {
+                        local_time_schema
+                    }
                     tombi_schema_store::ValueSchema::OneOf(one_of_schema) => {
                         return validate_one_of(
                             self,

--- a/crates/tombi-validator/src/validate/offset_date_time.rs
+++ b/crates/tombi-validator/src/validate/offset_date_time.rs
@@ -1,6 +1,6 @@
+use futures::{future::BoxFuture, FutureExt};
 use tombi_diagnostic::SetDiagnostics;
 use tombi_document_tree::{OffsetDateTime, ValueImpl};
-use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -1,7 +1,7 @@
-use tombi_diagnostic::SetDiagnostics;
-use tombi_document_tree::ValueImpl;
 use futures::{future::BoxFuture, FutureExt};
 use regex::Regex;
+use tombi_diagnostic::SetDiagnostics;
+use tombi_document_tree::ValueImpl;
 use tombi_schema_store::ValueType;
 
 use super::{validate_all_of, validate_any_of, validate_one_of, Validate};

--- a/rust/serde_tombi/src/document.rs
+++ b/rust/serde_tombi/src/document.rs
@@ -310,8 +310,8 @@ impl ToTomlString for tombi_document::LocalTime {
 
 #[cfg(test)]
 mod tests {
-    use tombi_test_lib::toml_text_assert_eq;
     use tombi_document::KeyKind;
+    use tombi_test_lib::toml_text_assert_eq;
 
     use crate::document::*;
 

--- a/rust/tombi-cli/src/error.rs
+++ b/rust/tombi-cli/src/error.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
+use nu_ansi_term::Style;
 use tombi_diagnostic::{
     printer::{Pretty, Simple},
     Level, Print,
 };
-use nu_ansi_term::Style;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
This commit reorganizes import statements for better readability and consistency across multiple files. It also includes minor formatting adjustments to enhance code clarity.