### PR TITLE
feat(lsp): add `tombi/getSchemas` command to fetch the current document schemas

### DIFF
--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -94,6 +94,20 @@ pub enum SchemaItem {
 }
 
 impl SchemaItem {
+    pub fn title(&self) -> Option<&str> {
+        match self {
+            Self::Root(item) => item.title.as_deref(),
+            Self::Sub(item) => item.title.as_deref(),
+        }
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Self::Root(item) => item.description.as_deref(),
+            Self::Sub(item) => item.description.as_deref(),
+        }
+    }
+
     pub fn path(&self) -> &str {
         match self {
             Self::Root(item) => &item.path,
@@ -129,8 +143,14 @@ impl SchemaItem {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct RootSchema {
+    /// # Title of the schema
+    pub title: Option<String>,
+
+    /// # Description of the schema
+    pub description: Option<String>,
+
     /// # The TOML version that the schema is available
     pub toml_version: Option<TomlVersion>,
 
@@ -151,8 +171,14 @@ pub struct RootSchema {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct SubSchema {
+    /// # Title of the schema
+    pub title: Option<String>,
+
+    /// # Description of the schema
+    pub description: Option<String>,
+
     /// # The accessors to apply the sub schema
     #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
     #[cfg_attr(feature = "jsonschema", schemars(example = "tool.tombi"))]

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -90,6 +90,7 @@ macro_rules! test_format {
                             toml_version: None,
                             path,
                             include: vec!["*.toml".to_string()],
+                            ..Default::default()
                         })],
                         None,
                     )
@@ -190,6 +191,7 @@ macro_rules! test_format {
                             toml_version: None,
                             path,
                             include: vec!["*.toml".to_string()],
+                            ..Default::default()
                             })],
                         None,
                     )

--- a/crates/tombi-linter/src/lib.rs
+++ b/crates/tombi-linter/src/lib.rs
@@ -80,6 +80,7 @@ macro_rules! test_lint {
                             toml_version: None,
                             path,
                             include: vec!["*.toml".to_string()],
+                            ..Default::default()
                         })],
                         None,
                     )
@@ -175,6 +176,7 @@ macro_rules! test_lint {
                             toml_version: None,
                             path,
                             include: vec!["*.toml".to_string()],
+                            ..Default::default()
                         })],
                         None,
                     )

--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -26,13 +26,13 @@ use crate::{
     goto_definition::into_definition_locations,
     goto_type_definition::into_type_definition_locations,
     handler::{
-        AssociateSchemaParams, GetStatusResponse, GetTomlVersionResponse, ListSchemasParams,
-        ListSchemasResponse, RefreshCacheParams, TomlVersionSource, handle_associate_schema,
-        handle_code_action,
+        AssociateSchemaParams, GetSchemasParams, GetSchemasResponse, GetStatusResponse,
+        GetTomlVersionResponse, ListSchemasParams, ListSchemasResponse, RefreshCacheParams,
+        TomlVersionSource, handle_associate_schema, handle_code_action,
         handle_completion, handle_diagnostic, handle_did_change, handle_did_change_configuration,
         handle_did_change_watched_files, handle_did_close, handle_did_open, handle_did_save,
         handle_document_link, handle_document_symbol, handle_folding_range, handle_formatting,
-        handle_get_status, handle_get_toml_version, handle_goto_declaration,
+        handle_get_schemas, handle_get_status, handle_get_toml_version, handle_goto_declaration,
         handle_goto_definition, handle_goto_type_definition, handle_hover, handle_initialize,
         handle_initialized, handle_list_schemas, handle_refresh_cache,
         handle_semantic_tokens_full, handle_shutdown, handle_update_config, handle_update_schema,
@@ -231,6 +231,14 @@ impl Backend {
         params: ListSchemasParams,
     ) -> Result<ListSchemasResponse, tower_lsp::jsonrpc::Error> {
         handle_list_schemas(self, params).await
+    }
+
+    #[inline]
+    pub async fn get_schemas(
+        &self,
+        params: GetSchemasParams,
+    ) -> Result<GetSchemasResponse, tower_lsp::jsonrpc::Error> {
+        handle_get_schemas(self, params).await
     }
 
     #[inline]

--- a/crates/tombi-lsp/src/handler/get_schemas.rs
+++ b/crates/tombi-lsp/src/handler/get_schemas.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use crate::{Backend, config_manager::ConfigSchemaStore, handler::list_schemas::SchemaInfo};
+
+use itertools::Either;
+use tower_lsp::lsp_types::TextDocumentIdentifier;
+
+/// Normalize an optional text field by trimming whitespace and converting empty strings to None.
+fn normalize_optional_text(input: Option<String>) -> Option<String> {
+    input.and_then(|s| if s.trim().is_empty() { None } else { Some(s) })
+}
+
+fn schema_info_from_store(
+    store_schema: Option<tombi_schema_store::Schema>,
+    uri: tombi_uri::SchemaUri,
+    toml_version: Option<String>,
+) -> SchemaInfo {
+    if let Some(store_schema) = store_schema {
+        SchemaInfo {
+            title: normalize_optional_text(store_schema.title),
+            description: normalize_optional_text(store_schema.description),
+            toml_version: store_schema
+                .toml_version
+                .map(|v| v.to_string())
+                .or(toml_version),
+            uri,
+            catalog_uri: store_schema.catalog_uri,
+        }
+    } else {
+        SchemaInfo {
+            title: None,
+            description: None,
+            toml_version,
+            uri,
+            catalog_uri: None,
+        }
+    }
+}
+
+/// Handle the `tombi/getSchemas` request to list resolved schemas for a document.
+///
+/// This returns the *resolved* schema URIs for the given document (root schema plus
+/// any referenced sub-schemas), based on the document contents and current schema-store.
+#[tracing::instrument(level = "debug", skip_all)]
+pub async fn handle_get_schemas(
+    backend: &Backend,
+    params: TextDocumentIdentifier,
+) -> Result<GetSchemasResponse, tower_lsp::jsonrpc::Error> {
+    tracing::info!("handle_get_schemas");
+    tracing::trace!(?params);
+
+    let TextDocumentIdentifier { uri } = params;
+    let text_document_uri: tombi_uri::Uri = uri.into();
+
+    let ConfigSchemaStore { schema_store, .. } = backend
+        .config_manager
+        .config_schema_store_for_uri(&text_document_uri)
+        .await;
+
+    let document_sources = backend.document_sources.read().await;
+    let Some(document_source) = document_sources.get(&text_document_uri) else {
+        return Ok(GetSchemasResponse { schemas: vec![] });
+    };
+
+    let directive_schema_uri = document_source
+        .ast()
+        .schema_document_comment_directive(text_document_uri.to_file_path().ok().as_deref())
+        .and_then(|directive| directive.uri.ok());
+
+    let mut schema_by_uri: HashMap<tombi_uri::SchemaUri, tombi_schema_store::Schema> =
+        HashMap::new();
+    for schema in schema_store.list_schemas().await {
+        match schema_by_uri.get_mut(&schema.schema_uri) {
+            Some(existing) => {
+                if schema.source == tombi_schema_store::SchemaSource::Config {
+                    if normalize_optional_text(schema.title.clone()).is_some() {
+                        existing.title = schema.title;
+                    }
+                    if normalize_optional_text(schema.description.clone()).is_some() {
+                        existing.description = schema.description;
+                    }
+                } else {
+                    *existing = schema;
+                }
+            }
+            None => {
+                schema_by_uri.insert(schema.schema_uri.clone(), schema);
+            }
+        }
+    }
+
+    let source_schema = schema_store
+        .resolve_source_schema_from_ast(
+            document_source.ast(),
+            Some(Either::Left(&text_document_uri)),
+        )
+        .await
+        .ok()
+        .flatten();
+
+    let Some(source_schema) = source_schema else {
+        return Ok(GetSchemasResponse { schemas: vec![] });
+    };
+
+    let mut schemas = Vec::new();
+
+    if let Some(root_schema) = source_schema.root_schema.as_ref() {
+        let root_uri: tombi_uri::SchemaUri = root_schema.schema_uri.clone();
+        let mut schema_info = schema_info_from_store(
+            schema_by_uri.get(&root_uri).cloned(),
+            root_uri.clone(),
+            root_schema.toml_version().map(|v| v.to_string()),
+        );
+
+        if schema_info.title.is_none() && Some(&root_uri) == directive_schema_uri.as_ref() {
+            schema_info.title = Some("Document Directive Schema".to_string());
+        }
+
+        schemas.push(schema_info);
+    }
+
+    for sub_schema_uri in source_schema.sub_schema_uri_map.values() {
+        if schemas
+            .iter()
+            .any(|s: &SchemaInfo| &s.uri == sub_schema_uri)
+        {
+            continue;
+        }
+
+        schemas.push(schema_info_from_store(
+            schema_by_uri.get(sub_schema_uri).cloned(),
+            sub_schema_uri.clone(),
+            None,
+        ));
+    }
+
+    Ok(GetSchemasResponse { schemas })
+}
+
+pub type GetSchemasParams = TextDocumentIdentifier;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSchemasResponse {
+    pub schemas: Vec<SchemaInfo>,
+}

--- a/crates/tombi-lsp/src/handler/list_schemas.rs
+++ b/crates/tombi-lsp/src/handler/list_schemas.rs
@@ -40,7 +40,7 @@ pub struct ListSchemasResponse {
     pub schemas: Vec<SchemaInfo>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaInfo {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -25,6 +25,7 @@ pub mod handler {
     mod document_symbol;
     mod folding_range;
     mod formatting;
+    mod get_schemas;
     mod get_status;
     mod get_toml_version;
     mod goto_declaration;
@@ -55,6 +56,7 @@ pub mod handler {
     pub use document_symbol::handle_document_symbol;
     pub use folding_range::handle_folding_range;
     pub use formatting::handle_formatting;
+    pub use get_schemas::{GetSchemasParams, GetSchemasResponse, handle_get_schemas};
     pub use get_status::{GetStatusResponse, handle_get_status};
     pub use get_toml_version::{
         GetTomlVersionResponse, TomlVersionSource, handle_get_toml_version,
@@ -107,6 +109,7 @@ pub async fn serve(_args: impl Into<Args>, offline: bool, no_cache: bool) {
     .custom_method("tombi/getStatus", Backend::get_status)
     .custom_method("tombi/getTomlVersion", Backend::get_toml_version)
     .custom_method("tombi/listSchemas", Backend::list_schemas)
+    .custom_method("tombi/getSchemas", Backend::get_schemas)
     .custom_method("tombi/updateSchema", Backend::update_schema)
     .custom_method("tombi/updateConfig", Backend::update_config)
     .custom_method("tombi/associateSchema", Backend::associate_schema)

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -783,6 +783,7 @@ mod completion_edit {
                                     toml_version: None,
                                     path: schema_uri.to_string(),
                                     include: vec!["*.toml".to_string()],
+                                    ..Default::default()
                                 }),
                             ],
                             None

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1671,6 +1671,7 @@ mod completion_labels {
                                 toml_version: None,
                                 path: schema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
+                                ..Default::default()
                             })],
                             None,
                         )
@@ -1694,6 +1695,7 @@ mod completion_labels {
                                 path: subschema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
                                 root: subschema.root.to_string(),
+                                ..Default::default()
                             })],
                             None,
                         )

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -570,6 +570,7 @@ macro_rules! test_document_link {
                             toml_version: None,
                             path: schema_uri.to_string(),
                             include: vec!["*.toml".to_string()],
+                            ..Default::default()
                         })],
                         None,
                     )
@@ -593,6 +594,7 @@ macro_rules! test_document_link {
                             path: subschema_uri.to_string(),
                             include: vec!["*.toml".to_string()],
                             root: subschema.root.clone(),
+                            ..Default::default()
                         })],
                         None,
                     )

--- a/crates/tombi-lsp/tests/test_get_schemas.rs
+++ b/crates/tombi-lsp/tests/test_get_schemas.rs
@@ -1,0 +1,86 @@
+use tombi_test_lib::project_root_path;
+
+macro_rules! test_get_schemas {
+    ($(#[$attr:meta])* async fn $name:ident($toml_text:expr, $source_path:expr $(, $arg:expr)* $(,)?) -> Ok($expected:expr);) => {
+        $(#[$attr])*
+        async fn $name() {
+            tombi_test_lib::init_tracing();
+
+            let source_path: std::path::PathBuf = $source_path;
+
+            let (service, _) = tower_lsp::LspService::new(|client| {
+                tombi_lsp::Backend::new(client, &tombi_lsp::backend::Options::default())
+            });
+
+            let backend = service.inner();
+
+            $(
+                backend
+                    .config_manager
+                    .load_config_schemas(&[$arg], None)
+                    .await;
+            )*
+
+            let toml_file_url = tower_lsp::lsp_types::Url::from_file_path(&source_path)
+                .expect("failed to convert source file path to URL");
+
+            let toml_text = textwrap::dedent($toml_text).trim().to_string();
+
+            tombi_lsp::handler::handle_did_open(
+                backend,
+                tower_lsp::lsp_types::DidOpenTextDocumentParams {
+                    text_document: tower_lsp::lsp_types::TextDocumentItem {
+                        uri: toml_file_url.clone(),
+                        language_id: "toml".to_string(),
+                        version: 0,
+                        text: toml_text,
+                    },
+                },
+            )
+            .await;
+
+            let response = tombi_lsp::handler::handle_get_schemas(
+                backend,
+                tower_lsp::lsp_types::TextDocumentIdentifier { uri: toml_file_url },
+            )
+            .await
+            .unwrap();
+
+            let mut actual: Vec<std::path::PathBuf> = response
+                .schemas
+                .into_iter()
+                .filter_map(|schema| schema.uri.to_file_path().ok())
+                .collect();
+            actual.sort();
+
+            let mut expected: Vec<std::path::PathBuf> = $expected;
+            expected.sort();
+
+            pretty_assertions::assert_eq!(actual, expected);
+        }
+    };
+}
+
+mod get_schemas_tests {
+    use super::*;
+
+    test_get_schemas!(
+        #[tokio::test]
+        async fn root_schema_config_applies_to_document(
+            r#"
+            a = 1
+            "#,
+            project_root_path().join("tmp/unknown.toml"),
+            tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: tombi_schema_store::SchemaUri::from_file_path(
+                    project_root_path().join("schemas/type-test.schema.json"),
+                )
+                .unwrap()
+                .to_string(),
+                include: vec!["*.toml".to_string()],
+                ..Default::default()
+            }),
+        ) -> Ok(vec![project_root_path().join("schemas/type-test.schema.json")]);
+    );
+}

--- a/crates/tombi-lsp/tests/test_goto_declaration.rs
+++ b/crates/tombi-lsp/tests/test_goto_declaration.rs
@@ -261,6 +261,7 @@ mod goto_declaration_tests {
                                 toml_version: None,
                                 path: schema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
+                                ..Default::default()
                             })],
                             None,
                         )
@@ -284,6 +285,7 @@ mod goto_declaration_tests {
                                 path: subschema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
                                 root: subschema.root.clone(),
+                                ..Default::default()
                             })],
                             None,
                         )

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -554,6 +554,7 @@ mod goto_definition_tests {
                                 toml_version: None,
                                 path: schema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
+                                ..Default::default()
                             })],
                             None,
                         )
@@ -577,6 +578,7 @@ mod goto_definition_tests {
                                 path: subschema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
                                 root: subschema.root.clone(),
+                                ..Default::default()
                             })],
                             None,
                         )

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -537,6 +537,7 @@ mod goto_type_definition_tests {
                                 toml_version: None,
                                 path: schema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
+                                ..Default::default()
                             })],
                             None,
                         )
@@ -560,6 +561,7 @@ mod goto_type_definition_tests {
                                 path: subschema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
                                 root: subschema.root.clone(),
+                                ..Default::default()
                             })],
                             None,
                         )

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -549,6 +549,7 @@ mod hover_keys_value {
                                 toml_version: None,
                                 path: schema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
+                                ..Default::default()
                             })],
                             None,
                         )
@@ -572,6 +573,7 @@ mod hover_keys_value {
                                 path: subschema_uri.to_string(),
                                 include: vec!["*.toml".to_string()],
                                 root: subschema.root.clone(),
+                                ..Default::default()
                             })],
                             None,
                         )

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -67,6 +67,14 @@ pub struct Schema {
     pub catalog_uri: Option<Arc<tombi_uri::CatalogUri>>,
     pub include: Vec<String>,
     pub sub_root_keys: Option<Vec<SchemaAccessor>>,
+    pub source: SchemaSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaSource {
+    Catalog,
+    Config,
+    Directive,
 }
 
 pub trait FindSchemaCandidates {

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -174,13 +174,14 @@ impl SchemaStore {
             tracing::debug!("Load schema from config: {}", schema_uri);
 
             self.schemas.write().await.push(crate::Schema {
-                title: None,
-                description: None,
+                title: schema.title().map(ToOwned::to_owned),
+                description: schema.description().map(ToOwned::to_owned),
                 schema_uri,
                 catalog_uri: None,
                 include: schema.include().to_vec(),
                 toml_version: schema.toml_version(),
                 sub_root_keys: schema.root().and_then(SchemaAccessor::parse),
+                source: crate::SchemaSource::Config,
             });
         }))
         .await;
@@ -323,6 +324,7 @@ impl SchemaStore {
                     include: schema.file_match,
                     toml_version: None,
                     sub_root_keys: None,
+                    source: crate::SchemaSource::Catalog,
                 });
             }
         }
@@ -760,6 +762,7 @@ impl SchemaStore {
             include,
             toml_version: options.toml_version,
             sub_root_keys: None,
+            source: crate::SchemaSource::Directive,
         };
 
         let mut schemas = self.schemas.write().await;

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -670,11 +670,15 @@ Apply a schema to the entire TOML document.
 
 ```toml
 [[schemas]]
-toml-version = "v1.0.0"  # optional
+title = "My Schema"               # optional
+description = "Project schema"     # optional
+toml-version = "v1.0.0"            # optional
 path = "https://example.com/schema.json"
 include = ["example.toml"]
 ```
 
+- `title`(optional): Title shown when listing schemas
+- `description`(optional): Description shown when listing schemas
 - `toml-version`(optional): The TOML version that the schema is available for
 - `path`: The schema path (URL or local file path)
 - `include`: File match patterns to apply this schema (supports glob patterns)
@@ -686,11 +690,15 @@ Sub schemas are mainly provided for configuring extension features, such as the 
 
 ```toml
 [[schemas]]
+title = "Taskipy Schema"          # optional
+description = "Tool section"       # optional
 root = "tool.taskipy"
 path = "schemas/partial-taskipy.schema.json"
 include = ["pyproject.toml"]
 ```
 
+- `title`(optional): Title shown when listing schemas
+- `description`(optional): Description shown when listing schemas
 - `root`: The accessor path to apply the sub-schema (e.g., `"tools.tombi"`, `"items[0].name"`)
 - `path`: The schema path (URL or local file path)
 - `include`: File match patterns to apply this schema (supports glob patterns)

--- a/docs/src/routes/docs/language-server/command.mdx
+++ b/docs/src/routes/docs/language-server/command.mdx
@@ -141,6 +141,56 @@ response.schemas.forEach(schema => {
 
 ---
 
+### tombi/getSchemas
+
+Get the resolved schemas for a TOML document.
+
+This returns the resolved root schema (if any) plus any referenced sub-schemas, enriched with metadata where available.
+
+#### Request
+
+```typescript
+interface GetSchemasParams {
+  textDocument: TextDocumentIdentifier;
+}
+```
+
+#### Response
+
+```typescript
+interface GetSchemasResponse {
+  schemas: {
+    title?: string;
+    description?: string;
+    tomlVersion?: string;
+    uri: string;
+    catalogUri?: string;
+  }[];
+}
+```
+
+- `title` / `description`: Metadata from the schema store if available.
+  - If the schema is configured via `[[schemas]]`, `title` and `description` from config are used.
+  - If a `#:schema` document directive is used and the schema is not found in the store, `title` is set to `"Document Directive Schema"`.
+- `tomlVersion`: TOML version required by the schema.
+- `uri`: Schema URI.
+- `catalogUri`: Schema catalog URI (e.g., Schema Store), when known.
+
+#### Example
+
+```typescript
+// Get resolved schemas for the current document
+const response = await client.sendRequest("tombi/getSchemas", {
+  textDocument: { uri: "file:///path/to/Cargo.toml" }
+});
+
+response.schemas.forEach(schema => {
+  console.log(schema.uri, schema.title);
+});
+```
+
+---
+
 ### tombi/updateSchema
 
 Update a schema from its remote source. This is useful when you want to refresh the schema without restarting the language server.

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -890,6 +890,20 @@
       "title": "The schema for the root table",
       "type": "object",
       "properties": {
+        "title": {
+          "title": "Title of the schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "title": "Description of the schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "toml-version": {
           "title": "The TOML version that the schema is available",
           "anyOf": [
@@ -926,6 +940,20 @@
       "title": "The schema for the sub value",
       "type": "object",
       "properties": {
+        "title": {
+          "title": "Title of the schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "title": "Description of the schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "root": {
           "title": "The accessors to apply the sub schema",
           "type": "string",


### PR DESCRIPTION
Hi 👋🏼 

Following #1423, I now have the LSP schemas listing since the release v0.7.19 (thanks for it) but I was still missing the document schemas. I tried using the hover and/or goToDefinition, but this only works on a valid statements so it's not possible to know which schemas is active on an empty document, on root whitespaces or on invalid nodes.

Given it seems not that complicated as the schemas were already retrieved at multiple place, I gave it try.

So there it is, this PR adds:
- a `tombi/getSchemas` LSP method with its documentation, it returns the same format that `tombi/listSchemas`
- allows optional `title` and `description` on config schemas

Schema declared using the schema directive have a special name "Document Directive Schema"

