### PR TITLE
fix: prevent recursive schema deadlocks by cloning schemas behind locks

### DIFF
--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -28,7 +28,7 @@ where
         let mut total_diagnostics = vec![];
         let mut total_score = 0;
 
-        let mut schemas = all_of_schema.schemas.write().await;
+        let mut schemas = all_of_schema.schemas.write().await.clone();
         for referable_schema in schemas.iter_mut() {
             let current_schema = if let Ok(Some(current_schema)) = referable_schema
                 .resolve(

--- a/crates/tombi-validator/src/validate/any_of.rs
+++ b/crates/tombi-validator/src/validate/any_of.rs
@@ -39,7 +39,7 @@ where
             .await?;
         }
 
-        let mut schemas = any_of_schema.schemas.write().await;
+        let mut schemas = any_of_schema.schemas.write().await.clone();
         let mut total_error = crate::Error::new();
 
         for referable_schema in schemas.iter_mut() {

--- a/crates/tombi-validator/src/validate/one_of.rs
+++ b/crates/tombi-validator/src/validate/one_of.rs
@@ -40,7 +40,7 @@ where
 
         let mut valid_count = 0;
 
-        let mut schemas = one_of_schema.schemas.write().await;
+        let mut schemas = one_of_schema.schemas.write().await.clone();
         let mut each_results = Vec::with_capacity(schemas.len());
         for referable_schema in schemas.iter_mut() {
             let current_schema = if let Ok(Some(current_schema)) = referable_schema

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -174,6 +174,7 @@ async fn validate_table(
             .properties
             .write()
             .await
+            .clone()
             .get_mut(&SchemaAccessor::from(&accessor))
         {
             matched_key = true;
@@ -212,7 +213,7 @@ async fn validate_table(
                 PropertySchema {
                     property_schema, ..
                 },
-            ) in pattern_properties.write().await.iter_mut()
+            ) in pattern_properties.write().await.clone().iter_mut()
             {
                 let Ok(pattern) = tombi_regex::Regex::new(pattern_key) else {
                     tracing::warn!("Invalid regex pattern property: {}", pattern_key);
@@ -291,7 +292,8 @@ async fn validate_table(
             if let Some((_, referable_additional_property_schema)) =
                 &table_schema.additional_property_schema
             {
-                let mut referable_schema = referable_additional_property_schema.write().await;
+                let mut referable_schema =
+                    referable_additional_property_schema.write().await.clone();
                 if let Ok(Some(current_schema)) = referable_schema
                     .resolve(
                         current_schema.schema_uri.clone(),


### PR DESCRIPTION
When validating a document using a schema with recursive elements, deadlocks could occur due to guards not being dropped. Cloning probably isn't the most sophisticated way to fix this but it does the job