### PR TITLE
Fix oneOf hover branch selection

### DIFF
--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -141,8 +141,8 @@ where
             }
         }
 
-        let mut hover_value_content = if one_hover_value_contents.len() == 1 {
-            one_hover_value_contents
+        let mut hover_value_content = if valid_hover_value_contents.len() == 1 {
+            valid_hover_value_contents
                 .into_iter()
                 .next()
                 .map(|mut hover_content| {
@@ -157,8 +157,8 @@ where
 
                     hover_content
                 })
-        } else if valid_hover_value_contents.len() == 1 {
-            valid_hover_value_contents
+        } else if one_hover_value_contents.len() == 1 {
+            one_hover_value_contents
                 .into_iter()
                 .next()
                 .map(|mut hover_content| {

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -645,6 +645,7 @@ mod completion_labels {
                 "format-assertion-vocab-test.schema.json",
                 "if-then-else-test.schema.json",
                 "min-max-contains-test.schema.json",
+                "one-of-hover-discriminator-test.schema.json",
                 "partial-taskipy.schema.json",
                 "prefix-items-test.schema.json",
                 "recursive-anchor-ref-test.schema.json",

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
-    cargo_feature_navigation_fixture_path, cargo_schema_path, pyproject_schema_path,
+    cargo_feature_navigation_fixture_path, cargo_schema_path,
+    one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
 };
 
@@ -559,6 +560,28 @@ mod hover_keys_value {
                         ),
                     ],
                 )),
+            });
+        );
+    }
+
+    mod one_of_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn one_of_hover_prefers_single_valid_branch(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(one_of_hover_discriminator_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos[0].hooks[0].id",
+                "Value": "String",
+                "Default": "\"builtin-hook\""
             });
         );
     }

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -166,6 +166,12 @@ pub fn format_assertion_vocab_test_schema_path() -> PathBuf {
         .join("format-assertion-vocab-test.schema.json")
 }
 
+pub fn one_of_hover_discriminator_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("one-of-hover-discriminator-test.schema.json")
+}
+
 pub fn unevaluated_items_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")

--- a/extensions/tombi-extension-cargo/src/cargo_lock.rs
+++ b/extensions/tombi-extension-cargo/src/cargo_lock.rs
@@ -321,10 +321,7 @@ mod tests {
         );
 
         assert_eq!(dependency.name, "toml");
-        assert_eq!(
-            dependency.version.as_deref(),
-            Some("0.9.12+spec-1.1.0")
-        );
+        assert_eq!(dependency.version.as_deref(), Some("0.9.12+spec-1.1.0"));
     }
 
     #[test]

--- a/schemas/one-of-hover-discriminator-test.schema.json
+++ b/schemas/one-of-hover-discriminator-test.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "repos": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "repo": {
+                "const": "remote"
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "default": "remote-hook"
+                    }
+                  },
+                  "required": ["id"]
+                }
+              }
+            },
+            "required": ["repo", "hooks"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "repo": {
+                "const": "builtin"
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "default": "builtin-hook"
+                    }
+                  },
+                  "required": ["id"]
+                }
+              }
+            },
+            "required": ["repo", "hooks"]
+          }
+        ]
+      }
+    }
+  },
+  "required": ["repos"]
+}


### PR DESCRIPTION
## Summary

- fix oneOf hover selection to prefer the single schema branch that actually validates
- add a hover test covering discriminator-like oneOf behavior
- add a dedicated schema fixture for the new test

## Testing

- cargo test -p tombi-lsp one_of_hover_prefers_single_valid_branch -- --nocapture
- cargo test -p tombi-lsp hover_keys_value::pyproject_schema::pyproject_project_readme -- --nocapture