### PR TITLE
fix: terminal pop-up problem with vscode extension in Windows system

### DIFF
--- a/editors/vscode/src/bootstrap.ts
+++ b/editors/vscode/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, spawnSync } from "node:child_process";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as vscode from "vscode";
@@ -196,10 +196,15 @@ function createDirectTombiBin(
 
 function createNodeModulesTombiBin(bin: NodeModulesTombiBin): TombiBin {
   if (bin.kind === "node-script") {
+    const node = "node";
     return {
       source: "node_modules",
       binPath: bin.binPath,
-      command: process.execPath,
+      command:
+        process.platform === "win32" &&
+        spawnSync(node, ["-v"]).stdout.byteLength
+          ? node
+          : process.execPath,
       args: [bin.binPath],
     };
   }


### PR DESCRIPTION
Sorry, I accidentally thought it was my own project when submitting for synchronization. The text message only wrote "1" and submitted it, so I have to open a new pull request.

This time, `node` detection in the `path` of the environment variable is added, which may only be suitable as a temporary solution.

I thought of several other solutions:
1. Directly run the executable file instead of the js script file
2. Add `runtime` settings, use `node` by default, and watch changes in this setting
3. I am not sure whether this solution is effective. I just saw that the `lsp-sample` provided by vscode does this, but `oxc` does not. Add `transport` to serverOptions, which requires the executable file to support new arguments, such as `--stdio`, otherwise an error will be reported.