### PR TITLE
feat: add document link tests for root package in Cargo.toml

### DIFF
--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -256,6 +256,49 @@ mod document_link_tests {
                 }
             ]));
         );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn cargo_root_package(
+                r#"
+                [package]
+                name = "root-package"
+                version = "0.1.0"
+
+                [dependencies]
+                tombi-ast = { workspace = true }
+
+                [workspace]
+                members = ["crates/*"]
+
+                [workspace.dependencies]
+                serde = "1.0"
+                tombi-ast = { path = "crates/tombi-ast" }
+                "#,
+                project_root_path().join("Cargo.toml"),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://crates.io/crates/serde",
+                    range: 11:0..11:5,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CrateIo,
+                },
+                {
+                    path: project_root_path().join("crates/tombi-ast/Cargo.toml"),
+                    range: 12:0..12:9,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CargoToml,
+                },
+                {
+                    path: project_root_path().join("crates/tombi-ast/Cargo.toml"),
+                    range: 12:22..12:38,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CargoToml,
+                },
+                {
+                    path: project_root_path().join("crates/tombi-ast/Cargo.toml"),
+                    range: 8:12..8:20,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CargoTomlFirstMember,
+                },
+            ]));
+        );
     }
 
     mod tombi_schema {

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -81,6 +81,16 @@ pub async fn document_link(
             &cargo_toml_path,
             toml_version,
         )?);
+
+        // For Root Package
+        // See: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
+        if document_tree.contains_key("package") {
+            document_links.extend(document_link_for_crate_cargo_toml(
+                document_tree,
+                &cargo_toml_path,
+                toml_version,
+            )?);
+        }
     } else {
         document_links.extend(document_link_for_crate_cargo_toml(
             document_tree,


### PR DESCRIPTION
Fix: https://github.com/tombi-toml/tombi/issues/544

- Implemented new tests for document links in the root package of a Cargo workspace.
- Enhanced the document link functionality to support links for dependencies defined in the root package.