### PR TITLE
Include `schemas` dir in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "bin"
+include = [{ path = "schemas/**/*", format = "sdist" }]
 manifest-path = "rust/tombi-cli/Cargo.toml"
 module-name = "tombi"
 python-source = "python/tombi/src"


### PR DESCRIPTION
Fixes #729

Can confirm this sdist tarball builds successfully on Termux:

<img width="2560" height="1600" alt="Screenshot_20250722-143107_Termux" src="https://github.com/user-attachments/assets/be82c54f-74b1-495d-b1e9-c34900ad504c" />