### PR TITLE
feat: parse the new table keys order

### DIFF
--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -1,3 +1,4 @@
+use tombi_schema_store::TableGroupOrder;
 use tombi_x_keyword::{ArrayValuesOrder, StringFormat, TableKeysOrder};
 
 use super::display_value::DisplayValue;
@@ -69,7 +70,7 @@ pub struct ValueConstraints {
     pub max_keys: Option<usize>,
     pub key_patterns: Option<Vec<String>>,
     pub additional_keys: Option<bool>,
-    pub keys_order: Option<TableKeysOrder>,
+    pub keys_order: Option<Vec<TableGroupOrder>>,
 }
 
 impl std::fmt::Display for ValueConstraints {
@@ -173,7 +174,10 @@ impl std::fmt::Display for ValueConstraints {
         }
 
         if let Some(keys_order) = &self.keys_order {
-            write!(f, "Keys Order: `{keys_order}`\n\n")?;
+            write!(f, "Keys Order:\n\n")?;
+            for key in keys_order.iter() {
+                write!(f, "- `{key}`\n\n")?;
+            }
         }
 
         Ok(())

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -14,6 +14,7 @@ mod referable_schema;
 mod schema_context;
 mod source_schema;
 mod string_schema;
+mod table_order_schema;
 mod table_schema;
 mod value_schema;
 
@@ -36,6 +37,7 @@ pub use referable_schema::{is_online_url, CurrentSchema, Referable};
 pub use schema_context::SchemaContext;
 pub use source_schema::{SourceSchema, SubSchemaUriMap};
 pub use string_schema::StringSchema;
+pub use table_order_schema::TableGroupOrder;
 pub use table_schema::TableSchema;
 pub use tombi_accessor::{SchemaAccessor, SchemaAccessors};
 pub use tombi_uri::{CatalogUri, SchemaUri};

--- a/crates/tombi-schema-store/src/schema/table_order_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_order_schema.rs
@@ -1,0 +1,42 @@
+use tombi_x_keyword::{TableGroup, TableKeysOrder, X_TOMBI_TABLE_KEYS_ORDER};
+
+#[derive(Debug, Clone)]
+pub struct TableOrderSchema {
+    pub orders: Vec<TableGroupOrder>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableGroupOrder {
+    pub target: TableGroup,
+    pub order: TableKeysOrder,
+}
+
+impl TableOrderSchema {
+    pub fn new(object: &tombi_json::ObjectNode) -> Option<Self> {
+        let mut sort_orders = vec![];
+        for (group_name, order) in &object.properties {
+            let Ok(target) = TableGroup::try_from(group_name.value.as_str()) else {
+                tracing::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}: {group_name}");
+                return None;
+            };
+
+            let Some(Ok(order)) = order.as_str().map(TableKeysOrder::try_from) else {
+                tracing::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}.{group_name}: {order}");
+                return None;
+            };
+            sort_orders.push(TableGroupOrder { target, order });
+        }
+
+        // Maybe validate that the order "all" in the first position cannot be combined with other orders?
+
+        Some(Self {
+            orders: sort_orders,
+        })
+    }
+}
+
+impl std::fmt::Display for TableGroupOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.target, self.order)
+    }
+}

--- a/crates/tombi-schema-store/src/schema/table_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_schema.rs
@@ -5,13 +5,16 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use tombi_future::{BoxFuture, Boxable};
 use tombi_json::StringNode;
-use tombi_x_keyword::{StringFormat, TableKeysOrder, X_TOMBI_TABLE_KEYS_ORDER};
+use tombi_x_keyword::{StringFormat, TableGroup, TableKeysOrder, X_TOMBI_TABLE_KEYS_ORDER};
 
 use super::{
     CurrentSchema, FindSchemaCandidates, PropertySchema, SchemaAccessor, SchemaDefinitions,
     SchemaItem, SchemaPatternProperties, SchemaUri, ValueSchema,
 };
-use crate::{Accessor, Referable, SchemaProperties, SchemaStore};
+use crate::{
+    schema::table_order_schema::{TableGroupOrder, TableOrderSchema},
+    Accessor, Referable, SchemaProperties, SchemaStore,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct TableSchema {
@@ -25,7 +28,7 @@ pub struct TableSchema {
     pub required: Option<Vec<String>>,
     pub min_properties: Option<usize>,
     pub max_properties: Option<usize>,
-    pub keys_order: Option<TableKeysOrder>,
+    pub keys_order: Option<Vec<TableGroupOrder>>,
     pub default: Option<tombi_json::Object>,
     pub const_value: Option<tombi_json::Object>,
     pub enumerate: Option<Vec<tombi_json::Object>>,
@@ -95,12 +98,19 @@ impl TableSchema {
         let keys_order = match object_node.get(X_TOMBI_TABLE_KEYS_ORDER) {
             Some(tombi_json::ValueNode::String(StringNode { value: order, .. })) => {
                 match TableKeysOrder::try_from(order.as_str()) {
-                    Ok(val) => Some(val),
+                    Ok(val) => Some(vec![TableGroupOrder {
+                        target: TableGroup::All,
+                        order: val,
+                    }]),
                     Err(_) => {
                         tracing::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}: {order}");
                         None
                     }
                 }
+            }
+            Some(tombi_json::ValueNode::Object(object_node)) => {
+                let order_schema = TableOrderSchema::new(object_node);
+                order_schema.map(|schema| schema.orders)
             }
             Some(order) => {
                 tracing::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}: {}", order.to_string());

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -42,6 +42,42 @@ impl<'a> TryFrom<&'a str> for ArrayValuesOrder {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum TableGroup {
+    All,
+    Properties,
+    AdditionalProperties,
+    PatternProperties,
+}
+
+impl std::fmt::Display for TableGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TableGroup::All => write!(f, "all"),
+            TableGroup::Properties => write!(f, "properties"),
+            TableGroup::AdditionalProperties => write!(f, "additionalProperties"),
+            TableGroup::PatternProperties => write!(f, "patternProperties"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for TableGroup {
+    type Error = &'a str;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        match value {
+            "all" => Ok(TableGroup::All),
+            "properties" => Ok(TableGroup::Properties),
+            "additionalProperties" => Ok(TableGroup::AdditionalProperties),
+            "patternProperties" => Ok(TableGroup::PatternProperties),
+            _ => Err("Invalid table group"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum TableKeysOrder {
     Ascending,
     Descending,


### PR DESCRIPTION
I started implementing #933 .

Next step will be figuring out how to do the following
> After sorting the data split by each `target`, Tombi merges the data according to the order of the array.

I will certainly have to touch https://github.com/tombi-toml/tombi/blob/main/crates/tombi-ast-editor/src/rule/table_keys_order.rs