### PR TITLE
fix: update root_schema_url to return string representation

### DIFF
--- a/crates/tombi-schema-store/src/schema/source_schema.rs
+++ b/crates/tombi-schema-store/src/schema/source_schema.rs
@@ -13,7 +13,10 @@ pub struct SourceSchema {
 
 impl std::fmt::Debug for SourceSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let root_schema_url = self.root_schema.as_ref().map(|schema| &schema.schema_url);
+        let root_schema_url = self
+            .root_schema
+            .as_ref()
+            .map(|schema| schema.schema_url.to_string());
         let sub_schema_url_map = self
             .sub_schema_url_map
             .iter()

--- a/tombi.toml
+++ b/tombi.toml
@@ -20,7 +20,7 @@ enabled = true
 catalog = {
   paths = [
     "tombi:///json/catalog.json",
-    # "https://json.schemastore.org/api/json/catalog.json",
+    "https://json.schemastore.org/api/json/catalog.json",
   ],
 }
 


### PR DESCRIPTION
Updated the root_schema_url in SourceSchema's Debug implementation to return a string representation of the schema URL instead of a reference.