### PR TITLE
refactor: update ListSchemasParams to be optional

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -28,13 +28,12 @@ use crate::{
     handler::{
         AssociateSchemaParams, GetStatusResponse, GetTomlVersionResponse, ListSchemasParams,
         ListSchemasResponse, RefreshCacheParams, TomlVersionSource, handle_associate_schema,
-        handle_code_action,
-        handle_completion, handle_diagnostic, handle_did_change, handle_did_change_configuration,
-        handle_did_change_watched_files, handle_did_close, handle_did_open, handle_did_save,
-        handle_document_link, handle_document_symbol, handle_folding_range, handle_formatting,
-        handle_get_status, handle_get_toml_version, handle_goto_declaration,
-        handle_goto_definition, handle_goto_type_definition, handle_hover, handle_initialize,
-        handle_initialized, handle_list_schemas, handle_refresh_cache,
+        handle_code_action, handle_completion, handle_diagnostic, handle_did_change,
+        handle_did_change_configuration, handle_did_change_watched_files, handle_did_close,
+        handle_did_open, handle_did_save, handle_document_link, handle_document_symbol,
+        handle_folding_range, handle_formatting, handle_get_status, handle_get_toml_version,
+        handle_goto_declaration, handle_goto_definition, handle_goto_type_definition, handle_hover,
+        handle_initialize, handle_initialized, handle_list_schemas, handle_refresh_cache,
         handle_semantic_tokens_full, handle_shutdown, handle_update_config, handle_update_schema,
         push_diagnostics,
     },
@@ -228,7 +227,7 @@ impl Backend {
     #[inline]
     pub async fn list_schemas(
         &self,
-        params: ListSchemasParams,
+        params: Option<ListSchemasParams>,
     ) -> Result<ListSchemasResponse, tower_lsp::jsonrpc::Error> {
         handle_list_schemas(self, params).await
     }

--- a/crates/tombi-lsp/src/handler/list_schemas.rs
+++ b/crates/tombi-lsp/src/handler/list_schemas.rs
@@ -9,7 +9,7 @@ use crate::Backend;
 #[tracing::instrument(level = "debug", skip_all)]
 pub async fn handle_list_schemas(
     backend: &Backend,
-    _params: ListSchemasParams,
+    _params: Option<ListSchemasParams>,
 ) -> Result<ListSchemasResponse, tower_lsp::jsonrpc::Error> {
     tracing::info!("handle_list_schemas");
 

--- a/editors/vscode/src/lsp/client.ts
+++ b/editors/vscode/src/lsp/client.ts
@@ -43,7 +43,6 @@ export const associateSchema = new RequestType<
   void
 >("tombi/associateSchema");
 
-export type ListSchemasParams = Record<string, never>;
 export type SchemaInfo = {
   title?: string;
   description?: string;
@@ -52,7 +51,7 @@ export type SchemaInfo = {
   catalogUri?: string;
 };
 export const listSchemas = new RequestType<
-  ListSchemasParams,
+  void,
   { schemas: SchemaInfo[] },
   void
 >("tombi/listSchemas");


### PR DESCRIPTION
- Changed the ListSchemasParams parameter to Option<ListSchemasParams> in both the backend and handler to allow for more flexible handling of schema requests.
- Updated the corresponding client type definition to reflect this change, enhancing the overall API consistency.