### PR TITLE
Support BBEdit hang on LSP shutdown

### DIFF
--- a/rust/tombi-cli/src/app/command/lsp.rs
+++ b/rust/tombi-cli/src/app/command/lsp.rs
@@ -1,5 +1,4 @@
 use crate::app::CommonArgs;
-use std::time::Duration;
 
 /// Run TOML Language Server.
 #[derive(Debug, clap::Args)]
@@ -19,7 +18,8 @@ pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
         args.common.offline,
         args.common.no_cache,
     ));
-    runtime.shutdown_timeout(Duration::from_secs(1));
+
+    runtime.shutdown_timeout(std::time::Duration::from_secs(1));
 
     Ok(())
 }

--- a/rust/tombi-cli/src/app/command/lsp.rs
+++ b/rust/tombi-cli/src/app/command/lsp.rs
@@ -1,4 +1,5 @@
 use crate::app::CommonArgs;
+use std::time::Duration;
 
 /// Run TOML Language Server.
 #[derive(Debug, clap::Args)]
@@ -9,14 +10,16 @@ pub struct Args {
 
 pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
     let args: Args = args.into();
-    tokio::runtime::Builder::new_current_thread()
+    let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .build()?
-        .block_on(tombi_lsp::serve(
-            tombi_lsp::Args {},
-            args.common.offline,
-            args.common.no_cache,
-        ));
+        .build()?;
+
+    runtime.block_on(tombi_lsp::serve(
+        tombi_lsp::Args {},
+        args.common.offline,
+        args.common.no_cache,
+    ));
+    runtime.shutdown_timeout(Duration::from_secs(1));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- limit Tokio runtime shutdown wait time for the LSP CLI path
- avoid indefinite process hangs when background tasks are still running during editor shutdown
- keep the change isolated to the CLI runtime teardown path

## Testing
- cargo test -p tombi-cli

Closes #1000