### PR TITLE
Set up CI for building and releasing Snap package

### DIFF
--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -1,0 +1,43 @@
+name: Release Snap package
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TOMBI_VERSION: ""
+
+jobs:
+  release-snap:
+    name: snapcraft (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64, armhf]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/set-version
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: snap-${{ env.TOMBI_VERSION }}-${{ matrix.arch }}
+          path: ${{ steps.build.outputs.snap }}
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ github.ref == 'refs/heads/main' && 'edge' || 'stable' }}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,13 +7,15 @@ description: |
   Language Server to help you maintain clean and consistent TOML files
 grade: stable
 confinement: classic
+platforms:
+  amd64:
+  arm64:
+  armhf:
 
 parts:
   tombi:
     plugin: rust
-    source-type: git
-    source: https://github.com/tombi-toml/tombi
-    source-tag: "v0.0.0-dev"
+    source: .
     rust-use-global-lto: true
     rust-inherit-ldflags: true
     build-attributes:

--- a/xtask/src/command/set_version.rs
+++ b/xtask/src/command/set_version.rs
@@ -101,10 +101,6 @@ fn set_snapcraft_yaml_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
         &format!(r#"version: "{DEV_VERSION}""#),
         &format!(r#"version: "{version}""#),
     );
-    patch.replace(
-        &format!(r#"source-tag: "v{DEV_VERSION}""#),
-        &format!(r#"source-tag: "v{version}""#),
-    );
     patch.commit(sh)?;
     Ok(())
 }


### PR DESCRIPTION
This is a follow-up to #1014, to set up CI for building and publishing the `tombi` Snap package. I worked with @karljs on this to finish getting the approval set up on the Snap Store side, so it should be ready to go now.

After this is merged, it will need the SNAPCRAFT_STORE_CREDENTIALS secret to be defined in GitHub; otherwise it will still build the snap and upload the artifact to GitHub but will fail on the final step to publish the package to the Snap Store. If you can provide the email address that you would like to use for administering the Snap, I can send an invite. From there you could generate the credentials using this command:

```bash
snapcraft export-login --snaps=tombi \
      --acls package_access,package_push,package_update,package_release \
      tombi_snap_store_credentials.txt
```

Some details about the changes to the `snapcraft.yaml`:
- In the `snapcraft.yaml`, I switched the `source` to use the local directory, which will have already been checked out from GitHub using the appropriate branch/tag. This avoids the need to hard-code the GitHub URL, which would also trigger a second checkout of the repo.
- I restricted the  `platforms` to the subset that builds successfully (`amd64`, `arm64`, `armhf`).

The way that the CI process would work with this setup:
- When the workflow triggers in response to a push to the `main` branch, it will publish to the `edge` channel (under version "0.0.0-dev"), which is for development builds. When it triggers in response to a `v*` tag, it will publish to the `stable` channel (using the tag as the version).
- When users install the snap (e.g. with the command `snap install tombi`) it will use the most recently published version from the stable channel. The version string itself is irrelevant; i.e. it doesn't care which has a higher version number. So any push to a "v*" tag will become the new published `stable` version.
