### PR TITLE
ci: update rust toolchain installation step

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup target add ${{ matrix.target }}
-
+      - uses: Swatinem/rust-cache@v2
       - uses: pnpm/action-setup@v4
         with:
           run_install: false

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -44,7 +44,7 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
 
     xshell::cmd!(
         sh,
-        "cargo build --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
+        "cargo build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
     )
     .run()?;
 


### PR DESCRIPTION
- Added a step to use rust-cache for caching Rust toolchain installations in the CI workflow.
- Modified the cargo build command to use the --locked flag for better dependency management.