### PR TITLE
feat: add error and warning codes for diagnostics

### DIFF
--- a/crates/tombi-diagnostic/examples/diagnostics.rs
+++ b/crates/tombi-diagnostic/examples/diagnostics.rs
@@ -38,8 +38,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let source_file = source_file();
 
-    let warning = Diagnostic::new_warning("Some warning occured.".to_owned(), ((2, 1), (2, 3)));
-    let error = Diagnostic::new_error("Some error occured.".to_owned(), ((2, 1), (2, 3)));
+    let warning = Diagnostic::new_warning(
+        "Some warning occured.",
+        "tombi-diagnostic",
+        ((2, 1), (2, 3)),
+    );
+    let error = Diagnostic::new_error("Some error occured.", "tombi-diagnostic", ((2, 1), (2, 3)));
 
     warning.print(&mut Pretty);
     warning.with_source_file(&source_file).print(&mut Pretty);

--- a/crates/tombi-diagnostic/src/lib.rs
+++ b/crates/tombi-diagnostic/src/lib.rs
@@ -7,6 +7,7 @@ pub use printer::Print;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Diagnostic {
     level: level::Level,
+    code: String,
     message: String,
     range: tombi_text::Range,
     source_file: Option<std::path::PathBuf>,
@@ -14,9 +15,14 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     #[inline]
-    pub fn new_warning(message: impl Into<String>, range: impl Into<tombi_text::Range>) -> Self {
+    pub fn new_warning(
+        message: impl Into<String>,
+        code: impl Into<String>,
+        range: impl Into<tombi_text::Range>,
+    ) -> Self {
         Self {
             level: level::Level::WARNING,
+            code: code.into(),
             message: message.into(),
             range: range.into(),
             source_file: None,
@@ -24,9 +30,14 @@ impl Diagnostic {
     }
 
     #[inline]
-    pub fn new_error(message: impl Into<String>, range: impl Into<tombi_text::Range>) -> Self {
+    pub fn new_error(
+        message: impl Into<String>,
+        code: impl Into<String>,
+        range: impl Into<tombi_text::Range>,
+    ) -> Self {
         Self {
             level: level::Level::ERROR,
+            code: code.into(),
             message: message.into(),
             range: range.into(),
             source_file: None,

--- a/crates/tombi-document-tree/src/error.rs
+++ b/crates/tombi-document-tree/src/error.rs
@@ -83,6 +83,24 @@ impl Error {
         self.to_string()
     }
 
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::DuplicateKey { .. } => "duplicate-key",
+            Self::ConflictTable { .. } => "conflict-table",
+            Self::ConflictArray { .. } => "conflict-array",
+            Self::ParseIntError { .. } => "parse-int-error",
+            Self::ParseFloatError { .. } => "parse-float-error",
+            Self::ParseStringError { .. } => "parse-string-error",
+            Self::ParseOffsetDateTimeError { .. } => "parse-offset-date-time-error",
+            Self::ParseLocalDateTimeError { .. } => "parse-local-date-time-error",
+            Self::ParseLocalDateError { .. } => "parse-local-date-error",
+            Self::ParseLocalTimeError { .. } => "parse-local-time-error",
+            Self::ParseDateTimeError { .. } => "parse-date-time-error",
+            Self::ParseCommentError { .. } => "parse-comment-error",
+            Self::IncompleteNode { .. } => "incomplete-node",
+        }
+    }
+
     pub fn range(&self) -> tombi_text::Range {
         match self {
             Self::DuplicateKey { range, .. } => *range,
@@ -108,18 +126,20 @@ impl tombi_diagnostic::SetDiagnostics for Error {
         match self {
             Self::ConflictArray { range1, range2 } => {
                 let diagnostic1 =
-                    tombi_diagnostic::Diagnostic::new_error(self.to_message(), range1);
+                    tombi_diagnostic::Diagnostic::new_error(self.to_message(), self.code(), range1);
                 if !diagnostics.contains(&diagnostic1) {
                     diagnostics.push(diagnostic1);
                 }
                 diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
                     self.to_message(),
+                    self.code(),
                     range2,
                 ));
             }
             _ => {
                 diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
                     self.to_message(),
+                    self.code(),
                     self.range(),
                 ));
             }

--- a/crates/tombi-linter/src/error.rs
+++ b/crates/tombi-linter/src/error.rs
@@ -7,10 +7,18 @@ pub struct Error {
     pub range: tombi_text::Range,
 }
 
+impl Error {
+    #[inline]
+    pub fn code(&self) -> &'static str {
+        match self.kind {}
+    }
+}
+
 impl tombi_diagnostic::SetDiagnostics for Error {
     fn set_diagnostics(self, diagnostics: &mut Vec<tombi_diagnostic::Diagnostic>) {
         diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
             self.kind.to_string(),
+            self.code(),
             self.range,
         ))
     }

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -47,8 +47,11 @@ impl<'a> Linter<'a> {
                 Ok(Some(schema)) => Some(schema),
                 Ok(None) => None,
                 Err((err, range)) => {
-                    self.diagnostics
-                        .push(Diagnostic::new_error(err.to_string(), range));
+                    self.diagnostics.push(Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        range,
+                    ));
                     None
                 }
             }

--- a/crates/tombi-linter/src/severity.rs
+++ b/crates/tombi-linter/src/severity.rs
@@ -15,18 +15,30 @@ pub struct Severity {
     pub range: tombi_text::Range,
 }
 
+impl Severity {
+    pub fn code(&self) -> &'static str {
+        match self.kind {
+            SeverityKind::KeyEmpty => "key-empty",
+            SeverityKind::DottedKeysOutOfOrder => "dotted-keys-out-of-order",
+            SeverityKind::TablesOutOfOrder => "tables-out-of-order",
+        }
+    }
+}
+
 impl tombi_diagnostic::SetDiagnostics for Severity {
     fn set_diagnostics(self, diagnostics: &mut Vec<tombi_diagnostic::Diagnostic>) {
         match self.level {
             tombi_config::SeverityLevel::Error => {
                 diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
                     self.kind.to_string(),
+                    self.code(),
                     self.range,
                 ));
             }
             tombi_config::SeverityLevel::Warn => {
                 diagnostics.push(tombi_diagnostic::Diagnostic::new_warning(
                     self.kind.to_string(),
+                    self.code(),
                     self.range,
                 ));
             }

--- a/crates/tombi-parser/src/error.rs
+++ b/crates/tombi-parser/src/error.rs
@@ -91,6 +91,36 @@ impl Error {
         self.kind
     }
 
+    #[inline]
+    pub fn code(&self) -> &'static str {
+        match self.kind {
+            ErrorKind::InvalidKey => "invalid-key",
+            ErrorKind::InvalidBasicString => "invalid-basic-string",
+            ErrorKind::InvalidLiteralString => "invalid-literal-string",
+            ErrorKind::InvalidMultilineBasicString => "invalid-multiline-basic-string",
+            ErrorKind::InvalidMultilineLiteralString => "invalid-multiline-literal-string",
+            ErrorKind::InvalidNumber => "invalid-number",
+            ErrorKind::InvalidOffsetDateTime => "invalid-offset-date-time",
+            ErrorKind::InvalidLocalDateTime => "invalid-local-date-time",
+            ErrorKind::InvalidLocalDate => "invalid-local-date",
+            ErrorKind::InvalidLocalTime => "invalid-local-time",
+            ErrorKind::InvalidLineBreak => "invalid-line-break",
+            ErrorKind::InvalidToken => "invalid-token",
+            ErrorKind::UnknownLine => "unknown-line",
+            ErrorKind::ExpectedKey => "expected-key",
+            ErrorKind::ExpectedValue => "expected-value",
+            ErrorKind::ExpectedEqual => "expected-equal",
+            ErrorKind::ExpectedComma => "expected-comma",
+            ErrorKind::ExpectedBracketEnd => "expected-bracket-end",
+            ErrorKind::ExpectedDoubleBracketEnd => "expected-double-bracket-end",
+            ErrorKind::ExpectedBraceEnd => "expected-brace-end",
+            ErrorKind::ExpectedLineBreak => "expected-line-break",
+            ErrorKind::ForbiddenKeysLastPeriod => "forbidden-keys-last-period",
+            ErrorKind::InlineTableMustSingleLine => "inline-table-must-single-line",
+            ErrorKind::ForbiddenInlineTableLastComma => "forbidden-inline-table-last-comma",
+        }
+    }
+
     pub fn to_message(&self) -> String {
         self.kind.to_string()
     }
@@ -153,6 +183,7 @@ impl tombi_diagnostic::SetDiagnostics for Error {
     fn set_diagnostics(self, diagnostics: &mut Vec<tombi_diagnostic::Diagnostic>) {
         diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
             self.to_message(),
+            self.code(),
             self.range(),
         ));
     }

--- a/crates/tombi-schema-store/src/error.rs
+++ b/crates/tombi-schema-store/src/error.rs
@@ -85,3 +85,35 @@ pub enum Error {
     #[error("schema must be an object: {schema_url}")]
     SchemaMustBeObject { schema_url: SchemaUrl },
 }
+
+impl Error {
+    #[inline]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::DocumentLockError { .. } => "document-lock-error",
+            Self::ReferenceLockError { .. } => "reference-lock-error",
+            Self::SchemaLockError => "schema-lock-error",
+            Self::DefinitionNotFound { .. } => "definition-not-found",
+            Self::CatalogPathConvertUrlFailed { .. } => "catalog-path-convert-url-failed",
+            Self::CatalogUrlFetchFailed { .. } => "catalog-url-fetch-failed",
+            Self::InvalidCatalogFileUrl { .. } => "invalid-catalog-file-url",
+            Self::CatalogFileReadFailed { .. } => "catalog-file-read-failed",
+            Self::UnsupportedSchemaUrl { .. } => "unsupported-schema-url",
+            Self::InvalidSchemaUrl { .. } => "invalid-schema-url",
+            Self::InvalidSchemaUrlOrFilePath { .. } => "invalid-schema-url-or-file-path",
+            Self::SchemaFileNotFound { .. } => "schema-file-not-found",
+            Self::SchemaResourceNotFound { .. } => "schema-resource-not-found",
+            Self::SchemaFileReadFailed { .. } => "schema-file-read-failed",
+            Self::SchemaFileParseFailed { .. } => "schema-file-parse-failed",
+            Self::SchemaFetchFailed { .. } => "schema-fetch-failed",
+            Self::UnsupportedSourceUrl { .. } => "unsupported-source-url",
+            Self::SourceUrlParseFailed { .. } => "source-url-parse-failed",
+            Self::InvalidFilePath { .. } => "invalid-file-path",
+            Self::InvalidJsonFormat { .. } => "invalid-json-format",
+            Self::InvalidJsonSchemaReference { .. } => "invalid-json-schema-reference",
+            Self::UnsupportedReference { .. } => "unsupported-reference",
+            Self::UnsupportedUrlSchema { .. } => "unsupported-url-schema",
+            Self::SchemaMustBeObject { .. } => "schema-must-be-object",
+        }
+    }
+}

--- a/crates/tombi-validator/src/error.rs
+++ b/crates/tombi-validator/src/error.rs
@@ -90,9 +90,40 @@ pub struct Error {
     pub range: tombi_text::Range,
 }
 
+impl Error {
+    #[inline]
+    pub fn code(&self) -> &'static str {
+        match self.kind {
+            ErrorKind::KeyRequired { .. } => "key-required",
+            ErrorKind::KeyNotAllowed { .. } => "key-not-allowed",
+            ErrorKind::TypeMismatch { .. } => "type-mismatch",
+            ErrorKind::Const { .. } => "const",
+            ErrorKind::Enumerate { .. } => "enumerate",
+            ErrorKind::MaximumInteger { .. } => "maximum-integer",
+            ErrorKind::MinimumInteger { .. } => "minimum-integer",
+            ErrorKind::ExclusiveMaximumInteger { .. } => "exclusive-maximum-integer",
+            ErrorKind::ExclusiveMinimumInteger { .. } => "exclusive-minimum-integer",
+            ErrorKind::MultipleOfInteger { .. } => "multiple-of-integer",
+            ErrorKind::MaximumFloat { .. } => "maximum-float",
+            ErrorKind::MinimumFloat { .. } => "minimum-float",
+            ErrorKind::ExclusiveMaximumFloat { .. } => "exclusive-maximum-float",
+            ErrorKind::ExclusiveMinimumFloat { .. } => "exclusive-minimum-float",
+            ErrorKind::MultipleOfFloat { .. } => "multiple-of-float",
+            ErrorKind::MaximumLength { .. } => "maximum-length",
+            ErrorKind::MinimumLength { .. } => "minimum-length",
+            ErrorKind::Pattern { .. } => "pattern",
+            ErrorKind::MaxItems { .. } => "max-items",
+            ErrorKind::MinItems { .. } => "min-items",
+            ErrorKind::MaxProperties { .. } => "max-properties",
+            ErrorKind::MinProperties { .. } => "min-properties",
+            ErrorKind::PatternProperty { .. } => "pattern-property",
+        }
+    }
+}
+
 impl From<Error> for tombi_diagnostic::Diagnostic {
     fn from(error: Error) -> Self {
-        tombi_diagnostic::Diagnostic::new_error(error.kind.to_string(), error.range)
+        tombi_diagnostic::Diagnostic::new_error(error.kind.to_string(), error.code(), error.range)
     }
 }
 

--- a/crates/tombi-validator/src/warning.rs
+++ b/crates/tombi-validator/src/warning.rs
@@ -13,10 +13,21 @@ pub struct Warning {
     pub range: tombi_text::Range,
 }
 
+impl Warning {
+    #[inline]
+    pub fn code(&self) -> &'static str {
+        match self.kind {
+            WarningKind::Deprecated { .. } => "deprecated",
+            WarningKind::StrictAdditionalProperties { .. } => "strict-additional-properties",
+        }
+    }
+}
+
 impl tombi_diagnostic::SetDiagnostics for Warning {
     fn set_diagnostics(self, diagnostics: &mut Vec<tombi_diagnostic::Diagnostic>) {
         diagnostics.push(tombi_diagnostic::Diagnostic::new_warning(
             self.kind.to_string(),
+            self.code(),
             self.range,
         ))
     }


### PR DESCRIPTION
This commit introduces a `code` method for the `Error`, `Warning`, and `Severity` structs, allowing for more detailed diagnostics. The `Diagnostic` struct is updated to include a code parameter, enhancing error and warning messages with specific codes. This change improves the clarity and usability of diagnostics throughout the linter and validator components.