### PR TITLE
feat: replace DefaultValue with DisplayValue in hover content

### DIFF
--- a/crates/tombi-lsp/src/hover/all_of.rs
+++ b/crates/tombi-lsp/src/hover/all_of.rs
@@ -4,7 +4,7 @@ use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DefaultValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_all_of_hover_content<'a: 'b, 'b, T>(
@@ -27,7 +27,7 @@ where
         let default = all_of_schema
             .default
             .as_ref()
-            .and_then(|default| DefaultValue::try_from(default).ok());
+            .and_then(|default| DisplayValue::try_from(default).ok());
 
         for referable_schema in all_of_schema.schemas.write().await.iter_mut() {
             let Ok(Some(current_schema)) = referable_schema

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DefaultValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_any_of_hover_content<'a: 'b, 'b, T>(
@@ -28,7 +28,7 @@ where
         let default = any_of_schema
             .default
             .as_ref()
-            .and_then(|default| DefaultValue::try_from(default).ok());
+            .and_then(|default| DisplayValue::try_from(default).ok());
 
         for referable_schema in any_of_schema.schemas.write().await.iter_mut() {
             let Ok(Some(CurrentSchema { value_schema, .. })) = referable_schema

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -1,19 +1,19 @@
 use tombi_x_keyword::{ArrayValuesOrder, TableKeysOrder};
 
-use super::default_value::DefaultValue;
+use super::default_value::DisplayValue;
 
 #[derive(Debug, Clone, Default)]
 pub struct ValueConstraints {
     // Common
-    pub enumerate: Option<Vec<DefaultValue>>,
-    pub default: Option<DefaultValue>,
+    pub enumerate: Option<Vec<DisplayValue>>,
+    pub default: Option<DisplayValue>,
 
     // Integer OR Float
-    pub minimum: Option<DefaultValue>,
-    pub maximum: Option<DefaultValue>,
-    pub exclusive_minimum: Option<DefaultValue>,
-    pub exclusive_maximum: Option<DefaultValue>,
-    pub multiple_of: Option<DefaultValue>,
+    pub minimum: Option<DisplayValue>,
+    pub maximum: Option<DisplayValue>,
+    pub exclusive_minimum: Option<DisplayValue>,
+    pub exclusive_maximum: Option<DisplayValue>,
+    pub multiple_of: Option<DisplayValue>,
     // String
     pub min_length: Option<usize>,
     pub max_length: Option<usize>,

--- a/crates/tombi-lsp/src/hover/default_value.rs
+++ b/crates/tombi-lsp/src/hover/default_value.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone)]
-pub enum DefaultValue {
+pub enum DisplayValue {
     Boolean(bool),
     Integer(i64),
     Float(f64),
@@ -8,25 +8,25 @@ pub enum DefaultValue {
     LocalDateTime(String),
     LocalDate(String),
     LocalTime(String),
-    Array(Vec<DefaultValue>),
-    Table(Vec<(String, DefaultValue)>),
+    Array(Vec<DisplayValue>),
+    Table(Vec<(String, DisplayValue)>),
 }
 
-impl TryFrom<&tombi_json::Value> for DefaultValue {
+impl TryFrom<&tombi_json::Value> for DisplayValue {
     type Error = ();
 
     fn try_from(value: &tombi_json::Value) -> Result<Self, Self::Error> {
         match value {
-            tombi_json::Value::Bool(boolean) => Ok(DefaultValue::Boolean(*boolean)),
+            tombi_json::Value::Bool(boolean) => Ok(DisplayValue::Boolean(*boolean)),
             tombi_json::Value::Number(number) => match number {
-                tombi_json::Number::Integer(integer) => Ok(DefaultValue::Integer(*integer)),
-                tombi_json::Number::Float(float) => Ok(DefaultValue::Float(*float)),
+                tombi_json::Number::Integer(integer) => Ok(DisplayValue::Integer(*integer)),
+                tombi_json::Number::Float(float) => Ok(DisplayValue::Float(*float)),
             },
-            tombi_json::Value::String(string) => Ok(DefaultValue::String(string.clone())),
-            tombi_json::Value::Array(array) => Ok(DefaultValue::Array(
+            tombi_json::Value::String(string) => Ok(DisplayValue::String(string.clone())),
+            tombi_json::Value::Array(array) => Ok(DisplayValue::Array(
                 array.iter().map(|item| item.try_into().unwrap()).collect(),
             )),
-            tombi_json::Value::Object(object) => Ok(DefaultValue::Table(
+            tombi_json::Value::Object(object) => Ok(DisplayValue::Table(
                 object
                     .iter()
                     .map(|(key, value)| (key.clone(), value.try_into().unwrap()))
@@ -37,18 +37,18 @@ impl TryFrom<&tombi_json::Value> for DefaultValue {
     }
 }
 
-impl std::fmt::Display for DefaultValue {
+impl std::fmt::Display for DisplayValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DefaultValue::Boolean(boolean) => write!(f, "{}", boolean),
-            DefaultValue::Integer(integer) => write!(f, "{}", integer),
-            DefaultValue::Float(float) => write!(f, "{}", float),
-            DefaultValue::String(string) => write!(f, "\"{}\"", string.replace("\"", "\\\"")),
-            DefaultValue::OffsetDateTime(offset_date_time) => write!(f, "{}", offset_date_time),
-            DefaultValue::LocalDateTime(local_date_time) => write!(f, "{}", local_date_time),
-            DefaultValue::LocalDate(local_date) => write!(f, "{}", local_date),
-            DefaultValue::LocalTime(local_time) => write!(f, "{}", local_time),
-            DefaultValue::Array(array) => {
+            DisplayValue::Boolean(boolean) => write!(f, "{}", boolean),
+            DisplayValue::Integer(integer) => write!(f, "{}", integer),
+            DisplayValue::Float(float) => write!(f, "{}", float),
+            DisplayValue::String(string) => write!(f, "\"{}\"", string.replace("\"", "\\\"")),
+            DisplayValue::OffsetDateTime(offset_date_time) => write!(f, "{}", offset_date_time),
+            DisplayValue::LocalDateTime(local_date_time) => write!(f, "{}", local_date_time),
+            DisplayValue::LocalDate(local_date) => write!(f, "{}", local_date),
+            DisplayValue::LocalTime(local_time) => write!(f, "{}", local_time),
+            DisplayValue::Array(array) => {
                 write!(f, "[")?;
                 for (i, value) in array.iter().enumerate() {
                     if i > 0 {
@@ -58,7 +58,7 @@ impl std::fmt::Display for DefaultValue {
                 }
                 write!(f, "]")
             }
-            DefaultValue::Table(table) => {
+            DisplayValue::Table(table) => {
                 write!(f, "{{ ")?;
                 for (i, (key, value)) in table.iter().enumerate() {
                     if i > 0 {

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DefaultValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_one_of_hover_content<'a: 'b, 'b, T>(
@@ -28,7 +28,7 @@ where
         let default = one_of_schema
             .default
             .as_ref()
-            .and_then(|default| DefaultValue::try_from(default).ok());
+            .and_then(|default| DisplayValue::try_from(default).ok());
 
         for referable_schema in one_of_schema.schemas.write().await.iter_mut() {
             let Ok(Some(CurrentSchema { value_schema, .. })) = referable_schema

--- a/crates/tombi-lsp/src/hover/value/boolean.rs
+++ b/crates/tombi-lsp/src/hover/value/boolean.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, BooleanSchema, CurrentSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,11 +113,11 @@ impl GetHoverContent for BooleanSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Boolean,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DefaultValue::Boolean),
+                    default: self.default.map(DisplayValue::Boolean),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::Boolean(*value))
+                            .map(|value| DisplayValue::Boolean(*value))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/float.rs
+++ b/crates/tombi-lsp/src/hover/value/float.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, FloatSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,18 +113,18 @@ impl GetHoverContent for FloatSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Float,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DefaultValue::Float),
+                    default: self.default.map(DisplayValue::Float),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::Float(*value))
+                            .map(|value| DisplayValue::Float(*value))
                             .collect()
                     }),
-                    minimum: self.minimum.map(DefaultValue::Float),
-                    maximum: self.maximum.map(DefaultValue::Float),
-                    exclusive_minimum: self.exclusive_minimum.map(DefaultValue::Float),
-                    exclusive_maximum: self.exclusive_maximum.map(DefaultValue::Float),
-                    multiple_of: self.multiple_of.map(DefaultValue::Float),
+                    minimum: self.minimum.map(DisplayValue::Float),
+                    maximum: self.maximum.map(DisplayValue::Float),
+                    exclusive_minimum: self.exclusive_minimum.map(DisplayValue::Float),
+                    exclusive_maximum: self.exclusive_maximum.map(DisplayValue::Float),
+                    multiple_of: self.multiple_of.map(DisplayValue::Float),
                     ..Default::default()
                 }),
                 schema_url: current_schema.map(|schema| schema.schema_url.as_ref().clone()),

--- a/crates/tombi-lsp/src/hover/value/integer.rs
+++ b/crates/tombi-lsp/src/hover/value/integer.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, IntegerSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,18 +113,18 @@ impl GetHoverContent for IntegerSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Integer,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DefaultValue::Integer),
+                    default: self.default.map(DisplayValue::Integer),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::Integer(*value))
+                            .map(|value| DisplayValue::Integer(*value))
                             .collect()
                     }),
-                    minimum: self.minimum.map(DefaultValue::Integer),
-                    maximum: self.maximum.map(DefaultValue::Integer),
-                    exclusive_minimum: self.exclusive_minimum.map(DefaultValue::Integer),
-                    exclusive_maximum: self.exclusive_maximum.map(DefaultValue::Integer),
-                    multiple_of: self.multiple_of.map(DefaultValue::Integer),
+                    minimum: self.minimum.map(DisplayValue::Integer),
+                    maximum: self.maximum.map(DisplayValue::Integer),
+                    exclusive_minimum: self.exclusive_minimum.map(DisplayValue::Integer),
+                    exclusive_maximum: self.exclusive_maximum.map(DisplayValue::Integer),
+                    multiple_of: self.multiple_of.map(DisplayValue::Integer),
                     ..Default::default()
                 }),
                 schema_url: current_schema.map(|schema| schema.schema_url.as_ref().clone()),

--- a/crates/tombi-lsp/src/hover/value/local_date.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalDateSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -108,11 +108,11 @@ impl GetHoverContent for LocalDateSchema {
                     default: self
                         .default
                         .as_ref()
-                        .map(|value| DefaultValue::LocalDate(value.clone())),
+                        .map(|value| DisplayValue::LocalDate(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::LocalDate(value.clone()))
+                            .map(|value| DisplayValue::LocalDate(value.clone()))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalDateTimeSchema, ValueSche
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -108,11 +108,11 @@ impl GetHoverContent for LocalDateTimeSchema {
                     default: self
                         .default
                         .as_ref()
-                        .map(|value| DefaultValue::LocalDateTime(value.clone())),
+                        .map(|value| DisplayValue::LocalDateTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::LocalDateTime(value.clone()))
+                            .map(|value| DisplayValue::LocalDateTime(value.clone()))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/local_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalTimeSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -108,11 +108,11 @@ impl GetHoverContent for LocalTimeSchema {
                     default: self
                         .default
                         .as_ref()
-                        .map(|value| DefaultValue::LocalTime(value.clone())),
+                        .map(|value| DisplayValue::LocalTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::LocalTime(value.clone()))
+                            .map(|value| DisplayValue::LocalTime(value.clone()))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/offset_date_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, OffsetDateTimeSchema, ValueSch
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -108,11 +108,11 @@ impl GetHoverContent for OffsetDateTimeSchema {
                     default: self
                         .default
                         .as_ref()
-                        .map(|value| DefaultValue::OffsetDateTime(value.clone())),
+                        .map(|value| DisplayValue::OffsetDateTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::OffsetDateTime(value.clone()))
+                            .map(|value| DisplayValue::OffsetDateTime(value.clone()))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/string.rs
+++ b/crates/tombi-lsp/src/hover/value/string.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, StringSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DefaultValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -116,11 +116,11 @@ impl GetHoverContent for StringSchema {
                     default: self
                         .default
                         .as_ref()
-                        .map(|value| DefaultValue::String(value.clone())),
+                        .map(|value| DisplayValue::String(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DefaultValue::String(value.clone()))
+                            .map(|value| DisplayValue::String(value.clone()))
                             .collect()
                     }),
                     min_length: self.min_length,


### PR DESCRIPTION
Updated hover content implementations to use DisplayValue instead of DefaultValue for better representation of default values across various schemas.