### PR TITLE
docs: add CodeTabs component for command display

### DIFF
--- a/docs/src/components/CodeTabs.tsx
+++ b/docs/src/components/CodeTabs.tsx
@@ -1,0 +1,53 @@
+import { createSignal, For } from "solid-js";
+import { CodeBlock } from "./CodeBlock";
+
+export type Tab = {
+  key: string;
+  label: string;
+  command: string;
+};
+
+type CodeTabsProps = {
+  tabs: Tab[];
+  defaultKey?: string;
+  language?: string;
+};
+
+export default function CodeTabs(props: CodeTabsProps) {
+  const [active, setActive] = createSignal(
+    props.defaultKey || props.tabs[0].key,
+  );
+  const current = () => props.tabs.find((tab) => tab.key === active());
+
+  return (
+    <div>
+      <For each={props.tabs}>
+        {(tab) => (
+          <button
+            type="button"
+            onClick={() => setActive(tab.key)}
+            class={`px-4 font-semibold text-base cursor-pointer bg-transparent border-0 relative
+                ${
+                  active() === tab.key
+                    ? "text-gray-800 dark:text-gray-100"
+                    : "text-gray-500 dark:text-gray-400"
+                }
+                focus-visible:outline-none
+              `}
+            style="min-width: 64px; height: 40px;"
+            data-key={tab.key}
+          >
+            {tab.label}
+            {active() === tab.key && (
+              <div class="absolute bottom-0 left-0 w-full h-1 bg-tombi-700 dark:bg-yellow" />
+            )}
+          </button>
+        )}
+      </For>
+      <CodeBlock
+        code={current()?.command || ""}
+        language={props.language || "bash"}
+      />
+    </div>
+  );
+}

--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -1,3 +1,5 @@
+import CodeTabs from "../../components/CodeTabs";
+
 # Installation
 
 ## CLI
@@ -22,21 +24,52 @@ uvx tombi
 
 ### Project Installation
 
-```bash
-uv add --dev tombi
-```
+<CodeTabs
+  tabs={[
+    {
+      key: "uv",
+      label: "uv",
+      command: "uv add --dev tombi",
+    },
+    {
+      key: "poetry",
+      label: "poetry",
+      command: "poetry add --dev tombi",
+    },
+    {
+      key: "hatch",
+      label: "hatch",
+      command: "hatch add --dev tombi",
+    },
+    {
+      key: "pip",
+      label: "pip",
+      command: "pip install tombi",
+    },
+  ]}
+  defaultKey="uv"
+  language="bash"
+/>
+
 
 ### Global Installation
 
-```bash
-uv tool install tombi
-```
-
-Or
-
-```bash
-pipx install tombi
-```
+<CodeTabs
+  tabs={[
+    {
+      key: "uv",
+      label: "uv",
+      command: "uv tool install tombi",
+    },
+    {
+      key: "pipx",
+      label: "pipx",
+      command: "pipx install tombi",
+    },
+  ]}
+  defaultKey="uv"
+  language="bash"
+/>
 
 ## VSCode/Cursor
 


### PR DESCRIPTION
Introduces a new CodeTabs component to enhance documentation by allowing users to switch between different installation commands for various package managers. This improves usability and clarity in the installation instructions.