### PR TITLE
refactor: change tooltip type to Cow for DocumentLink

### DIFF
--- a/crates/tombi-extension/src/document_link.rs
+++ b/crates/tombi-extension/src/document_link.rs
@@ -1,8 +1,10 @@
+use std::borrow::Cow;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DocumentLink {
     pub target: tower_lsp::lsp_types::Url,
     pub range: tombi_text::Range,
-    pub tooltip: String,
+    pub tooltip: Cow<'static, str>,
 }
 
 impl From<DocumentLink> for tower_lsp::lsp_types::DocumentLink {
@@ -10,7 +12,7 @@ impl From<DocumentLink> for tower_lsp::lsp_types::DocumentLink {
         tower_lsp::lsp_types::DocumentLink {
             range: value.range.into(),
             target: Some(value.target),
-            tooltip: Some(value.tooltip),
+            tooltip: Some(value.tooltip.into_owned()),
             data: None,
         }
     }

--- a/crates/tombi-lsp/src/handler/document_link.rs
+++ b/crates/tombi-lsp/src/handler/document_link.rs
@@ -41,7 +41,7 @@ pub async fn handle_document_link(
     if let Some((Ok(schema_url), range)) =
         root.file_schema_url(text_document.uri.to_file_path().ok().as_deref())
     {
-        let tooltip = "Open JSON Schema".to_string();
+        let tooltip = "Open JSON Schema".into();
         document_links.push(
             tombi_extension::DocumentLink {
                 range,

--- a/extensions/tombi-extension-tombi/src/document_link.rs
+++ b/extensions/tombi-extension-tombi/src/document_link.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use tombi_config::TomlVersion;
 use tombi_document_tree::dig_keys;
 use tower_lsp::lsp_types::TextDocumentIdentifier;
@@ -7,12 +9,30 @@ pub enum DocumentLinkToolTip {
     Schema,
 }
 
+impl Into<&'static str> for &DocumentLinkToolTip {
+    fn into(self) -> &'static str {
+        match self {
+            DocumentLinkToolTip::Catalog => "Open JSON Schema Catalog",
+            DocumentLinkToolTip::Schema => "Open JSON Schema",
+        }
+    }
+}
+
+impl Into<&'static str> for DocumentLinkToolTip {
+    fn into(self) -> &'static str {
+        (&self).into()
+    }
+}
+
+impl Into<Cow<'static, str>> for DocumentLinkToolTip {
+    fn into(self) -> Cow<'static, str> {
+        Cow::Borrowed(self.into())
+    }
+}
+
 impl std::fmt::Display for DocumentLinkToolTip {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DocumentLinkToolTip::Catalog => write!(f, "Open JSON Schema Catalog"),
-            DocumentLinkToolTip::Schema => write!(f, "Open JSON Schema"),
-        }
+        write!(f, "{}", Into::<&'static str>::into(self))
     }
 }
 
@@ -53,7 +73,7 @@ pub async fn document_link(
                 document_links.push(tombi_extension::DocumentLink {
                     target,
                     range: path.unquoted_range(),
-                    tooltip: DocumentLinkToolTip::Catalog.to_string(),
+                    tooltip: DocumentLinkToolTip::Catalog.into(),
                 });
             }
         }
@@ -71,7 +91,7 @@ pub async fn document_link(
                 document_links.push(tombi_extension::DocumentLink {
                     target,
                     range: path.unquoted_range(),
-                    tooltip: DocumentLinkToolTip::Catalog.to_string(),
+                    tooltip: DocumentLinkToolTip::Catalog.into(),
                 });
             }
         }
@@ -94,7 +114,7 @@ pub async fn document_link(
             document_links.push(tombi_extension::DocumentLink {
                 target,
                 range: path.unquoted_range(),
-                tooltip: DocumentLinkToolTip::Schema.to_string(),
+                tooltip: DocumentLinkToolTip::Schema.into(),
             });
         }
     }


### PR DESCRIPTION
Updated the tooltip field in DocumentLink to use Cow<'static, str> for better memory management and flexibility. Adjusted related code to ensure compatibility with the new type.