### PR TITLE
fix: tombi-diagnostic lsp feature

### DIFF
--- a/crates/tombi-diagnostic/Cargo.toml
+++ b/crates/tombi-diagnostic/Cargo.toml
@@ -20,4 +20,4 @@ tracing-subscriber.workspace = true
 
 [features]
 default = ["lsp"]
-lsp = ["tower-lsp"]
+lsp = ["dep:tower-lsp"]


### PR DESCRIPTION
`tower-lsp` was incorrectly specified as a feature, not an optional dependency.