### PR TITLE
fix: enable comment directive completion for keys not in schema properties

### DIFF
--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -183,72 +183,100 @@ impl FindCompletionContents for tombi_document_tree::Table {
 
                                         return contents;
                                     }
-                                } else if keys.len() == 1 {
-                                    let property_keys = table_schema
-                                        .properties
-                                        .read()
+                                } else {
+                                    // When the key is not in the schema properties,
+                                    // still try the value for comment directive handling.
+                                    let contents = value
+                                        .find_completion_contents(
+                                            position,
+                                            &keys[1..],
+                                            &accessors
+                                                .iter()
+                                                .cloned()
+                                                .chain(std::iter::once(accessor))
+                                                .collect_vec(),
+                                            None,
+                                            schema_context,
+                                            completion_hint,
+                                        )
                                         .await
-                                        .keys()
-                                        .cloned()
+                                        .into_iter()
+                                        .filter(|c| c.in_comment)
                                         .collect_vec();
-                                    for property_key in property_keys {
-                                        let key_name = property_key.to_string();
-                                        if !key_name.starts_with(accessor_str) {
-                                            continue;
-                                        }
+                                    if !contents.is_empty() {
+                                        return contents;
+                                    }
 
-                                        if let Some(value) = self.get(&key_name)
-                                            && check_used_table_value(
-                                                value,
-                                                accessors.is_empty(),
-                                                completion_hint,
-                                            )
-                                        {
-                                            continue;
-                                        }
-
-                                        if let Ok(Some(current_schema)) = table_schema
-                                            .resolve_property_schema(
-                                                &property_key,
-                                                current_schema.schema_uri.clone(),
-                                                current_schema.definitions.clone(),
-                                                schema_context.store,
-                                            )
+                                    if keys.len() == 1 {
+                                        let property_keys = table_schema
+                                            .properties
+                                            .read()
                                             .await
-                                        {
-                                            log::trace!(
-                                                "property_schema = {:?}",
-                                                &current_schema.value_schema
-                                            );
-
-                                            let Some(mut contents) =
-                                                collect_table_key_completion_contents(
-                                                    self,
-                                                    &key_name,
-                                                    position,
-                                                    accessors,
-                                                    table_schema,
-                                                    &current_schema,
-                                                    schema_context,
-                                                    completion_hint,
-                                                )
-                                                .await
-                                            else {
+                                            .keys()
+                                            .cloned()
+                                            .collect_vec();
+                                        for property_key in property_keys {
+                                            let key_name = property_key.to_string();
+                                            if !key_name.starts_with(accessor_str) {
                                                 continue;
-                                            };
-
-                                            if !contents.is_empty()
-                                                && current_schema.value_schema.deprecated().await
-                                                    == Some(true)
-                                            {
-                                                for content in &mut contents {
-                                                    if !content.in_comment {
-                                                        content.deprecated = Some(true);
-                                                    }
-                                                }
                                             }
 
-                                            completion_contents.extend(contents);
+                                            if let Some(value) = self.get(&key_name)
+                                                && check_used_table_value(
+                                                    value,
+                                                    accessors.is_empty(),
+                                                    completion_hint,
+                                                )
+                                            {
+                                                continue;
+                                            }
+
+                                            if let Ok(Some(current_schema)) = table_schema
+                                                .resolve_property_schema(
+                                                    &property_key,
+                                                    current_schema.schema_uri.clone(),
+                                                    current_schema.definitions.clone(),
+                                                    schema_context.store,
+                                                )
+                                                .await
+                                            {
+                                                log::trace!(
+                                                    "property_schema = {:?}",
+                                                    &current_schema.value_schema
+                                                );
+
+                                                let Some(mut contents) =
+                                                    collect_table_key_completion_contents(
+                                                        self,
+                                                        &key_name,
+                                                        position,
+                                                        accessors,
+                                                        table_schema,
+                                                        &current_schema,
+                                                        schema_context,
+                                                        completion_hint,
+                                                    )
+                                                    .await
+                                                else {
+                                                    continue;
+                                                };
+
+                                                if !contents.is_empty()
+                                                    && current_schema
+                                                        .value_schema
+                                                        .deprecated()
+                                                        .await
+                                                        == Some(true)
+                                                {
+                                                    for content in &mut contents {
+                                                        if !content.in_comment {
+                                                            content.deprecated = Some(true);
+                                                        }
+                                                    }
+                                                }
+
+                                                completion_contents.extend(contents);
+                                            }
                                         }
                                     }
                                 }

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1710,6 +1710,47 @@ mod completion_labels {
         }
     }
 
+    mod type_test_schema {
+        use tombi_test_lib::type_test_schema_path;
+
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn type_test_schema(
+                "█",
+                SchemaPath(type_test_schema_path()),
+            ) -> Ok([
+                "array",
+                "boolean",
+                "float",
+                "integer",
+                "literal",
+                "local-date",
+                "local-date-time",
+                "local-time",
+                "offset-date-time",
+                "string",
+                "table",
+                "table-allows-empty-key",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn type_test_schema_invalid_key_comment_directive(
+                r#"
+                # tombi: lint.█
+                "" = 1
+                "#,
+                SchemaPath(type_test_schema_path()),
+            ) -> Ok([
+                "rules",
+                "{}",
+            ]);
+        }
+    }
+
     mod with_subschema {
         use tombi_test_lib::{pyproject_schema_path, type_test_schema_path};
 


### PR DESCRIPTION
## Summary
- Add fallback handling so comment directive completion works even for keys not defined in the schema properties
- Fix the case where `# tombi: lint.█` on an invalid key like `"" = 1` would return no completions instead of the expected directive options
- Add test cases `type_test_schema_invalid_key_comment_directive` and `type_test_schema`

## Test plan
- [x] `type_test_schema_invalid_key_comment_directive` test passes
- [x] `type_test_schema` test passes
- [x] All 116 existing completion label tests pass
- [x] Code reviewed via `/simplify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)