### PR TITLE
chore: update schemars version and fix descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ef2a6523400a2228db974a8ddc9e1d3deaa04f51bddd7832ef8d7e531bafcc"
+checksum = "2038a099f2fc8a48cdc0a8a50e106d5563690aab7bbf055be1c343a50887dad2"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2372,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d4e1945a3c9e58edaa708449b026519f7f4197185e1b5dbc689615c1ad724d"
+checksum = "50cbf115b853c2a7748af35f5270fd508da77c351b81dc36178e06cc17a14f17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 ] }
 rstest = { version = "0.25.0" }
 rustc-hash = { version = "2.1.1" }
-schemars = { version = "1.0.0-alpha.17", features = ["preserve_order", "url2"] }
+schemars = { version = "1.0.0-alpha.21", features = ["preserve_order", "url2"] }
 semver = { version = "1.0.26" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/schemas/tombi.schema.json
+++ b/schemas/tombi.schema.json
@@ -2,7 +2,7 @@
   "$id": "https://json.schemastore.org/tombi.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Tombi",
-  "description": "**Tombi** (鳶) is a toolkit for TOML; providing a formatter/linter and language server.\n See the [GitHub repository](https://github.com/tombi-toml/tombi) for more information.",
+  "description": "**Tombi** (鳶) is a toolkit for TOML; providing a formatter/linter and language server.\nSee the [GitHub repository](https://github.com/tombi-toml/tombi) for more information.",
   "type": "object",
   "properties": {
     "format": {
@@ -31,7 +31,7 @@
     },
     "include": {
       "title": "File patterns to include.",
-      "description": "The file match pattern to include in formatting and linting.\n Supports glob pattern.",
+      "description": "The file match pattern to include in formatting and linting.\nSupports glob pattern.",
       "type": [
         "array",
         "null"
@@ -43,7 +43,7 @@
     },
     "exclude": {
       "title": "File patterns to exclude.",
-      "description": "The file match pattern to exclude from formatting and linting.\n Supports glob pattern.",
+      "description": "The file match pattern to exclude from formatting and linting.\nSupports glob pattern.",
       "type": [
         "array",
         "null"
@@ -123,7 +123,7 @@
     },
     "FormatOptions": {
       "title": "Formatter options.",
-      "description": "To avoid needless discussion of formatting rules,\n we do not currently have a configuration item for formatting.",
+      "description": "To avoid needless discussion of formatting rules,\nwe do not currently have a configuration item for formatting.",
       "type": "object",
       "additionalProperties": false,
       "x-tombi-table-keys-order": "schema"
@@ -151,7 +151,7 @@
       "properties": {
         "key-empty": {
           "title": "Key empty.",
-          "description": "Check if the key is empty.\n ```toml\n \"\" = true\n ```",
+          "description": "Check if the key is empty.\n```toml\n\"\" = true\n```",
           "anyOf": [
             {
               "$ref": "#/definitions/SeverityLevelDefaultWarn"
@@ -404,7 +404,7 @@
         },
         "strict": {
           "title": "Enable or disable strict schema validation.",
-          "description": "If `additionalProperties` is not specified in the JSON Schema,\n the strict mode treats it as `additionalProperties: false`,\n which is different from the JSON Schema specification.",
+          "description": "If `additionalProperties` is not specified in the JSON Schema,\nthe strict mode treats it as `additionalProperties: false`,\nwhich is different from the JSON Schema specification.",
           "anyOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
@@ -444,7 +444,7 @@
       "properties": {
         "paths": {
           "title": "The schema catalog path/url array.",
-          "description": "The catalog is evaluated after the schemas specified by [[schemas]].\\\n Schemas are loaded in order from the beginning of the catalog list.",
+          "description": "The catalog is evaluated after the schemas specified by [[schemas]].\\\nSchemas are loaded in order from the beginning of the catalog list.",
           "type": [
             "array",
             "null"
@@ -469,10 +469,10 @@
       "properties": {
         "path": {
           "title": "The schema catalog path or url.",
-          "description": "**🚧 Deprecated 🚧**\\\n Please use `schema.catalog.paths` instead.",
+          "description": "**🚧 Deprecated 🚧**\\\nPlease use `schema.catalog.paths` instead.",
           "anyOf": [
             {
-              "$ref": "#/definitions/OneOrMany_for_SchemaCatalogPath"
+              "$ref": "#/definitions/OneOrMany"
             },
             {
               "type": "null"
@@ -484,7 +484,7 @@
       },
       "additionalProperties": false
     },
-    "OneOrMany_for_SchemaCatalogPath": {
+    "OneOrMany": {
       "anyOf": [
         {
           "$ref": "#/definitions/SchemaCatalogPath"
@@ -531,7 +531,7 @@
         },
         "include": {
           "title": "The file match pattern of the schema.",
-          "description": "The file match pattern to include the target to apply the schema.\n Supports glob pattern.",
+          "description": "The file match pattern to include the target to apply the schema.\nSupports glob pattern.",
           "type": "array",
           "items": {
             "type": "string"
@@ -568,7 +568,7 @@
         },
         "include": {
           "title": "The file match pattern of the sub schema.",
-          "description": "The file match pattern to include the target to apply the sub schema.\n Supports glob pattern.",
+          "description": "The file match pattern to include the target to apply the sub schema.\nSupports glob pattern.",
           "type": "array",
           "items": {
             "type": "string"
@@ -594,7 +594,7 @@
         },
         "include": {
           "title": "The file match pattern of the sub schema.",
-          "description": "The file match pattern to include the target to apply the sub schema.\n Supports glob pattern.",
+          "description": "The file match pattern to include the target to apply the sub schema.\nSupports glob pattern.",
           "type": "array",
           "items": {
             "type": "string"
@@ -603,7 +603,7 @@
         },
         "root-keys": {
           "title": "The keys to apply the sub schema.",
-          "description": "**🚧 Deprecated 🚧**\\\n Please use `schemas[*].root` instead.",
+          "description": "**🚧 Deprecated 🚧**\\\nPlease use `schemas[*].root` instead.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
- Updated schemars and schemars_derive versions to 1.0.0-alpha.21 in Cargo.lock and Cargo.toml.
- Improved formatting of descriptions in tombi.schema.json for better readability.