### PR TITLE
feat: update LSP version check to use TOMBI_DEV_VERSION constant

### DIFF
--- a/editors/vscode/src/command/select-schema.ts
+++ b/editors/vscode/src/command/select-schema.ts
@@ -1,6 +1,7 @@
 import { gte } from "semver";
 import * as vscode from "vscode";
 import type * as node from "vscode-languageclient/node";
+import { TOMBI_DEV_VERSION } from "@/extension";
 import { log } from "@/logging";
 import { listSchemas, type SchemaInfo } from "@/lsp/client";
 
@@ -14,7 +15,7 @@ export async function selectSchema(
     // Check LSP version
     if (
       lspVersion &&
-      lspVersion !== "0.0.0-dev" &&
+      lspVersion !== TOMBI_DEV_VERSION &&
       !gte(lspVersion, MIN_VERSION)
     ) {
       const message = `Select Schema requires Tombi v${MIN_VERSION} or later. Current version: ${lspVersion}. Please update Tombi.`;

--- a/editors/vscode/src/extension/index.ts
+++ b/editors/vscode/src/extension/index.ts
@@ -27,6 +27,7 @@ export const SUPPORT_TOMBI_CONFIG_FILENAMES = [
   "tombi/config.toml",
 ];
 export const SUPPORT_JSON_LANGUAGES = ["json"];
+export const TOMBI_DEV_VERSION = "0.0.0-dev";
 
 export class Extension {
   private statusBarItem: vscode.StatusBarItem;
@@ -153,7 +154,10 @@ export class Extension {
         let configPath: string | undefined;
         let ignore: IgnoreReason | undefined;
 
-        if (gte(this.lspVersion, "0.5.1") || this.lspVersion === "0.0.0-dev") {
+        if (
+          gte(this.lspVersion, "0.5.1") ||
+          this.lspVersion === TOMBI_DEV_VERSION
+        ) {
           // Use getStatus for versions >= 0.5.1
           const response = await this.client.sendRequest(getStatus, {
             uri: editor.document.uri.toString(),


### PR DESCRIPTION
- Replaced hardcoded version string with TOMBI_DEV_VERSION constant in selectSchema command for improved maintainability.
- Updated version comparison logic in the Extension class to utilize the new constant, ensuring consistent version handling across the codebase.