### PR TITLE
fix: use proper download path for windows, leaving macos/linux as is

### DIFF
--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -131,10 +131,18 @@ impl TombiExtension {
                 zed::Os::Windows => zed::DownloadedFileType::Zip,
                 _ => zed::DownloadedFileType::Gzip,
             };
-            zed::download_file(&asset.download_url, &binary_path, file_kind)
-                .map_err(|e| format!("failed to download file: {e}"))?;
 
-            zed::make_file_executable(&binary_path)?;
+            match platform {
+                zed::Os::Windows => {
+                    zed::download_file(&asset.download_url, &version_dir, file_kind)
+                        .map_err(|e| format!("failed to download file: {e}"))?;
+                }
+                _ => {
+                    zed::download_file(&asset.download_url, &binary_path, file_kind)
+                        .map_err(|e| format!("failed to download file: {e}"))?;
+                    zed::make_file_executable(&binary_path)?;
+                }
+            }
 
             let entries = fs::read_dir(".")
                 .map_err(|err| format!("failed to list working directory {err}"))?;


### PR DESCRIPTION
links to: #961

Previously the extension would create 2 nested folders on windows if the `&binary_path` was passed as the path, this adds a check for windows so that it uses `&version_dir` (hopefully) fixing the issue


I tested this on windows and in a linux vm. I can't test it on macos but I imagine if it works on linux it will work on macos as well