### PR TITLE
feat: add linting functionality to tombi-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "tombi-formatter",
  "tombi-future",
  "tombi-lexer",
+ "tombi-linter",
  "tombi-schema-store",
  "tombi-text",
  "tombi-url",

--- a/rust/tombi-wasm/Cargo.toml
+++ b/rust/tombi-wasm/Cargo.toml
@@ -26,6 +26,7 @@ tombi-diagnostic = { workspace = true, features = ["wasm"] }
 tombi-formatter.workspace = true
 tombi-future = { workspace = true, features = ["wasm"] }
 tombi-lexer.workspace = true
+tombi-linter.workspace = true
 tombi-schema-store = { workspace = true, features = ["wasm"] }
 tombi-text = { workspace = true, features = ["wasm"] }
 tombi-url = { workspace = true, features = ["wasm"] }

--- a/rust/tombi-wasm/src/lib.rs
+++ b/rust/tombi-wasm/src/lib.rs
@@ -54,8 +54,6 @@ pub fn format(source: String, file_path: Option<String>, toml_version: Option<St
                 strict: schema_options.and_then(|schema_options| schema_options.strict()),
             });
 
-        tracing::info!("config_path: {:?}", config_path);
-        tracing::info!("config: {:?}", config);
         if let Err(error) = schema_store
             .load_config(&config, config_path.as_deref())
             .await
@@ -88,6 +86,84 @@ pub fn format(source: String, file_path: Option<String>, toml_version: Option<St
     future_to_promise(async move {
         match inner_format(source, file_path, toml_version).await {
             Ok(t) => Ok(JsValue::from_str(&t)),
+            Err(e) => Err(serde_wasm_bindgen::to_value(&e).unwrap()),
+        }
+    })
+}
+
+#[wasm_bindgen]
+pub fn lint(source: String, file_path: Option<String>, toml_version: Option<String>) -> Promise {
+    #[derive(serde::Serialize, Debug)]
+    #[serde(untagged)]
+    #[serde(rename_all = "camelCase")]
+    enum LintError {
+        Error { error: String },
+        Diagnostics { diagnostics: Vec<Diagnostic> },
+    }
+
+    async fn inner_lint(
+        source: String,
+        file_path: Option<String>,
+        toml_version: Option<String>,
+    ) -> Result<(), LintError> {
+        let toml_version = match toml_version {
+            Some(v) => match TomlVersion::from_str(&v) {
+                Some(v) => v,
+                None => {
+                    return Err(LintError::Error {
+                        error: "Invalid TOML version".to_string(),
+                    });
+                }
+            },
+            None => TomlVersion::default(),
+        };
+
+        let (config, config_path) = match serde_tombi::config::load_with_path() {
+            Ok((config, config_path)) => (config, config_path),
+            Err(err) => {
+                return Err(LintError::Error {
+                    error: err.to_string(),
+                });
+            }
+        };
+
+        let schema_options = config.schema.as_ref();
+        let schema_store =
+            tombi_schema_store::SchemaStore::new_with_options(tombi_schema_store::Options {
+                offline: None,
+                strict: schema_options.and_then(|schema_options| schema_options.strict()),
+            });
+
+        if let Err(error) = schema_store
+            .load_config(&config, config_path.as_deref())
+            .await
+            .map_err(|e| e.to_string())
+        {
+            return Err(LintError::Error { error });
+        }
+
+        let lint_options = config.lint.clone().unwrap_or_default();
+
+        let file_path_buf = file_path.map(|path| std::path::PathBuf::from(path));
+        match tombi_linter::Linter::new(
+            toml_version,
+            &lint_options,
+            file_path_buf
+                .as_deref()
+                .map(|path| itertools::Either::Right(path)),
+            &schema_store,
+        )
+        .lint(&source)
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(diagnostics) => Err(LintError::Diagnostics { diagnostics }),
+        }
+    }
+
+    future_to_promise(async move {
+        match inner_lint(source, file_path, toml_version).await {
+            Ok(_) => Ok(JsValue::NULL),
             Err(e) => Err(serde_wasm_bindgen::to_value(&e).unwrap()),
         }
     })

--- a/rust/tombi-wasm/www/index.html
+++ b/rust/tombi-wasm/www/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Formatter Demo</title>
+        <title>Tombi Playground (WASM)</title>
         <style>
             body { font-family: sans-serif; margin: 2rem; }
             textarea { width: 100%; height: 10rem; }
@@ -10,7 +10,7 @@
         </style>
     </head>
     <body>
-        <h1>TOML Formatter (WASM)</h1>
+        <h1>TOML Playground (WASM)</h1>
 
         <label>
             File name:
@@ -25,24 +25,29 @@
         </label>
         <br>
 
-        <button id="run">Format</button>
+        <button id="run">Run</button>
 
         <h2>Result</h2>
         <pre id="output"></pre>
 
         <script type="module">
-            import init, { format } from "./pkg/tombi_wasm.js";
+            import init, { format, lint } from "./pkg/tombi_wasm.js";
 
             init().then(() => {
                 document.getElementById("run").onclick = async () => {
                     const filename = document.getElementById("file-name").value;
-                    const text = document.getElementById("content").value;
+                    const content = document.getElementById("content");
                     const output = document.getElementById("output");
 
                     try {
-                        const result = await format(text, filename);
+                        const new_content = await format(content.value, filename);
 
-                        output.textContent = result.toString();
+                        content.value = new_content;
+                    } catch (error) {
+                    }
+                    try {
+                        await lint(content.value, filename);
+                        output.textContent = "";
                     } catch (error) {
                         output.textContent = JSON.stringify(error, null, 2);
                     }


### PR DESCRIPTION
- Introduced a new `lint` function to perform linting on TOML files.
- Updated the HTML interface to include linting capabilities.
- Added `tombi-linter` as a workspace dependency.
- Modified the title and header in the HTML for better clarity.