### PR TITLE
feat: add ConfigManager.

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -25,6 +25,7 @@ use tower_lsp::{
 };
 
 use crate::{
+    config_manager::{ConfigManager, ConfigSchemaStore},
     document::DocumentSource,
     goto_definition::into_definition_locations,
     handler::{
@@ -44,9 +45,7 @@ pub struct Backend {
     #[allow(dead_code)]
     pub client: tower_lsp::Client,
     pub document_sources: Arc<tokio::sync::RwLock<AHashMap<Url, DocumentSource>>>,
-    config_path: Arc<tokio::sync::RwLock<Option<std::path::PathBuf>>>,
-    config: Arc<tokio::sync::RwLock<Config>>,
-    pub schema_store: tombi_schema_store::SchemaStore,
+    pub config_manager: Arc<ConfigManager>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -58,29 +57,10 @@ pub struct Options {
 impl Backend {
     #[inline]
     pub fn new(client: tower_lsp::Client, options: &Options) -> Self {
-        let (config, config_path) = match serde_tombi::config::load_with_path() {
-            Ok((config, config_path)) => (config, config_path),
-            Err(err) => {
-                tracing::error!("{err}");
-                (Config::default(), None)
-            }
-        };
-
-        let options = tombi_schema_store::Options {
-            offline: options.offline,
-            strict: config.schema.as_ref().and_then(|schema| schema.strict()),
-            cache: Some(tombi_cache::Options {
-                no_cache: options.no_cache,
-                ..Default::default()
-            }),
-        };
-
         Self {
             client,
             document_sources: Default::default(),
-            config_path: Arc::new(tokio::sync::RwLock::new(config_path)),
-            config: Arc::new(tokio::sync::RwLock::new(config)),
-            schema_store: tombi_schema_store::SchemaStore::new_with_options(options),
+            config_manager: Arc::new(ConfigManager::new(options)),
         }
     }
 
@@ -98,12 +78,19 @@ impl Backend {
             }
         };
 
+        let ConfigSchemaStore {
+            config,
+            schema_store,
+        } = self
+            .config_manager
+            .config_schema_store_for_url(text_document_uri)
+            .await;
+
         let source_schema = if let Some(parsed) =
             tombi_parser::parse_document_header_comments(&document_source.text)
                 .cast::<tombi_ast::Root>()
         {
-            match self
-                .schema_store
+            match schema_store
                 .resolve_source_schema_from_ast(
                     &parsed.tree(),
                     Some(Either::Left(text_document_uri)),
@@ -126,7 +113,7 @@ impl Backend {
                     .as_ref()
                     .and_then(|root| root.toml_version())
             })
-            .unwrap_or(self.config.read().await.toml_version.unwrap_or_default());
+            .unwrap_or(config.toml_version.unwrap_or_default());
 
         Some(tombi_parser::parse(&document_source.text, toml_version))
     }
@@ -164,37 +151,46 @@ impl Backend {
     ) -> Option<tombi_document_tree::DocumentTree> {
         let root = self.get_incomplete_ast(text_document_uri).await?;
 
-        let source_schema = self
-            .schema_store
+        let ConfigSchemaStore {
+            config,
+            schema_store,
+        } = self
+            .config_manager
+            .config_schema_store_for_url(text_document_uri)
+            .await;
+
+        let source_schema = schema_store
             .resolve_source_schema_from_ast(&root, Some(Either::Left(text_document_uri)))
             .await
             .ok()
             .flatten();
 
-        let (toml_version, _) = self.source_toml_version(source_schema.as_ref()).await;
+        let (toml_version, _) = self
+            .source_toml_version(source_schema.as_ref(), &config)
+            .await;
 
         root.try_into_document_tree(toml_version).ok()
     }
 
     #[inline]
-    pub async fn config(&self) -> Config {
-        self.config.read().await.clone()
+    pub async fn config(&self, text_document_uri: &Url) -> Config {
+        self.config_manager
+            .config_schema_store_for_url(text_document_uri)
+            .await
+            .config
     }
 
     #[inline]
-    pub async fn update_config_with_path(&self, config: Config, config_path: std::path::PathBuf) {
-        *self.config.write().await = config;
-        *self.config_path.write().await = Some(config_path);
-    }
-
-    #[inline]
-    pub async fn config_path(&self) -> Option<std::path::PathBuf> {
-        self.config_path.read().await.clone()
+    pub async fn config_path(&self, text_document_uri: &Url) -> Option<std::path::PathBuf> {
+        self.config_manager
+            .get_config_path_for_url(text_document_uri)
+            .await
     }
 
     pub async fn source_toml_version(
         &self,
         source_schema: Option<&SourceSchema>,
+        config: &Config,
     ) -> (TomlVersion, &'static str) {
         if let Some(SourceSchema {
             root_schema: Some(document_schema),
@@ -206,7 +202,7 @@ impl Backend {
             }
         }
 
-        if let Some(toml_version) = self.config.read().await.toml_version {
+        if let Some(toml_version) = config.toml_version {
             return (toml_version, "config");
         }
 

--- a/crates/tombi-lsp/src/config_manager.rs
+++ b/crates/tombi-lsp/src/config_manager.rs
@@ -1,0 +1,309 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use serde_tombi::config::load_with_path;
+use tombi_config::Config;
+use tombi_schema_store::{SchemaStore, SchemaUrl};
+use tower_lsp::lsp_types::Url;
+
+/// Holds a Config and its associated SchemaStore
+#[derive(Debug, Clone)]
+pub struct ConfigSchemaStore {
+    pub config: Config,
+    pub schema_store: SchemaStore,
+}
+
+impl ConfigSchemaStore {
+    pub fn new(config: Config, schema_store: SchemaStore) -> Self {
+        Self {
+            config,
+            schema_store,
+        }
+    }
+}
+
+/// Manages configuration files and their associated schema stores for different source files
+#[derive(Debug)]
+pub struct ConfigManager {
+    /// Maps source file paths to their associated config file paths
+    source_config_paths: Arc<tokio::sync::RwLock<AHashMap<PathBuf, PathBuf>>>,
+    /// Maps config file paths to their ConfigSchemaStore
+    config_schema_stores: Arc<tokio::sync::RwLock<AHashMap<PathBuf, ConfigSchemaStore>>>,
+    /// Default ConfigSchemaStore when no config file is found
+    default_config_schema_store: Arc<tokio::sync::RwLock<Option<ConfigSchemaStore>>>,
+
+    backend_options: crate::backend::Options,
+}
+
+impl ConfigManager {
+    pub fn new(backend_options: &crate::backend::Options) -> Self {
+        // Try to load the default config
+        let (config, config_path) =
+            match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
+                Ok((config, config_path)) => (config, config_path),
+                Err(err) => {
+                    tracing::error!("Failed to load default config: {err}");
+                    (Config::default(), None)
+                }
+            };
+
+        // Initialize config_schema_stores with the default config if it has a path
+        let mut config_schema_stores = AHashMap::new();
+        let mut default_config_schema_store = None;
+        if let Some(config_path) = config_path {
+            let schema_options = schema_store_options(&config, backend_options);
+            config_schema_stores.insert(
+                config_path,
+                ConfigSchemaStore::new(config, SchemaStore::new_with_options(schema_options)),
+            );
+        } else {
+            default_config_schema_store = Some(ConfigSchemaStore::new(
+                config,
+                SchemaStore::new_with_options(Default::default()),
+            ));
+        }
+
+        Self {
+            source_config_paths: Arc::new(tokio::sync::RwLock::new(AHashMap::new())),
+            config_schema_stores: Arc::new(tokio::sync::RwLock::new(config_schema_stores)),
+            default_config_schema_store: Arc::new(tokio::sync::RwLock::new(
+                default_config_schema_store,
+            )),
+            backend_options: backend_options.clone(),
+        }
+    }
+
+    /// Get config for a URL
+    pub async fn config_schema_store_for_url(&self, url: &Url) -> ConfigSchemaStore {
+        if let Ok(path) = url.to_file_path() {
+            self.config_schema_store_for_file(&path).await
+        } else {
+            self.default_config_schema_store().await
+        }
+    }
+
+    /// Get or compute the config for a given TOML file path
+    pub async fn config_schema_store_for_file(
+        &self,
+        text_document_path: &Path,
+    ) -> ConfigSchemaStore {
+        // Check if we already have a config path for this source file
+        let mut source_config_paths = self.source_config_paths.write().await;
+        let config_path: PathBuf = match source_config_paths.get(text_document_path) {
+            Some(config_path) => config_path.to_owned(),
+            None => {
+                let text_document_path_buf: PathBuf = text_document_path.to_path_buf();
+                if let Ok((config, Some(config_path_buf))) =
+                    load_with_path(text_document_path_buf.parent().map(|p| p.to_path_buf()))
+                {
+                    source_config_paths.insert(text_document_path_buf, config_path_buf.clone());
+
+                    let schema_options = schema_store_options(&config, &self.backend_options);
+                    let mut config_schema_stores = self.config_schema_stores.write().await;
+                    let ConfigSchemaStore {
+                        config,
+                        schema_store,
+                    } = config_schema_stores
+                        .entry(config_path_buf.clone())
+                        .or_insert_with(|| {
+                            ConfigSchemaStore::new(
+                                config,
+                                SchemaStore::new_with_options(schema_options),
+                            )
+                        });
+
+                    if schema_store.is_empty().await {
+                        tracing::info!("add new SchemaStore for {config_path_buf:?}");
+                        if let Err(err) = schema_store
+                            .load_config(&config, Some(&config_path_buf))
+                            .await
+                        {
+                            tracing::error!("failed to load config: {err}");
+                        }
+                    }
+
+                    config_path_buf
+                } else {
+                    return self.default_config_schema_store().await;
+                }
+            }
+        };
+
+        let config_schema_stores = self.config_schema_stores.read().await;
+        if let Some(config_schema_store) = config_schema_stores.get(&config_path) {
+            config_schema_store.clone()
+        } else {
+            self.default_config_schema_store().await
+        }
+    }
+
+    /// Update a specific config and its path
+    pub async fn update_config_with_path(
+        &self,
+        config: Config,
+        config_path: PathBuf,
+    ) -> Result<(), tombi_schema_store::Error> {
+        let schema_options = schema_store_options(&config, &self.backend_options);
+
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        let config_schema_store =
+            config_schema_stores
+                .entry(config_path.clone())
+                .or_insert(ConfigSchemaStore::new(
+                    config.clone(),
+                    SchemaStore::new_with_options(schema_options),
+                ));
+        config_schema_store
+            .schema_store
+            .reload_config(&config, Some(&config_path))
+            .await?;
+        config_schema_store.config = config;
+        Ok(())
+    }
+
+    /// Get the default config
+    async fn default_config_schema_store(&self) -> ConfigSchemaStore {
+        let mut default_config_schema_store = self.default_config_schema_store.write().await;
+        if let Some(ref config_schema_store) = *default_config_schema_store {
+            config_schema_store.clone()
+        } else {
+            let config = Config::default();
+            let schema_options = schema_store_options(&config, &self.backend_options);
+            let config_schema_store =
+                ConfigSchemaStore::new(config, SchemaStore::new_with_options(schema_options));
+            *default_config_schema_store = Some(config_schema_store.clone());
+            config_schema_store
+        }
+    }
+
+    /// Get the config path for a specific URL
+    pub async fn get_config_path_for_url(&self, url: &Url) -> Option<PathBuf> {
+        if let Ok(path) = url.to_file_path() {
+            let source_config_paths = self.source_config_paths.read().await;
+            if let Some(config_path) = source_config_paths.get(&path) {
+                return Some(config_path.clone());
+            }
+        }
+        None
+    }
+
+    pub async fn update_schema(
+        &self,
+        schema_url: &SchemaUrl,
+    ) -> Result<bool, tombi_schema_store::Error> {
+        let mut updated = false;
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        for config_schema_store in config_schema_stores.values_mut() {
+            updated |= config_schema_store
+                .schema_store
+                .update_schema(schema_url)
+                .await?;
+        }
+        if let Some(ConfigSchemaStore { schema_store, .. }) =
+            &mut *self.default_config_schema_store.write().await
+        {
+            updated |= schema_store.update_schema(schema_url).await?;
+        }
+        Ok(updated)
+    }
+
+    pub async fn associate_schema(&self, schema_url: &SchemaUrl, file_match: &[String]) {
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        for config_schema_store in config_schema_stores.values_mut() {
+            config_schema_store
+                .schema_store
+                .associate_schema(schema_url.clone(), file_match.to_vec())
+                .await;
+        }
+        if let Some(ConfigSchemaStore { schema_store, .. }) =
+            &mut *self.default_config_schema_store.write().await
+        {
+            schema_store
+                .associate_schema(schema_url.clone(), file_match.to_vec())
+                .await;
+        }
+    }
+
+    pub async fn load(&self) -> Result<(), tombi_schema_store::Error> {
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        for (
+            config_path,
+            ConfigSchemaStore {
+                config,
+                schema_store,
+            },
+        ) in config_schema_stores.iter_mut()
+        {
+            schema_store.load_config(config, Some(config_path)).await?;
+        }
+
+        if let Some(ConfigSchemaStore {
+            config,
+            schema_store,
+        }) = &mut *self.default_config_schema_store.write().await
+        {
+            schema_store.load_config(config, None).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn refresh_cache(&self) -> Result<bool, tombi_schema_store::Error> {
+        let mut updated = false;
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        for (
+            config_path,
+            ConfigSchemaStore {
+                config,
+                schema_store,
+            },
+        ) in config_schema_stores.iter_mut()
+        {
+            updated |= schema_store
+                .refresh_cache(config, Some(config_path))
+                .await?;
+        }
+
+        if let Some(ConfigSchemaStore {
+            config,
+            schema_store,
+        }) = &mut *self.default_config_schema_store.write().await
+        {
+            updated |= schema_store.refresh_cache(config, None).await?;
+        }
+
+        Ok(updated)
+    }
+
+    pub async fn load_schemas(
+        &self,
+        schemas: &[tombi_config::Schema],
+        base_dir_path: Option<&std::path::Path>,
+    ) {
+        let mut config_schema_stores = self.config_schema_stores.write().await;
+        for ConfigSchemaStore { schema_store, .. } in config_schema_stores.values_mut() {
+            schema_store.load_schemas(schemas, base_dir_path).await;
+        }
+
+        if let Some(ConfigSchemaStore { schema_store, .. }) =
+            &mut *self.default_config_schema_store.write().await
+        {
+            schema_store.load_schemas(schemas, base_dir_path).await;
+        }
+    }
+}
+
+fn schema_store_options(
+    config: &Config,
+    backend_options: &crate::backend::Options,
+) -> tombi_schema_store::Options {
+    tombi_schema_store::Options {
+        offline: backend_options.offline,
+        strict: config.schema.as_ref().and_then(|schema| schema.strict()),
+        cache: Some(tombi_cache::Options {
+            no_cache: backend_options.no_cache,
+            ..Default::default()
+        }),
+    }
+}

--- a/crates/tombi-lsp/src/handler/associate_schema.rs
+++ b/crates/tombi-lsp/src/handler/associate_schema.rs
@@ -36,8 +36,9 @@ pub async fn handle_associate_schema(backend: &Backend, params: AssociateSchemaP
         return;
     };
 
+    // Use dummy URL to get default config_schema_store since this is a global operation
     backend
-        .schema_store
-        .associate_schema(schema_url, params.file_match)
+        .config_manager
+        .associate_schema(&schema_url, &params.file_match)
         .await;
 }

--- a/crates/tombi-lsp/src/handler/initialize.rs
+++ b/crates/tombi-lsp/src/handler/initialize.rs
@@ -30,14 +30,7 @@ pub async fn handle_initialize(
     }
 
     tracing::info!("Loading config...");
-    if let Err(error) = backend
-        .schema_store
-        .load_config(
-            &backend.config().await,
-            backend.config_path().await.as_deref(),
-        )
-        .await
-    {
+    if let Err(error) = backend.config_manager.load().await {
         let error_message = error.to_string();
 
         tracing::error!("{error_message}");

--- a/crates/tombi-lsp/src/handler/refresh_cache.rs
+++ b/crates/tombi-lsp/src/handler/refresh_cache.rs
@@ -12,14 +12,7 @@ pub async fn handle_refresh_cache(
 ) -> Result<bool, tower_lsp::jsonrpc::Error> {
     tracing::info!("handle_refresh_cache");
 
-    match backend
-        .schema_store
-        .refresh_cache(
-            &backend.config().await,
-            backend.config_path().await.as_deref(),
-        )
-        .await
-    {
+    match backend.config_manager.refresh_cache().await {
         Ok(true) => {
             tracing::info!("Cache refreshed");
             Ok(true)

--- a/crates/tombi-lsp/src/handler/update_schema.rs
+++ b/crates/tombi-lsp/src/handler/update_schema.rs
@@ -13,13 +13,11 @@ pub async fn handle_update_schema(
     tracing::info!("handle_update_schema");
     tracing::trace!(?params);
 
-    let TextDocumentIdentifier {
-        uri: schema_url, ..
-    } = params;
+    let TextDocumentIdentifier { uri, .. } = params;
 
     match backend
-        .schema_store
-        .update_schema(&SchemaUrl::new(schema_url))
+        .config_manager
+        .update_schema(&SchemaUrl::new(uri))
         .await
     {
         Ok(is_updated) => Ok(is_updated),

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod code_action;
 mod completion;
+mod config_manager;
 mod document;
 mod goto_definition;
 mod goto_type_definition;

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -556,7 +556,7 @@ mod completion_edit {
                             .as_str(),
                         );
                     backend
-                        .schema_store
+                        .config_manager
                         .load_schemas(
                             &[
                                 tombi_config::Schema::Root(tombi_config::RootSchema {

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1292,7 +1292,7 @@ mod completion_labels {
                         );
 
                     backend
-                        .schema_store
+                        .config_manager
                         .load_schemas(
                             &[
                                 tombi_config::Schema::Root(
@@ -1543,7 +1543,7 @@ mod completion_labels {
                         );
 
                     backend
-                        .schema_store
+                        .config_manager
                         .load_schemas(
                             &[
                                 tombi_config::Schema::Root(
@@ -1569,7 +1569,7 @@ mod completion_labels {
                     );
 
                 backend
-                    .schema_store
+                    .config_manager
                     .load_schemas(
                         &[
                             tombi_config::Schema::Sub(

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -178,7 +178,7 @@ mod goto_type_definition_tests {
                             .as_str(),
                         );
                     backend
-                        .schema_store
+                        .config_manager
                         .load_schemas(
                             &[tombi_config::Schema::Root(tombi_config::RootSchema {
                                 toml_version: None,

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -464,7 +464,7 @@ mod hover_keys_value {
                         .as_str(),
                     );
                     backend
-                        .schema_store
+                        .config_manager
                         .load_schemas(
                             &[
                                 tombi_config::Schema::Root(

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -36,6 +36,10 @@ impl SchemaStore {
         Self::new_with_options(crate::Options::default())
     }
 
+    pub async fn is_empty(&self) -> bool {
+        self.document_schemas.read().await.is_empty() && self.schemas.read().await.is_empty()
+    }
+
     /// New with options
     ///
     /// Create a store with the given options.
@@ -676,12 +680,8 @@ async fn load_catalog_from_cache_ignoring_ttl(
         if let Some(options) = &mut cache_options {
             options.cache_ttl = None;
         }
-        if let Ok(Some(catalog)) = load_catalog_from_cache(
-            catalog_url,
-            catalog_cache_path,
-            cache_options.as_ref(),
-        )
-        .await
+        if let Ok(Some(catalog)) =
+            load_catalog_from_cache(catalog_url, catalog_cache_path, cache_options.as_ref()).await
         {
             return Ok(Some(catalog));
         }
@@ -722,12 +722,8 @@ async fn load_json_schema_from_cache_ignoring_ttl(
         if let Some(options) = &mut cache_options {
             options.cache_ttl = None;
         }
-        if let Ok(Some(schema_value)) = load_json_schema_from_cache(
-            schema_url,
-            schema_cache_path,
-            cache_options.as_ref(),
-        )
-        .await
+        if let Ok(Some(schema_value)) =
+            load_json_schema_from_cache(schema_url, schema_cache_path, cache_options.as_ref()).await
         {
             return Ok(Some(schema_value));
         }

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -128,8 +128,9 @@ pub fn try_from_url(config_url: &url::Url) -> Result<Option<Config>, tombi_confi
 }
 
 pub fn load_with_path_and_level(
+    search_dir: Option<std::path::PathBuf>,
 ) -> Result<(Config, Option<std::path::PathBuf>, ConfigLevel), tombi_config::Error> {
-    if let Ok(mut current_dir) = std::env::current_dir() {
+    if let Some(mut current_dir) = search_dir {
         loop {
             let config_path = current_dir.join(TOMBI_TOML_FILENAME);
             tracing::trace!("Checking config file at {:?}", &config_path);
@@ -183,14 +184,16 @@ pub fn load_with_path_and_level(
 }
 
 #[inline]
-pub fn load_with_path() -> Result<(Config, Option<std::path::PathBuf>), tombi_config::Error> {
-    let (config, config_path, _) = load_with_path_and_level()?;
+pub fn load_with_path(
+    search_dir: Option<std::path::PathBuf>,
+) -> Result<(Config, Option<std::path::PathBuf>), tombi_config::Error> {
+    let (config, config_path, _) = load_with_path_and_level(search_dir)?;
     Ok((config, config_path))
 }
 
 #[inline]
-pub fn load() -> Result<Config, tombi_config::Error> {
-    let (config, _, _) = load_with_path_and_level()?;
+pub fn load(search_dir: Option<std::path::PathBuf>) -> Result<Config, tombi_config::Error> {
+    let (config, _, _) = load_with_path_and_level(search_dir)?;
     Ok(config)
 }
 

--- a/rust/serde_tombi/src/de.rs
+++ b/rust/serde_tombi/src/de.rs
@@ -130,7 +130,8 @@ impl Deserializer<'_> {
                     }
                 }
                 None => {
-                    let (config, config_path) = crate::config::load_with_path()?;
+                    let (config, config_path) =
+                        crate::config::load_with_path(std::env::current_dir().ok())?;
 
                     if let Some(new_toml_version) = config.toml_version {
                         toml_version = new_toml_version;

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -129,7 +129,8 @@ impl Serializer<'_> {
                     }
                 }
                 None => {
-                    let (config, config_path) = crate::config::load_with_path()?;
+                    let (config, config_path) =
+                        crate::config::load_with_path(std::env::current_dir().ok())?;
                     schema_store
                         .load_config(&config, config_path.as_deref())
                         .await?;

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -74,14 +74,16 @@ where
     crate::Error: Print<P>,
     P: Clone + Send + 'static,
 {
-    let (config, config_path, config_level) = serde_tombi::config::load_with_path_and_level()
-        .inspect_err(|_| {
-            if FileInputType::from(args.files.as_ref()) == FileInputType::Stdin {
-                if let Err(error) = std::io::copy(&mut std::io::stdin(), &mut std::io::stdout()) {
-                    tracing::error!("failed to copy stdin to stdout: {}", error);
-                }
+    let (config, config_path, config_level) = serde_tombi::config::load_with_path_and_level(
+        std::env::current_dir().ok(),
+    )
+    .inspect_err(|_| {
+        if FileInputType::from(args.files.as_ref()) == FileInputType::Stdin {
+            if let Err(error) = std::io::copy(&mut std::io::stdin(), &mut std::io::stdout()) {
+                tracing::error!("failed to copy stdin to stdout: {}", error);
             }
-        })?;
+        }
+    })?;
 
     let toml_version = config.toml_version.unwrap_or_default();
     let schema_options = config.schema.as_ref();

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -59,7 +59,8 @@ where
     crate::Error: Print<P>,
     P: Clone + Send + 'static,
 {
-    let (config, config_path, config_level) = serde_tombi::config::load_with_path_and_level()?;
+    let (config, config_path, config_level) =
+        serde_tombi::config::load_with_path_and_level(std::env::current_dir().ok())?;
 
     let toml_version = config.toml_version.unwrap_or_default();
     let schema_options = config.schema.as_ref();

--- a/rust/tombi-wasm/src/lib.rs
+++ b/rust/tombi-wasm/src/lib.rs
@@ -40,14 +40,15 @@ pub fn format(source: String, file_path: Option<String>, toml_version: Option<St
             None => TomlVersion::default(),
         };
 
-        let (config, config_path) = match serde_tombi::config::load_with_path() {
-            Ok((config, config_path)) => (config, config_path),
-            Err(err) => {
-                return Err(FormatError::Error {
-                    error: err.to_string(),
-                });
-            }
-        };
+        let (config, config_path) =
+            match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
+                Ok((config, config_path)) => (config, config_path),
+                Err(err) => {
+                    return Err(FormatError::Error {
+                        error: err.to_string(),
+                    });
+                }
+            };
 
         let schema_options = config.schema.as_ref();
         let schema_store =
@@ -121,14 +122,15 @@ pub fn lint(source: String, file_path: Option<String>, toml_version: Option<Stri
             None => TomlVersion::default(),
         };
 
-        let (config, config_path) = match serde_tombi::config::load_with_path() {
-            Ok((config, config_path)) => (config, config_path),
-            Err(err) => {
-                return Err(LintError::Error {
-                    error: err.to_string(),
-                });
-            }
-        };
+        let (config, config_path) =
+            match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
+                Ok((config, config_path)) => (config, config_path),
+                Err(err) => {
+                    return Err(LintError::Error {
+                        error: err.to_string(),
+                    });
+                }
+            };
 
         let schema_options = config.schema.as_ref();
         let schema_store =


### PR DESCRIPTION
Fix: https://github.com/tombi-toml/tombi/issues/772

LSP had a single Config and SchemaStore starting from the directory where it was launched.

This PR will modify the logic to have a corresponding Config and SchemaStore for each file based on the file path.