### PR TITLE
feat: Build IntelliJ plugin on push and pull request

### DIFF
--- a/.github/workflows/ci_intellij_plugin.yml
+++ b/.github/workflows/ci_intellij_plugin.yml
@@ -1,0 +1,193 @@
+name: CI IntelliJ Plugin
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - editors/intellij/**
+      - .github/workflows/ci_intellij_plugin.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    outputs:
+      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
+
+    steps:
+      -
+        name: Fetch sources
+        uses: actions/checkout@v4
+      -
+        name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      -
+        name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      -
+        name: Export properties
+        id: properties
+        shell: bash
+        working-directory: ./editors/intellij
+        run: |
+          chmod +x ./gradlew
+          PROPERTIES="$(./gradlew properties --console=plain -q)"
+          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
+      -
+        name: Build plugin
+        working-directory: ./editors/intellij
+        run: |
+          ./gradlew buildPlugin
+      -
+        name: Prepare plugin artifact
+        id: artifact
+        shell: bash
+        working-directory: ./editors/intellij
+        run: |
+          cd build/distributions
+          FILENAME=`ls *.zip`
+          unzip "$FILENAME" -d content
+
+          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.filename }}
+          path: ./editors/intellij/build/distributions/content/*/*
+
+  test:
+    name: Test
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+
+    steps:
+      -
+        name: Fetch sources
+        uses: actions/checkout@v4
+      -
+        name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      -
+        name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      -
+        name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      -
+        name: Set up Tombi
+        run: |
+          uv tool install tombi
+      -
+        name: Run tests
+        working-directory: ./editors/intellij
+        run: |
+          chmod +x ./gradlew
+          ./gradlew check
+      -
+        name: Upload result
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-result
+          path: ${{ github.workspace }}/editors/intellij/build/reports/tests
+
+  inspect:
+    name: Inspect
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
+
+    steps:
+      -
+        name: Maximize build space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+      -
+        name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      -
+        name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      -
+        name: Run Qodana
+        uses: JetBrains/qodana-action@v2025.1
+        with:
+          args: --project-dir,editors/intellij
+          cache-default-branch-only: true
+
+  verify:
+    name: Verify
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Maximize build space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+      -
+        name: Fetch sources
+        uses: actions/checkout@v4
+      -
+        name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      -
+        name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      -
+        name: Set up IDEs cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
+          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+      -
+        name: Run verifier
+        continue-on-error: true
+        working-directory: ./editors/intellij
+        run: |
+          chmod +x ./gradlew
+          ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+      -
+        name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pluginVerifier-result
+          path: ${{ github.workspace }}/editors/intellij/build/reports/pluginVerifier

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,9 @@ maturin dev --uv && tombi
 To get started, open the `editors/intellij` subdirectory in IntelliJ IDEA,
 then configure Gradle.
 
+When a pull request is opened, the plugin will be built automatically.
+The plugin artifact can then be downloaded from the corresponding workflow run.
+
 ### Building the plugin
 
 ```shell
@@ -46,7 +49,7 @@ $ ./gradlew check
 
 ### Resources
 
-* [IntelliJ Platform SDK Documentation](https://plugins.jetbrains.com/docs/intellij/welcome.html).
+* [IntelliJ Platform SDK Documentation](https://plugins.jetbrains.com/docs/intellij/welcome.html)
 * [JetBrains Marketplace Documentation](https://plugins.jetbrains.com/docs/marketplace/discover-jetbrains-marketplace.html)
 * [InteliJ Platform Explorer](https://plugins.jetbrains.com/intellij-platform-explorer/extensions)
 

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
@@ -4,7 +4,6 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.lsp.api.LspServerDescriptor
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import org.eclipse.lsp4j.ClientCapabilities
 import tombi.message


### PR DESCRIPTION
Follow-up to #722.

This change adds a new workflow that will build the IntelliJ plugin, upload the artifacts and run its tests. This workflow is run on push (all changes) and pull request (only to related files).
