### PR TITLE
Revert "feat: zed plugin download file path incorrect"

### DIFF
--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -131,7 +131,7 @@ impl TombiExtension {
                 zed::Os::Windows => zed::DownloadedFileType::Zip,
                 _ => zed::DownloadedFileType::Gzip,
             };
-            zed::download_file(&asset.download_url, &version_dir, file_kind)
+            zed::download_file(&asset.download_url, &binary_path, file_kind)
                 .map_err(|e| format!("failed to download file: {e}"))?;
 
             zed::make_file_executable(&binary_path)?;


### PR DESCRIPTION
Reverts tombi-toml/tombi#853