### PR TITLE
Fix module path in README example

### DIFF
--- a/crates/tombi-document-tree/README.md
+++ b/crates/tombi-document-tree/README.md
@@ -3,7 +3,7 @@
 This crate is a library for representing the tree structure of documents using AST.
 
 ```text
-ast::Root -> tombi_document_tree::DocumentTree -> tombi_document::Document
+tombi_ast::Root -> tombi_document_tree::DocumentTree -> tombi_document::Document
 ```
 
 In the process of converting to tombi_document_tree::DocumentTree,


### PR DESCRIPTION
Updated the README to reflect the correct module path for AST.