### PR TITLE
change: Inherit process.env for server options

### DIFF
--- a/editors/vscode/src/options/server-options.ts
+++ b/editors/vscode/src/options/server-options.ts
@@ -15,6 +15,7 @@ export function serverOptions(
     args,
     options: {
       env: {
+        ...process.env,
         NO_COLOR: "1",
       },
     },


### PR DESCRIPTION
Fix https://github.com/tombi-toml/tombi/issues/1035

## Summary

Make the VSCode extension’s Language Server inherit `process.env` so proxy-related variables (e.g., `HTTP_PROXY`, `HTTPS_PROXY`, `SSL_CERT_FILE`) are preserved.

## Changes

- Add `...process.env` to `env` in `editors/vscode/src/options/server-options.ts`