### PR TITLE
docs: update JSON Schema Store links in documentation

### DIFF
--- a/crates/tombi-schema-store/README.md
+++ b/crates/tombi-schema-store/README.md
@@ -2,5 +2,5 @@
 
 This crate provides the schema store for TOML.
 
-Currently, this depends on [JSON Schema](https://json-schema.org/), and includes schema management and the ability to automatically read schemas from the [JSON Schema Store](https://www.schemastore.org/json/).
+Currently, this depends on [JSON Schema](https://json-schema.org/), and includes schema management and the ability to automatically read schemas from the [JSON Schema Store](https://www.schemastore.org/).
 In the future, it may support [TOML Schema](https://github.com/toml-lang/toml/issues/792), but there is no progress on the specification.

--- a/docs/src/routes/docs/concepts/index.mdx
+++ b/docs/src/routes/docs/concepts/index.mdx
@@ -13,7 +13,7 @@ Let's stop discussing the formatting rules on your team.
 
 TOML is used in multiple programming languages and tools, so it needs to be formatted according to their rules.  
 Don't worry! You don't need to specify the rules,
-Tombi will automatically apply the rules by getting the schema from the [JSON Schema Store](https://www.schemastore.org/json/).
+Tombi will automatically apply the rules by getting the schema from the [JSON Schema Store](https://www.schemastore.org).
 
 Those rules are determined by the schema provider, not your team.  
 Just like new programming languages come with formatters from the beginning, the schema provider determines those rules as well.

--- a/docs/src/routes/docs/json-schema.mdx
+++ b/docs/src/routes/docs/json-schema.mdx
@@ -12,7 +12,7 @@ This section explains how Tombi prioritizes the application of `x-tombi-*` keys 
 
 1. `#:schema` directive in the TOML file's top comment (compatible with [Taplo](https://taplo.tamasfe.dev/configuration/directives.html#the-schema-directive))
 2. JSON Schema specified in [the Tombi configuration file](/docs/configuration#search-priority)
-3. JSON Schema from the [JSON Schema Store](https://www.schemastore.org/json/)
+3. JSON Schema from the [JSON Schema Store](https://www.schemastore.org)
 
 ## Formatting
 ### x-tombi-toml-version


### PR DESCRIPTION
Corrected links to the JSON Schema Store in README and related documents for consistency and accuracy.