### PR TITLE
fix: terminal pop-up problem with vscode extension in Windows system

### DIFF
--- a/editors/vscode/src/bootstrap.ts
+++ b/editors/vscode/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, spawnSync } from "node:child_process";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as vscode from "vscode";
@@ -196,10 +196,15 @@ function createDirectTombiBin(
 
 function createNodeModulesTombiBin(bin: NodeModulesTombiBin): TombiBin {
   if (bin.kind === "node-script") {
+    const node = "node";
     return {
       source: "node_modules",
       binPath: bin.binPath,
-      command: process.platform === "win32" ? "node" : process.execPath,
+      command:
+        process.platform === "win32" &&
+        spawnSync(node, ["-v"]).stdout.byteLength
+          ? node
+          : process.execPath,
       args: [bin.binPath],
     };
   }


### PR DESCRIPTION
`process.execPath` returns the absolute path of vscode in the Windows system. If the Windows system uses the built-in `node` runtime of vscode to run the js script, a pop-up window will appear. Therefore, in the Windows system, use the `node` in the path instead. This should be applicable to most situations. If necessary, you can add `deno` and `bun` runtime detection. The `oxc` project also simply uses `node` instead of `process.execPath`.