### PR TITLE
feat: enhance comment completion with schema URL support

### DIFF
--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -23,10 +23,12 @@ use tombi_schema_store::{
     ValueSchema,
 };
 use tombi_syntax::{SyntaxElement, SyntaxKind};
+use tower_lsp::lsp_types::Url;
 
 pub async fn get_completion_contents(
     root: tombi_ast::Root,
     position: tombi_text::Position,
+    text_document_uri: &Url,
     schema_context: &tombi_schema_store::SchemaContext<'_>,
 ) -> Vec<CompletionContent> {
     let mut keys: Vec<tombi_document_tree::Key> = vec![];
@@ -47,7 +49,7 @@ pub async fn get_completion_contents(
 
         if let Some(SyntaxElement::Token(token)) = node.first_child_or_token() {
             if token.kind() == SyntaxKind::COMMENT && token.range().contains(position) {
-                return get_comment_completion_contents(&root, position);
+                return get_comment_completion_contents(&root, position, text_document_uri);
             }
         }
 

--- a/crates/tombi-lsp/src/completion/comment.rs
+++ b/crates/tombi-lsp/src/completion/comment.rs
@@ -1,10 +1,12 @@
 use tombi_ast::AstToken;
+use tower_lsp::lsp_types::Url;
 
 use super::{CompletionContent, CompletionEdit};
 
 pub fn get_comment_completion_contents(
     root: &tombi_ast::Root,
     position: tombi_text::Position,
+    text_document_uri: &Url,
 ) -> Vec<CompletionContent> {
     if root.file_schema_url(None).is_some() {
         return Vec::with_capacity(0);
@@ -17,14 +19,19 @@ pub fn get_comment_completion_contents(
             if comment_range.contains(position) {
                 let comment_text = comment.syntax().text();
 
-                if (position.column - comment_range.start.column == 2)
-                    && comment_text.get(0..2) == Some("#:")
-                {
+                if comment_text.get(0..2) == Some("#:") {
+                    let mut comment_prefix = comment_range;
+                    comment_prefix.start.column += 2;
+
                     return vec![CompletionContent::new_comment_directive(
                         "schema",
                         "Schema URL/Path",
                         "This directive specifies the schema URL or path for the document.",
-                        CompletionEdit::new_comment_schema_directive(position),
+                        CompletionEdit::new_comment_schema_directive(
+                            position,
+                            comment_prefix,
+                            text_document_uri,
+                        ),
                     )];
                 }
             }

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -95,6 +95,7 @@ pub async fn handle_completion(
         get_completion_contents(
             root,
             position.into(),
+            &text_document.uri,
             &tombi_schema_store::SchemaContext {
                 toml_version,
                 root_schema,


### PR DESCRIPTION
Updated the comment completion functionality to include schema URL generation based on the document's URI. This change allows for more dynamic and context-aware completions when using the comment directive.