### PR TITLE
fix(tombi-json): handle UTF-16 surrogate pairs in unicode escape sequ…

### DIFF
--- a/crates/tombi-json/src/lib.rs
+++ b/crates/tombi-json/src/lib.rs
@@ -963,4 +963,49 @@ mod tests {
             Some("\u{0000}\u{0001}\u{0002}\u{0008}\u{000C}")
         );
     }
+
+    #[test]
+    fn test_surrogate_pairs() {
+        // Test emoji using surrogate pairs (🎉 = U+1F389)
+        let json = r#""\uD83C\uDF89""#;
+        let value_node = ValueNode::from_str(json).unwrap();
+        assert!(value_node.is_string());
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("🎉"));
+
+        // Test another emoji (😀 = U+1F600)
+        let json = r#""\uD83D\uDE00""#;
+        let value_node = ValueNode::from_str(json).unwrap();
+        assert!(value_node.is_string());
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("😀"));
+
+        // Test mathematical alphanumeric symbols (𝐀 = U+1D400)
+        let json = r#""\uD835\uDC00""#;
+        let value_node = ValueNode::from_str(json).unwrap();
+        assert!(value_node.is_string());
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("𝐀"));
+    }
+
+    #[test]
+    fn test_invalid_surrogate_pairs() {
+        // High surrogate without low surrogate
+        let json = r#""\uD800""#;
+        assert!(ValueNode::from_str(json).is_err());
+
+        // Low surrogate without high surrogate
+        let json = r#""\uDC00""#;
+        assert!(ValueNode::from_str(json).is_err());
+
+        // High surrogate followed by non-surrogate
+        let json = r#""\uD800\u0041""#;
+        assert!(ValueNode::from_str(json).is_err());
+    }
+
+    #[test]
+    fn test_mixed_surrogate_and_regular() {
+        // Mix of regular characters and surrogate pairs
+        let json = r#""Hello \uD83D\uDE00 World!""#;
+        let value_node = ValueNode::from_str(json).unwrap();
+        assert!(value_node.is_string());
+        pretty_assertions::assert_eq!(value_node.as_str(), Some("Hello 😀 World!"));
+    }
 }

--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -99,9 +99,47 @@ impl<'a> Parser<'a> {
                                         _ => return Err(Error::InvalidUnicodeEscape),
                                     }
                                 }
-                                match std::char::from_u32(code_point) {
-                                    Some(unicode_char) => processed.push(unicode_char),
-                                    None => return Err(Error::InvalidUnicodeCodePoint),
+
+                                // Check for surrogate pairs
+                                if (0xD800..=0xDBFF).contains(&code_point) {
+                                    // High surrogate - expect low surrogate to follow
+                                    if chars.next() == Some('\\') && chars.next() == Some('u') {
+                                        let mut low_surrogate = 0u32;
+                                        for _ in 0..4 {
+                                            match chars.next() {
+                                                Some(hex) if hex.is_ascii_hexdigit() => {
+                                                    low_surrogate = low_surrogate * 16
+                                                        + hex.to_digit(16).unwrap();
+                                                }
+                                                _ => return Err(Error::InvalidUnicodeEscape),
+                                            }
+                                        }
+
+                                        if (0xDC00..=0xDFFF).contains(&low_surrogate) {
+                                            // Valid surrogate pair - decode to actual Unicode code point
+                                            let high = code_point - 0xD800;
+                                            let low = low_surrogate - 0xDC00;
+                                            let unicode_code_point = 0x10000 + (high << 10) + low;
+
+                                            match std::char::from_u32(unicode_code_point) {
+                                                Some(unicode_char) => processed.push(unicode_char),
+                                                None => return Err(Error::InvalidUnicodeCodePoint),
+                                            }
+                                        } else {
+                                            return Err(Error::InvalidUnicodeCodePoint);
+                                        }
+                                    } else {
+                                        return Err(Error::InvalidUnicodeCodePoint);
+                                    }
+                                } else if (0xDC00..=0xDFFF).contains(&code_point) {
+                                    // Low surrogate without high surrogate
+                                    return Err(Error::InvalidUnicodeCodePoint);
+                                } else {
+                                    // Regular Unicode code point
+                                    match std::char::from_u32(code_point) {
+                                        Some(unicode_char) => processed.push(unicode_char),
+                                        None => return Err(Error::InvalidUnicodeCodePoint),
+                                    }
                                 }
                             }
                             _ => return Err(Error::InvalidEscapeSequence),


### PR DESCRIPTION
## Overview

Standard JSON implementations support unicode escapes (`\uXXXX`) not only for single code points but also for surrogate pairs (`\uXXXX\uXXXX`).
Currently, tombi-json supports only single code points, so this PR adds support for surrogate pairs.

## References

The JSON standard specification refers to surrogate pairs as follows:

[RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259#autoid-10:~:text=To%20escape%20an%20extended%20character%20that%20is%20not%20in%20the%20Basic%20Multilingual%0A%20%20%20Plane%2C%20the%20character%20is%20represented%20as%20a%2012%2Dcharacter%20sequence%2C%0A%20%20%20encoding%20the%20UTF%2D16%20surrogate%20pair.%20%20So%2C%20for%20example%2C%20a%20string%0A%20%20%20containing%20only%20the%20G%20clef%20character%20(U%2B1D11E)%20may%20be%20represented%20as%0A%20%20%20%22%5CuD834%5CuDD1E%22.)
[RFC 8259 (Japanese Translation)](https://tex2e.github.io/rfc-translater/html/rfc8259.html#:~:text=To%20escape%20an,%E3%81%8C%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82)