### PR TITLE
feat: enhance get_status handler to include schema information

### DIFF
--- a/crates/tombi-lsp/src/handler/get_status.rs
+++ b/crates/tombi-lsp/src/handler/get_status.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
+use itertools::Either;
 use tombi_config::TomlVersion;
 use tombi_glob::{MatchResult, matches_file_patterns};
+use tombi_uri::SchemaUri;
 use tower_lsp::lsp_types::TextDocumentIdentifier;
 
 use crate::{backend::Backend, config_manager::ConfigSchemaStore, handler::TomlVersionSource};
@@ -19,20 +21,89 @@ pub async fn handle_get_status(
     let ConfigSchemaStore {
         config,
         config_path,
-        ..
+        schema_store,
     } = backend
         .config_manager
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    let (toml_version, source) = {
+    let (toml_version, source, schema) = {
         let document_sources = backend.document_sources.read().await;
         if let Some(document_source) = document_sources.get(&text_document_uri) {
-            backend
+            let (toml_version, source) = backend
                 .text_document_toml_version_and_source(&text_document_uri, document_source.text())
-                .await
+                .await;
+
+            // Get schema information
+            let schema = if let Some(parsed) =
+                tombi_parser::parse_document_header_comments(document_source.text())
+                    .cast::<tombi_ast::Root>()
+            {
+                let root = parsed.tree();
+
+                // Get schema URI from resolve_source_schema_from_ast
+                // (internally checks comment directive first, then falls back to other methods)
+                let schema_uri = match schema_store
+                    .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))
+                    .await
+                {
+                    Ok(Some(source_schema)) => {
+                        source_schema.root_schema.as_ref().map(|s| s.schema_uri.clone())
+                    }
+                    _ => None,
+                };
+
+                // If schema URI is available, get detailed information
+                if let Some(schema_uri) = schema_uri {
+                    // First, search in list_schemas
+                    let schemas = schema_store.list_schemas().await;
+                    if let Some(schema) = schemas.iter().find(|s| s.schema_uri == schema_uri) {
+                        Some(SchemaStatus {
+                            title: schema.title.clone(),
+                            description: schema.description.clone(),
+                            uri: schema_uri,
+                        })
+                    } else {
+                        // If not found in list_schemas, get from DocumentSchema
+                        match schema_store.try_get_document_schema(&schema_uri).await {
+                            Ok(Some(doc_schema)) => {
+                                // Get title/description from DocumentSchema
+                                let (title, description) = if let Some(value_schema) =
+                                    &doc_schema.value_schema
+                                {
+                                    (
+                                        value_schema.title().map(|s| s.to_string()),
+                                        value_schema.description().map(|s| s.to_string()),
+                                    )
+                                } else {
+                                    (None, None)
+                                };
+                                Some(SchemaStatus {
+                                    title,
+                                    description,
+                                    uri: schema_uri,
+                                })
+                            }
+                            _ => {
+                                // Return URI only even if schema cannot be retrieved
+                                Some(SchemaStatus {
+                                    title: None,
+                                    description: None,
+                                    uri: schema_uri,
+                                })
+                            }
+                        }
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            (toml_version, source, schema)
         } else {
-            (TomlVersion::default(), TomlVersionSource::Default)
+            (TomlVersion::default(), TomlVersionSource::Default, None)
         }
     };
 
@@ -50,6 +121,7 @@ pub async fn handle_get_status(
         source,
         config_path,
         ignore,
+        schema,
     })
 }
 
@@ -58,8 +130,22 @@ pub async fn handle_get_status(
 pub struct GetStatusResponse {
     pub toml_version: TomlVersion,
     pub source: TomlVersionSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore: Option<IgnoreReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<SchemaStatus>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub uri: SchemaUri,
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/editors/vscode/src/extension/index.ts
+++ b/editors/vscode/src/extension/index.ts
@@ -8,6 +8,7 @@ import {
   getStatus,
   getTomlVersion,
   type IgnoreReason,
+  type SchemaStatus,
   updateConfig,
   updateSchema,
 } from "@/lsp/client";
@@ -153,6 +154,7 @@ export class Extension {
         let source: string;
         let configPath: string | undefined;
         let ignore: IgnoreReason | undefined;
+        let schema: SchemaStatus | undefined;
 
         if (
           gte(this.lspVersion, "0.5.1") ||
@@ -166,6 +168,7 @@ export class Extension {
           source = response.source;
           configPath = response.configPath;
           ignore = response.ignore;
+          schema = response.schema;
         } else {
           // Use getTomlVersion for versions < 0.5.1
           const response = await this.client.sendRequest(getTomlVersion, {
@@ -178,6 +181,10 @@ export class Extension {
         let text = `TOML: ${tomlVersion} (${source})`;
         let tooltip = `Tombi: ${this.lspVersion}\nTOML: ${tomlVersion} (${source})\nConfig: ${configPath ?? "default"}`;
         let color: string | vscode.ThemeColor | undefined;
+
+        if (schema) {
+          tooltip += `\nSchema: ${schema.uri}`;
+        }
 
         if (ignore) {
           text = `$(extensions-warning-message) ${text}`;

--- a/editors/vscode/src/lsp/client.ts
+++ b/editors/vscode/src/lsp/client.ts
@@ -8,6 +8,12 @@ export type IgnoreReason =
   | "include-file-pattern-not-matched"
   | "exclude-file-pattern-matched";
 
+export type SchemaStatus = {
+  title?: string;
+  description?: string;
+  uri: string;
+};
+
 export type GetTomlVersionParams = TextDocumentIdentifier;
 export const getTomlVersion = new RequestType<
   GetTomlVersionParams,
@@ -65,6 +71,7 @@ export const getStatus = new RequestType<
     source: TomlVersionSource;
     configPath?: string;
     ignore?: IgnoreReason;
+    schema?: SchemaStatus;
   },
   void
 >("tombi/getStatus");


### PR DESCRIPTION
- Updated the `handle_get_status` function to retrieve and return schema details alongside TOML version and source.
- Introduced `SchemaStatus` struct to encapsulate schema title, description, and URI.
- Modified the response structure to include optional schema data, improving the LSP client integration in VSCode.