### PR TITLE
feat: add examples field on hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,7 @@ dependencies = [
  "tokio",
  "tombi-ast",
  "tombi-config",
+ "tombi-date-time",
  "tombi-diagnostic",
  "tombi-document",
  "tombi-document-tree",

--- a/crates/tombi-json/src/node.rs
+++ b/crates/tombi-json/src/node.rs
@@ -293,6 +293,23 @@ impl ObjectNode {
     }
 }
 
+impl From<ObjectNode> for Object {
+    fn from(node: ObjectNode) -> Self {
+        node.properties
+            .into_iter()
+            .map(|(k, v)| (k.value, v.into()))
+            .collect()
+    }
+}
+
+impl From<&ObjectNode> for Object {
+    fn from(node: &ObjectNode) -> Self {
+        node.properties
+            .iter()
+            .map(|(k, v)| (k.value.clone(), v.into()))
+            .collect()
+    }
+}
 impl std::fmt::Display for ObjectNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -25,6 +25,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tombi-ast.workspace = true
 tombi-config.workspace = true
+tombi-date-time.workspace = true
 tombi-diagnostic.workspace = true
 tombi-document.workspace = true
 tombi-document-tree.workspace = true

--- a/crates/tombi-lsp/src/hover.rs
+++ b/crates/tombi-lsp/src/hover.rs
@@ -1,7 +1,7 @@
 mod all_of;
 mod any_of;
 mod constraints;
-mod default_value;
+mod display_value;
 mod one_of;
 mod value;
 

--- a/crates/tombi-lsp/src/hover/all_of.rs
+++ b/crates/tombi-lsp/src/hover/all_of.rs
@@ -4,7 +4,7 @@ use futures::{future::BoxFuture, FutureExt};
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, display_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_all_of_hover_content<'a: 'b, 'b, T>(

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, display_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_any_of_hover_content<'a: 'b, 'b, T>(

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -1,12 +1,13 @@
 use tombi_x_keyword::{ArrayValuesOrder, TableKeysOrder};
 
-use super::default_value::DisplayValue;
+use super::display_value::DisplayValue;
 
 #[derive(Debug, Clone, Default)]
 pub struct ValueConstraints {
     // Common
     pub enumerate: Option<Vec<DisplayValue>>,
     pub default: Option<DisplayValue>,
+    pub examples: Option<Vec<DisplayValue>>,
 
     // Integer OR Float
     pub minimum: Option<DisplayValue>,
@@ -46,6 +47,14 @@ impl std::fmt::Display for ValueConstraints {
 
         if let Some(default) = &self.default {
             write!(f, "Default: `{}`\n\n", default)?;
+        }
+
+        if let Some(examples) = &self.examples {
+            write!(f, "Examples:\n\n")?;
+            for example in examples {
+                write!(f, "  - `{}`\n\n", example)?;
+            }
+            writeln!(f)?;
         }
 
         if let Some(minimum) = &self.minimum {

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaUrl};
 
 use super::{
-    constraints::ValueConstraints, default_value::DisplayValue, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, display_value::DisplayValue, GetHoverContent, HoverContent,
 };
 
 pub fn get_one_of_hover_content<'a: 'b, 'b, T>(

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -7,7 +7,8 @@ use tombi_schema_store::{
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, one_of::get_one_of_hover_content, GetHoverContent, HoverContent,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
+    GetHoverContent, HoverContent,
 };
 
 impl GetHoverContent for tombi_document_tree::Array {
@@ -231,6 +232,22 @@ impl GetHoverContent for ArraySchema {
                 accessors: Accessors::new(accessors.to_vec()),
                 value_type: ValueType::Array,
                 constraints: Some(ValueConstraints {
+                    enumerate: self.enumerate.as_ref().map(|enumerate| {
+                        enumerate
+                            .iter()
+                            .filter_map(|value| DisplayValue::try_from(value).ok())
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .and_then(|default| DisplayValue::try_from(default).ok()),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .filter_map(|example| DisplayValue::try_from(example).ok())
+                            .collect()
+                    }),
                     min_items: self.min_items,
                     max_items: self.max_items,
                     unique_items: self.unique_items,

--- a/crates/tombi-lsp/src/hover/value/boolean.rs
+++ b/crates/tombi-lsp/src/hover/value/boolean.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, BooleanSchema, CurrentSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,11 +113,17 @@ impl GetHoverContent for BooleanSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Boolean,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DisplayValue::Boolean),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
                             .map(|value| DisplayValue::Boolean(*value))
+                            .collect()
+                    }),
+                    default: self.default.map(DisplayValue::Boolean),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .map(|example| DisplayValue::Boolean(*example))
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/float.rs
+++ b/crates/tombi-lsp/src/hover/value/float.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, FloatSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,11 +113,17 @@ impl GetHoverContent for FloatSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Float,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DisplayValue::Float),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
                             .map(|value| DisplayValue::Float(*value))
+                            .collect()
+                    }),
+                    default: self.default.map(DisplayValue::Float),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .map(|example| DisplayValue::Float(*example))
                             .collect()
                     }),
                     minimum: self.minimum.map(DisplayValue::Float),

--- a/crates/tombi-lsp/src/hover/value/integer.rs
+++ b/crates/tombi-lsp/src/hover/value/integer.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, IntegerSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,11 +113,17 @@ impl GetHoverContent for IntegerSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::Integer,
                 constraints: Some(ValueConstraints {
-                    default: self.default.map(DisplayValue::Integer),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
                             .map(|value| DisplayValue::Integer(*value))
+                            .collect()
+                    }),
+                    default: self.default.map(DisplayValue::Integer),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .map(|example| DisplayValue::Integer(*example))
                             .collect()
                     }),
                     minimum: self.minimum.map(DisplayValue::Integer),

--- a/crates/tombi-lsp/src/hover/value/local_date.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalDateSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -105,14 +105,20 @@ impl GetHoverContent for LocalDateSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::LocalDate,
                 constraints: Some(ValueConstraints {
-                    default: self
-                        .default
-                        .as_ref()
-                        .map(|value| DisplayValue::LocalDate(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DisplayValue::LocalDate(value.clone()))
+                            .filter_map(|value| DisplayValue::try_new_local_date(value).ok())
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .and_then(|value| DisplayValue::try_new_local_date(value).ok()),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .filter_map(|example| DisplayValue::try_new_local_date(example).ok())
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalDateTimeSchema, ValueSche
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -105,14 +105,22 @@ impl GetHoverContent for LocalDateTimeSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::LocalDateTime,
                 constraints: Some(ValueConstraints {
-                    default: self
-                        .default
-                        .as_ref()
-                        .map(|value| DisplayValue::LocalDateTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DisplayValue::LocalDateTime(value.clone()))
+                            .filter_map(|value| DisplayValue::try_new_local_date_time(value).ok())
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .and_then(|value| DisplayValue::try_new_local_date_time(value).ok()),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .filter_map(|example| {
+                                DisplayValue::try_new_local_date_time(example).ok()
+                            })
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/local_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, LocalTimeSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -105,14 +105,20 @@ impl GetHoverContent for LocalTimeSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::LocalTime,
                 constraints: Some(ValueConstraints {
-                    default: self
-                        .default
-                        .as_ref()
-                        .map(|value| DisplayValue::LocalTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DisplayValue::LocalTime(value.clone()))
+                            .filter_map(|value| DisplayValue::try_new_local_time(value).ok())
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .and_then(|value| DisplayValue::try_new_local_time(value).ok()),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .filter_map(|example| DisplayValue::try_new_local_time(example).ok())
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/offset_date_time.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, OffsetDateTimeSchema, ValueSch
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -105,14 +105,22 @@ impl GetHoverContent for OffsetDateTimeSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::OffsetDateTime,
                 constraints: Some(ValueConstraints {
-                    default: self
-                        .default
-                        .as_ref()
-                        .map(|value| DisplayValue::OffsetDateTime(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
-                            .map(|value| DisplayValue::OffsetDateTime(value.clone()))
+                            .filter_map(|value| DisplayValue::try_new_offset_date_time(value).ok())
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .and_then(|value| DisplayValue::try_new_offset_date_time(value).ok()),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .filter_map(|example| {
+                                DisplayValue::try_new_offset_date_time(example).ok()
+                            })
                             .collect()
                     }),
                     ..Default::default()

--- a/crates/tombi-lsp/src/hover/value/string.rs
+++ b/crates/tombi-lsp/src/hover/value/string.rs
@@ -3,7 +3,7 @@ use tombi_schema_store::{Accessor, CurrentSchema, StringSchema, ValueSchema};
 
 use crate::hover::{
     all_of::get_all_of_hover_content, any_of::get_any_of_hover_content,
-    constraints::ValueConstraints, default_value::DisplayValue, one_of::get_one_of_hover_content,
+    constraints::ValueConstraints, display_value::DisplayValue, one_of::get_one_of_hover_content,
     GetHoverContent, HoverContent,
 };
 
@@ -113,14 +113,20 @@ impl GetHoverContent for StringSchema {
                 accessors: tombi_schema_store::Accessors::new(accessors.to_vec()),
                 value_type: tombi_schema_store::ValueType::String,
                 constraints: Some(ValueConstraints {
-                    default: self
-                        .default
-                        .as_ref()
-                        .map(|value| DisplayValue::String(value.clone())),
                     enumerate: self.enumerate.as_ref().map(|value| {
                         value
                             .iter()
                             .map(|value| DisplayValue::String(value.clone()))
+                            .collect()
+                    }),
+                    default: self
+                        .default
+                        .as_ref()
+                        .map(|value| DisplayValue::String(value.clone())),
+                    examples: self.examples.as_ref().map(|examples| {
+                        examples
+                            .iter()
+                            .map(|example| DisplayValue::String(example.clone()))
                             .collect()
                     }),
                     min_length: self.min_length,

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -423,6 +423,15 @@ impl GetHoverContent for TableSchema {
                 accessors: Accessors::new(accessors.to_vec()),
                 value_type: ValueType::Table,
                 constraints: Some(ValueConstraints {
+                    enumerate: self
+                        .enumerate
+                        .as_ref()
+                        .map(|enumerate| enumerate.iter().map(|example| example.into()).collect()),
+                    default: self.default.as_ref().map(|default| default.into()),
+                    examples: self
+                        .examples
+                        .as_ref()
+                        .map(|examples| examples.iter().map(|example| example.into()).collect()),
                     required_keys: self.required.clone(),
                     max_keys: self.max_properties,
                     min_keys: self.min_properties,

--- a/crates/tombi-schema-store/src/schema/all_of_schema.rs
+++ b/crates/tombi-schema-store/src/schema/all_of_schema.rs
@@ -12,6 +12,7 @@ pub struct AllOfSchema {
     pub range: tombi_text::Range,
     pub schemas: ReferableValueSchemas,
     pub default: Option<tombi_json::Value>,
+    pub examples: Option<Vec<tombi_json::Value>>,
     pub deprecated: Option<bool>,
 }
 
@@ -43,6 +44,10 @@ impl AllOfSchema {
             description,
             schemas: Arc::new(tokio::sync::RwLock::new(schemas)),
             default: object.get("default").cloned().map(|v| v.into()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|array| array.items.iter().map(|v| v.into()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/any_of_schema.rs
+++ b/crates/tombi-schema-store/src/schema/any_of_schema.rs
@@ -12,6 +12,7 @@ pub struct AnyOfSchema {
     pub range: tombi_text::Range,
     pub schemas: ReferableValueSchemas,
     pub default: Option<tombi_json::Value>,
+    pub examples: Option<Vec<tombi_json::Value>>,
     pub deprecated: Option<bool>,
 }
 
@@ -43,6 +44,10 @@ impl AnyOfSchema {
             description,
             schemas: Arc::new(tokio::sync::RwLock::new(schemas)),
             default: object.get("default").cloned().map(|v| v.into()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|array| array.items.iter().map(|v| v.into()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/array_schema.rs
+++ b/crates/tombi-schema-store/src/schema/array_schema.rs
@@ -18,6 +18,9 @@ pub struct ArraySchema {
     pub min_items: Option<usize>,
     pub max_items: Option<usize>,
     pub unique_items: Option<bool>,
+    pub enumerate: Option<Vec<tombi_json::Value>>,
+    pub default: Option<tombi_json::Value>,
+    pub examples: Option<Vec<tombi_json::Value>>,
     pub values_order: Option<ArrayValuesOrder>,
     pub deprecated: Option<bool>,
 }
@@ -44,6 +47,18 @@ impl ArraySchema {
                 .get("maxItems")
                 .and_then(|v| v.as_u64().map(|n| n as usize)),
             unique_items: object.get("uniqueItems").and_then(|v| v.as_bool()),
+            enumerate: object
+                .get("enum")
+                .and_then(|v| v.as_array())
+                .map(|array| array.items.iter().map(|v| v.into()).collect()),
+            default: object
+                .get("default")
+                .and_then(|v| v.as_array())
+                .map(|array| array.into()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|array| array.items.iter().map(|v| v.into()).collect()),
             values_order: object
                 .get(X_TOMBI_ARRAY_VALUES_ORDER)
                 // NOTE: support old name

--- a/crates/tombi-schema-store/src/schema/boolean_schema.rs
+++ b/crates/tombi-schema-store/src/schema/boolean_schema.rs
@@ -5,6 +5,7 @@ pub struct BooleanSchema {
     pub range: tombi_text::Range,
     pub default: Option<bool>,
     pub enumerate: Option<Vec<bool>>,
+    pub examples: Option<Vec<bool>>,
     pub deprecated: Option<bool>,
 }
 
@@ -21,6 +22,10 @@ impl BooleanSchema {
             enumerate: object
                 .get("enum")
                 .and_then(|value| value.as_array())
+                .map(|array| array.items.iter().filter_map(|v| v.as_bool()).collect()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
                 .map(|array| array.items.iter().filter_map(|v| v.as_bool()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,

--- a/crates/tombi-schema-store/src/schema/float_schema.rs
+++ b/crates/tombi-schema-store/src/schema/float_schema.rs
@@ -10,6 +10,7 @@ pub struct FloatSchema {
     pub multiple_of: Option<f64>,
     pub enumerate: Option<Vec<f64>>,
     pub default: Option<f64>,
+    pub examples: Option<Vec<f64>>,
     pub deprecated: Option<bool>,
 }
 
@@ -32,6 +33,10 @@ impl FloatSchema {
                 .and_then(|v| v.as_array())
                 .map(|v| v.items.iter().filter_map(|v| v.as_f64()).collect()),
             default: object.get("default").and_then(|v| v.as_f64()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|v| v.items.iter().filter_map(|v| v.as_f64()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/integer_schema.rs
+++ b/crates/tombi-schema-store/src/schema/integer_schema.rs
@@ -10,6 +10,7 @@ pub struct IntegerSchema {
     pub multiple_of: Option<i64>,
     pub enumerate: Option<Vec<i64>>,
     pub default: Option<i64>,
+    pub examples: Option<Vec<i64>>,
     pub deprecated: Option<bool>,
 }
 
@@ -32,6 +33,10 @@ impl IntegerSchema {
                 .and_then(|v| v.as_array())
                 .map(|v| v.items.iter().filter_map(|v| v.as_i64()).collect()),
             default: object.get("default").and_then(|v| v.as_i64()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|v| v.items.iter().filter_map(|v| v.as_i64()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/local_date_schema.rs
+++ b/crates/tombi-schema-store/src/schema/local_date_schema.rs
@@ -5,6 +5,7 @@ pub struct LocalDateSchema {
     pub range: tombi_text::Range,
     pub enumerate: Option<Vec<String>>,
     pub default: Option<String>,
+    pub examples: Option<Vec<String>>,
     pub deprecated: Option<bool>,
 }
 
@@ -27,6 +28,12 @@ impl LocalDateSchema {
             default: object
                 .get("default")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
+            examples: object.get("examples").and_then(|v| v.as_array()).map(|v| {
+                v.items
+                    .iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect()
+            }),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/local_date_time_schema.rs
+++ b/crates/tombi-schema-store/src/schema/local_date_time_schema.rs
@@ -5,6 +5,7 @@ pub struct LocalDateTimeSchema {
     pub range: tombi_text::Range,
     pub enumerate: Option<Vec<String>>,
     pub default: Option<String>,
+    pub examples: Option<Vec<String>>,
     pub deprecated: Option<bool>,
 }
 
@@ -27,6 +28,12 @@ impl LocalDateTimeSchema {
             default: object
                 .get("default")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
+            examples: object.get("examples").and_then(|v| v.as_array()).map(|v| {
+                v.items
+                    .iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect()
+            }),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
             range: object.range,
         }

--- a/crates/tombi-schema-store/src/schema/local_time_schema.rs
+++ b/crates/tombi-schema-store/src/schema/local_time_schema.rs
@@ -5,6 +5,7 @@ pub struct LocalTimeSchema {
     pub range: tombi_text::Range,
     pub enumerate: Option<Vec<String>>,
     pub default: Option<String>,
+    pub examples: Option<Vec<String>>,
     pub deprecated: Option<bool>,
 }
 
@@ -28,6 +29,12 @@ impl LocalTimeSchema {
             default: object
                 .get("default")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
+            examples: object.get("examples").and_then(|v| v.as_array()).map(|v| {
+                v.items
+                    .iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect()
+            }),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
         }
     }

--- a/crates/tombi-schema-store/src/schema/offset_date_time_schema.rs
+++ b/crates/tombi-schema-store/src/schema/offset_date_time_schema.rs
@@ -5,6 +5,7 @@ pub struct OffsetDateTimeSchema {
     pub range: tombi_text::Range,
     pub enumerate: Option<Vec<String>>,
     pub default: Option<String>,
+    pub examples: Option<Vec<String>>,
     pub deprecated: Option<bool>,
 }
 
@@ -28,6 +29,12 @@ impl OffsetDateTimeSchema {
             default: object
                 .get("default")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
+            examples: object.get("examples").and_then(|v| v.as_array()).map(|v| {
+                v.items
+                    .iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect()
+            }),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
         }
     }

--- a/crates/tombi-schema-store/src/schema/one_of_schema.rs
+++ b/crates/tombi-schema-store/src/schema/one_of_schema.rs
@@ -12,6 +12,7 @@ pub struct OneOfSchema {
     pub range: tombi_text::Range,
     pub schemas: ReferableValueSchemas,
     pub default: Option<tombi_json::Value>,
+    pub examples: Option<Vec<tombi_json::Value>>,
     pub deprecated: Option<bool>,
 }
 
@@ -44,6 +45,10 @@ impl OneOfSchema {
             range: object.range,
             schemas: Arc::new(tokio::sync::RwLock::new(schemas)),
             default: object.get("default").cloned().map(|v| v.into()),
+            examples: object
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|array| array.items.iter().map(|v| v.into()).collect()),
             deprecated: object.get("deprecated").and_then(|v| v.as_bool()),
         }
     }

--- a/crates/tombi-schema-store/src/schema/string_schema.rs
+++ b/crates/tombi-schema-store/src/schema/string_schema.rs
@@ -7,6 +7,7 @@ pub struct StringSchema {
     pub max_length: Option<usize>,
     pub pattern: Option<String>,
     pub enumerate: Option<Vec<String>>,
+    pub examples: Option<Vec<String>>,
     pub default: Option<String>,
     pub deprecated: Option<bool>,
 }
@@ -31,6 +32,13 @@ impl StringSchema {
                 .get("pattern")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
             enumerate: object.get("enum").and_then(|v| v.as_array()).map(|a| {
+                a.items
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .map(ToString::to_string)
+                    .collect()
+            }),
+            examples: object.get("examples").and_then(|v| v.as_array()).map(|a| {
                 a.items
                     .iter()
                     .filter_map(|v| v.as_str())

--- a/crates/tombi-schema-store/src/schema/table_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_schema.rs
@@ -25,6 +25,9 @@ pub struct TableSchema {
     pub min_properties: Option<usize>,
     pub max_properties: Option<usize>,
     pub keys_order: Option<TableKeysOrder>,
+    pub default: Option<tombi_json::Object>,
+    pub enumerate: Option<Vec<tombi_json::Object>>,
+    pub examples: Option<Vec<tombi_json::Object>>,
     pub deprecated: Option<bool>,
 }
 
@@ -148,6 +151,25 @@ impl TableSchema {
                 .get("maxProperties")
                 .and_then(|v| v.as_u64().map(|u| u as usize)),
             keys_order,
+            enumerate: object_node.get("enum").and_then(|v| v.as_array()).map(|v| {
+                v.items
+                    .iter()
+                    .filter_map(|v| v.as_object().map(|v| v.into()))
+                    .collect()
+            }),
+            default: object_node
+                .get("default")
+                .and_then(|v| v.as_object())
+                .map(|v| v.into()),
+            examples: object_node
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .map(|v| {
+                    v.items
+                        .iter()
+                        .filter_map(|v| v.as_object().map(|v| v.into()))
+                        .collect()
+                }),
             deprecated: object_node.get("deprecated").and_then(|v| v.as_bool()),
         }
     }


### PR DESCRIPTION
- Introduced an `examples` field to various schema structs including `OneOfSchema`, `BooleanSchema`, `FloatSchema`, `AllOfSchema`, `AnyOfSchema`, `IntegerSchema`, `LocalTimeSchema`, `LocalDateSchema`, and `OffsetDateTimeSchema`.
- Updated the implementation to handle the new `examples` field in the corresponding methods.