### PR TITLE
feat: implement inline table validation for TOML v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,9 +4195,14 @@ dependencies = [
  "serde",
  "serde_json",
  "textwrap",
+ "tokio",
  "tombi-ast",
+ "tombi-config",
+ "tombi-diagnostic",
  "tombi-document-tree",
+ "tombi-linter",
  "tombi-parser",
+ "tombi-schema-store",
  "tombi-toml-version",
 ]
 

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -2,7 +2,7 @@ pub mod definitions;
 
 use std::fmt::Write;
 
-use itertools::{Either, Itertools};
+use itertools::Either;
 use tombi_comment_directive::TOMBI_COMMENT_DIRECTIVE_TOML_VERSION;
 use tombi_config::{IndentStyle, TomlVersion};
 use tombi_diagnostic::{Diagnostic, SetDiagnostics};
@@ -110,16 +110,6 @@ impl<'a> Formatter<'a> {
         };
 
         let (root, errors) = parsed.into_root_and_errors();
-        let errors = errors
-            .into_iter()
-            .filter(|error| {
-                !matches!(
-                    error.kind(),
-                    tombi_parser::ErrorKind::InlineTableMustSingleLine
-                        | tombi_parser::ErrorKind::ForbiddenInlineTableLastComma
-                )
-            })
-            .collect_vec();
 
         if !errors.is_empty() {
             let mut diagnostics = vec![];

--- a/crates/tombi-linter/src/diagnostic.rs
+++ b/crates/tombi-linter/src/diagnostic.rs
@@ -6,6 +6,10 @@ pub enum DiagnosticKind {
     DottedKeysOutOfOrder,
     #[error("Defining tables out-of-order is discouraged")]
     TablesOutOfOrder,
+    #[error("inline table must be single line in TOML v1.0.0 or earlier")]
+    InlineTableMustSingleLine,
+    #[error("trailing comma in inline table not allowed in TOML v1.0.0 or earlier")]
+    ForbiddenInlineTableLastComma,
 }
 
 #[derive(Debug)]
@@ -21,6 +25,8 @@ impl Diagnostic {
             DiagnosticKind::KeyEmpty => "key-empty",
             DiagnosticKind::DottedKeysOutOfOrder => "dotted-keys-out-of-order",
             DiagnosticKind::TablesOutOfOrder => "tables-out-of-order",
+            DiagnosticKind::InlineTableMustSingleLine => "inline-table-must-single-line",
+            DiagnosticKind::ForbiddenInlineTableLastComma => "forbidden-inline-table-last-comma",
         }
     }
 }

--- a/crates/tombi-linter/src/lint/value/inline_table.rs
+++ b/crates/tombi-linter/src/lint/value/inline_table.rs
@@ -7,6 +7,7 @@ impl Lint for tombi_ast::InlineTable {
         async move {
             crate::rule::KeyEmptyRule::check(self, l).await;
             crate::rule::DottedKeysOutOfOrderRule::check(self, l).await;
+            crate::rule::InlineTableTomlVersionRule::check(self, l).await;
 
             for key_value in self.key_values() {
                 key_value.lint(l).await;

--- a/crates/tombi-linter/src/rule.rs
+++ b/crates/tombi-linter/src/rule.rs
@@ -1,7 +1,9 @@
 mod dotted_keys_out_of_order;
+mod inline_table_toml_version;
 mod key_empty;
 mod tables_out_of_order;
 pub use dotted_keys_out_of_order::DottedKeysOutOfOrderRule;
+pub use inline_table_toml_version::InlineTableTomlVersionRule;
 pub use key_empty::KeyEmptyRule;
 pub use tables_out_of_order::TablesOutOfOrderRule;
 

--- a/crates/tombi-linter/src/rule/inline_table_toml_version.rs
+++ b/crates/tombi-linter/src/rule/inline_table_toml_version.rs
@@ -9,8 +9,6 @@ impl Rule<tombi_ast::InlineTable> for InlineTableTomlVersionRule {
         if l.toml_version() != TomlVersion::V1_0_0 {
             return;
         }
-
-        // InlineTableMustSingleLine: inline table must be single line in TOML v1.0.0
         let brace_start = match node.brace_start() {
             Some(t) => t,
             None => return,
@@ -31,8 +29,6 @@ impl Rule<tombi_ast::InlineTable> for InlineTableTomlVersionRule {
                 range: node.range(),
             });
         }
-
-        // ForbiddenInlineTableLastComma: trailing comma not allowed in TOML v1.0.0
         if node.has_last_key_value_trailing_comma() {
             if let Some(comma_range) = node
                 .key_values_with_comma()

--- a/crates/tombi-linter/src/rule/inline_table_toml_version.rs
+++ b/crates/tombi-linter/src/rule/inline_table_toml_version.rs
@@ -1,0 +1,124 @@
+use tombi_config::{SeverityLevel, TomlVersion};
+
+use crate::{Diagnostic, DiagnosticKind, Rule};
+
+pub struct InlineTableTomlVersionRule;
+
+impl Rule<tombi_ast::InlineTable> for InlineTableTomlVersionRule {
+    async fn check(node: &tombi_ast::InlineTable, l: &mut crate::Linter<'_>) {
+        if l.toml_version() != TomlVersion::V1_0_0 {
+            return;
+        }
+
+        // InlineTableMustSingleLine: inline table must be single line in TOML v1.0.0
+        let brace_start = match node.brace_start() {
+            Some(t) => t,
+            None => return,
+        };
+        let brace_end = match node.brace_end() {
+            Some(t) => t,
+            None => return,
+        };
+        let table_span = brace_end.range().start.line - brace_start.range().start.line;
+        let key_value_lines: u32 = node
+            .key_values()
+            .map(|kv| kv.range().end.line - kv.range().start.line)
+            .sum();
+        if table_span != key_value_lines {
+            l.extend_diagnostics(Diagnostic {
+                kind: DiagnosticKind::InlineTableMustSingleLine,
+                level: SeverityLevel::Error,
+                range: node.range(),
+            });
+        }
+
+        // ForbiddenInlineTableLastComma: trailing comma not allowed in TOML v1.0.0
+        if node.has_last_key_value_trailing_comma() {
+            if let Some(comma_range) = node
+                .key_values_with_comma()
+                .last()
+                .and_then(|(_, comma)| comma.map(|c| c.range()))
+            {
+                l.extend_diagnostics(Diagnostic {
+                    kind: DiagnosticKind::ForbiddenInlineTableLastComma,
+                    level: SeverityLevel::Error,
+                    range: comma_range,
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_lint;
+
+    test_lint! {
+        #[test]
+        fn inline_table_trailing_comma_v1_0_0(
+            "key = { a = 1, b = 2, }",
+            TomlVersion::V1_0_0,
+        ) -> Err([crate::DiagnosticKind::ForbiddenInlineTableLastComma])
+    }
+
+    test_lint! {
+        #[test]
+        fn inline_table_trailing_comma_v1_1_0_ok(
+            "key = { a = 1, b = 2, }",
+            TomlVersion::V1_1_0,
+        ) -> Ok(_)
+    }
+
+    test_lint! {
+        #[test]
+        fn inline_table_multi_line_v1_0_0(
+            r#"
+            key = {
+                key1 = 1,
+                key2 = 2,
+            }
+            "#,
+            TomlVersion::V1_0_0,
+        ) -> Err([
+            crate::DiagnosticKind::InlineTableMustSingleLine,
+            crate::DiagnosticKind::ForbiddenInlineTableLastComma,
+        ])
+    }
+
+    test_lint! {
+        #[test]
+        fn inline_table_multi_line_v1_0_0_no_trailing_comma(
+            r#"
+            json_like = {
+                first = "Tom",
+                last = "Preston-Werner"
+            }
+            "#,
+            TomlVersion::V1_0_0,
+        ) -> Err([crate::DiagnosticKind::InlineTableMustSingleLine])
+    }
+
+    test_lint! {
+        #[test]
+        fn inline_table_multi_line_v1_0_0_two_lines(
+            r#"
+            t = {a=1,
+            b=2}
+            "#,
+            TomlVersion::V1_0_0,
+        ) -> Err([crate::DiagnosticKind::InlineTableMustSingleLine])
+    }
+
+    test_lint! {
+        #[test]
+        fn inline_table_multi_line_v1_1_0_ok(
+            r#"
+            key = {
+                key1 = 1,
+                key2 = 2,
+            }
+            "#,
+            TomlVersion::V1_1_0,
+        ) -> Ok(_)
+    }
+}

--- a/crates/tombi-parser/src/error.rs
+++ b/crates/tombi-parser/src/error.rs
@@ -68,12 +68,6 @@ pub enum ErrorKind {
 
     #[error("forbidden last period in keys")]
     ForbiddenKeysLastPeriod,
-
-    #[error("inline table must be single line in TOML v1.0.0 or earlier")]
-    InlineTableMustSingleLine,
-
-    #[error("trailing comma in inline table not allowed in TOML v1.0.0 or earlier")]
-    ForbiddenInlineTableLastComma,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -116,8 +110,6 @@ impl Error {
             ErrorKind::ExpectedBraceEnd => "expected-brace-end",
             ErrorKind::ExpectedLineBreak => "expected-line-break",
             ErrorKind::ForbiddenKeysLastPeriod => "forbidden-keys-last-period",
-            ErrorKind::InlineTableMustSingleLine => "inline-table-must-single-line",
-            ErrorKind::ForbiddenInlineTableLastComma => "forbidden-inline-table-last-comma",
         }
     }
 

--- a/crates/tombi-parser/src/parse/inline_table.rs
+++ b/crates/tombi-parser/src/parse/inline_table.rs
@@ -1,4 +1,3 @@
-use tombi_config::TomlVersion;
 use tombi_syntax::{SyntaxKind::*, T};
 
 use crate::{
@@ -16,8 +15,6 @@ impl Parse for tombi_ast::InlineTable {
 
         leading_comments(p);
 
-        let begin_range = p.current_range();
-
         debug_assert!(p.at(T!['{']));
 
         p.eat(T!['{']);
@@ -26,8 +23,6 @@ impl Parse for tombi_ast::InlineTable {
 
         begin_dangling_comments(p);
 
-        let mut key_value_lines = 0;
-        let mut last_comma_range = None;
         loop {
             while p.eat(LINE_BREAK) {}
 
@@ -36,18 +31,12 @@ impl Parse for tombi_ast::InlineTable {
                 break;
             }
 
-            let start_line = p.nth_range(n).start.line;
-
             tombi_ast::KeyValue::parse(p);
-
-            key_value_lines += p.previous_range().end.line - start_line;
 
             let n = peek_leading_comments(p);
             if p.nth_at(n, T![,]) {
-                last_comma_range = Some(p.nth_range(n));
                 tombi_ast::Comma::parse(p);
             } else {
-                last_comma_range = None;
                 if !p.nth_at(n, T!['}']) {
                     p.error(crate::Error::new(ExpectedComma, p.current_range()));
                     p.bump_any();
@@ -57,27 +46,8 @@ impl Parse for tombi_ast::InlineTable {
 
         end_dangling_comments(p, true);
 
-        let end_range = p.current_range();
-
         if !p.eat(T!['}']) {
             p.error(crate::Error::new(ExpectedBraceEnd, p.current_range()));
-        }
-
-        if (end_range.start.line - begin_range.start.line) != key_value_lines
-            && p.toml_version == TomlVersion::V1_0_0
-        {
-            p.error(crate::Error::new(
-                InlineTableMustSingleLine,
-                begin_range + end_range,
-            ));
-        }
-        if let Some(comma_range) = last_comma_range
-            && p.toml_version == TomlVersion::V1_0_0
-        {
-            p.error(crate::Error::new(
-                ForbiddenInlineTableLastComma,
-                comma_range,
-            ));
         }
 
         trailing_comment(p);
@@ -90,7 +60,7 @@ impl Parse for tombi_ast::InlineTable {
 mod test {
     use tombi_config::TomlVersion;
 
-    use crate::{ErrorKind::*, test_parser};
+    use crate::test_parser;
 
     test_parser! {
         #[test]
@@ -109,35 +79,10 @@ mod test {
 
     test_parser! {
         #[test]
-        fn inline_table_multi_keys_with_trailing_comma_v1_0_0(
-            "key = { key = 1, key = 2, }", TomlVersion::V1_0_0
-        ) -> Err([
-            SyntaxError(ForbiddenInlineTableLastComma, 0:24..0:25),
-        ])
-    }
-
-    test_parser! {
-        #[test]
         fn inline_table_multi_keys_with_trailing_comma_v1_1_0(
             "key = { key = 1, key = 2, }",
             TomlVersion::V1_1_0
         ) -> Ok(_)
-    }
-
-    test_parser! {
-        #[test]
-        fn inline_table_multi_line_v1_0_0(r#"
-            key = {
-                key1 = 1,
-                key2 = 2,
-            }
-            "#,
-            TomlVersion::V1_0_0
-        ) -> Err([
-            SyntaxError(InlineTableMustSingleLine, 0:6..3:1),
-            SyntaxError(ForbiddenInlineTableLastComma, 2:12..2:13),
-
-        ])
     }
 
     test_parser! {
@@ -155,32 +100,6 @@ mod test {
             "#,
             TomlVersion::V1_0_0
         ) -> Ok(_)
-    }
-
-    test_parser! {
-        #[test]
-        fn invalid_inline_table_multi_line_in_v1_0_0(r#"
-            json_like = {
-                first = "Tom",
-                last = "Preston-Werner"
-            }
-            "#,
-            TomlVersion::V1_0_0
-        ) -> Err([
-            SyntaxError(InlineTableMustSingleLine, 0:12..3:1),
-        ])
-    }
-
-    test_parser! {
-        #[test]
-        fn invalid_inline_table_multi_line2_in_v1_0_0(r#"
-            t = {a=1,
-            b=2}
-            "#,
-            TomlVersion::V1_0_0
-        ) -> Err([
-            SyntaxError(InlineTableMustSingleLine, 0:4..1:4),
-        ])
     }
 
     test_parser! {

--- a/crates/tombi-parser/src/parser.rs
+++ b/crates/tombi-parser/src/parser.rs
@@ -10,6 +10,7 @@ pub(crate) struct Parser<'t> {
     source: &'t str,
     input_tokens: &'t [tombi_lexer::Token],
     pos: usize,
+    #[allow(dead_code)] // Reserved for future TOML version–dependent parsing
     pub toml_version: tombi_config::TomlVersion,
     pub tokens: Vec<tombi_lexer::Token>,
     pub(crate) events: Vec<crate::Event>,

--- a/toml-test/Cargo.toml
+++ b/toml-test/Cargo.toml
@@ -16,9 +16,14 @@ clap.workspace = true
 indexmap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tombi-ast.workspace = true
+tombi-config.workspace = true
+tombi-diagnostic.workspace = true
 tombi-document-tree.workspace = true
+tombi-linter.workspace = true
 tombi-parser.workspace = true
+tombi-schema-store.workspace = true
 tombi-toml-version.workspace = true
 
 [dev-dependencies]

--- a/toml-test/bin/decode.rs
+++ b/toml-test/bin/decode.rs
@@ -25,6 +25,33 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 fn decode(source: &str, toml_version: TomlVersion) -> Result<Value, anyhow::Error> {
+    // Run full linter in a dedicated thread so block_on does not deadlock with async runtime.
+    let source_owned = source.to_string();
+    let lint_result = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let schema_store = tombi_schema_store::SchemaStore::new();
+        let lint_options = tombi_config::LintOptions::default();
+        let linter = tombi_linter::Linter::new(
+            toml_version,
+            &lint_options,
+            None,
+            &schema_store,
+        );
+        rt.block_on(linter.lint(&source_owned))
+    })
+    .join()
+    .map_err(|_| anyhow::anyhow!("linter thread panicked"))?;
+
+    if let Err(diagnostics) = lint_result {
+        let errors: Vec<_> = diagnostics.iter().filter(|d| d.is_error()).collect();
+        if !errors.is_empty() {
+            for d in &errors {
+                eprintln!("{}", d.message());
+            }
+            return Err(anyhow::anyhow!(INVALID_MESSAGE));
+        }
+    }
+
     let p = tombi_parser::parse(source, toml_version);
 
     if !p.errors.is_empty() {
@@ -59,8 +86,7 @@ macro_rules! test_decode {
         fn $name:ident($source:expr, $toml_version:expr) -> Ok($expected:expr)
     } => {
         #[test]
-        fn $name() -> Result<(), Box<dyn std::error::Error>>
-        {
+        fn $name() -> Result<(), Box<dyn std::error::Error>> {
             let source = textwrap::dedent($source);
             let value = crate::decode(source.trim(), $toml_version)?;
             pretty_assertions::assert_eq!(

--- a/xtask/src/command/toml_test.rs
+++ b/xtask/src/command/toml_test.rs
@@ -45,7 +45,7 @@ fn decode_test(
 
     match xshell::cmd!(
         sh,
-        "toml-test test {options...} -color=never -toml={toml_test_version} -decoder {decoder}"
+        "toml-test test {options...} -color=never -timeout=10s -toml={toml_test_version} -decoder {decoder}"
     )
     .ignore_status()
     .output()


### PR DESCRIPTION
- Added `InlineTableTomlVersionRule` to enforce that inline tables must be single line and cannot have trailing commas in TOML v1.0.0.
- Updated the linter to check for these conditions and report appropriate diagnostics.
- Removed related error handling from the parser to streamline the validation process.
- Added tests to ensure correct behavior for inline tables under the specified TOML version.