### PR TITLE
fix: correct debug message path in load_with_path function

### DIFF
--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -145,7 +145,7 @@ pub fn load_with_path() -> Result<(Config, Option<std::path::PathBuf>), tombi_co
             match try_from_path(&pyproject_toml_path)? {
                 Some(config) => return Ok((config, Some(pyproject_toml_path))),
                 None => {
-                    tracing::debug!("No [tool.tombi] found in {:?}", &config_path);
+                    tracing::debug!("No [tool.tombi] found in {:?}", &pyproject_toml_path);
                 }
             };
         }


### PR DESCRIPTION
Updated the debug message in the load_with_path function to reference the correct variable for the TOML configuration path.