### PR TITLE
refactor: replace IndexMap with HashMap for memory efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,7 +2190,6 @@ name = "tombi-json-arena"
 version = "0.0.0-dev"
 dependencies = [
  "ahash",
- "indexmap",
  "thiserror",
  "tombi-json-lexer",
  "tombi-json-syntax",

--- a/crates/tombi-json-arena/Cargo.toml
+++ b/crates/tombi-json-arena/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 
 [dependencies]
 ahash.workspace = true
-indexmap.workspace = true
 thiserror.workspace = true
 tombi-json-lexer.workspace = true
 tombi-json-syntax.workspace = true

--- a/crates/tombi-json-arena/src/arena/object.rs
+++ b/crates/tombi-json-arena/src/arena/object.rs
@@ -1,9 +1,10 @@
 use super::{StrId, ValueId};
-use indexmap::IndexMap;
+use ahash::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectArena {
-    data: Vec<IndexMap<StrId, ValueId>>,
+    /// Note that this is not an IndexMap. We prioritize memory efficiency since it is only used for interpreting JSON Schema.
+    data: Vec<HashMap<StrId, ValueId>>,
 }
 
 impl ObjectArena {
@@ -11,13 +12,13 @@ impl ObjectArena {
         ObjectArena { data: Vec::new() }
     }
 
-    pub fn insert(&mut self, object: IndexMap<StrId, ValueId>) -> ObjectId {
+    pub fn insert(&mut self, object: HashMap<StrId, ValueId>) -> ObjectId {
         let id = ObjectId(self.data.len());
         self.data.push(object);
         id
     }
 
-    pub fn get(&self, id: ObjectId) -> Option<&IndexMap<StrId, ValueId>> {
+    pub fn get(&self, id: ObjectId) -> Option<&HashMap<StrId, ValueId>> {
         self.data.get(id.0)
     }
 }

--- a/crates/tombi-json-arena/src/lib.rs
+++ b/crates/tombi-json-arena/src/lib.rs
@@ -14,7 +14,7 @@ pub enum Value {
     Object(ObjectId),
 }
 
-use indexmap::IndexMap;
+use ahash::{HashMap, HashMapExt};
 use tombi_json_lexer::Token;
 use tombi_json_syntax::SyntaxKind;
 
@@ -151,7 +151,7 @@ fn parse_object(
     value_arena: &mut ValueArena,
 ) -> ValueId {
     *pos += 1; // skip {
-    let mut map = IndexMap::new();
+    let mut map = HashMap::new();
     loop {
         while *pos < tokens.len()
             && (tokens[*pos].kind().is_trivia() || tokens[*pos].kind() == SyntaxKind::COMMA)


### PR DESCRIPTION
Updated the ObjectArena structure to use HashMap instead of IndexMap, improving memory efficiency for JSON Schema interpretation. Removed indexmap dependency from Cargo.toml.