### PR TITLE
fix(parser): allow hex/octal/binary-like bare keys

### DIFF
--- a/crates/tombi-parser/src/parse/array_of_table.rs
+++ b/crates/tombi-parser/src/parse/array_of_table.rs
@@ -120,4 +120,34 @@ mod test {
             "#
         ) -> Err([SyntaxError(ExpectedLineBreak, 1:9..1:16)])
     }
+
+    test_parser! {
+        #[test]
+        fn hex_like_array_of_table_key(
+            r#"
+            [[0x96f]]
+            name = "hex-like"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn octal_like_array_of_table_key(
+            r#"
+            [[0o755]]
+            mode = "permissions"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn binary_like_array_of_table_key(
+            r#"
+            [[0b1010]]
+            flags = true
+            "#
+        ) -> Ok(_)
+    }
 }

--- a/crates/tombi-parser/src/parse/key.rs
+++ b/crates/tombi-parser/src/parse/key.rs
@@ -47,7 +47,7 @@ pub fn eat_key(p: &mut Parser<'_>) -> bool {
             m.complete(p, kind);
             true
         }
-        INTEGER_DEC | BOOLEAN | LOCAL_DATE => {
+        INTEGER_DEC | INTEGER_HEX | INTEGER_OCT | INTEGER_BIN | BOOLEAN | LOCAL_DATE => {
             let m = p.start();
             p.bump_remap(BARE_KEY);
             m.complete(p, BARE_KEY);

--- a/crates/tombi-parser/src/parse/key_value.rs
+++ b/crates/tombi-parser/src/parse/key_value.rs
@@ -199,4 +199,53 @@ mod test {
             "#
         ) -> Ok(_)
     }
+
+    test_parser! {
+        #[test]
+        fn hex_like_bare_keys(
+            r#"
+            0x96f = "hex-like key"
+            0xDEADBEEF = "another hex-like"
+            a.0xABC = "dotted hex"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn octal_like_bare_keys(
+            r#"
+            0o755 = "octal-like key"
+            0o777.permissions = "dotted octal"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn binary_like_bare_keys(
+            r#"
+            0b1010 = "binary-like key"
+            0b11.0b00 = "dotted binary"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn hex_key_with_hex_value(
+            r#"
+            0x96f = 0x96f
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn inline_table_with_hex_key(
+            r#"
+            table = { 0x96f = "value" }
+            "#
+        ) -> Ok(_)
+    }
 }

--- a/crates/tombi-parser/src/parse/table.rs
+++ b/crates/tombi-parser/src/parse/table.rs
@@ -137,4 +137,35 @@ mod test {
             SyntaxError(ExpectedLineBreak, 1:9..1:16),
         ])
     }
+
+    test_parser! {
+        #[test]
+        fn hex_like_table_key(
+            r#"
+            [0x96f]
+            submodule = "extensions/0x96f"
+            version = "1.3.5"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn octal_like_table_key(
+            r#"
+            [0o755]
+            value = "octal key"
+            "#
+        ) -> Ok(_)
+    }
+
+    test_parser! {
+        #[test]
+        fn binary_like_table_key(
+            r#"
+            [0b1010]
+            value = "binary key"
+            "#
+        ) -> Ok(_)
+    }
 }

--- a/crates/tombi-parser/src/token_set.rs
+++ b/crates/tombi-parser/src/token_set.rs
@@ -15,6 +15,12 @@ pub(crate) const TS_KEY_FIRST: TokenSet = TokenSet::new(&[
     LITERAL_STRING,
     // 1234 = "value"
     INTEGER_DEC,
+    // 0x96f = "value"
+    INTEGER_HEX,
+    // 0o755 = "value"
+    INTEGER_OCT,
+    // 0b1010 = "value"
+    INTEGER_BIN,
     // 3.14159 = "pi"
     FLOAT,
     // true = "value"


### PR DESCRIPTION
## Description

Fixes parsing of table headers like [`[0x96f]`][zed-extensions:example] which was incorrectly reporting `expected ']'` (`expected-bracket-end`).

[zed-extensions:example]: https://github.com/zed-industries/extensions/blob/4c7eb0c75c180cd0198b9d537b9555284044b5d1/extensions.toml#L1 "Same as example below"

### Problem

Tokens like `0x96f`, `0o755`, `0b1010` were being lexed as `INTEGER_HEX`/`INTEGER_OCT`/`INTEGER_BIN`, but the parser's `eat_key()` function didn't recognize these as valid key tokens.
Per TOML spec, bare keys can contain `A-Za-z0-9_-` and are always interpreted as strings; the `0x`/`0o`/`0b` prefixes only apply to integer values, not keys.

### Solution

Added `INTEGER_HEX`, `INTEGER_BIN`, `INTEGER_OCT` to:

- `eat_key()` remapping (same as `INTEGER_DEC`)
- `TS_KEY_FIRST` token set

### Testing

Added 11 tests covering all 3 token types across table headers, key-values, and array of tables, plus edge cases for mixed key/value contexts and inline tables.

### Example (this now parses correctly)

```toml
[0x96f]
submodule = "extensions/0x96f"
version = "1.3.5"
```
