### PR TITLE
fix: update node filtering logic to exclude TABLE and ARRAY_OF_TABLE kinds

### DIFF
--- a/crates/tombi-ast/src/impls/root.rs
+++ b/crates/tombi-ast/src/impls/root.rs
@@ -111,7 +111,12 @@ impl crate::Root {
         support::node::end_dangling_comments(
             self.syntax()
                 .children_with_tokens()
-                .take_while(|node_or_token| node_or_token.kind() != SyntaxKind::TABLE),
+                .take_while(|node_or_token| {
+                    !matches!(
+                        node_or_token.kind(),
+                        SyntaxKind::TABLE | SyntaxKind::ARRAY_OF_TABLE
+                    )
+                }),
         )
     }
 

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -266,6 +266,22 @@ mod test {
     }
 
     test_format! {
+        // https://github.com/tombi-toml/tombi/issues/1527
+        #[tokio::test]
+        async fn test_issue_1527_toml(
+            r#"
+            some-global-entry = "a value"
+
+            # The comment which will get removed
+
+            [[some-array]]
+            an-optional = "entry"
+            "#,
+            TomlVersion::V1_1_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
         #[tokio::test]
         async fn test_sample_toml(
 r#"


### PR DESCRIPTION
fix: https://github.com/tombi-toml/tombi/issues/1527