### PR TITLE
fix: collect not/if_then_else diagnostics in anyOf/oneOf validation

### DIFF
--- a/crates/tombi-validator/src/validate/any_of.rs
+++ b/crates/tombi-validator/src/validate/any_of.rs
@@ -114,8 +114,8 @@ where
         if total_error.diagnostics.is_empty() && total_diagnostics.is_empty() {
             Ok(())
         } else {
-            total_diagnostics.extend(total_error.diagnostics);
-            Err(total_diagnostics.into())
+            total_error.prepend_diagnostics(total_diagnostics);
+            Err(total_error)
         }
     }
     .boxed()

--- a/crates/tombi-validator/src/validate/one_of.rs
+++ b/crates/tombi-validator/src/validate/one_of.rs
@@ -103,9 +103,9 @@ where
                 match result {
                     Ok(()) if total_diagnostics.is_empty() => return Ok(()),
                     Ok(()) => return Err(total_diagnostics.into()),
-                    Err(error) if !has_error_level_diagnostics(&error) => {
-                        total_diagnostics.extend(error.diagnostics);
-                        return Err(total_diagnostics.into());
+                    Err(mut error) if !has_error_level_diagnostics(&error) => {
+                        error.prepend_diagnostics(total_diagnostics);
+                        return Err(error);
                     }
                     Err(_) => {}
                 }
@@ -151,8 +151,8 @@ where
 
                 Err(total_diagnostics.into())
             } else {
-                total_diagnostics.extend(error.diagnostics);
-                Err(total_diagnostics.into())
+                error.prepend_diagnostics(total_diagnostics);
+                Err(error)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Changed `anyOf` and `oneOf` validation to collect diagnostics from `not` and `if_then_else` sub-validations instead of short-circuiting with `?` operator
- Diagnostics from `not`/`if_then_else` are now properly merged into the final validation result
- Ensures all relevant diagnostics are reported together rather than stopping at the first `not`/`if_then_else` error

## Test plan
- [ ] Verify `anyOf` validation correctly reports `not` diagnostics alongside schema match results
- [ ] Verify `oneOf` validation correctly reports `if_then_else` diagnostics alongside schema match results
- [ ] Verify no regression in existing validation behavior when `not`/`if_then_else` are not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)