### PR TITLE
feat: enhance`workspace/didChangeConfiguration` support

### DIFF
--- a/crates/tombi-lsp/src/handler/did_change_configuration.rs
+++ b/crates/tombi-lsp/src/handler/did_change_configuration.rs
@@ -1,7 +1,35 @@
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 
+use crate::backend::Backend;
+
 #[tracing::instrument(level = "debug", skip_all)]
-pub async fn handle_did_change_configuration(params: DidChangeConfigurationParams) {
+pub async fn handle_did_change_configuration(
+    backend: &Backend,
+    params: DidChangeConfigurationParams,
+) {
     tracing::info!("handle_did_change_configuration");
     tracing::trace!(?params);
+
+    // Extract tombi settings from the settings object
+    // The settings structure is expected to be:
+    // {
+    //   "tombi": {
+    //     "toml-version": "v1.0.0",
+    //     ...
+    //   }
+    // }
+    let settings = params.settings;
+    if let Some(tombi_settings) = settings.get("tombi") {
+        match serde_json::from_value::<tombi_config::Config>(tombi_settings.clone()) {
+            Ok(config) => {
+                tracing::info!("Updating editor config: {:?}", config);
+                backend.config_manager.update_editor_config(config).await;
+            }
+            Err(err) => {
+                tracing::error!("Failed to parse editor config: {}", err);
+            }
+        }
+    } else {
+        tracing::debug!("No tombi settings found in didChangeConfiguration");
+    }
 }

--- a/crates/tombi-lsp/src/handler/get_toml_version.rs
+++ b/crates/tombi-lsp/src/handler/get_toml_version.rs
@@ -63,6 +63,12 @@ pub enum TomlVersionSource {
     /// ```
     Config,
 
+    /// Editor settings
+    ///
+    /// Settings passed from the editor via `workspace/didChangeConfiguration`.
+    /// Has lower priority than config files but higher than default.
+    Editor,
+
     /// Default
     Default,
 }


### PR DESCRIPTION
https://github.com/tombi-toml/tombi/issues/1453

- Introduced DefaultConfigSource enum to differentiate between default and editor configurations.
- Updated ConfigManager to handle editor-specific configurations, allowing dynamic updates via workspace/didChangeConfiguration.
- Modified backend logic to return appropriate TomlVersionSource based on the configuration source.
- Improved error handling and logging for configuration loading processes.
- Refactored related functions to streamline schema association and loading.