### PR TITLE
ci: increase timeout for VSCode extension publishing

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -115,7 +115,7 @@ jobs:
         run: npx ovsx publish --no-dependencies --pat ${{ secrets.OPEN_VSX_ACCESS_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
         if: startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
-        timeout-minutes: 2
+        timeout-minutes: 5
 
       - name: Upload tombi-cli artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updated the timeout for the VSCode extension publishing step from 2 to 5 minutes to accommodate longer processing times.