### PR TITLE
Feature/add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ libcairo.2.dylib
 
 # node
 node_modules
+
+# envrc
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1748970125,
+        "narHash": "sha256-UDyigbDGv8fvs9aS95yzFfOKkEjx1LO3PL3DsKopohA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "323b5746d89e04b22554b061522dfce9e4c49b18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749285348,
@@ -18,9 +51,10 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "wild": "wild"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -43,45 +77,18 @@
         "type": "github"
       }
     },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": [
-          "wild",
-          "nixpkgs"
-        ]
-      },
+    "systems": {
       "locked": {
-        "lastModified": 1749177458,
-        "narHash": "sha256-9HNq3EHZIvvxXQyEn0sYOywcESF1Xqw2Q8J1ZewcXuk=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d58933b88cef7a05e9677e94352fd6fedba402cd",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "wild": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay_2"
-      },
-      "locked": {
-        "lastModified": 1749506444,
-        "narHash": "sha256-5CCo/kWxNjr9jbhB642oc69r3+0Zn+jAl9u6hDkfEEk=",
-        "owner": "davidlattimore",
-        "repo": "wild",
-        "rev": "154544358675316bf82d800cbf843764ebaa9271",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davidlattimore",
-        "repo": "wild",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,91 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "wild": "wild"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749523120,
+        "narHash": "sha256-lEhEK8qE8xto2Wnj4f7R+VRSg7M6tgTTkJVTZ2QxXOI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d0727dbab79c5a28289f3c03e4fac7d5b95bafb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "wild",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749177458,
+        "narHash": "sha256-9HNq3EHZIvvxXQyEn0sYOywcESF1Xqw2Q8J1ZewcXuk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d58933b88cef7a05e9677e94352fd6fedba402cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "wild": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1749506444,
+        "narHash": "sha256-5CCo/kWxNjr9jbhB642oc69r3+0Zn+jAl9u6hDkfEEk=",
+        "owner": "davidlattimore",
+        "repo": "wild",
+        "rev": "154544358675316bf82d800cbf843764ebaa9271",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davidlattimore",
+        "repo": "wild",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,9 +40,20 @@
           p: p.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml
         );
 
+        # All the files in the source directory
+        unfilteredRoot = ./.;
+        src = nixpkgs.lib.fileset.toSource {
+          root = unfilteredRoot;
+          fileset = nixpkgs.lib.fileset.unions [
+            # Default files from crane (Rust and cargo files)
+            (craneLib.fileset.commonCargoSources unfilteredRoot)
+            # Also keep any JSON files
+            (nixpkgs.lib.fileset.fileFilter (file: file.hasExt "json") unfilteredRoot)
+          ];
+        };
+
         tombiPkg = craneLib.buildPackage {
-          pname = "tombi";
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          inherit src;
 
           doCheck = true;
           doNotSign = false;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Nix-flake development environment for my personal website";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    wild = {
+      url = "github:davidlattimore/wild";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      wild,
+    }:
+    let
+      system = "x86_64-linux";
+      overlays = [
+        (import rust-overlay)
+        wild.overlays.default
+      ];
+      pkgs = import nixpkgs {
+        inherit system overlays;
+      };
+
+      wildStdenv = pkgs.useWildLinker pkgs.stdenv;
+    in
+    with pkgs;
+    {
+      devShells.${system}.default = mkShell.override { stdenv = wildStdenv; } {
+        buildInputs = [
+          (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+          clang
+          openssl
+          pkg-config
+        ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,47 +3,67 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };
     };
-
-    wild = {
-      url = "github:davidlattimore/wild";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
     {
       self,
+      crane,
+      flake-utils,
       nixpkgs,
       rust-overlay,
-      wild,
     }:
-    let
-      system = "x86_64-linux";
-      overlays = [
-        (import rust-overlay)
-        wild.overlays.default
-      ];
-      pkgs = import nixpkgs {
-        inherit system overlays;
-      };
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
 
-      wildStdenv = pkgs.useWildLinker pkgs.stdenv;
-    in
-    with pkgs;
-    {
-      devShells.${system}.default = mkShell.override { stdenv = wildStdenv; } {
-        buildInputs = [
-          (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
-          clang
-          openssl
-          pkg-config
-        ];
-      };
-    };
+        craneLib = (crane.mkLib pkgs).overrideToolchain (
+          p: p.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml
+        );
+
+        tombiPkg = craneLib.buildPackage {
+          pname = "tombi";
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
+
+          doCheck = true;
+          doNotSign = false;
+        };
+      in
+      {
+        checks = {
+          inherit tombiPkg;
+        };
+
+        packages.default = tombiPkg;
+
+        devShells.default = craneLib.devShell {
+          # Inherit inputs from checks
+          checks = self.checks.${system};
+
+          packages = with pkgs; [
+            openssl
+            pkg-config
+          ];
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,9 @@
         tombiPkg = craneLib.buildPackage {
           inherit src;
 
-          doCheck = true;
+          # Can't run 'cargo test' after build since nix
+          # doesn't allow for network calls in sandbox
+          doCheck = false;
           doNotSign = false;
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
         tombiPkg = craneLib.buildPackage {
           inherit src;
 
+          pname = "tombi";
           # Can't run 'cargo test' after build since nix
           # doesn't allow for network calls in sandbox
           doCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Nix-flake development environment for my personal website";
+  description = "Nix-flake development environment for tombi";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
## What?

This PR addresses issue #305 and makes it possible for Nix users to use `tombi`

## How?

This PR adds the following files:

`flake.nix` -> the recipe for how to actually build `tombi` both as an executable package as well as locally in a development shell
`flake.lock` -> metadata that pins exact dependency versions in the `flake.nix` so things don't break all of a sudden
`.envrc` -> allows contributors with Nix to simply run `direnv allow .` in the directory and BOOM, they can build `tombi`

The PR also adds `.direnv/` to the `.gitignore` file. As far as I know, this directory contains all of the stuff that Nix uses to facilitate the dev shell environment for working on `tombi`.

## What does this look like in practice?

[As of 10 minutes ago, I'm using `tombi` in my own .dotfiles](https://github.com/johnDeSilencio/NicksOS/commit/42a2644d614b6d5998991764596eb4449e40c8f7)

---

I've been using NixOS as my daily driver for over a year now, but Nix is _so_ hard to read - let alone write. I know you said that you aren't a Nix user, but if anyone has suggestions on how I can improve this flake, I'm all ears!

@ya7010 amazing work you've done here! I much prefer this to `taplo`. Open source is often a thankless job - thank you for all of your hard work on this super cool language server :)

- Nick