### PR TITLE
feat: add rust toolchain configuration file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "stable"
+components = [
+  "clippy",
+  "rust-analyzer",
+  "rustfmt",
+]


### PR DESCRIPTION
Add a new rust-toolchain.toml file to specify the stable channel and include essential components like clippy, rust-analyzer, and rustfmt.