### PR TITLE
feat: replace get_tombi_github_schema_url with get_tombi_scheme_content

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -282,7 +282,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>, tower_lsp::jsonrpc::Error> {
         handle_hover(self, params)
             .await
-            .map(|response| response.map(|hover_content| hover_content.into()))
+            .map(|response| response.map(Into::into))
     }
 
     async fn folding_range(

--- a/crates/tombi-lsp/src/goto_definition.rs
+++ b/crates/tombi-lsp/src/goto_definition.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use ahash::AHashMap;
 use itertools::Itertools;
-use tombi_schema_store::get_tombi_github_schema_url;
+use tombi_schema_store::get_tombi_scheme_content;
 use tower_lsp::lsp_types::{
     CreateFile, CreateFileOptions, DocumentChangeOperation, DocumentChanges,
     GotoDefinitionResponse, OneOf, OptionalVersionedTextDocumentIdentifier, ResourceOp,
@@ -63,10 +63,9 @@ pub async fn open_remote_file(
         }
         "tombi" => {
             let remote_url = Url::parse(&format!("untitled://{}", url.path())).unwrap();
-            let Some(github_schema_url) = get_tombi_github_schema_url(url) else {
+            let Some(content) = get_tombi_scheme_content(url) else {
                 return Ok(None);
             };
-            let content = fetch_remote_content(&github_schema_url).await?;
             open_remote_content(backend, &remote_url, content).await?;
             Ok(Some(remote_url))
         }

--- a/crates/tombi-schema-store/src/lib.rs
+++ b/crates/tombi-schema-store/src/lib.rs
@@ -54,3 +54,18 @@ pub fn dig_accessors<'a>(
 
     Some((current_accessor, value))
 }
+
+pub fn get_tombi_scheme_content(schema_url: &url::Url) -> Option<&'static str> {
+    match schema_url.path() {
+        "/json/schemas/cargo.schema.json" => {
+            Some(include_str!("../../../schemas/cargo.schema.json"))
+        }
+        "/json/schemas/pyproject.schema.json" => {
+            Some(include_str!("../../../schemas/pyproject.schema.json"))
+        }
+        "/json/schemas/tombi.schema.json" => {
+            Some(include_str!("../../../schemas/tombi.schema.json"))
+        }
+        _ => None,
+    }
+}

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -1,6 +1,7 @@
 use std::{ops::Deref, str::FromStr, sync::Arc};
 
 use crate::{
+    get_tombi_scheme_content,
     json::{CatalogUrl, JsonCatalog},
     DocumentSchema, HttpClient, SchemaAccessor, SchemaAccessors, SchemaUrl, SourceSchema,
 };
@@ -285,21 +286,10 @@ impl SchemaStore {
                 tombi_json::ValueNode::from_reader(std::io::Cursor::new(bytes))
             }
             "tombi" => {
-                let content = match schema_url.path() {
-                    "/json/schemas/cargo.schema.json" => {
-                        include_str!("../../../schemas/cargo.schema.json")
-                    }
-                    "/json/schemas/pyproject.schema.json" => {
-                        include_str!("../../../schemas/pyproject.schema.json")
-                    }
-                    "/json/schemas/tombi.schema.json" => {
-                        include_str!("../../../schemas/tombi.schema.json")
-                    }
-                    _ => {
-                        return Err(crate::Error::SchemaResourceNotFound {
-                            schema_url: schema_url.to_owned(),
-                        });
-                    }
+                let Some(content) = get_tombi_scheme_content(schema_url) else {
+                    return Err(crate::Error::SchemaResourceNotFound {
+                        schema_url: schema_url.to_owned(),
+                    });
                 };
                 tombi_json::ValueNode::from_str(content)
             }


### PR DESCRIPTION
Updated the schema fetching logic to use the new get_tombi_scheme_content function, improving code clarity and maintainability. Adjusted related usages in the LanguageServer implementation and the SchemaStore.