### PR TITLE
Add always-output option for TOML formatting

### DIFF
--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -20,7 +20,7 @@ pub struct Args {
 
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn run(args: Args, offline: bool) -> Result<(), crate::Error> {
-    let (success_num, nmt_needed_num, error_num) = match inner_run(args, Pretty, offline) {
+    let (success_num, not_needed_num, error_num) = match inner_run(args, Pretty, offline) {
         Ok((success_num, not_needed_num, error_num)) => (success_num, not_needed_num, error_num),
         Err(error) => {
             tracing::error!("{}", error);

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -228,22 +228,21 @@ where
         {
             Ok(formatted) => {
                 if check {
-                    print!("{formatted}");
                     if source != formatted {
-                        return Err(());
-                    } else {
-                        return Ok(false);
-                    }
-                } else {
-                    if source != formatted {
-                        print!("{formatted}");
-                        Ok(true)
+                        crate::error::NotFormattedError::from(file.source())
+                            .into_error()
+                            .print(&mut printer);
+                        Err(())
                     } else {
                         Ok(false)
                     }
+                } else {
+                    print!("{formatted}");
+                    Ok(source != formatted)
                 }
             }
             Err(diagnostics) => {
+                print!("{source}");
                 diagnostics.print(&mut printer);
                 Err(())
             }


### PR DESCRIPTION
Introduce an `always-output` option to allow users to output formatted TOML to stdout even when there are no changes, enhancing usability for standard input scenarios.

fix: #450