### PR TITLE
:page_facing_up: set classifier for MIT license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ version = "0.0.0-dev"  # We use git tags for versioning. This is just a placehol
 description = "🦅 TOML Toolkit 🦅"
 readme = "python/tombi/README.md"
 requires-python = ">=3.10"
+classifiers = [
+    "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
+]
 dependencies = []
 
 [project.urls]


### PR DESCRIPTION
This will allow automatic license recognition using dedicated tools, such as https://github.com/dhatim/python-license-check