### PR TITLE
docs: update installation instructions for tombi

### DIFF
--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -14,14 +14,28 @@ curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --version 0.
 
 ## Python
 
+### Quick Try
+
 ```bash
-pipx install tombi
+uvx tombi
+```
+
+### Project Installation
+
+```bash
+uv add --dev tombi
+```
+
+### Global Installation
+
+```bash
+uv tool install tombi
 ```
 
 Or
 
 ```bash
-uvx tombi
+pipx install tombi
 ```
 
 ## VSCode/Cursor


### PR DESCRIPTION
Added new sections for quick try, project installation, and global installation using `uv` commands, while retaining the `pipx` installation method.