### PR TITLE
Fix race condition with pypi release

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -215,6 +215,7 @@ jobs:
   update-dependents:
     name: Notify pre-commit mirror
     runs-on: ubuntu-latest
+    needs: [release-python]
     steps:
       - name: "Update pre-commit mirror"
         uses: actions/github-script@v7


### PR DESCRIPTION
The last [pre-commit mirror update](https://github.com/tombi-toml/tombi-pre-commit/actions/runs/15463061010) was triggered before the package was uploaded to pypi.

This ensures the motify step only run when the pypi upload is done.