### PR TITLE
feat: verbose flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,16 +566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-verbosity-flag"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1"
-dependencies = [
- "clap",
- "log",
-]
-
-[[package]]
 name = "clap_builder"
 version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,7 +3489,6 @@ name = "tombi-cli"
 version = "0.0.0-dev"
 dependencies = [
  "clap",
- "clap-verbosity-flag",
  "clap_complete",
  "itertools 0.14.0",
  "nu-ansi-term 0.50.1",
@@ -3586,7 +3575,6 @@ name = "tombi-diagnostic"
 version = "0.0.0-dev"
 dependencies = [
  "clap",
- "clap-verbosity-flag",
  "nu-ansi-term 0.50.1",
  "serde",
  "tombi-text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ anyhow = "1.0.98"
 bytes = "1.10.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.37", features = ["derive", "env", "string"] }
-clap-verbosity-flag = "3.0.2"
 console_error_panic_hook = "0.1.7"
 convert_case = "0.6.0"
 countme = "3.0.1"

--- a/crates/tombi-accessor/src/schema_accessor.rs
+++ b/crates/tombi-accessor/src/schema_accessor.rs
@@ -16,7 +16,7 @@ impl SchemaAccessor {
     /// # Examples
     ///
     /// ```
-    /// use tombi_schema_store::{SchemaAccessor, Accessor};
+    /// use tombi_accessor::{SchemaAccessor, Accessor};
     ///
     /// let accessors = SchemaAccessor::parse("key1[*].key2").unwrap();
     /// assert_eq!(accessors.len(), 3);

--- a/crates/tombi-diagnostic/Cargo.toml
+++ b/crates/tombi-diagnostic/Cargo.toml
@@ -14,7 +14,6 @@ wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 clap.workspace = true
-clap-verbosity-flag.workspace = true
 tracing-subscriber.workspace = true
 
 [features]

--- a/crates/tombi-diagnostic/examples/diagnostics.rs
+++ b/crates/tombi-diagnostic/examples/diagnostics.rs
@@ -1,15 +1,11 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 use tombi_diagnostic::{printer::Pretty, Diagnostic, Print};
 use tracing_subscriber::prelude::*;
 
 #[derive(clap::Parser)]
-pub struct Args {
-    #[command(flatten)]
-    verbose: Verbosity<InfoLevel>,
-}
+pub struct Args {}
 
 pub fn project_root_path() -> PathBuf {
     let dir = std::env::var("CARGO_MANIFEST_DIR")
@@ -27,12 +23,9 @@ pub fn source_file() -> PathBuf {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = Args::parse_from(std::env::args_os());
+    let _args = Args::parse_from(std::env::args_os());
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::from(
-            args.verbose.log_level_filter().to_string(),
-        ))
         .with(tracing_subscriber::fmt::layer().pretty().without_time())
         .init();
 

--- a/rust/tombi-cli/Cargo.toml
+++ b/rust/tombi-cli/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 [dependencies]
 clap.workspace = true
 clap_complete = "4.5.58"
-clap-verbosity-flag.workspace = true
 itertools.workspace = true
 nu-ansi-term.workspace = true
 serde_tombi.workspace = true

--- a/rust/tombi-cli/src/app/options.rs
+++ b/rust/tombi-cli/src/app/options.rs
@@ -1,0 +1,55 @@
+/// Verbosity level for logging
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VerbosityLevel {
+    /// No verbose output (default)
+    #[default]
+    Default,
+
+    /// Verbose output (-v)
+    Verbose,
+
+    /// Very verbose output (-vv)
+    VeryVerbose,
+}
+
+impl VerbosityLevel {
+    /// Convert to tracing log level filter
+    pub fn log_level_filter(self) -> tracing_subscriber::filter::LevelFilter {
+        match self {
+            VerbosityLevel::Default => tracing_subscriber::filter::LevelFilter::INFO,
+            VerbosityLevel::Verbose => tracing_subscriber::filter::LevelFilter::DEBUG,
+            VerbosityLevel::VeryVerbose => tracing_subscriber::filter::LevelFilter::TRACE,
+        }
+    }
+}
+
+/// Verbosity flag that supports -v and -vv only
+#[derive(clap::Args, Debug, Clone)]
+pub struct Verbosity {
+    /// Verbose logging level
+    ///
+    /// -v: DEBUG
+    ///
+    /// -vv: TRACE
+    ///
+    /// [default: INFO]
+    ///
+    #[clap(short = 'v', long, action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
+}
+
+impl Verbosity {
+    /// Get the verbosity level
+    pub fn verbosity_level(&self) -> VerbosityLevel {
+        match self.verbose {
+            0 => VerbosityLevel::Default,
+            1 => VerbosityLevel::Verbose,
+            2.. => VerbosityLevel::VeryVerbose,
+        }
+    }
+
+    /// Get the log level filter
+    pub fn log_level_filter(&self) -> tracing_subscriber::filter::LevelFilter {
+        self.verbosity_level().log_level_filter()
+    }
+}

--- a/rust/tombi-cli/src/app/tracing_formatter.rs
+++ b/rust/tombi-cli/src/app/tracing_formatter.rs
@@ -43,15 +43,15 @@ impl TombiFormatter {
     }
 }
 
-impl From<clap_verbosity_flag::log::LevelFilter> for TombiFormatter {
-    fn from(level: clap_verbosity_flag::log::LevelFilter) -> Self {
+impl From<tracing_subscriber::filter::LevelFilter> for TombiFormatter {
+    fn from(level: tracing_subscriber::filter::LevelFilter) -> Self {
         let level = match level {
-            clap_verbosity_flag::log::LevelFilter::Off => None,
-            clap_verbosity_flag::log::LevelFilter::Error => Some(tracing::Level::ERROR),
-            clap_verbosity_flag::log::LevelFilter::Warn => Some(tracing::Level::WARN),
-            clap_verbosity_flag::log::LevelFilter::Info => Some(tracing::Level::INFO),
-            clap_verbosity_flag::log::LevelFilter::Debug => Some(tracing::Level::DEBUG),
-            clap_verbosity_flag::log::LevelFilter::Trace => Some(tracing::Level::TRACE),
+            tracing_subscriber::filter::LevelFilter::OFF => None,
+            tracing_subscriber::filter::LevelFilter::ERROR => Some(tracing::Level::ERROR),
+            tracing_subscriber::filter::LevelFilter::WARN => Some(tracing::Level::WARN),
+            tracing_subscriber::filter::LevelFilter::INFO => Some(tracing::Level::INFO),
+            tracing_subscriber::filter::LevelFilter::DEBUG => Some(tracing::Level::DEBUG),
+            tracing_subscriber::filter::LevelFilter::TRACE => Some(tracing::Level::TRACE),
         };
 
         Self { level }


### PR DESCRIPTION
Remove the quit option.

In practice, the quit option is never used, and it further interferes with the functionality of other options(like `--diff`) that output to the log.