### PR TITLE
feat: add workspace code action for Cargo.toml

### DIFF
--- a/crates/tombi-schema-store/src/accessor.rs
+++ b/crates/tombi-schema-store/src/accessor.rs
@@ -55,6 +55,15 @@ impl PartialEq<SchemaAccessor> for Accessor {
     }
 }
 
+impl PartialEq<&str> for Accessor {
+    fn eq(&self, other: &&str) -> bool {
+        match self {
+            Accessor::Key(key) => key == *other,
+            _ => false,
+        }
+    }
+}
+
 /// A collection of `Accessor`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Accessors(Vec<Accessor>);

--- a/extensions/tombi-extension-cargo/src/code_action.rs
+++ b/extensions/tombi-extension-cargo/src/code_action.rs
@@ -17,6 +17,10 @@ pub fn code_action(
 
     let mut code_actions = Vec::new();
 
+    if let Some(action) = workspace_code_action(text_document, document_tree, accessors, contexts) {
+        code_actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
     if let Some(action) =
         crate_version_code_action(text_document, document_tree, accessors, contexts)
     {
@@ -28,6 +32,79 @@ pub fn code_action(
     } else {
         Some(code_actions)
     })
+}
+
+fn workspace_code_action(
+    text_document: &TextDocumentIdentifier,
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    _contexts: &[AccessorContext],
+) -> Option<CodeAction> {
+    if accessors.len() < 2 {
+        return None;
+    }
+
+    if !matches!(accessors.get(0), Some(a) if a == &"package") {
+        return None;
+    }
+
+    let Accessor::Key(key) = &accessors[1] else {
+        return None;
+    };
+
+    if ![
+        "authors",
+        "categories",
+        "description",
+        "documentation",
+        "edition",
+        "exclude",
+        "homepage",
+        "include",
+        "keywords",
+        "license-file",
+        "license",
+        "publish",
+        "readme",
+        "repository",
+        "rust-version",
+        "version",
+    ]
+    .contains(&key.as_str())
+    {
+        return None;
+    }
+
+    let Some((_, value)) = dig_accessors(document_tree, &accessors[..2]) else {
+        return None;
+    };
+
+    if let tombi_document_tree::Value::Table(table) = value {
+        if table.get("workspace").is_some() {
+            return None; // Workspace already exists
+        }
+    };
+
+    return Some(CodeAction {
+        title: "Use inherited workspace settings".to_string(),
+        kind: Some(tower_lsp::lsp_types::CodeActionKind::REFACTOR_REWRITE),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: text_document.clone().uri,
+                    version: None,
+                },
+                edits: vec![OneOf::Left(TextEdit {
+                    range: value.symbol_range().into(),
+                    new_text: "{ workspace = true }".to_string(),
+                })],
+            }])),
+            change_annotations: None,
+        }),
+        ..Default::default()
+    });
 }
 
 fn crate_version_code_action(


### PR DESCRIPTION
Implement a new code action that suggests using inherited workspace settings in Cargo.toml files. This includes checks for existing workspace settings and validates accessor keys.