### PR TITLE
build(cli): Generate man pages at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b4c3c54b30f0d9adcb47f25f61fcce35c4dd8916638c6b82fbd5f4fb4179e2"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3517,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
+ "clap_mangen",
  "itertools 0.14.0",
  "nu-ansi-term 0.50.1",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = "1.0.98"
 bytes = "1.10.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive", "env", "string"] }
+clap_complete = "4.5.58"
 clap-verbosity-flag = "3.0.2"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"

--- a/rust/tombi-cli/Cargo.toml
+++ b/rust/tombi-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-clap_complete = "4.5.58"
+clap_complete.workspace = true
 clap-verbosity-flag.workspace = true
 itertools.workspace = true
 nu-ansi-term.workspace = true
@@ -32,4 +32,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [build-dependencies]
+clap.workspace = true
+clap_complete.workspace = true
+clap_mangen = "0.2.29"
+clap-verbosity-flag.workspace = true
 regex.workspace = true

--- a/rust/tombi-cli/build.rs
+++ b/rust/tombi-cli/build.rs
@@ -1,6 +1,10 @@
-use std::process::Command;
+use std::{env, io, process::Command};
 
-fn main() {
+use clap::CommandFactory;
+
+include!("src/args.rs");
+
+fn main() -> io::Result<()> {
     let re = regex::Regex::new(r"^v\d+\.\d+\.\d+$").unwrap();
 
     // Try to get version from git tag
@@ -24,4 +28,10 @@ fn main() {
 
     println!("cargo:rustc-env=__TOMBI_VERSION={git_version}");
     println!("cargo:rerun-if-changed=.git/HEAD");
+
+    if let Ok(out_dir) = env::var("OUT_DIR") {
+        let cmd = Args::command().about("TOML Toolkit");
+        clap_mangen::generate_to(cmd, out_dir)?;
+    }
+    Ok(())
 }

--- a/rust/tombi-cli/src/app.rs
+++ b/rust/tombi-cli/src/app.rs
@@ -1,55 +1,11 @@
 mod command;
 mod tracing_formatter;
 
-use clap::{
-    builder::styling::{AnsiColor, Color, Style},
-    Parser,
-};
-use clap_verbosity_flag::{log, InfoLevel, Verbosity};
+use clap_verbosity_flag::log;
 use tracing_formatter::TombiFormatter;
 use tracing_subscriber::prelude::*;
 
-#[derive(clap::Parser)]
-#[command(
-    name="tombi",
-    about = app_about(),
-    version = env!("__TOMBI_VERSION").trim_start_matches('v'),
-    styles=app_styles(),
-    disable_help_subcommand(true),
-)]
-pub struct Args {
-    #[command(subcommand)]
-    pub subcommand: command::TomlCommand,
-
-    #[command(flatten)]
-    verbose: Verbosity<InfoLevel>,
-}
-
-impl<I, T> From<I> for Args
-where
-    I: IntoIterator<Item = T>,
-    T: Into<std::ffi::OsString> + Clone,
-{
-    #[inline]
-    fn from(value: I) -> Self {
-        Self::parse_from(value)
-    }
-}
-
-#[derive(clap::Args, Debug)]
-struct CommonArgs {
-    /// Disable network access
-    ///
-    /// Don't fetch from remote and use local schemas cache.
-    #[clap(long, global = true, env("TOMBI_OFFLINE"))]
-    offline: bool,
-
-    /// Do not use cache
-    ///
-    /// Fetch the latest data from remote and save it to the cache
-    #[clap(long, global = true, env("TOMBI_NO_CACHE"))]
-    no_cache: bool,
-}
+use crate::args::{Args, TomlCommand};
 
 /// Convert [`clap_verbosity_flag::log::LevelFilter`] to [`tracing_subscriber::filter::LevelFilter`]
 fn convert_log_level_filter(level: log::LevelFilter) -> tracing_subscriber::filter::LevelFilter {
@@ -87,60 +43,9 @@ pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
         .init();
 
     match args.subcommand {
-        command::TomlCommand::Format(args) => command::format::run(args),
-        command::TomlCommand::Lint(args) => command::lint::run(args),
-        command::TomlCommand::Lsp(args) => command::lsp::run(args),
-        command::TomlCommand::Completion(args) => command::completion::run(args),
+        TomlCommand::Format(args) => command::format::run(args),
+        TomlCommand::Lint(args) => command::lint::run(args),
+        TomlCommand::Lsp(args) => command::lsp::run(args),
+        TomlCommand::Completion(args) => command::completion::run(args),
     }
-}
-
-fn app_about() -> String {
-    let title = "Tombi";
-    let title_style = Style::new()
-        .bold()
-        .bg_color(Some(Color::Ansi(AnsiColor::Blue)))
-        .fg_color(Some(Color::Ansi(AnsiColor::White)));
-
-    let desc_style = Style::new()
-        .bg_color(Some(Color::Ansi(AnsiColor::Blue)))
-        .fg_color(Some(Color::Ansi(AnsiColor::White)));
-
-    format!(
-        "{title_style}                          {title} {title_style:#}{desc_style}: TOML Toolkit                          {desc_style:#}"
-    )
-}
-
-const fn app_styles() -> clap::builder::Styles {
-    clap::builder::Styles::plain()
-        .header(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
-        )
-        .error(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Red))),
-        )
-        .usage(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
-        )
-        .literal(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
-        )
-        .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan))))
-        .valid(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Green))),
-        )
-        .invalid(
-            Style::new()
-                .bold()
-                .fg_color(Some(Color::Ansi(AnsiColor::Red))),
-        )
 }

--- a/rust/tombi-cli/src/app/command.rs
+++ b/rust/tombi-cli/src/app/command.rs
@@ -2,17 +2,3 @@ pub mod completion;
 pub mod format;
 pub mod lint;
 pub mod lsp;
-
-#[derive(clap::Subcommand)]
-pub enum TomlCommand {
-    #[command(alias = "fmt")]
-    Format(format::Args),
-
-    #[command(alias = "check")]
-    Lint(lint::Args),
-
-    #[command(alias = "serve")]
-    Lsp(lsp::Args),
-
-    Completion(completion::Args),
-}

--- a/rust/tombi-cli/src/app/command/completion.rs
+++ b/rust/tombi-cli/src/app/command/completion.rs
@@ -1,16 +1,12 @@
+use std::io;
+
 use clap::CommandFactory;
 
-/// Generate shell completion.
-#[derive(clap::Args, Debug)]
-pub struct Args {
-    /// Shell to generate completion for
-    #[arg(value_enum)]
-    shell: clap_complete::Shell,
-}
+use crate::args::{Args, CompletionArgs};
 
-pub fn run(args: Args) -> Result<(), crate::Error> {
-    let mut cmd = crate::app::Args::command();
+pub fn run(args: CompletionArgs) -> Result<(), crate::Error> {
+    let mut cmd = Args::command();
     let name = cmd.get_name().to_string();
-    clap_complete::generate(args.shell, &mut cmd, name, &mut std::io::stdout());
+    clap_complete::generate(args.shell, &mut cmd, name, &mut io::stdout());
     Ok(())
 }

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -4,34 +4,10 @@ use tombi_diagnostic::{printer::Pretty, Diagnostic, Print};
 use tombi_formatter::formatter::definitions::FormatDefinitions;
 use tombi_glob::{FileInputType, FileSearch};
 
-use crate::app::CommonArgs;
-
-/// Format TOML files.
-#[derive(clap::Args, Debug)]
-pub struct Args {
-    /// List of files or directories to format
-    ///
-    /// If the only argument is "-", the standard input will be used
-    ///
-    /// [default: if "tombi.toml" exists, format project directory, otherwise format current directory]
-    files: Vec<String>,
-
-    /// Check only and don't overwrite files.
-    #[arg(long, default_value_t = false)]
-    check: bool,
-
-    /// Filename to use when reading from stdin
-    ///
-    /// This is useful for determining which JSON Schema should be applied, for more rich formatting.
-    #[arg(long)]
-    stdin_filename: Option<String>,
-
-    #[command(flatten)]
-    common: CommonArgs,
-}
+use crate::args::FormatArgs;
 
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn run(args: Args) -> Result<(), crate::Error> {
+pub fn run(args: FormatArgs) -> Result<(), crate::Error> {
     let (success_num, not_needed_num, error_num) = match inner_run(args, Pretty) {
         Ok((success_num, not_needed_num, error_num)) => (success_num, not_needed_num, error_num),
         Err(error) => {
@@ -73,7 +49,7 @@ pub fn run(args: Args) -> Result<(), crate::Error> {
 }
 
 fn inner_run<P>(
-    args: Args,
+    args: FormatArgs,
     mut printer: P,
 ) -> Result<(usize, usize, usize), Box<dyn std::error::Error>>
 where

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -3,30 +3,10 @@ use tombi_config::{LintOptions, TomlVersion};
 use tombi_diagnostic::{printer::Pretty, Diagnostic, Print};
 use tombi_glob::FileSearch;
 
-use crate::app::CommonArgs;
-
-/// Lint TOML files.
-#[derive(clap::Args, Debug)]
-pub struct Args {
-    /// List of files or directories to lint
-    ///
-    /// If the only argument is "-", the standard input will be used
-    ///
-    /// [default: if "tombi.toml" exists, lint project directory, otherwise lint current directory]
-    files: Vec<String>,
-
-    /// Filename to use when reading from stdin
-    ///
-    /// This is useful for determining which JSON Schema should be applied, for more rich linting.
-    #[arg(long)]
-    stdin_filename: Option<String>,
-
-    #[command(flatten)]
-    common: CommonArgs,
-}
+use crate::args::LintArgs;
 
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn run(args: Args) -> Result<(), crate::Error> {
+pub fn run(args: LintArgs) -> Result<(), crate::Error> {
     let (success_num, error_num) = match inner_run(args, Pretty) {
         Ok((success_num, error_num)) => (success_num, error_num),
         Err(error) => {
@@ -58,7 +38,10 @@ pub fn run(args: Args) -> Result<(), crate::Error> {
     Ok(())
 }
 
-fn inner_run<P>(args: Args, mut printer: P) -> Result<(usize, usize), Box<dyn std::error::Error>>
+fn inner_run<P>(
+    args: LintArgs,
+    mut printer: P,
+) -> Result<(usize, usize), Box<dyn std::error::Error>>
 where
     Diagnostic: Print<P>,
     crate::Error: Print<P>,

--- a/rust/tombi-cli/src/app/command/lsp.rs
+++ b/rust/tombi-cli/src/app/command/lsp.rs
@@ -1,14 +1,6 @@
-use crate::app::CommonArgs;
+use crate::args::LspArgs;
 
-/// Run TOML Language Server.
-#[derive(Debug, clap::Args)]
-pub struct Args {
-    #[command(flatten)]
-    common: CommonArgs,
-}
-
-pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
-    let args: Args = args.into();
+pub fn run(args: LspArgs) -> Result<(), crate::Error> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?

--- a/rust/tombi-cli/src/args.rs
+++ b/rust/tombi-cli/src/args.rs
@@ -1,0 +1,172 @@
+use clap::{
+    builder::styling::{AnsiColor, Color, Style},
+    Parser,
+};
+use clap_complete::Shell;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+#[derive(clap::Parser)]
+#[command(
+    name = "tombi",
+    about = app_about(),
+    version = option_env!("__TOMBI_VERSION").map_or(env!("CARGO_PKG_VERSION"), |v| v.trim_start_matches('v')),
+    styles = app_styles(),
+    disable_help_subcommand(true),
+)]
+pub struct Args {
+    #[command(subcommand)]
+    pub subcommand: TomlCommand,
+
+    #[command(flatten)]
+    pub verbose: Verbosity<InfoLevel>,
+}
+
+impl<I, T> From<I> for Args
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    #[inline]
+    fn from(value: I) -> Self {
+        Self::parse_from(value)
+    }
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CommonArgs {
+    /// Disable network access.
+    ///
+    /// Don't fetch from remote and use local schemas cache.
+    #[clap(long, global = true, env("TOMBI_OFFLINE"))]
+    pub offline: bool,
+
+    /// Do not use cache.
+    ///
+    /// Fetch the latest data from remote and save it to the cache.
+    #[clap(long, global = true, env("TOMBI_NO_CACHE"))]
+    pub no_cache: bool,
+}
+
+#[derive(clap::Subcommand)]
+pub enum TomlCommand {
+    #[command(alias = "fmt")]
+    Format(FormatArgs),
+
+    #[command(alias = "check")]
+    Lint(LintArgs),
+
+    #[command(alias = "serve")]
+    Lsp(LspArgs),
+
+    Completion(CompletionArgs),
+}
+
+/// Format TOML files.
+#[derive(clap::Args, Debug)]
+pub struct FormatArgs {
+    /// List of files or directories to format.
+    ///
+    /// If the only argument is "-", the standard input will be used.
+    ///
+    /// [default: if "tombi.toml" exists, format project directory, otherwise format current directory]
+    pub files: Vec<String>,
+
+    /// Check only and don't overwrite files.
+    #[arg(long, default_value_t = false)]
+    pub check: bool,
+
+    /// Filename to use when reading from stdin.
+    ///
+    /// This is useful for determining which JSON Schema should be applied, for more rich formatting.
+    #[arg(long)]
+    pub stdin_filename: Option<String>,
+
+    #[command(flatten)]
+    pub common: CommonArgs,
+}
+
+/// Lint TOML files.
+#[derive(clap::Args, Debug)]
+pub struct LintArgs {
+    /// List of files or directories to lint.
+    ///
+    /// If the only argument is "-", the standard input will be used.
+    ///
+    /// [default: if "tombi.toml" exists, lint project directory, otherwise lint current directory]
+    pub files: Vec<String>,
+
+    /// Filename to use when reading from stdin.
+    ///
+    /// This is useful for determining which JSON Schema should be applied, for more rich linting.
+    #[arg(long)]
+    pub stdin_filename: Option<String>,
+
+    #[command(flatten)]
+    pub common: CommonArgs,
+}
+
+/// Run TOML Language Server.
+#[derive(Debug, clap::Args)]
+pub struct LspArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+}
+
+/// Generate shell completion.
+#[derive(clap::Args, Debug)]
+pub struct CompletionArgs {
+    /// Shell to generate completion for.
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+fn app_about() -> String {
+    let title = "Tombi";
+    let title_style = Style::new()
+        .bold()
+        .bg_color(Some(Color::Ansi(AnsiColor::Blue)))
+        .fg_color(Some(Color::Ansi(AnsiColor::White)));
+
+    let desc_style = Style::new()
+        .bg_color(Some(Color::Ansi(AnsiColor::Blue)))
+        .fg_color(Some(Color::Ansi(AnsiColor::White)));
+
+    format!(
+        "{title_style}                          {title} {title_style:#}{desc_style}: TOML Toolkit                          {desc_style:#}"
+    )
+}
+
+const fn app_styles() -> clap::builder::Styles {
+    clap::builder::Styles::plain()
+        .header(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+        )
+        .error(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Red))),
+        )
+        .usage(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Blue))),
+        )
+        .literal(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Cyan))),
+        )
+        .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan))))
+        .valid(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Green))),
+        )
+        .invalid(
+            Style::new()
+                .bold()
+                .fg_color(Some(Color::Ansi(AnsiColor::Red))),
+        )
+}

--- a/rust/tombi-cli/src/main.rs
+++ b/rust/tombi-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod args;
 mod error;
 
 pub use error::Error;


### PR DESCRIPTION
This will generate man pages in `OUT_DIR` directory when you run `cargo build`.

[Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/tombi/-/blob/0b42033a99c7e0a7ece04b0a74ddb0a22efebcb3/PKGBUILD), [Homebrew](https://github.com/Homebrew/homebrew-core/blob/7c0ef529c78dca0dc325b626222d1610b44b13bd/Formula/t/tombi.rb) and [Nix](https://github.com/NixOS/nixpkgs/blob/c23193b943c6c689d70ee98ce3128239ed9e32d1/pkgs/by-name/to/tombi/package.nix) seem to build this command by `cargo build` instead of `xtask`.

Generation and distribution using `xtask` is not implemented.

Closes #1011