### PR TITLE
feat: add `tombi-url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,7 @@ dependencies = [
  "tombi-text",
  "tombi-toml-text",
  "tombi-toml-version",
+ "tombi-url",
  "tracing",
  "typed-builder",
  "url",
@@ -1953,6 +1954,7 @@ dependencies = [
  "tombi-text",
  "tombi-toml-text",
  "tombi-toml-version",
+ "tombi-url",
  "tracing",
  "url",
 ]
@@ -2013,6 +2015,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tombi-toml-version",
+ "tombi-url",
  "tombi-x-keyword",
  "tracing",
  "url",
@@ -2380,6 +2383,7 @@ dependencies = [
  "tombi-future",
  "tombi-json",
  "tombi-text",
+ "tombi-url",
  "tombi-x-keyword",
  "tracing",
  "url",
@@ -2430,6 +2434,13 @@ dependencies = [
  "clap",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "tombi-url"
+version = "0.0.0"
+dependencies = [
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tombi-test-lib = { path = "crates/tombi-test-lib" }
 tombi-text = { path = "crates/tombi-text" }
 tombi-toml-text = { path = "crates/tombi-toml-text" }
 tombi-toml-version = { path = "crates/tombi-toml-version" }
+tombi-url = { path = "crates/tombi-url" }
 tombi-validator = { path = "crates/tombi-validator" }
 tombi-x-keyword = { path = "crates/tombi-x-keyword" }
 tower-lsp = { version = "0.20.0" }

--- a/crates/tombi-ast/Cargo.toml
+++ b/crates/tombi-ast/Cargo.toml
@@ -12,5 +12,6 @@ tombi-syntax.workspace = true
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
+tombi-url.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/tombi-ast/src/impls/comment.rs
+++ b/crates/tombi-ast/src/impls/comment.rs
@@ -1,4 +1,5 @@
 use crate::{AstToken, Comment};
+use tombi_url::url_from_file_path;
 
 impl Comment {
     pub fn schema_url(
@@ -33,7 +34,7 @@ impl Comment {
                 }
 
                 Some((
-                    url::Url::from_file_path(&schema_file_path).map_err(|_| url_str.to_string()),
+                    url_from_file_path(&schema_file_path).map_err(|_| url_str.to_string()),
                     schema_url_range,
                 ))
             } else {

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -12,6 +12,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
 tombi-toml-version.workspace = true
+tombi-url.workspace = true
 tombi-x-keyword.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/tombi-config/src/types/schema_catalog_path.rs
+++ b/crates/tombi-config/src/types/schema_catalog_path.rs
@@ -1,4 +1,5 @@
 use super::OneOrMany;
+use tombi_url::url_from_file_path;
 
 /// Generic value that can be either single or multiple
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,8 +20,8 @@ impl SchemaCatalogPath {
         match self.0.parse() {
             Ok(url) => Ok(url),
             Err(err) => match base_dirpath {
-                Some(base_dirpath) => url::Url::from_file_path(base_dirpath.join(&self.0)),
-                None => url::Url::from_file_path(&self.0),
+                Some(base_dirpath) => url_from_file_path(base_dirpath.join(&self.0)),
+                None => url_from_file_path(&self.0),
             }
             .map_err(|_| err),
         }

--- a/crates/tombi-schema-store/Cargo.toml
+++ b/crates/tombi-schema-store/Cargo.toml
@@ -25,6 +25,7 @@ tombi-document-tree.workspace = true
 tombi-future.workspace = true
 tombi-json.workspace = true
 tombi-text.workspace = true
+tombi-url.workspace = true
 tombi-x-keyword.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/tombi-schema-store/src/schema/schema_url.rs
+++ b/crates/tombi-schema-store/src/schema/schema_url.rs
@@ -1,3 +1,5 @@
+use tombi_url::url_from_file_path;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize)]
 pub struct SchemaUrl(url::Url);
 
@@ -19,7 +21,7 @@ impl SchemaUrl {
 
     #[inline]
     pub fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Self, crate::Error> {
-        match url::Url::from_file_path(&path) {
+        match url_from_file_path(&path) {
             Ok(url) => Ok(Self(url)),
             Err(_) => Err(crate::Error::InvalidSchemaUrl {
                 schema_url: path.as_ref().to_string_lossy().to_string(),

--- a/crates/tombi-url/Cargo.toml
+++ b/crates/tombi-url/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tombi-url"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+url.workspace = true
+
+[features]
+default = ["native"]
+native = []
+wasm = []

--- a/crates/tombi-url/README.md
+++ b/crates/tombi-url/README.md
@@ -1,0 +1,6 @@
+# Url
+
+This crate is a utility library for cross-platform `Url` compatibility.
+
+In (non-WASI) WASM environments, methods such as `url::Url::from_file_path`, which handle `file://` URLs, are not available.  
+This crate provides functions that simply fallback to `Err(())` in such scenarios, improving compatibility within WASM environments.

--- a/crates/tombi-url/src/lib.rs
+++ b/crates/tombi-url/src/lib.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "wasm"))]
+mod on_native;
+#[cfg(not(feature = "wasm"))]
+pub use on_native::*;
+
+#[cfg(feature = "wasm")]
+mod on_wasm;
+#[cfg(feature = "wasm")]
+pub use on_wasm::*;

--- a/crates/tombi-url/src/on_native.rs
+++ b/crates/tombi-url/src/on_native.rs
@@ -1,0 +1,7 @@
+pub fn url_from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<url::Url, ()> {
+    url::Url::from_file_path(path)
+}
+
+pub fn url_to_file_path(url: &url::Url) -> Result<std::path::PathBuf, ()> {
+    url.to_file_path()
+}

--- a/crates/tombi-url/src/on_wasm.rs
+++ b/crates/tombi-url/src/on_wasm.rs
@@ -1,0 +1,7 @@
+pub fn url_from_file_path<P: AsRef<std::path::Path>>(_path: P) -> Result<url::Url, ()> {
+    Err(())
+}
+
+pub fn url_to_file_path(_url: &url::Url) -> Result<std::path::PathBuf, ()> {
+    Err(())
+}

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -28,6 +28,7 @@ tombi-schema-store.workspace = true
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
+tombi-url.workspace = true
 tracing.workspace = true
 typed-builder.workspace = true
 url.workspace = true

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -2,6 +2,7 @@ use tombi_ast::AstNode;
 use tombi_config::{
     Config, TomlVersion, CONFIG_FILENAME, PYPROJECT_FILENAME, TOMBI_CONFIG_TOML_VERSION,
 };
+use tombi_url::url_to_file_path;
 
 /// Parse the TOML text into a `Config` struct.
 ///
@@ -110,8 +111,7 @@ pub fn try_from_path<P: AsRef<std::path::Path>>(
 pub fn try_from_url(config_url: url::Url) -> Result<Option<Config>, tombi_config::Error> {
     match config_url.scheme() {
         "file" => {
-            let config_path = config_url
-                .to_file_path()
+            let config_path = url_to_file_path(&config_url)
                 .map_err(|_| tombi_config::Error::ConfigUrlParseFailed { config_url })?;
             try_from_path(config_path)
         }


### PR DESCRIPTION
## Overview

This PR introduces a new crate, `tombi-url`, ensuring compatibility of `Url::from_file_path` with (non-WASI) WASM environments. It replaces the use of methods like `Url::from_file_path` within tombi with the ones provided by `tombi-url`.

## Details

In (non-WASI) WASM environments, methods such as `url::Url::from_file_path`, which handle `file://` URLs, are unavailable (they are not defined at all due to `#[cfg]` conditions).
This PR adds a compatibility layer named `tombi-url`, which switches implementations depending on the build target (more precisely, the `wasm` feature). Specifically, in WASM environments, it simply falls back to returning `Err(())`.

## References

This PR is part of the larger draft PR #371.
It is also one of the PRs addressing issue #291, resolving #417.