### PR TITLE
Add granular LSP feature toggles

### DIFF
--- a/crates/tombi-config/src/lib.rs
+++ b/crates/tombi-config/src/lib.rs
@@ -131,6 +131,162 @@ impl Config {
             .and_then(Extensions::tombi_features)
     }
 
+    pub fn lsp_code_action_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::code_action_enabled)
+    }
+
+    pub fn lsp_code_action_dot_keys_to_inline_table_enabled(&self) -> bool {
+        self.lsp.as_ref().map_or(
+            true,
+            LspOptions::code_action_dot_keys_to_inline_table_enabled,
+        )
+    }
+
+    pub fn lsp_code_action_inline_table_to_dot_keys_enabled(&self) -> bool {
+        self.lsp.as_ref().map_or(
+            true,
+            LspOptions::code_action_inline_table_to_dot_keys_enabled,
+        )
+    }
+
+    pub fn lsp_code_action_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::code_action_extension_enabled)
+    }
+
+    pub fn lsp_completion_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::completion_enabled)
+    }
+
+    pub fn lsp_completion_directive_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::completion_directive_enabled)
+    }
+
+    pub fn lsp_completion_schema_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::completion_schema_enabled)
+    }
+
+    pub fn lsp_completion_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::completion_extension_enabled)
+    }
+
+    pub fn lsp_diagnostic_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::diagnostic_enabled)
+    }
+
+    pub fn lsp_document_link_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::document_link_enabled)
+    }
+
+    pub fn lsp_document_link_schema_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::document_link_schema_enabled)
+    }
+
+    pub fn lsp_document_link_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::document_link_extension_enabled)
+    }
+
+    pub fn lsp_formatting_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::formatting_enabled)
+    }
+
+    pub fn lsp_goto_declaration_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_declaration_enabled)
+    }
+
+    pub fn lsp_goto_declaration_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_declaration_extension_enabled)
+    }
+
+    pub fn lsp_goto_definition_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_definition_enabled)
+    }
+
+    pub fn lsp_goto_definition_schema_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_definition_schema_enabled)
+    }
+
+    pub fn lsp_goto_definition_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_definition_extension_enabled)
+    }
+
+    pub fn lsp_goto_type_definition_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_type_definition_enabled)
+    }
+
+    pub fn lsp_goto_type_definition_directive_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_type_definition_directive_enabled)
+    }
+
+    pub fn lsp_goto_type_definition_schema_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::goto_type_definition_schema_enabled)
+    }
+
+    pub fn lsp_hover_enabled(&self) -> bool {
+        self.lsp.as_ref().map_or(true, LspOptions::hover_enabled)
+    }
+
+    pub fn lsp_hover_directive_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::hover_directive_enabled)
+    }
+
+    pub fn lsp_hover_schema_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::hover_schema_enabled)
+    }
+
+    pub fn lsp_hover_extension_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::hover_extension_enabled)
+    }
+
+    pub fn lsp_workspace_diagnostic_enabled(&self) -> bool {
+        self.lsp
+            .as_ref()
+            .map_or(true, LspOptions::workspace_diagnostic_enabled)
+    }
+
     pub fn merge_format(&self, override_options: Option<&OverrideFormatOptions>) -> FormatOptions {
         let options = self.format.clone().unwrap_or_default();
         let base_rules = options.rules.unwrap_or_default();

--- a/crates/tombi-config/src/server.rs
+++ b/crates/tombi-config/src/server.rs
@@ -1,4 +1,14 @@
-use crate::BoolDefaultTrue;
+use crate::{BoolDefaultTrue, EnabledOnly, ToggleFeature};
+
+macro_rules! default_to_features {
+    ($enum:ident, $features:ident) => {
+        impl Default for $enum {
+            fn default() -> Self {
+                Self::Features($features::default())
+            }
+        }
+    };
+}
 
 /// # Language Server options
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -8,95 +18,214 @@ use crate::BoolDefaultTrue;
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending)))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct LspOptions {
-    /// # Code Action Feature options
+    /// # Code Action feature options
     pub code_action: Option<LspCodeAction>,
 
-    /// # Completion Feature options
+    /// # Completion feature options
     pub completion: Option<LspCompletion>,
 
-    /// # Diagnostic Feature options
+    /// # Diagnostic feature options
     pub diagnostic: Option<LspDiagnostic>,
 
-    /// # Document Link Feature options
+    /// # Document Link feature options
     pub document_link: Option<LspDocumentLink>,
 
-    /// # Formatting Feature options
+    /// # Formatting feature options
     pub formatting: Option<LspFormatting>,
 
-    /// # Goto Declaration Feature options
-    pub goto_declaration: Option<LspGotoDefinition>,
+    /// # Goto Declaration feature options
+    pub goto_declaration: Option<LspGotoDeclaration>,
 
-    /// # Goto Definition Feature options
+    /// # Goto Definition feature options
     pub goto_definition: Option<LspGotoDefinition>,
 
-    /// # Goto Type Definition Feature options
-    pub goto_type_definition: Option<LspGotoDefinition>,
+    /// # Goto Type Definition feature options
+    pub goto_type_definition: Option<LspGotoTypeDefinition>,
 
-    /// # Hover Feature options
+    /// # Hover feature options
     pub hover: Option<LspHover>,
 
-    /// # Workspace Diagnostics Feature options
+    /// # Workspace Diagnostics feature options
     pub workspace_diagnostic: Option<LspWorkspaceDiagnostic>,
 }
 
 impl LspOptions {
-    pub const fn default() -> Self {
-        Self {
-            code_action: None,
-            completion: None,
-            diagnostic: None,
-            document_link: None,
-            formatting: None,
-            goto_declaration: None,
-            goto_definition: None,
-            goto_type_definition: None,
-            hover: None,
-            workspace_diagnostic: None,
-        }
+    pub fn code_action_enabled(&self) -> bool {
+        self.code_action
+            .as_ref()
+            .map_or(true, LspCodeAction::enabled)
+    }
+
+    pub fn code_action_dot_keys_to_inline_table_enabled(&self) -> bool {
+        self.code_action
+            .as_ref()
+            .map_or(true, LspCodeAction::dot_keys_to_inline_table_enabled)
+    }
+
+    pub fn code_action_inline_table_to_dot_keys_enabled(&self) -> bool {
+        self.code_action
+            .as_ref()
+            .map_or(true, LspCodeAction::inline_table_to_dot_keys_enabled)
+    }
+
+    pub fn code_action_extension_enabled(&self) -> bool {
+        self.code_action
+            .as_ref()
+            .map_or(true, LspCodeAction::extension_enabled)
+    }
+
+    pub fn completion_enabled(&self) -> bool {
+        self.completion
+            .as_ref()
+            .map_or(true, LspCompletion::enabled)
+    }
+
+    pub fn completion_directive_enabled(&self) -> bool {
+        self.completion
+            .as_ref()
+            .map_or(true, LspCompletion::directive_enabled)
+    }
+
+    pub fn completion_schema_enabled(&self) -> bool {
+        self.completion
+            .as_ref()
+            .map_or(true, LspCompletion::schema_enabled)
+    }
+
+    pub fn completion_extension_enabled(&self) -> bool {
+        self.completion
+            .as_ref()
+            .map_or(true, LspCompletion::extension_enabled)
+    }
+
+    pub fn diagnostic_enabled(&self) -> bool {
+        self.diagnostic
+            .as_ref()
+            .map_or(true, LspDiagnostic::enabled)
+    }
+
+    pub fn document_link_enabled(&self) -> bool {
+        self.document_link
+            .as_ref()
+            .map_or(true, LspDocumentLink::enabled)
+    }
+
+    pub fn document_link_schema_enabled(&self) -> bool {
+        self.document_link
+            .as_ref()
+            .map_or(true, LspDocumentLink::schema_enabled)
+    }
+
+    pub fn document_link_extension_enabled(&self) -> bool {
+        self.document_link
+            .as_ref()
+            .map_or(true, LspDocumentLink::extension_enabled)
+    }
+
+    pub fn formatting_enabled(&self) -> bool {
+        self.formatting
+            .as_ref()
+            .map_or(true, LspFormatting::enabled)
+    }
+
+    pub fn goto_declaration_enabled(&self) -> bool {
+        self.goto_declaration
+            .as_ref()
+            .map_or(true, LspGotoDeclaration::enabled)
+    }
+
+    pub fn goto_declaration_extension_enabled(&self) -> bool {
+        self.goto_declaration
+            .as_ref()
+            .map_or(true, LspGotoDeclaration::extension_enabled)
+    }
+
+    pub fn goto_definition_enabled(&self) -> bool {
+        self.goto_definition
+            .as_ref()
+            .map_or(true, LspGotoDefinition::enabled)
+    }
+
+    pub fn goto_definition_schema_enabled(&self) -> bool {
+        self.goto_definition
+            .as_ref()
+            .map_or(true, LspGotoDefinition::schema_enabled)
+    }
+
+    pub fn goto_definition_extension_enabled(&self) -> bool {
+        self.goto_definition
+            .as_ref()
+            .map_or(true, LspGotoDefinition::extension_enabled)
+    }
+
+    pub fn goto_type_definition_enabled(&self) -> bool {
+        self.goto_type_definition
+            .as_ref()
+            .map_or(true, LspGotoTypeDefinition::enabled)
+    }
+
+    pub fn goto_type_definition_directive_enabled(&self) -> bool {
+        self.goto_type_definition
+            .as_ref()
+            .map_or(true, LspGotoTypeDefinition::directive_enabled)
+    }
+
+    pub fn goto_type_definition_schema_enabled(&self) -> bool {
+        self.goto_type_definition
+            .as_ref()
+            .map_or(true, LspGotoTypeDefinition::schema_enabled)
+    }
+
+    pub fn hover_enabled(&self) -> bool {
+        self.hover.as_ref().map_or(true, LspHover::enabled)
+    }
+
+    pub fn hover_directive_enabled(&self) -> bool {
+        self.hover
+            .as_ref()
+            .map_or(true, LspHover::directive_enabled)
+    }
+
+    pub fn hover_schema_enabled(&self) -> bool {
+        self.hover.as_ref().map_or(true, LspHover::schema_enabled)
+    }
+
+    pub fn hover_extension_enabled(&self) -> bool {
+        self.hover
+            .as_ref()
+            .map_or(true, LspHover::extension_enabled)
+    }
+
+    pub fn workspace_diagnostic_enabled(&self) -> bool {
+        self.workspace_diagnostic
+            .as_ref()
+            .map_or(true, LspWorkspaceDiagnostic::enabled)
     }
 }
 
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspHover {
-    /// # Enable hover feature
+pub struct LspDiagnostic {
+    /// # Enable diagnostic feature
     ///
-    /// Whether to enable hover.
+    /// Whether to enable diagnostics.
     pub enabled: Option<BoolDefaultTrue>,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspCodeAction {
-    /// # Enable code action feature
-    ///
-    /// Whether to enable code action.
-    pub enabled: Option<BoolDefaultTrue>,
+impl LspDiagnostic {
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or_default().value()
+    }
 }
 
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspCompletion {
-    /// # Enable completion feature
-    ///
-    /// Whether to enable completion.
-    pub enabled: Option<BoolDefaultTrue>,
-}
-
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
 pub struct LspFormatting {
     /// # Enable formatting feature
     ///
@@ -104,50 +233,513 @@ pub struct LspFormatting {
     pub enabled: Option<BoolDefaultTrue>,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspDiagnostic {
-    /// # Enable diagnostic feature
-    ///
-    /// Whether to enable diagnostic.
-    pub enabled: Option<BoolDefaultTrue>,
+impl LspFormatting {
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or_default().value()
+    }
 }
 
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspDocumentLink {
-    /// # Enable document link feature
-    ///
-    /// Whether to enable document link.
-    pub enabled: Option<BoolDefaultTrue>,
-}
-
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct LspGotoDefinition {
-    /// # Enable goto definition feature
-    ///
-    /// Whether to enable goto definition.
-    pub enabled: Option<BoolDefaultTrue>,
-}
-
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
-#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
-#[derive(Debug, Default, Clone, PartialEq)]
 pub struct LspWorkspaceDiagnostic {
     /// # Enable workspace diagnostic feature
     ///
-    /// Whether to enable workspace diagnostic.
+    /// Whether to enable workspace diagnostics.
     pub enabled: Option<BoolDefaultTrue>,
+}
+
+impl LspWorkspaceDiagnostic {
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or_default().value()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspCompletion {
+    Enabled(EnabledOnly),
+    Features(LspCompletionFeatureTree),
+}
+
+default_to_features!(LspCompletion, LspCompletionFeatureTree);
+
+impl LspCompletion {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn directive_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .directive
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn schema_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .schema
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspCompletionFeatureTree {
+    /// # Directive completion feature
+    ///
+    /// Whether completion is available in Tombi comment directives.
+    pub directive: Option<ToggleFeature>,
+
+    /// # Schema completion feature
+    ///
+    /// Whether schema-driven completion is enabled.
+    pub schema: Option<ToggleFeature>,
+
+    /// # Extension completion feature
+    ///
+    /// Whether extension-provided completion is enabled.
+    pub extension: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspHover {
+    Enabled(EnabledOnly),
+    Features(LspHoverFeatureTree),
+}
+
+default_to_features!(LspHover, LspHoverFeatureTree);
+
+impl LspHover {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn directive_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .directive
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn schema_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .schema
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspHoverFeatureTree {
+    /// # Directive hover feature
+    ///
+    /// Whether hover is available in Tombi comment directives.
+    pub directive: Option<ToggleFeature>,
+
+    /// # Schema hover feature
+    ///
+    /// Whether schema-derived hover is enabled.
+    pub schema: Option<ToggleFeature>,
+
+    /// # Extension hover feature
+    ///
+    /// Whether extension-provided hover is enabled.
+    pub extension: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspDocumentLink {
+    Enabled(EnabledOnly),
+    Features(LspDocumentLinkFeatureTree),
+}
+
+default_to_features!(LspDocumentLink, LspDocumentLinkFeatureTree);
+
+impl LspDocumentLink {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn schema_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .schema
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspDocumentLinkFeatureTree {
+    /// # Schema document link feature
+    ///
+    /// Whether schema directives produce document links.
+    pub schema: Option<ToggleFeature>,
+
+    /// # Extension document link feature
+    ///
+    /// Whether extension-provided document links are enabled.
+    pub extension: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspGotoDefinition {
+    Enabled(EnabledOnly),
+    Features(LspGotoDefinitionFeatureTree),
+}
+
+default_to_features!(LspGotoDefinition, LspGotoDefinitionFeatureTree);
+
+impl LspGotoDefinition {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn schema_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .schema
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspGotoDefinitionFeatureTree {
+    /// # Schema go-to-definition feature
+    ///
+    /// Whether go-to-definition resolves schema directives.
+    pub schema: Option<ToggleFeature>,
+
+    /// # Extension go-to-definition feature
+    ///
+    /// Whether extension-provided go-to-definition is enabled.
+    pub extension: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspGotoDeclaration {
+    Enabled(EnabledOnly),
+    Features(LspGotoDeclarationFeatureTree),
+}
+
+default_to_features!(LspGotoDeclaration, LspGotoDeclarationFeatureTree);
+
+impl LspGotoDeclaration {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspGotoDeclarationFeatureTree {
+    /// # Extension go-to-declaration feature
+    ///
+    /// Whether extension-provided go-to-declaration is enabled.
+    pub extension: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspGotoTypeDefinition {
+    Enabled(EnabledOnly),
+    Features(LspGotoTypeDefinitionFeatureTree),
+}
+
+default_to_features!(LspGotoTypeDefinition, LspGotoTypeDefinitionFeatureTree);
+
+impl LspGotoTypeDefinition {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn directive_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .directive
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn schema_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .schema
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspGotoTypeDefinitionFeatureTree {
+    /// # Directive go-to-type-definition feature
+    ///
+    /// Whether go-to-type-definition resolves Tombi comment directives.
+    pub directive: Option<ToggleFeature>,
+
+    /// # Schema go-to-type-definition feature
+    ///
+    /// Whether go-to-type-definition resolves schema-backed types.
+    pub schema: Option<ToggleFeature>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum LspCodeAction {
+    Enabled(EnabledOnly),
+    Features(LspCodeActionFeatureTree),
+}
+
+default_to_features!(LspCodeAction, LspCodeActionFeatureTree);
+
+impl LspCodeAction {
+    pub fn enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => enabled.enabled(),
+            Self::Features(_) => true,
+        }
+    }
+
+    pub fn dot_keys_to_inline_table_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .dot_keys_to_inline_table
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn inline_table_to_dot_keys_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .inline_table_to_dot_keys
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+
+    pub fn extension_enabled(&self) -> bool {
+        self.enabled()
+            && match self {
+                Self::Enabled(_) => true,
+                Self::Features(features) => features
+                    .extension
+                    .as_ref()
+                    .map_or(true, ToggleFeature::enabled),
+            }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "jsonschema",
+    schemars(extend(
+        "x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending
+    ))
+)]
+pub struct LspCodeActionFeatureTree {
+    /// # Dot-keys to inline-table code action feature
+    ///
+    /// Whether the code action converting dot-keys to inline tables is enabled.
+    pub dot_keys_to_inline_table: Option<ToggleFeature>,
+
+    /// # Inline-table to dot-keys code action feature
+    ///
+    /// Whether the code action converting inline tables to dot-keys is enabled.
+    pub inline_table_to_dot_keys: Option<ToggleFeature>,
+
+    /// # Extension code action feature
+    ///
+    /// Whether extension-provided code actions are enabled.
+    pub extension: Option<ToggleFeature>,
 }

--- a/crates/tombi-linter/tests/integration/tombi_schema.rs
+++ b/crates/tombi-linter/tests/integration/tombi_schema.rs
@@ -69,6 +69,23 @@ test_lint! {
 
 test_lint! {
     #[test]
+    fn test_tombi_schema_lsp_feature_tree(
+        r#"
+        [lsp]
+        completion = { directive.enabled = false, schema.enabled = true, extension.enabled = false }
+        hover = { directive.enabled = false, schema.enabled = true, extension.enabled = false }
+        document-link = { schema.enabled = false, extension.enabled = true }
+        goto-definition = { schema.enabled = false, extension.enabled = true }
+        goto-declaration = { extension.enabled = false }
+        goto-type-definition = { directive.enabled = false, schema.enabled = true }
+        code-action = { dot-keys-to-inline-table.enabled = false, inline-table-to-dot-keys.enabled = true, extension.enabled = false }
+        "#,
+        SchemaPath(tombi_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
     fn test_tombi_schema_lint_rules_deprecated(
         r#"
         [[schemas]]

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -44,14 +44,7 @@ pub async fn get_diagnostics_result(
         .config_schema_store_for_uri(text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|lsp| lsp.diagnostic.as_ref())
-        .and_then(|diagnostic| diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_diagnostic_enabled() {
         log::debug!("`lsp.diagnostic.enabled` is false");
         return None;
     }

--- a/crates/tombi-lsp/src/handler/code_action.rs
+++ b/crates/tombi-lsp/src/handler/code_action.rs
@@ -29,14 +29,7 @@ pub async fn handle_code_action(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.code_action.as_ref())
-        .and_then(|code_action| code_action.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_code_action_enabled() {
         log::debug!("`server.code_action.enabled` is false");
         return Ok(None);
     }
@@ -65,29 +58,34 @@ pub async fn handle_code_action(
 
     let mut code_actions = Vec::new();
 
-    if let Some(code_action) = dot_keys_to_inline_table_code_action(
-        &text_document_uri,
-        line_index,
-        &root,
-        &document_tree,
-        &accessors,
-        &accessor_contexts,
-    ) {
+    if config.lsp_code_action_dot_keys_to_inline_table_enabled()
+        && let Some(code_action) = dot_keys_to_inline_table_code_action(
+            &text_document_uri,
+            line_index,
+            &root,
+            &document_tree,
+            &accessors,
+            &accessor_contexts,
+        )
+    {
         code_actions.push(CodeActionOrCommand::CodeAction(code_action));
     }
 
-    if let Some(code_action) = inline_table_to_dot_keys_code_action(
-        &text_document_uri,
-        line_index,
-        &root,
-        &document_tree,
-        &accessors,
-        &accessor_contexts,
-    ) {
+    if config.lsp_code_action_inline_table_to_dot_keys_enabled()
+        && let Some(code_action) = inline_table_to_dot_keys_code_action(
+            &text_document_uri,
+            line_index,
+            &root,
+            &document_tree,
+            &accessors,
+            &accessor_contexts,
+        )
+    {
         code_actions.push(CodeActionOrCommand::CodeAction(code_action));
     }
 
-    if config.cargo_extension_enabled()
+    if config.lsp_code_action_extension_enabled()
+        && config.cargo_extension_enabled()
         && let Some(extension_code_actions) = tombi_extension_cargo::code_action(
             &text_document_uri,
             line_index,
@@ -102,7 +100,8 @@ pub async fn handle_code_action(
         code_actions.extend(extension_code_actions);
     }
 
-    if config.pyproject_extension_enabled()
+    if config.lsp_code_action_extension_enabled()
+        && config.pyproject_extension_enabled()
         && let Some(extension_code_actions) = tombi_extension_pyproject::code_action(
             &text_document_uri,
             &root,

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -42,26 +42,8 @@ pub async fn handle_completion(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.completion.as_ref())
-        .and_then(|completion| completion.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_completion_enabled() {
         log::debug!("`server.completion.enabled` is false");
-        return Ok(None);
-    }
-
-    if !config
-        .schema
-        .as_ref()
-        .and_then(|s| s.enabled)
-        .unwrap_or_default()
-        .value()
-    {
-        log::debug!("`schema.enabled` is false");
         return Ok(None);
     }
 
@@ -109,16 +91,32 @@ pub async fn handle_completion(
     let mut completion_items = Vec::new();
 
     let comment_context = get_comment_context(&root, position);
+    let directive_completion_enabled = config.lsp_completion_directive_enabled();
+    let schema_completion_enabled = config.lsp_completion_schema_enabled()
+        && config
+            .schema
+            .as_ref()
+            .and_then(|s| s.enabled)
+            .unwrap_or_default()
+            .value();
+    let extension_completion_enabled = config.lsp_completion_extension_enabled();
+
+    if comment_context.is_some() && !directive_completion_enabled {
+        log::debug!("`lsp.completion.directive.enabled` is false");
+        return Ok(Some(Vec::with_capacity(0)));
+    }
+
     let (keys, completion_hint) = match &comment_context {
         Some(CommentContext::DocumentDirective(comment)) => {
-            if let Some(comment_completion_contents) =
-                get_document_comment_directive_completion_contents(
-                    &root,
-                    comment,
-                    position,
-                    &text_document_uri,
-                )
-                .await
+            if directive_completion_enabled
+                && let Some(comment_completion_contents) =
+                    get_document_comment_directive_completion_contents(
+                        &root,
+                        comment,
+                        position,
+                        &text_document_uri,
+                    )
+                    .await
             {
                 return Ok(Some(comment_completion_contents));
             }
@@ -157,16 +155,18 @@ pub async fn handle_completion(
                 strict: None,
             };
 
-            completion_items.extend(
-                find_completion_contents_with_tree(
-                    &document_tree,
-                    position,
-                    &keys,
-                    &schema_context,
-                    completion_hint,
-                )
-                .await,
-            );
+            if schema_completion_enabled {
+                completion_items.extend(
+                    find_completion_contents_with_tree(
+                        &document_tree,
+                        position,
+                        &keys,
+                        &schema_context,
+                        completion_hint,
+                    )
+                    .await,
+                );
+            }
 
             (keys, completion_hint)
         }
@@ -187,7 +187,8 @@ pub async fn handle_completion(
     let accessors = tombi_document_tree::get_accessors(&document_tree, &keys, position);
     let offline = schema_store.offline();
     let cache_options = schema_store.cache_options();
-    if config.tombi_extension_enabled()
+    if extension_completion_enabled
+        && config.tombi_extension_enabled()
         && let Some(items) = tombi_extension_tombi::completion(
             &text_document_uri,
             &document_tree,
@@ -202,7 +203,8 @@ pub async fn handle_completion(
     {
         completion_items.extend(items);
     }
-    if config.cargo_extension_enabled()
+    if extension_completion_enabled
+        && config.cargo_extension_enabled()
         && let Some(items) = tombi_extension_cargo::completion(
             &text_document_uri,
             &document_tree,
@@ -219,7 +221,8 @@ pub async fn handle_completion(
     {
         completion_items.extend(items);
     }
-    if config.pyproject_extension_enabled()
+    if extension_completion_enabled
+        && config.pyproject_extension_enabled()
         && let Some(items) = tombi_extension_pyproject::completion(
             &text_document_uri,
             &document_tree,

--- a/crates/tombi-lsp/src/handler/document_link.rs
+++ b/crates/tombi-lsp/src/handler/document_link.rs
@@ -20,14 +20,7 @@ pub async fn handle_document_link(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.document_link.as_ref())
-        .and_then(|document_link| document_link.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_document_link_enabled() {
         log::debug!("`server.document_link.enabled` is false");
         return Ok(None);
     }
@@ -43,11 +36,13 @@ pub async fn handle_document_link(
 
     let mut document_links = vec![];
 
-    if let Some(SchemaDocumentCommentDirective {
-        uri: Ok(schema_uri),
-        uri_range: range,
-        ..
-    }) = root.schema_document_comment_directive(text_document_uri.to_file_path().ok().as_deref())
+    if config.lsp_document_link_schema_enabled()
+        && let Some(SchemaDocumentCommentDirective {
+            uri: Ok(schema_uri),
+            uri_range: range,
+            ..
+        }) =
+            root.schema_document_comment_directive(text_document_uri.to_file_path().ok().as_deref())
     {
         let tooltip = "Open JSON Schema".into();
         document_links.push(
@@ -62,7 +57,8 @@ pub async fn handle_document_link(
 
     let document_tree = document_source.document_tree();
 
-    if config.cargo_extension_enabled()
+    if config.lsp_document_link_extension_enabled()
+        && config.cargo_extension_enabled()
         && let Some(locations) = tombi_extension_cargo::document_link(
             &text_document_uri,
             &document_tree,
@@ -78,7 +74,8 @@ pub async fn handle_document_link(
         );
     }
 
-    if config.tombi_extension_enabled()
+    if config.lsp_document_link_extension_enabled()
+        && config.tombi_extension_enabled()
         && let Some(locations) = tombi_extension_tombi::document_link(
             &text_document_uri,
             &document_tree,
@@ -94,7 +91,8 @@ pub async fn handle_document_link(
         );
     }
 
-    if config.pyproject_extension_enabled()
+    if config.lsp_document_link_extension_enabled()
+        && config.pyproject_extension_enabled()
         && let Some(locations) = tombi_extension_pyproject::document_link(
             &text_document_uri,
             &document_tree,

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -35,14 +35,7 @@ pub async fn handle_formatting(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.formatting.as_ref())
-        .and_then(|formatting| formatting.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_formatting_enabled() {
         log::debug!("`server.formatting.enabled` is false");
         return Ok(None);
     }

--- a/crates/tombi-lsp/src/handler/goto_declaration.rs
+++ b/crates/tombi-lsp/src/handler/goto_declaration.rs
@@ -28,14 +28,7 @@ pub async fn handle_goto_declaration(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.goto_declaration.as_ref())
-        .and_then(|goto_declaration| goto_declaration.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_goto_declaration_enabled() {
         log::debug!("`server.goto_declaration.enabled` is false");
         return Ok(None);
     }
@@ -58,7 +51,8 @@ pub async fn handle_goto_declaration(
     let document_tree = document_source.document_tree();
     let accessors = tombi_document_tree::get_accessors(&document_tree, &keys, position);
 
-    if config.cargo_extension_enabled()
+    if config.lsp_goto_declaration_extension_enabled()
+        && config.cargo_extension_enabled()
         && let Some(locations) = tombi_extension_cargo::goto_declaration(
             &text_document_uri,
             &document_tree,
@@ -71,7 +65,8 @@ pub async fn handle_goto_declaration(
         return Ok(locations.into());
     }
 
-    if config.pyproject_extension_enabled()
+    if config.lsp_goto_declaration_extension_enabled()
+        && config.pyproject_extension_enabled()
         && let Some(locations) = tombi_extension_pyproject::goto_declaration(
             &text_document_uri,
             &document_tree,

--- a/crates/tombi-lsp/src/handler/goto_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_definition.rs
@@ -27,14 +27,7 @@ pub async fn handle_goto_definition(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.goto_definition.as_ref())
-        .and_then(|goto_definition| goto_definition.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_goto_definition_enabled() {
         log::debug!("`server.goto_definition.enabled` is false");
         return Ok(Default::default());
     }
@@ -50,7 +43,9 @@ pub async fn handle_goto_definition(
 
     let position = position.into_lsp(line_index);
 
-    if let Some(location) = resolve_schema_definition_location(&root, &text_document_uri, position)
+    if config.lsp_goto_definition_schema_enabled()
+        && let Some(location) =
+            resolve_schema_definition_location(&root, &text_document_uri, position)
     {
         return Ok(Some(vec![location]));
     }
@@ -62,7 +57,8 @@ pub async fn handle_goto_definition(
     let document_tree = document_source.document_tree();
     let accessors = tombi_document_tree::get_accessors(&document_tree, &keys, position);
 
-    if config.cargo_extension_enabled()
+    if config.lsp_goto_definition_extension_enabled()
+        && config.cargo_extension_enabled()
         && let Some(locations) = tombi_extension_cargo::goto_definition(
             &text_document_uri,
             &document_tree,
@@ -75,7 +71,8 @@ pub async fn handle_goto_definition(
         return Ok(locations.into());
     }
 
-    if config.pyproject_extension_enabled()
+    if config.lsp_goto_definition_extension_enabled()
+        && config.pyproject_extension_enabled()
         && let Some(locations) = tombi_extension_pyproject::goto_definition(
             &text_document_uri,
             &document_tree,
@@ -88,7 +85,8 @@ pub async fn handle_goto_definition(
         return Ok(locations.into());
     }
 
-    if config.tombi_extension_enabled()
+    if config.lsp_goto_definition_extension_enabled()
+        && config.tombi_extension_enabled()
         && let Some(locations) = tombi_extension_tombi::goto_definition(
             &text_document_uri,
             &document_tree,

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -39,14 +39,7 @@ pub async fn handle_goto_type_definition(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.goto_type_definition.as_ref())
-        .and_then(|goto_type_definition| goto_type_definition.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_goto_type_definition_enabled() {
         log::debug!("`server.goto_type_definition.enabled` is false");
         return Ok(Default::default());
     }
@@ -62,8 +55,9 @@ pub async fn handle_goto_type_definition(
 
     let position = position.into_lsp(line_index);
 
-    if let Some(type_definition) =
-        get_tombi_document_comment_directive_type_definition(&root, position).await
+    if config.lsp_goto_type_definition_directive_enabled()
+        && let Some(type_definition) =
+            get_tombi_document_comment_directive_type_definition(&root, position).await
     {
         return Ok(Some(vec![tombi_extension::DefinitionLocation {
             uri: type_definition.schema_uri.into(),
@@ -82,6 +76,10 @@ pub async fn handle_goto_type_definition(
     };
 
     if keys.is_empty() && range.is_none() {
+        return Ok(Default::default());
+    }
+
+    if !config.lsp_goto_type_definition_schema_enabled() {
         return Ok(Default::default());
     }
 

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -37,14 +37,7 @@ pub async fn handle_hover(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.hover.as_ref())
-        .and_then(|hover| hover.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !config.lsp_hover_enabled() {
         log::debug!("`server.hover.enabled` is false");
         return Ok(None);
     }
@@ -70,9 +63,13 @@ pub async fn handle_hover(
         .flatten();
 
     let source_path = text_document_uri.to_file_path().ok();
+    let schema_hover_enabled = config.lsp_hover_schema_enabled();
+    let extension_hover_enabled = config.lsp_hover_extension_enabled();
     // Check if position is in a #:tombi comment directive
-    if let Some(content) =
-        get_document_comment_directive_hover_content(&root, position, source_path.as_deref()).await
+    if config.lsp_hover_directive_enabled()
+        && let Some(content) =
+            get_document_comment_directive_hover_content(&root, position, source_path.as_deref())
+                .await
     {
         return Ok(Some(content));
     }
@@ -87,98 +84,117 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let mut hover_content = get_hover_content(
-        &document_tree,
-        position,
-        &keys,
-        &SchemaContext {
-            toml_version,
-            root_schema: source_schema
-                .as_ref()
-                .and_then(|s| s.root_schema.as_deref()),
-            sub_schema_uri_map: source_schema.as_ref().map(|s| &s.sub_schema_uri_map),
-            deprecated_lint_level: source_schema.as_ref().and_then(|s| s.deprecated_lint_level),
-            schema_visits: Default::default(),
-            store: &schema_store,
-            strict: None,
-        },
-    )
-    .await;
+    let mut hover_content = if schema_hover_enabled || extension_hover_enabled {
+        get_hover_content(
+            &document_tree,
+            position,
+            &keys,
+            &SchemaContext {
+                toml_version,
+                root_schema: if schema_hover_enabled {
+                    source_schema
+                        .as_ref()
+                        .and_then(|s| s.root_schema.as_deref())
+                } else {
+                    None
+                },
+                sub_schema_uri_map: if schema_hover_enabled {
+                    source_schema.as_ref().map(|s| &s.sub_schema_uri_map)
+                } else {
+                    None
+                },
+                deprecated_lint_level: if schema_hover_enabled {
+                    source_schema.as_ref().and_then(|s| s.deprecated_lint_level)
+                } else {
+                    None
+                },
+                schema_visits: Default::default(),
+                store: &schema_store,
+                strict: None,
+            },
+        )
+        .await
+    } else {
+        None
+    };
 
     if let Some(HoverContent::Value(hover_value_content)) = &mut hover_content {
         hover_value_content.range = range;
 
-        let accessors = tombi_document_tree::get_accessors(&document_tree, &keys, position);
-        let offline = schema_store.offline();
-        let cache_options = schema_store.cache_options();
-        let tombi_hover_enabled = config
-            .tombi_extension_features()
-            .map_or(true, tombi_config::TombiExtensionFeatures::hover_enabled);
-        let cargo_dependency_detail_hover_enabled = config.cargo_extension_features().map_or(
-            true,
-            tombi_config::CargoExtensionFeatures::dependency_detail_hover_enabled,
-        );
-        let pyproject_dependency_detail_hover_enabled =
-            config.pyproject_extension_features().map_or(
+        if extension_hover_enabled {
+            let accessors = tombi_document_tree::get_accessors(&document_tree, &keys, position);
+            let offline = schema_store.offline();
+            let cache_options = schema_store.cache_options();
+            let tombi_hover_enabled = config
+                .tombi_extension_features()
+                .map_or(true, tombi_config::TombiExtensionFeatures::hover_enabled);
+            let cargo_dependency_detail_hover_enabled = config.cargo_extension_features().map_or(
                 true,
-                tombi_config::PyprojectExtensionFeatures::dependency_detail_hover_enabled,
+                tombi_config::CargoExtensionFeatures::dependency_detail_hover_enabled,
             );
+            let pyproject_dependency_detail_hover_enabled =
+                config.pyproject_extension_features().map_or(
+                    true,
+                    tombi_config::PyprojectExtensionFeatures::dependency_detail_hover_enabled,
+                );
 
-        let extension_hover = if tombi_hover_enabled {
-            tombi_extension_tombi::hover(
-                &text_document_uri,
-                &document_tree,
-                &accessors,
-                position,
-                toml_version,
-                offline,
-            )
-            .await?
-        } else {
-            None
-        };
-        let extension_hover = match extension_hover {
-            some @ Some(_) => some,
-            None if cargo_dependency_detail_hover_enabled => {
-                tombi_extension_cargo::hover(
+            let extension_hover = if tombi_hover_enabled {
+                tombi_extension_tombi::hover(
                     &text_document_uri,
                     &document_tree,
                     &accessors,
                     position,
                     toml_version,
                     offline,
-                    cache_options,
                 )
                 .await?
-            }
-            None => None,
-        };
-        let extension_hover = match extension_hover {
-            some @ Some(_) => some,
-            None if pyproject_dependency_detail_hover_enabled => {
-                tombi_extension_pyproject::hover(
-                    &text_document_uri,
-                    &document_tree,
-                    &accessors,
-                    position,
-                    toml_version,
-                    offline,
-                    cache_options,
-                )
-                .await?
-            }
-            None => None,
-        };
+            } else {
+                None
+            };
+            let extension_hover = match extension_hover {
+                some @ Some(_) => some,
+                None if cargo_dependency_detail_hover_enabled => {
+                    tombi_extension_cargo::hover(
+                        &text_document_uri,
+                        &document_tree,
+                        &accessors,
+                        position,
+                        toml_version,
+                        offline,
+                        cache_options,
+                    )
+                    .await?
+                }
+                None => None,
+            };
+            let extension_hover = match extension_hover {
+                some @ Some(_) => some,
+                None if pyproject_dependency_detail_hover_enabled => {
+                    tombi_extension_pyproject::hover(
+                        &text_document_uri,
+                        &document_tree,
+                        &accessors,
+                        position,
+                        toml_version,
+                        offline,
+                        cache_options,
+                    )
+                    .await?
+                }
+                None => None,
+            };
 
-        if let Some(metadata) = extension_hover {
-            if metadata.title.is_some() {
-                hover_value_content.title = metadata.title;
-            }
-            if metadata.description.is_some() {
-                hover_value_content.description = metadata.description;
+            if let Some(metadata) = extension_hover {
+                if metadata.title.is_some() {
+                    hover_value_content.title = metadata.title;
+                }
+                if metadata.description.is_some() {
+                    hover_value_content.description = metadata.description;
+                }
             }
         }
     }
+
     Ok(hover_content)
 }
 

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -107,14 +107,7 @@ async fn publish_workspace_diagnostics(
 /// Check if workspace diagnostic is enabled for the given workspace config
 #[inline]
 fn is_workspace_diagnostic_enabled(workspace_config: &WorkspaceConfig) -> bool {
-    workspace_config
-        .config
-        .lsp
-        .as_ref()
-        .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
-        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
+    workspace_config.config.lsp_workspace_diagnostic_enabled()
 }
 
 pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_uri::Uri) -> bool {

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -408,7 +408,10 @@ mod completion_labels {
                 "#,
                 SchemaPath(tombi_schema_path()),
             ) -> Ok([
+                "directive",
                 "enabled",
+                "extension",
+                "schema",
                 "{}"
             ]);
         }
@@ -422,7 +425,10 @@ mod completion_labels {
                 "#,
                 SchemaPath(tombi_schema_path()),
             ) -> Ok([
+                "directive",
                 "enabled",
+                "extension",
+                "schema",
                 "{}"
             ]);
         }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -434,6 +434,145 @@ mod hover_keys_value {
             });
         );
 
+        #[tokio::test]
+        async fn cargo_workspace_dependency_hover_metadata_with_lsp_schema_disabled()
+        -> Result<(), Box<dyn std::error::Error>> {
+            use std::io::Write;
+
+            use tombi_lsp::Backend;
+            use tombi_lsp::handler::{handle_did_open, handle_hover};
+            use tombi_text::IntoLsp;
+            use tower_lsp::{
+                LspService,
+                lsp_types::{
+                    DidOpenTextDocumentParams, HoverParams, TextDocumentIdentifier,
+                    TextDocumentItem, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+                },
+            };
+
+            tombi_test_lib::init_log();
+
+            let source_path =
+                tombi_test_lib::project_root_path().join("crates/tombi-lsp/Cargo.toml");
+            let schema_file_path = cargo_schema_path();
+            let source = textwrap::dedent(
+                r#"
+                [dependencies]
+                tombi-extension-cargo█ = { workspace = true }
+                "#,
+            )
+            .trim()
+            .to_string();
+
+            let index = source
+                .find('█')
+                .ok_or("failed to find hover position marker")?;
+            let mut toml_text = source;
+            toml_text.remove(index);
+
+            let mut temp_file = tempfile::NamedTempFile::new()?;
+            temp_file.write_all(toml_text.as_bytes())?;
+
+            let line_index =
+                tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
+
+            let (service, _) = LspService::new(|client| Backend::new(client, &Default::default()));
+            let backend = service.inner();
+
+            let config_schema_store = backend
+                .config_manager
+                .config_schema_store_for_file(&source_path)
+                .await;
+
+            let mut test_config = config_schema_store.config;
+            let lsp_config: tombi_config::Config = serde_tombi::from_str_async(
+                r#"
+                [lsp.hover]
+                schema.enabled = false
+                extension.enabled = true
+                "#,
+            )
+            .await?;
+            test_config.lsp = lsp_config.lsp;
+
+            let schema_uri = tombi_schema_store::SchemaUri::from_file_path(&schema_file_path)
+                .map_err(|_| "failed to convert schema path to URL")?;
+            let mut existing_schemas = test_config.schemas.take().unwrap_or_default();
+            existing_schemas.push(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: schema_uri.to_string(),
+                include: vec!["*.toml".to_string()],
+                lint: None,
+            }));
+            test_config.schemas = Some(existing_schemas);
+
+            if let Some(config_path) = config_schema_store.config_path {
+                backend
+                    .config_manager
+                    .update_config_with_path(test_config, &config_path)
+                    .await?;
+            } else {
+                backend
+                    .config_manager
+                    .update_editor_config(test_config)
+                    .await;
+            }
+
+            let toml_file_url = Url::from_file_path(&source_path)
+                .map_err(|_| "failed to convert file path to URL")?;
+
+            handle_did_open(
+                backend,
+                DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: toml_file_url.clone(),
+                        language_id: "toml".to_string(),
+                        version: 0,
+                        text: toml_text.clone(),
+                    },
+                },
+            )
+            .await;
+
+            let hover = handle_hover(
+                &backend,
+                HoverParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri: toml_file_url },
+                        position: (tombi_text::Position::default()
+                            + tombi_text::RelativePosition::of(&toml_text[..index]))
+                        .into_lsp(&line_index),
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                },
+            )
+            .await?;
+
+            let Some(tombi_lsp::HoverContent::Value(hover_content)) = hover else {
+                return Err("failed to handle hover content".into());
+            };
+
+            assert!(
+                hover_content.schema_uri.is_none(),
+                "schema metadata should be disabled"
+            );
+            pretty_assertions::assert_eq!(
+                hover_content.accessors.to_string(),
+                "dependencies.tombi-extension-cargo"
+            );
+            pretty_assertions::assert_eq!(hover_content.value_type.to_string(), "Table");
+            pretty_assertions::assert_eq!(
+                hover_content.title.as_deref(),
+                Some("tombi-extension-cargo")
+            );
+            pretty_assertions::assert_eq!(
+                hover_content.description.as_deref(),
+                Some("Tombi extension for Cargo.toml")
+            );
+
+            Ok(())
+        }
+
         test_hover_keys_value!(
             #[tokio::test]
             async fn cargo_remote_dependency_hover_offline(

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -567,7 +567,7 @@
       "type": "object",
       "properties": {
         "code-action": {
-          "title": "Code Action Feature options",
+          "title": "Code Action feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspCodeAction"
@@ -578,7 +578,7 @@
           ]
         },
         "completion": {
-          "title": "Completion Feature options",
+          "title": "Completion feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspCompletion"
@@ -589,7 +589,7 @@
           ]
         },
         "diagnostic": {
-          "title": "Diagnostic Feature options",
+          "title": "Diagnostic feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspDiagnostic"
@@ -600,7 +600,7 @@
           ]
         },
         "document-link": {
-          "title": "Document Link Feature options",
+          "title": "Document Link feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspDocumentLink"
@@ -611,7 +611,7 @@
           ]
         },
         "formatting": {
-          "title": "Formatting Feature options",
+          "title": "Formatting feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspFormatting"
@@ -622,10 +622,10 @@
           ]
         },
         "goto-declaration": {
-          "title": "Goto Declaration Feature options",
+          "title": "Goto Declaration feature options",
           "anyOf": [
             {
-              "$ref": "#/definitions/LspGotoDefinition"
+              "$ref": "#/definitions/LspGotoDeclaration"
             },
             {
               "type": "null"
@@ -633,7 +633,7 @@
           ]
         },
         "goto-definition": {
-          "title": "Goto Definition Feature options",
+          "title": "Goto Definition feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspGotoDefinition"
@@ -644,10 +644,10 @@
           ]
         },
         "goto-type-definition": {
-          "title": "Goto Type Definition Feature options",
+          "title": "Goto Type Definition feature options",
           "anyOf": [
             {
-              "$ref": "#/definitions/LspGotoDefinition"
+              "$ref": "#/definitions/LspGotoTypeDefinition"
             },
             {
               "type": "null"
@@ -655,7 +655,7 @@
           ]
         },
         "hover": {
-          "title": "Hover Feature options",
+          "title": "Hover feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspHover"
@@ -666,7 +666,7 @@
           ]
         },
         "workspace-diagnostic": {
-          "title": "Workspace Diagnostics Feature options",
+          "title": "Workspace Diagnostics feature options",
           "anyOf": [
             {
               "$ref": "#/definitions/LspWorkspaceDiagnostic"
@@ -681,11 +681,21 @@
       "x-tombi-table-keys-order": "ascending"
     },
     "LspCodeAction": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspCodeActionFeatureTree"
+        }
+      ]
+    },
+    "EnabledOnly": {
       "type": "object",
       "properties": {
         "enabled": {
-          "title": "Enable code action feature",
-          "description": "Whether to enable code action.",
+          "title": "Enable feature",
+          "description": "Whether this feature is enabled.",
           "anyOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
@@ -702,12 +712,55 @@
       "type": "boolean",
       "default": true
     },
-    "LspCompletion": {
+    "LspCodeActionFeatureTree": {
+      "type": "object",
+      "properties": {
+        "dot-keys-to-inline-table": {
+          "title": "Dot-keys to inline-table code action feature",
+          "description": "Whether the code action converting dot-keys to inline tables is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inline-table-to-dot-keys": {
+          "title": "Inline-table to dot-keys code action feature",
+          "description": "Whether the code action converting inline tables to dot-keys is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extension": {
+          "title": "Extension code action feature",
+          "description": "Whether extension-provided code actions are enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
+    "ToggleFeature": {
       "type": "object",
       "properties": {
         "enabled": {
-          "title": "Enable completion feature",
-          "description": "Whether to enable completion.",
+          "title": "Enable feature",
+          "description": "Whether this nested feature is enabled.",
           "anyOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
@@ -720,12 +773,65 @@
       },
       "additionalProperties": false
     },
+    "LspCompletion": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspCompletionFeatureTree"
+        }
+      ]
+    },
+    "LspCompletionFeatureTree": {
+      "type": "object",
+      "properties": {
+        "directive": {
+          "title": "Directive completion feature",
+          "description": "Whether completion is available in Tombi comment directives.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "title": "Schema completion feature",
+          "description": "Whether schema-driven completion is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extension": {
+          "title": "Extension completion feature",
+          "description": "Whether extension-provided completion is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
     "LspDiagnostic": {
       "type": "object",
       "properties": {
         "enabled": {
           "title": "Enable diagnostic feature",
-          "description": "Whether to enable diagnostic.",
+          "description": "Whether to enable diagnostics.",
           "anyOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
@@ -739,14 +845,36 @@
       "additionalProperties": false
     },
     "LspDocumentLink": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspDocumentLinkFeatureTree"
+        }
+      ]
+    },
+    "LspDocumentLinkFeatureTree": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "title": "Enable document link feature",
-          "description": "Whether to enable document link.",
+        "schema": {
+          "title": "Schema document link feature",
+          "description": "Whether schema directives produce document links.",
           "anyOf": [
             {
-              "$ref": "#/definitions/BoolDefaultTrue"
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extension": {
+          "title": "Extension document link feature",
+          "description": "Whether extension-provided document links are enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
             },
             {
               "type": "null"
@@ -754,7 +882,8 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
     },
     "LspFormatting": {
       "type": "object",
@@ -774,15 +903,25 @@
       },
       "additionalProperties": false
     },
-    "LspGotoDefinition": {
+    "LspGotoDeclaration": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspGotoDeclarationFeatureTree"
+        }
+      ]
+    },
+    "LspGotoDeclarationFeatureTree": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "title": "Enable goto definition feature",
-          "description": "Whether to enable goto definition.",
+        "extension": {
+          "title": "Extension go-to-declaration feature",
+          "description": "Whether extension-provided go-to-declaration is enabled.",
           "anyOf": [
             {
-              "$ref": "#/definitions/BoolDefaultTrue"
+              "$ref": "#/definitions/ToggleFeature"
             },
             {
               "type": "null"
@@ -790,17 +929,134 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
+    "LspGotoDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspGotoDefinitionFeatureTree"
+        }
+      ]
+    },
+    "LspGotoDefinitionFeatureTree": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "title": "Schema go-to-definition feature",
+          "description": "Whether go-to-definition resolves schema directives.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extension": {
+          "title": "Extension go-to-definition feature",
+          "description": "Whether extension-provided go-to-definition is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
+    "LspGotoTypeDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspGotoTypeDefinitionFeatureTree"
+        }
+      ]
+    },
+    "LspGotoTypeDefinitionFeatureTree": {
+      "type": "object",
+      "properties": {
+        "directive": {
+          "title": "Directive go-to-type-definition feature",
+          "description": "Whether go-to-type-definition resolves Tombi comment directives.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "title": "Schema go-to-type-definition feature",
+          "description": "Whether go-to-type-definition resolves schema-backed types.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
     },
     "LspHover": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/LspHoverFeatureTree"
+        }
+      ]
+    },
+    "LspHoverFeatureTree": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "title": "Enable hover feature",
-          "description": "Whether to enable hover.",
+        "directive": {
+          "title": "Directive hover feature",
+          "description": "Whether hover is available in Tombi comment directives.",
           "anyOf": [
             {
-              "$ref": "#/definitions/BoolDefaultTrue"
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "title": "Schema hover feature",
+          "description": "Whether schema-derived hover is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extension": {
+          "title": "Extension hover feature",
+          "description": "Whether extension-provided hover is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeature"
             },
             {
               "type": "null"
@@ -808,14 +1064,15 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
     },
     "LspWorkspaceDiagnostic": {
       "type": "object",
       "properties": {
         "enabled": {
           "title": "Enable workspace diagnostic feature",
-          "description": "Whether to enable workspace diagnostic.",
+          "description": "Whether to enable workspace diagnostics.",
           "anyOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
@@ -1223,24 +1480,6 @@
         }
       ]
     },
-    "EnabledOnly": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable feature",
-          "description": "Whether this feature is enabled.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/BoolDefaultTrue"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
     "CargoExtensionFeatureTree": {
       "type": "object",
       "properties": {
@@ -1405,24 +1644,6 @@
       },
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
-    },
-    "ToggleFeature": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable feature",
-          "description": "Whether this nested feature is enabled.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/BoolDefaultTrue"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
     },
     "CargoInlayHintFeatures": {
       "anyOf": [


### PR DESCRIPTION
## Summary
- add nested LSP feature toggle config trees similar to extensions
- wire handlers to respect directive/schema/extension and code-action subfeature toggles
- regenerate `www.schemastore.org/tombi.json` and add hover regression coverage for `lsp.hover.schema.enabled = false`

## Testing
- cargo test -p tombi-config
- cargo test -p tombi-linter --test integration tombi_schema
- cargo test -p tombi-lsp --lib
- cargo test -p tombi-lsp --test test_hover
- cargo xtask codegen jsonschema