### PR TITLE
feat: update schema catalog handling to support paths array

### DIFF
--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -1,6 +1,6 @@
 use tombi_toml_version::TomlVersion;
 
-use crate::{BoolDefaultTrue, OneOrMany, SchemaCatalogPath};
+use crate::{BoolDefaultTrue, OneOrMany, SchemaCatalogPath, JSON_SCHEMA_STORE_CATALOG_URL};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -37,8 +37,8 @@ impl SchemaOptions {
             Some(
                 self.catalog
                     .as_ref()
-                    .and_then(|catalog| catalog.path.as_ref().map(|path| path.as_ref().to_vec()))
-                    .unwrap_or_else(|| vec![SchemaCatalogPath::default()]),
+                    .and_then(|catalog| catalog.paths().as_ref().map(|path| path.to_vec()))
+                    .unwrap_or_else(|| vec![JSON_SCHEMA_STORE_CATALOG_URL.into()]),
             )
         } else {
             None
@@ -49,24 +49,64 @@ impl SchemaOptions {
         self.strict.as_ref().map(|strict| strict.value())
     }
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum SchemaCatalog {
+    New(NewSchemaCatalog),
+    Old(SchemaCatalogOld),
+}
+
+impl Default for SchemaCatalog {
+    fn default() -> Self {
+        Self::New(NewSchemaCatalog::default())
+    }
+}
+impl SchemaCatalog {
+    pub fn paths(&self) -> Option<&[SchemaCatalogPath]> {
+        match self {
+            Self::New(item) => item.paths.as_ref().map(|v| v.as_slice()),
+            #[allow(deprecated)]
+            Self::Old(item) => item.path.as_ref().map(|v| v.as_ref()),
+        }
+    }
+}
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct SchemaCatalog {
-    /// # The schema catalog path or url.
+pub struct NewSchemaCatalog {
+    /// # The schema catalog path/url array.
     ///
     /// The catalog is evaluated after the schemas specified by [[schemas]].
+    #[cfg_attr(feature = "jsonschema", schemars(default = "catalog_paths_default"))]
+    #[cfg_attr(feature = "serde", serde(default = "catalog_paths_default"))]
+    pub paths: Option<Vec<SchemaCatalogPath>>,
+}
+
+fn catalog_paths_default() -> Option<Vec<SchemaCatalogPath>> {
+    Some(vec![JSON_SCHEMA_STORE_CATALOG_URL.into()])
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaCatalogOld {
+    /// # The schema catalog path or url.
     ///
-    /// You can specify multiple catalogs by making it an array.
-    /// If you specify an array, the catalogs are searched in order of priority starting from the first catalog.
-    /// If you want to disable the default catalog, specify an empty array.
+    /// **[Deprecated]** Please use `paths` instead.
     #[cfg_attr(
         feature = "jsonschema",
-        schemars(default = "SchemaCatalogPath::default")
+        schemars(default = "OneOrMany::<SchemaCatalogPath>::default")
     )]
+    #[cfg_attr(feature = "jsonschema", deprecated)]
     pub path: Option<OneOrMany<SchemaCatalogPath>>,
 }
 
@@ -184,7 +224,7 @@ pub struct OldSubSchema {
 
     /// # The keys to apply the sub schema.
     ///
-    /// Please use `root` instead.
+    /// **[Deprecated]** Please use `root` instead.
     #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
     #[cfg_attr(feature = "jsonschema", deprecated)]
     pub root_keys: Option<String>,
@@ -194,12 +234,14 @@ pub struct OldSubSchema {
 mod tests {
     use assert_matches::assert_matches;
 
+    use crate::JSON_SCHEMA_STORE_CATALOG_URL;
+
     use super::*;
 
     #[test]
     fn schema_catalog_paths_default() {
         let schema = SchemaOptions::default();
-        let _expected = [SchemaCatalogPath::default()];
+        let _expected = [JSON_SCHEMA_STORE_CATALOG_URL];
 
         assert_matches!(schema.catalog_paths(), Some(_expected));
     }
@@ -207,9 +249,9 @@ mod tests {
     #[test]
     fn schema_catalog_paths_empty() {
         let schema = SchemaOptions {
-            catalog: Some(SchemaCatalog {
-                path: Some(vec![].into()),
-            }),
+            catalog: Some(SchemaCatalog::New(NewSchemaCatalog {
+                paths: Some(vec![].into()),
+            })),
             ..Default::default()
         };
 

--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -101,7 +101,8 @@ fn catalog_paths_default() -> Option<Vec<SchemaCatalogPath>> {
 pub struct SchemaCatalogOld {
     /// # The schema catalog path or url.
     ///
-    /// **[Deprecated]** Please use `paths` instead.
+    /// **🚧 Deprecated 🚧**\
+    /// Please use `schema.catalog.paths` instead.
     #[cfg_attr(
         feature = "jsonschema",
         schemars(default = "OneOrMany::<SchemaCatalogPath>::default")
@@ -224,7 +225,8 @@ pub struct OldSubSchema {
 
     /// # The keys to apply the sub schema.
     ///
-    /// **[Deprecated]** Please use `root` instead.
+    /// **🚧 Deprecated 🚧**\
+    /// Please use `schemas[*].root` instead.
     #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
     #[cfg_attr(feature = "jsonschema", deprecated)]
     pub root_keys: Option<String>,

--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -38,7 +38,7 @@ impl SchemaOptions {
                 self.catalog
                     .as_ref()
                     .and_then(|catalog| catalog.paths().as_ref().map(|path| path.to_vec()))
-                    .unwrap_or_else(|| vec![JSON_SCHEMA_STORE_CATALOG_URL.into()]),
+                    .unwrap_or_default(),
             )
         } else {
             None

--- a/crates/tombi-config/src/types.rs
+++ b/crates/tombi-config/src/types.rs
@@ -16,4 +16,4 @@ pub use line_ending::LineEnding;
 pub use line_width::LineWidth;
 pub use one_or_many::OneOrMany;
 pub use quote_style::QuoteStyle;
-pub use schema_catalog_path::SchemaCatalogPath;
+pub use schema_catalog_path::{SchemaCatalogPath, JSON_SCHEMA_STORE_CATALOG_URL};

--- a/crates/tombi-config/src/types/schema_catalog_path.rs
+++ b/crates/tombi-config/src/types/schema_catalog_path.rs
@@ -1,6 +1,8 @@
 use super::OneOrMany;
 use tombi_url::url_from_file_path;
 
+pub const JSON_SCHEMA_STORE_CATALOG_URL: &str = "https://www.schemastore.org/api/json/catalog.json";
+
 /// Generic value that can be either single or multiple
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -34,14 +36,14 @@ impl std::fmt::Display for SchemaCatalogPath {
     }
 }
 
-impl Default for SchemaCatalogPath {
+impl Default for OneOrMany<SchemaCatalogPath> {
     fn default() -> Self {
-        SchemaCatalogPath("https://www.schemastore.org/api/json/catalog.json".to_string())
+        Self::One(JSON_SCHEMA_STORE_CATALOG_URL.into())
     }
 }
 
-impl Default for OneOrMany<SchemaCatalogPath> {
-    fn default() -> Self {
-        Self::One(SchemaCatalogPath::default())
+impl From<&str> for SchemaCatalogPath {
+    fn from(value: &str) -> Self {
+        SchemaCatalogPath(value.to_string())
     }
 }

--- a/crates/tombi-lsp/tests/completion_labels.rs
+++ b/crates/tombi-lsp/tests/completion_labels.rs
@@ -1,4 +1,3 @@
-use tombi_schema_store::json::DEFAULT_CATALOG_URL;
 use tombi_test_lib::{
     today_local_date, today_local_date_time, today_local_time, today_offset_date_time,
 };
@@ -250,14 +249,12 @@ mod completion_labels {
             async fn tombi_schema_catalog_path(
                 r#"
                 [schema.catalog]
-                path =█
+                paths =[█]
                 "#,
                 tombi_schema_path(),
             ) -> Ok([
-                format!("\"{}\"", DEFAULT_CATALOG_URL),
                 "\"\"",
                 "''",
-                "[]",
             ]);
         }
 
@@ -266,14 +263,12 @@ mod completion_labels {
             async fn tombi_schema_catalog_path2(
                 r#"
                 [schema.catalog]
-                path = █
+                paths = [█]
                 "#,
                 tombi_schema_path(),
             ) -> Ok([
-                format!("\"{}\"", DEFAULT_CATALOG_URL),
                 "\"\"",
                 "''",
-                "[]",
             ]);
         }
 
@@ -281,13 +276,10 @@ mod completion_labels {
             #[tokio::test]
             async fn tombi_schema_catalog_path_inline(
                 r#"
-                schema.catalog.path =█
+                schema.catalog.paths =█
                 "#,
                 tombi_schema_path(),
             ) -> Ok([
-                format!("\"{}\"", DEFAULT_CATALOG_URL),
-                "\"\"",
-                "''",
                 "[]",
             ]);
         }

--- a/crates/tombi-lsp/tests/document_link.rs
+++ b/crates/tombi-lsp/tests/document_link.rs
@@ -211,7 +211,7 @@ mod document_link_tests {
 
         test_document_link!(
             #[tokio::test]
-            async fn tombi_schema_catalog_path(
+            async fn tombi_schema_catalog_paths(
                 r#"
                 [schema]
                 catalog = { path = "https://www.schemastore.org/api/json/catalog.json" }
@@ -221,6 +221,23 @@ mod document_link_tests {
                 {
                     url: "https://www.schemastore.org/api/json/catalog.json",
                     range: 1:20..1:69,
+                    tooltip: tombi_extension_tombi::DocumentLinkToolTip::Catalog,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn tombi_schema_catalog_path(
+                r#"
+                [schema]
+                catalog = { paths = ["https://www.schemastore.org/api/json/catalog.json"] }
+                "#,
+                project_root_path().join("tombi.toml"),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://www.schemastore.org/api/json/catalog.json",
+                    range: 1:22..1:71,
                     tooltip: tombi_extension_tombi::DocumentLinkToolTip::Catalog,
                 }
             ]));

--- a/docs/src/routes/docs/configuration/index.mdx
+++ b/docs/src/routes/docs/configuration/index.mdx
@@ -39,9 +39,11 @@ hover.enabled = true
 [schema]
 enabled = true
 strict = true
-
-[schema.catalog]
-path = "https://www.schemastore.org/api/json/catalog.json"
+catalog = {
+  paths = [
+    "https://www.schemastore.org/api/json/catalog.json",
+  ],
+}
 
 # Root Schema
 [[schemas]]

--- a/extensions/tombi-extension-tombi/src/document_link.rs
+++ b/extensions/tombi-extension-tombi/src/document_link.rs
@@ -32,16 +32,49 @@ pub async fn document_link(
 
     let mut document_links = vec![];
 
-    if let Some((_, tombi_document_tree::Value::String(path))) =
-        dig_keys(document_tree, &["schema", "catalog", "path"])
-    {
-        if let Some(target) = crate::str2url(path.value(), &tombi_toml_path) {
-            document_links.push(tombi_extension::DocumentLink {
-                target,
-                range: path.unquoted_range(),
-                tooltip: DocumentLinkToolTip::Catalog.to_string(),
-            });
+    if let Some((_, path)) = dig_keys(document_tree, &["schema", "catalog", "path"]) {
+        let paths = match path {
+            tombi_document_tree::Value::String(path) => vec![path],
+            tombi_document_tree::Value::Array(paths) => paths
+                .iter()
+                .filter_map(|v| {
+                    if let tombi_document_tree::Value::String(s) = v {
+                        Some(s)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => Vec::with_capacity(0),
         };
+        for path in paths {
+            // Convert the path to a URL
+            if let Some(target) = crate::str2url(path.value(), &tombi_toml_path) {
+                document_links.push(tombi_extension::DocumentLink {
+                    target,
+                    range: path.unquoted_range(),
+                    tooltip: DocumentLinkToolTip::Catalog.to_string(),
+                });
+            }
+        }
+    }
+
+    if let Some((_, tombi_document_tree::Value::Array(paths))) =
+        dig_keys(document_tree, &["schema", "catalog", "paths"])
+    {
+        for path in paths.iter() {
+            let tombi_document_tree::Value::String(path) = path else {
+                continue;
+            };
+            // Convert the path to a URL
+            if let Some(target) = crate::str2url(path.value(), &tombi_toml_path) {
+                document_links.push(tombi_extension::DocumentLink {
+                    target,
+                    range: path.unquoted_range(),
+                    tooltip: DocumentLinkToolTip::Catalog.to_string(),
+                });
+            }
+        }
     }
 
     if let Some((_, tombi_document_tree::Value::Array(schemas))) =

--- a/tombi.schema.json
+++ b/tombi.schema.json
@@ -430,11 +430,45 @@
       "x-tombi-table-keys-order": "schema"
     },
     "SchemaCatalog": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NewSchemaCatalog"
+        },
+        {
+          "$ref": "#/definitions/SchemaCatalogOld"
+        }
+      ]
+    },
+    "NewSchemaCatalog": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "title": "The schema catalog path/url array.",
+          "description": "The catalog is evaluated after the schemas specified by [[schemas]].",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaCatalogPath"
+          },
+          "default": [
+            "https://www.schemastore.org/api/json/catalog.json"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SchemaCatalogPath": {
+      "description": "Generic value that can be either single or multiple",
+      "type": "string"
+    },
+    "SchemaCatalogOld": {
       "type": "object",
       "properties": {
         "path": {
           "title": "The schema catalog path or url.",
-          "description": "The catalog is evaluated after the schemas specified by [[schemas]].\n\n You can specify multiple catalogs by making it an array.\n If you specify an array, the catalogs are searched in order of priority starting from the first catalog.\n If you want to disable the default catalog, specify an empty array.",
+          "description": "**[Deprecated]** Please use `paths` instead.",
           "anyOf": [
             {
               "$ref": "#/definitions/OneOrMany_for_SchemaCatalogPath"
@@ -443,6 +477,7 @@
               "type": "null"
             }
           ],
+          "deprecated": true,
           "default": "https://www.schemastore.org/api/json/catalog.json"
         }
       },
@@ -460,10 +495,6 @@
           }
         }
       ]
-    },
-    "SchemaCatalogPath": {
-      "description": "Generic value that can be either single or multiple",
-      "type": "string"
     },
     "Schema": {
       "anyOf": [
@@ -571,7 +602,7 @@
         },
         "root-keys": {
           "title": "The keys to apply the sub schema.",
-          "description": "Please use `root` instead.",
+          "description": "**[Deprecated]** Please use `root` instead.",
           "type": [
             "string",
             "null"

--- a/tombi.schema.json
+++ b/tombi.schema.json
@@ -468,7 +468,7 @@
       "properties": {
         "path": {
           "title": "The schema catalog path or url.",
-          "description": "**[Deprecated]** Please use `paths` instead.",
+          "description": "**🚧 Deprecated 🚧**\\\n Please use `schema.catalog.paths` instead.",
           "anyOf": [
             {
               "$ref": "#/definitions/OneOrMany_for_SchemaCatalogPath"
@@ -602,7 +602,7 @@
         },
         "root-keys": {
           "title": "The keys to apply the sub schema.",
-          "description": "**[Deprecated]** Please use `root` instead.",
+          "description": "**🚧 Deprecated 🚧**\\\n Please use `schemas[*].root` instead.",
           "type": [
             "string",
             "null"

--- a/tombi.toml
+++ b/tombi.toml
@@ -17,7 +17,11 @@ document-link = { enabled = true }
 
 [schema]
 enabled = true
-catalog = { path = "https://www.schemastore.org/api/json/catalog.json" }
+catalog = {
+  paths = [
+    "https://www.schemastore.org/api/json/catalog.json",
+  ],
+}
 
 [[schemas]]
 path = "tombi.schema.json"


### PR DESCRIPTION
`schema.catalog.path` -> `schema.catalog.paths` in `tombi.toml`.

- Refactored schema catalog to use an array of paths instead of a single path.
- Updated related documentation and tests to reflect the new structure.
- Deprecated the old path field in favor of the new paths array.