### PR TITLE
docs: update note formatting in configuration documentation

### DIFF
--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -480,7 +480,7 @@ Check if the key is empty.
 ```
 
 <Note>
-This warning is suppressed when the JSON Schema for the table specifies `propertyNames.minLength: 0`, since the schema explicitly allows empty keys.
+This rule is disabled when the JSON Schema for the table specifies `propertyNames.minLength: 0`, since the schema explicitly allows empty keys.
 </Note>
 
 ### lint.rules.dotted-keys-out-of-order


### PR DESCRIPTION
Changed the warning note in the configuration documentation to use the <Note> tag for improved clarity and consistency in formatting.