### PR TITLE
Add `cargo-shear`

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -27,3 +27,16 @@ jobs:
       run: cargo build --verbose --locked
     - name: Run tests
       run: cargo nextest run --verbose --locked
+
+  cargo-shear:
+    name: "cargo shear"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: cargo-bins/cargo-binstall@v1.14.1
+      - run: cargo binstall --no-confirm cargo-shear
+      - run: cargo shear

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,12 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,33 +503,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -728,42 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,12 +712,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1343,16 +1262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,17 +1697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,15 +1723,6 @@ dependencies = [
  "tracing-futures",
  "url",
  "waker-fn",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2008,12 +1897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,12 +1995,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -2238,34 +2115,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "polling"
@@ -2944,10 +2793,8 @@ version = "0.0.0-dev"
 dependencies = [
  "chrono",
  "dirs",
- "futures",
  "indexmap",
- "itertools 0.14.0",
- "maplit",
+ "itertools",
  "pretty_assertions",
  "serde",
  "textwrap",
@@ -2956,14 +2803,12 @@ dependencies = [
  "tombi-ast",
  "tombi-config",
  "tombi-date-time",
- "tombi-diagnostic",
  "tombi-document",
  "tombi-document-tree",
  "tombi-formatter",
  "tombi-parser",
  "tombi-schema-store",
  "tombi-test-lib",
- "tombi-text",
  "tombi-toml-text",
  "tombi-toml-version",
  "tombi-url",
@@ -3394,16 +3239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,14 +3311,12 @@ version = "0.0.0-dev"
 name = "tombi-ast"
 version = "0.0.0-dev"
 dependencies = [
- "itertools 0.14.0",
- "thiserror 2.0.12",
+ "itertools",
  "tombi-syntax",
  "tombi-text",
  "tombi-toml-text",
  "tombi-toml-version",
  "tombi-url",
- "tracing",
  "url",
 ]
 
@@ -3491,10 +3324,8 @@ dependencies = [
 name = "tombi-ast-editor"
 version = "0.0.0-dev"
 dependencies = [
- "ahash",
- "futures",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "regex",
  "thiserror 2.0.12",
  "tombi-ast",
@@ -3503,7 +3334,6 @@ dependencies = [
  "tombi-parser",
  "tombi-schema-store",
  "tombi-syntax",
- "tombi-text",
  "tombi-toml-version",
  "tombi-validator",
  "tombi-version-sort",
@@ -3528,9 +3358,8 @@ version = "0.0.0-dev"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
- "itertools 0.14.0",
+ "itertools",
  "nu-ansi-term 0.50.1",
- "rayon",
  "regex",
  "serde_tombi",
  "thiserror 2.0.12",
@@ -3545,14 +3374,12 @@ dependencies = [
  "tombi-schema-store",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]
 name = "tombi-config"
 version = "0.0.0-dev"
 dependencies = [
- "clap",
  "pretty_assertions",
  "schemars",
  "serde",
@@ -3560,7 +3387,6 @@ dependencies = [
  "tombi-toml-version",
  "tombi-url",
  "tombi-x-keyword",
- "tracing",
  "url",
 ]
 
@@ -3574,7 +3400,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]
@@ -3585,10 +3410,8 @@ dependencies = [
  "clap-verbosity-flag",
  "nu-ansi-term 0.50.1",
  "serde",
- "thiserror 2.0.12",
  "tombi-text",
  "tower-lsp",
- "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
 ]
@@ -3597,9 +3420,8 @@ dependencies = [
 name = "tombi-document"
 version = "0.0.0-dev"
 dependencies = [
- "chrono",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3611,10 +3433,7 @@ dependencies = [
  "tombi-parser",
  "tombi-test-lib",
  "tombi-text",
- "tombi-toml-text",
  "tombi-toml-version",
- "tower-lsp",
- "tracing",
 ]
 
 [[package]]
@@ -3623,7 +3442,7 @@ version = "0.0.0-dev"
 dependencies = [
  "chrono",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "thiserror 2.0.12",
  "tombi-ast",
  "tombi-date-time",
@@ -3631,7 +3450,6 @@ dependencies = [
  "tombi-text",
  "tombi-toml-text",
  "tombi-toml-version",
- "tracing",
 ]
 
 [[package]]
@@ -3649,7 +3467,7 @@ version = "0.0.0-dev"
 dependencies = [
  "ahash",
  "glob",
- "itertools 0.14.0",
+ "itertools",
  "serde",
  "serde_json",
  "tombi-ast",
@@ -3675,7 +3493,6 @@ dependencies = [
  "tombi-schema-store",
  "tombi-text",
  "tower-lsp",
- "tracing",
 ]
 
 [[package]]
@@ -3683,24 +3500,22 @@ name = "tombi-extension-uv"
 version = "0.0.0-dev"
 dependencies = [
  "glob",
- "itertools 0.14.0",
+ "itertools",
  "tombi-ast",
  "tombi-config",
  "tombi-document-tree",
  "tombi-extension",
  "tombi-parser",
  "tombi-schema-store",
- "tombi-test-lib",
  "tombi-text",
  "tower-lsp",
- "tracing",
 ]
 
 [[package]]
 name = "tombi-formatter"
 version = "0.0.0-dev"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "rstest",
  "schemars",
@@ -3711,15 +3526,11 @@ dependencies = [
  "tombi-ast-editor",
  "tombi-config",
  "tombi-diagnostic",
- "tombi-document-tree",
- "tombi-json",
  "tombi-parser",
  "tombi-schema-store",
  "tombi-syntax",
  "tombi-test-lib",
- "tombi-text",
  "tracing",
- "tracing-subscriber",
  "unicode-segmentation",
  "url",
 ]
@@ -3735,7 +3546,6 @@ dependencies = [
 name = "tombi-glob"
 version = "0.0.0-dev"
 dependencies = [
- "criterion",
  "fast-glob",
  "ignore",
  "rayon",
@@ -3743,7 +3553,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tombi-config",
- "tracing",
 ]
 
 [[package]]
@@ -3751,7 +3560,7 @@ name = "tombi-json"
 version = "0.0.0-dev"
 dependencies = [
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "serde",
  "thiserror 2.0.12",
@@ -3759,19 +3568,16 @@ dependencies = [
  "tombi-json-syntax",
  "tombi-json-value",
  "tombi-text",
- "tracing",
 ]
 
 [[package]]
 name = "tombi-json-lexer"
 version = "0.0.0-dev"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "regex",
- "rstest",
  "textwrap",
- "thiserror 2.0.12",
  "tombi-json-syntax",
  "tombi-test-lib",
  "tombi-text",
@@ -3782,7 +3588,6 @@ dependencies = [
 name = "tombi-json-syntax"
 version = "0.0.0-dev"
 dependencies = [
- "pretty_assertions",
  "tombi-rg-tree",
 ]
 
@@ -3793,19 +3598,16 @@ dependencies = [
  "indexmap",
  "pretty_assertions",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "tombi-lexer"
 version = "0.0.0-dev"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "regex",
- "rstest",
  "textwrap",
- "thiserror 2.0.12",
  "tombi-syntax",
  "tombi-test-lib",
  "tombi-text",
@@ -3817,12 +3619,8 @@ name = "tombi-linter"
 version = "0.0.0-dev"
 dependencies = [
  "ahash",
- "futures",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
- "regex",
- "schemars",
- "serde",
  "thiserror 2.0.12",
  "tokio",
  "tombi-ast",
@@ -3831,12 +3629,9 @@ dependencies = [
  "tombi-document-tree",
  "tombi-parser",
  "tombi-schema-store",
- "tombi-syntax",
  "tombi-test-lib",
  "tombi-text",
  "tombi-validator",
- "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -3848,28 +3643,23 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "futures-util",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "regex",
  "reqwest",
  "rstest",
- "rustc-hash",
  "semver 1.0.26",
  "serde",
- "serde_json",
  "serde_tombi",
  "tempfile",
  "textwrap",
- "thiserror 2.0.12",
  "tokio",
  "tombi-ast",
  "tombi-cache",
  "tombi-config",
  "tombi-date-time",
  "tombi-diagnostic",
- "tombi-document",
  "tombi-document-tree",
  "tombi-extension",
  "tombi-extension-cargo",
@@ -3890,7 +3680,6 @@ dependencies = [
  "tombi-x-keyword",
  "tower-lsp",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3898,21 +3687,16 @@ name = "tombi-parser"
 version = "0.0.0-dev"
 dependencies = [
  "drop_bomb",
- "itertools 0.14.0",
  "pretty_assertions",
- "rstest",
  "textwrap",
  "thiserror 2.0.12",
  "tombi-ast",
  "tombi-config",
  "tombi-diagnostic",
- "tombi-document-tree",
  "tombi-lexer",
  "tombi-rg-tree",
  "tombi-syntax",
  "tombi-text",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3921,7 +3705,7 @@ version = "0.0.0-dev"
 dependencies = [
  "countme",
  "hashbrown 0.15.3",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "rustc-hash",
  "tombi-text",
@@ -3932,15 +3716,13 @@ name = "tombi-schema-store"
 version = "0.0.0-dev"
 dependencies = [
  "ahash",
- "async-trait",
  "bytes 1.10.1",
  "futures",
  "glob",
  "gloo-net",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
- "regex",
  "reqwest",
  "rstest",
  "serde",
@@ -3951,7 +3733,6 @@ dependencies = [
  "tombi-ast",
  "tombi-cache",
  "tombi-config",
- "tombi-document",
  "tombi-document-tree",
  "tombi-future",
  "tombi-json",
@@ -3966,10 +3747,8 @@ dependencies = [
 name = "tombi-syntax"
 version = "0.0.0-dev"
 dependencies = [
- "rstest",
  "thiserror 2.0.12",
  "tombi-rg-tree",
- "tombi-text",
 ]
 
 [[package]]
@@ -3977,7 +3756,6 @@ name = "tombi-test-lib"
 version = "0.0.0-dev"
 dependencies = [
  "chrono",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -4021,8 +3799,7 @@ dependencies = [
 name = "tombi-validator"
 version = "0.0.0-dev"
 dependencies = [
- "futures",
- "itertools 0.14.0",
+ "itertools",
  "regex",
  "thiserror 2.0.12",
  "tombi-diagnostic",
@@ -4037,7 +3814,7 @@ dependencies = [
 name = "tombi-version-sort"
 version = "0.0.0-dev"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
 ]
 
 [[package]]
@@ -4045,28 +3822,16 @@ name = "tombi-wasm"
 version = "0.0.0-dev"
 dependencies = [
  "console_error_panic_hook",
- "getrandom 0.3.3",
- "itertools 0.14.0",
+ "itertools",
  "js-sys",
- "log",
- "nu-ansi-term 0.50.1",
  "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "serde_tombi",
- "tokio",
  "tombi-config",
  "tombi-diagnostic",
  "tombi-formatter",
- "tombi-future",
- "tombi-lexer",
  "tombi-linter",
  "tombi-schema-store",
- "tombi-text",
- "tombi-url",
- "tracing",
- "tracing-subscriber",
- "tracing-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4075,8 +3840,6 @@ dependencies = [
 name = "tombi-x-keyword"
 version = "0.0.0-dev"
 dependencies = [
- "clap",
- "itertools 0.14.0",
  "schemars",
  "serde",
 ]
@@ -4086,10 +3849,8 @@ name = "toml-test"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "indexmap",
- "itertools 0.14.0",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -4097,7 +3858,6 @@ dependencies = [
  "tombi-ast",
  "tombi-document-tree",
  "tombi-parser",
- "tombi-text",
  "tombi-toml-version",
 ]
 
@@ -4263,17 +4023,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
-dependencies = [
- "tracing",
- "tracing-subscriber",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4969,14 +4718,13 @@ dependencies = [
  "clap",
  "convert_case",
  "flate2",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "proc-macro2",
  "quote",
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
  "time 0.3.41",
  "tombi-config",
  "ungrammar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bytes = "1.10.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive", "env", "string"] }
 clap-verbosity-flag = "3.0.2"
-compact_str = "0.9.0"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"
 countme = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ license = "MIT"
 [workspace.dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.98"
-async-trait = "0.1.88"
 bytes = "1.10.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive", "env", "string"] }
@@ -38,14 +37,11 @@ compact_str = "0.9.0"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"
 countme = "3.0.1"
-criterion = "0.5"
 dirs = { version = "6.0.0" }
 drop_bomb = "0.1.5"
 fast-glob = "0.3.0"
 flate2 = "1.0.35"
 futures = "0.3.31"
-futures-util = "0.3.31"
-getrandom = "0.3.3"
 glob = "0.3.2"
 gloo-net = "0.6.0"
 hashbrown = "0.15.3"
@@ -53,8 +49,6 @@ ignore = "0.4.20"
 indexmap = { version = "2.9.0", features = ["serde"] }
 itertools = "0.14.0"
 js-sys = "0.3.77"
-log = "0.4.27"
-maplit = { version = "1.0" }
 nu-ansi-term = "0.50.1"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.95"
@@ -68,7 +62,6 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 rstest = { version = "0.25.0" }
 rustc-hash = { version = "2.1.1" }
 schemars = { version = "1.0.2", features = ["preserve_order", "url2"] }
-semver = { version = "1.0.26" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_tombi = { default-features = false, path = "rust/serde_tombi" }
@@ -115,7 +108,6 @@ tombi-x-keyword = { path = "crates/tombi-x-keyword" }
 tower-lsp = { version = "0.20.0" }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tracing-wasm = "0.2.1"
 typed-builder = "0.21.0"
 ungrammar.version = "1.16.1"
 unicode-segmentation = "1.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 rstest = { version = "0.25.0" }
 rustc-hash = { version = "2.1.1" }
 schemars = { version = "1.0.2", features = ["preserve_order", "url2"] }
+semver = { version = "1.0.26" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_tombi = { default-features = false, path = "rust/serde_tombi" }
@@ -117,3 +118,6 @@ wasm-bindgen-futures = "0.4.50"
 xshell.version = "0.2.7"
 zed_extension_api = "0.1.0"
 zip = { version = "2.3.0" }
+
+[workspace.metadata.cargo-shear]
+ignored = ["semver"]

--- a/crates/tombi-ast-editor/Cargo.toml
+++ b/crates/tombi-ast-editor/Cargo.toml
@@ -7,8 +7,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash.workspace = true
-futures.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 regex.workspace = true
@@ -19,7 +17,6 @@ tombi-future.workspace = true
 tombi-parser.workspace = true
 tombi-schema-store.workspace = true
 tombi-syntax.workspace = true
-tombi-text.workspace = true
 tombi-toml-version.workspace = true
 tombi-validator.workspace = true
 tombi-version-sort.workspace = true

--- a/crates/tombi-ast/Cargo.toml
+++ b/crates/tombi-ast/Cargo.toml
@@ -7,11 +7,9 @@ license.workspace = true
 
 [dependencies]
 itertools.workspace = true
-thiserror.workspace = true
 tombi-syntax.workspace = true
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
 tombi-url.workspace = true
-tracing.workspace = true
 url.workspace = true

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -19,7 +19,6 @@ url.workspace = true
 pretty_assertions.workspace = true
 
 [features]
-clap = ["dep:clap"]
-default = ["clap", "serde"]
+default = ["serde"]
 jsonschema = ["dep:schemars", "serde", "tombi-toml-version/jsonschema"]
 serde = ["dep:serde"]

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -7,14 +7,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
 tombi-toml-version.workspace = true
 tombi-url.workspace = true
 tombi-x-keyword.workspace = true
-tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/tombi-date-time/Cargo.toml
+++ b/crates/tombi-date-time/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 chrono = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-diagnostic/Cargo.toml
+++ b/crates/tombi-diagnostic/Cargo.toml
@@ -8,10 +8,8 @@ license.workspace = true
 [dependencies]
 nu-ansi-term.workspace = true
 serde.workspace = true
-thiserror.workspace = true
 tombi-text.workspace = true
 tower-lsp = { workspace = true, optional = true }
-tracing.workspace = true
 wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/tombi-document-tree/Cargo.toml
+++ b/crates/tombi-document-tree/Cargo.toml
@@ -17,7 +17,6 @@ tombi-diagnostic = { workspace = true, optional = true }
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
-tracing.workspace = true
 
 [features]
 default = ["diagnostic"]

--- a/crates/tombi-document/Cargo.toml
+++ b/crates/tombi-document/Cargo.toml
@@ -26,5 +26,5 @@ tombi-test-lib.workspace = true
 
 [features]
 default = ["serde"]
-lsp = ["dep:tower-lsp", "tombi-text/lsp"]
-serde = ["chrono/serde", "dep:serde", "indexmap/serde"]
+lsp = ["tombi-text/lsp"]
+serde = ["dep:serde", "indexmap/serde"]

--- a/crates/tombi-document/Cargo.toml
+++ b/crates/tombi-document/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-chrono.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 serde = { workspace = true, optional = true }
@@ -17,10 +16,7 @@ tombi-date-time.workspace = true
 tombi-document-tree.workspace = true
 tombi-parser.workspace = true
 tombi-text.workspace = true
-tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
-tower-lsp = { workspace = true, optional = true }
-tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -14,12 +14,9 @@ tombi-ast.workspace = true
 tombi-ast-editor.workspace = true
 tombi-config.workspace = true
 tombi-diagnostic.workspace = true
-tombi-document-tree.workspace = true
-tombi-json.workspace = true
 tombi-parser.workspace = true
 tombi-schema-store.workspace = true
 tombi-syntax.workspace = true
-tombi-text.workspace = true
 tracing.workspace = true
 unicode-segmentation.workspace = true
 url.workspace = true
@@ -30,7 +27,6 @@ rstest.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tombi-test-lib.workspace = true
-tracing-subscriber.workspace = true
 
 [features]
 jsonschema = ["dep:schemars", "serde"]

--- a/crates/tombi-glob/Cargo.toml
+++ b/crates/tombi-glob/Cargo.toml
@@ -16,10 +16,8 @@ serde_tombi = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 tombi-config = { workspace = true }
-tracing.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/tombi-json-lexer/Cargo.toml
+++ b/crates/tombi-json-lexer/Cargo.toml
@@ -9,13 +9,11 @@ license.workspace = true
 [dependencies]
 itertools.workspace = true
 regex.workspace = true
-thiserror.workspace = true
 tombi-json-syntax = { path = "../tombi-json-syntax" }
 tombi-text.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-rstest.workspace = true
 textwrap.workspace = true
 tombi-test-lib.workspace = true

--- a/crates/tombi-json-syntax/Cargo.toml
+++ b/crates/tombi-json-syntax/Cargo.toml
@@ -7,5 +7,4 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pretty_assertions.workspace = true
 tombi-rg-tree.workspace = true

--- a/crates/tombi-json-value/Cargo.toml
+++ b/crates/tombi-json-value/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 indexmap.workspace = true
 serde = { workspace = true, optional = true }
-tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -15,7 +15,6 @@ tombi-json-lexer.workspace = true
 tombi-json-syntax.workspace = true
 tombi-json-value.workspace = true
 tombi-text.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-lexer/Cargo.toml
+++ b/crates/tombi-lexer/Cargo.toml
@@ -8,13 +8,11 @@ license.workspace = true
 [dependencies]
 itertools.workspace = true
 regex.workspace = true
-thiserror.workspace = true
 tombi-syntax.workspace = true
 tombi-text.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-rstest.workspace = true
 textwrap.workspace = true
 tombi-test-lib.workspace = true

--- a/crates/tombi-linter/Cargo.toml
+++ b/crates/tombi-linter/Cargo.toml
@@ -7,11 +7,7 @@ license.workspace = true
 
 [dependencies]
 ahash.workspace = true
-futures.workspace = true
 itertools.workspace = true
-regex.workspace = true
-schemars.workspace = true
-serde.workspace = true
 thiserror.workspace = true
 tombi-ast.workspace = true
 tombi-config.workspace = true
@@ -19,14 +15,11 @@ tombi-diagnostic.workspace = true
 tombi-document-tree.workspace = true
 tombi-parser.workspace = true
 tombi-schema-store.workspace = true
-tombi-syntax.workspace = true
 tombi-text.workspace = true
 tombi-validator.workspace = true
-tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tombi-test-lib.workspace = true
-tracing-subscriber.workspace = true

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -14,6 +14,7 @@ indexmap.workspace = true
 itertools.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_tombi.workspace = true
 tokio = { workspace = true, features = ["fs", "io-std", "rt-multi-thread"] }
@@ -55,3 +56,6 @@ clap = ["dep:clap"]
 default = ["clap", "native"]
 native = ["tombi-schema-store/native"]
 wasm = ["tombi-schema-store/wasm"]
+
+[package.metadata.cargo-shear]
+ignored = ["semver"]

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -10,24 +10,18 @@ ahash.workspace = true
 chrono.workspace = true
 clap = { workspace = true, optional = true }
 futures.workspace = true
-futures-util.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-rustc-hash.workspace = true
-semver.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_tombi.workspace = true
-thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "io-std", "rt-multi-thread"] }
 tombi-ast.workspace = true
 tombi-cache.workspace = true
 tombi-config.workspace = true
 tombi-date-time.workspace = true
 tombi-diagnostic.workspace = true
-tombi-document.workspace = true
 tombi-document-tree.workspace = true
 tombi-extension.workspace = true
 tombi-extension-cargo.workspace = true
@@ -47,7 +41,6 @@ tombi-validator.workspace = true
 tombi-x-keyword.workspace = true
 tower-lsp.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-parser/Cargo.toml
+++ b/crates/tombi-parser/Cargo.toml
@@ -7,23 +7,18 @@ license.workspace = true
 
 [dependencies]
 drop_bomb.workspace = true
-itertools.workspace = true
 thiserror.workspace = true
 tombi-ast.workspace = true
 tombi-config.workspace = true
 tombi-diagnostic = { workspace = true, optional = true }
-tombi-document-tree.workspace = true
 tombi-lexer.workspace = true
 tombi-rg-tree.workspace = true
 tombi-syntax.workspace = true
 tombi-text.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-rstest.workspace = true
 textwrap.workspace = true
-tracing-subscriber.workspace = true
 
 [features]
 default = ["diagnostic"]

--- a/crates/tombi-schema-store/Cargo.toml
+++ b/crates/tombi-schema-store/Cargo.toml
@@ -8,14 +8,12 @@ license.workspace = true
 
 [dependencies]
 ahash.workspace = true
-async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
 glob.workspace = true
 gloo-net = { workspace = true, optional = true }
 indexmap.workspace = true
 itertools.workspace = true
-regex.workspace = true
 reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -25,7 +23,6 @@ tokio.workspace = true
 tombi-ast.workspace = true
 tombi-cache.workspace = true
 tombi-config.workspace = true
-tombi-document.workspace = true
 tombi-document-tree.workspace = true
 tombi-future.workspace = true
 tombi-json.workspace = true

--- a/crates/tombi-syntax/Cargo.toml
+++ b/crates/tombi-syntax/Cargo.toml
@@ -6,7 +6,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-rstest.workspace = true
 thiserror.workspace = true
 tombi-rg-tree.workspace = true
-tombi-text.workspace = true

--- a/crates/tombi-test-lib/Cargo.toml
+++ b/crates/tombi-test-lib/Cargo.toml
@@ -8,5 +8,4 @@ license.workspace = true
 
 [dependencies]
 chrono.workspace = true
-tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/tombi-validator/Cargo.toml
+++ b/crates/tombi-validator/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures.workspace = true
 itertools.workspace = true
 regex.workspace = true
 thiserror.workspace = true

--- a/crates/tombi-x-keyword/Cargo.toml
+++ b/crates/tombi-x-keyword/Cargo.toml
@@ -11,7 +11,6 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [features]
-clap = ["dep:clap"]
-default = ["clap", "serde"]
+default = ["serde"]
 jsonschema = ["dep:schemars"]
 serde = ["dep:serde"]

--- a/crates/tombi-x-keyword/Cargo.toml
+++ b/crates/tombi-x-keyword/Cargo.toml
@@ -7,8 +7,6 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { workspace = true, optional = true }
-itertools.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 

--- a/extensions/tombi-extension-tombi/Cargo.toml
+++ b/extensions/tombi-extension-tombi/Cargo.toml
@@ -13,4 +13,3 @@ tombi-extension.workspace = true
 tombi-schema-store.workspace = true
 tombi-text.workspace = true
 tower-lsp.workspace = true
-tracing.workspace = true

--- a/extensions/tombi-extension-uv/Cargo.toml
+++ b/extensions/tombi-extension-uv/Cargo.toml
@@ -18,7 +18,5 @@ tombi-parser.workspace = true
 tombi-schema-store.workspace = true
 tombi-text.workspace = true
 tower-lsp.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
-tombi-test-lib.workspace = true

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -13,6 +13,7 @@ dirs.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 serde.workspace = true
+textwrap.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tombi-ast.workspace = true
@@ -39,3 +40,6 @@ tombi-test-lib.workspace = true
 default = ["native"]
 native = ["tokio/rt-multi-thread"]
 wasm = []
+
+[package.metadata.cargo-shear]
+ignored = ["textwrap"] # Used in `toml_text_assert_eq` macro

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -10,23 +10,19 @@ license.workspace = true
 [dependencies]
 chrono.workspace = true
 dirs.workspace = true
-futures.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 serde.workspace = true
-textwrap.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tombi-ast.workspace = true
 tombi-config.workspace = true
 tombi-date-time.workspace = true
-tombi-diagnostic.workspace = true
 tombi-document.workspace = true
 tombi-document-tree.workspace = true
 tombi-formatter.workspace = true
 tombi-parser.workspace = true
 tombi-schema-store.workspace = true
-tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true
 tombi-url.workspace = true
@@ -35,7 +31,6 @@ typed-builder.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-maplit.workspace = true
 pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tombi-test-lib.workspace = true

--- a/rust/tombi-cli/Cargo.toml
+++ b/rust/tombi-cli/Cargo.toml
@@ -16,7 +16,6 @@ clap.workspace = true
 clap-verbosity-flag.workspace = true
 itertools.workspace = true
 nu-ansi-term.workspace = true
-rayon.workspace = true
 serde_tombi.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -30,7 +29,6 @@ tombi-lsp = { workspace = true, features = ["clap", "native"] }
 tombi-schema-store = { workspace = true, features = ["native"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-url.workspace = true
 
 [build-dependencies]
 regex.workspace = true

--- a/rust/tombi-wasm/Cargo.toml
+++ b/rust/tombi-wasm/Cargo.toml
@@ -11,27 +11,15 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook.workspace = true
-getrandom = { workspace = true, features = ["wasm_js"] }
 itertools.workspace = true
 js-sys.workspace = true
-log.workspace = true
-nu-ansi-term.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_tombi = { workspace = true, default-features = false, features = ["wasm"] }
 serde-wasm-bindgen = "0.6.5"
-tokio = { workspace = true, features = ["fs", "macros"] }
 tombi-config.workspace = true
 tombi-diagnostic = { workspace = true, features = ["wasm"] }
 tombi-formatter.workspace = true
-tombi-future = { workspace = true, features = ["wasm"] }
-tombi-lexer.workspace = true
 tombi-linter.workspace = true
 tombi-schema-store = { workspace = true, features = ["wasm"] }
-tombi-text = { workspace = true, features = ["wasm"] }
-tombi-url = { workspace = true }
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-wasm.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true

--- a/toml-test/Cargo.toml
+++ b/toml-test/Cargo.toml
@@ -12,16 +12,13 @@ path = "bin/decode.rs"
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
 clap.workspace = true
 indexmap.workspace = true
-itertools.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tombi-ast.workspace = true
 tombi-document-tree.workspace = true
 tombi-parser.workspace = true
-tombi-text.workspace = true
 tombi-toml-version.workspace = true
 
 [dev-dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,7 +18,6 @@ quote = { workspace = true }
 schemars = { workspace = true, features = ["chrono04"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 time = { workspace = true }
 tombi-config = { workspace = true, features = ["jsonschema"] }
 ungrammar = { workspace = true }


### PR DESCRIPTION
Fixes #671

This removes a bunch of unused deps.

The tool has [some documented limitations](https://github.com/Boshen/cargo-shear?tab=readme-ov-file#limitation), I've done the documented workaround for the few cases that needed it.

I've also added a ci job inspired from [uv](https://github.com/astral-sh/uv/blob/4175e3eb4d7e484004d3eba6f0ecaded5810e03a/.github/workflows/ci.yml#L184), [ruff](https://github.com/astral-sh/ruff/blob/dca594f89fe0f892f8f939e09d799d2974a811d7/.github/workflows/ci.yaml#L676) or my tool [djangofmt](https://github.com/UnknownPlatypus/djangofmt/blob/main/.github/workflows/ci.yml#L153)