### PR TITLE
Fix oneOf hover branch selection

### DIFF
--- a/crates/tombi-lsp/src/hover.rs
+++ b/crates/tombi-lsp/src/hover.rs
@@ -113,6 +113,7 @@ impl PartialEq for HoverValueContent {
             && self.description == other.description
             && self.accessors == other.accessors
             && self.value_type == other.value_type
+            && self.constraints == other.constraints
             && self.range == other.range
     }
 }
@@ -125,6 +126,7 @@ impl std::hash::Hash for HoverValueContent {
         self.description.hash(state);
         self.accessors.hash(state);
         self.value_type.hash(state);
+        self.constraints.hash(state);
         self.range.hash(state);
     }
 }

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -36,7 +36,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ValueConstraints {
     // Common
     pub r#enum: Option<Vec<DisplayValue>>,

--- a/crates/tombi-lsp/src/hover/display_value.rs
+++ b/crates/tombi-lsp/src/hover/display_value.rs
@@ -19,6 +19,44 @@ pub enum DisplayValue {
     Table(Vec<(String, DisplayValue)>),
 }
 
+impl PartialEq for DisplayValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Boolean(a), Self::Boolean(b)) => a == b,
+            (Self::Integer(a), Self::Integer(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => a.to_bits() == b.to_bits(),
+            (Self::String(a), Self::String(b)) => a == b,
+            (Self::OffsetDateTime(a), Self::OffsetDateTime(b)) => a == b,
+            (Self::LocalDateTime(a), Self::LocalDateTime(b)) => a == b,
+            (Self::LocalDate(a), Self::LocalDate(b)) => a == b,
+            (Self::LocalTime(a), Self::LocalTime(b)) => a == b,
+            (Self::Array(a), Self::Array(b)) => a == b,
+            (Self::Table(a), Self::Table(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for DisplayValue {}
+
+impl std::hash::Hash for DisplayValue {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Boolean(value) => value.hash(state),
+            Self::Integer(value) => value.hash(state),
+            Self::Float(value) => value.to_bits().hash(state),
+            Self::String(value)
+            | Self::OffsetDateTime(value)
+            | Self::LocalDateTime(value)
+            | Self::LocalDate(value)
+            | Self::LocalTime(value) => value.hash(state),
+            Self::Array(values) => values.hash(state),
+            Self::Table(values) => values.hash(state),
+        }
+    }
+}
+
 impl DisplayValue {
     pub fn try_new_offset_date_time(
         local_date_time: &str,

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -141,8 +141,8 @@ where
             }
         }
 
-        let mut hover_value_content = if one_hover_value_contents.len() == 1 {
-            one_hover_value_contents
+        let mut hover_value_content = if valid_hover_value_contents.len() == 1 {
+            valid_hover_value_contents
                 .into_iter()
                 .next()
                 .map(|mut hover_content| {
@@ -157,8 +157,8 @@ where
 
                     hover_content
                 })
-        } else if valid_hover_value_contents.len() == 1 {
-            valid_hover_value_contents
+        } else if one_hover_value_contents.len() == 1 {
+            one_hover_value_contents
                 .into_iter()
                 .next()
                 .map(|mut hover_content| {

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -645,6 +645,7 @@ mod completion_labels {
                 "format-assertion-vocab-test.schema.json",
                 "if-then-else-test.schema.json",
                 "min-max-contains-test.schema.json",
+                "one-of-hover-discriminator-test.schema.json",
                 "partial-taskipy.schema.json",
                 "prefix-items-test.schema.json",
                 "recursive-anchor-ref-test.schema.json",

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
-    cargo_feature_navigation_fixture_path, cargo_schema_path, pyproject_schema_path,
+    cargo_feature_navigation_fixture_path, cargo_schema_path,
+    one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
 };
 
@@ -559,6 +560,28 @@ mod hover_keys_value {
                         ),
                     ],
                 )),
+            });
+        );
+    }
+
+    mod one_of_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn one_of_hover_prefers_single_valid_branch(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(one_of_hover_discriminator_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos[0].hooks[0].id",
+                "Value": "String",
+                "Default": "\"builtin-hook\""
             });
         );
     }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -584,6 +584,21 @@ mod hover_keys_value {
                 "Default": "\"builtin-hook\""
             });
         );
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn one_of_hover_does_not_leak_branch_default_when_no_branch_is_valid(
+                r#"
+                [[repos]]
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(one_of_hover_discriminator_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos[0]",
+                "Value": "Table"
+            });
+        );
     }
 
     mod pyproject_schema {

--- a/crates/tombi-schema-store/src/schema/array_schema.rs
+++ b/crates/tombi-schema-store/src/schema/array_schema.rs
@@ -271,7 +271,7 @@ impl FindSchemaCandidates for ArraySchema {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum XTombiArrayValuesOrder {
     All(ArrayValuesOrder),
     Groups(ArrayValuesOrderGroup),

--- a/crates/tombi-schema-store/src/schema/table_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_schema.rs
@@ -573,13 +573,13 @@ impl FindSchemaCandidates for TableSchema {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum XTombiTableKeysOrder {
     All(TableKeysOrder),
     Groups(Vec<TableKeysOrderGroup>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableKeysOrderGroup {
     pub target: TableKeysOrderGroupKind,
     pub order: TableKeysOrder,

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -166,6 +166,12 @@ pub fn format_assertion_vocab_test_schema_path() -> PathBuf {
         .join("format-assertion-vocab-test.schema.json")
 }
 
+pub fn one_of_hover_discriminator_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("one-of-hover-discriminator-test.schema.json")
+}
+
 pub fn unevaluated_items_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -7,7 +7,7 @@ pub const X_TOMBI_TABLE_KEYS_ORDER: &str = "x-tombi-table-keys-order";
 pub const X_TOMBI_STRING_FORMATS: &str = "x-tombi-string-formats";
 pub const X_TOMBI_ADDITIONAL_KEY_LABEL: &str = "x-tombi-additional-key-label";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum ArrayValuesOrder {
@@ -39,7 +39,7 @@ impl<'a> TryFrom<&'a str> for ArrayValuesOrder {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum ArrayValuesOrderGroup {
@@ -47,7 +47,7 @@ pub enum ArrayValuesOrderGroup {
     AnyOf(Vec<ArrayValuesOrder>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArrayValuesOrderBy(String);
 
@@ -71,7 +71,7 @@ impl PartialEq<ArrayValuesOrderBy> for String {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum TableKeysOrder {
@@ -106,7 +106,7 @@ impl<'a> TryFrom<&'a str> for TableKeysOrder {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum TableKeysOrderGroupKind {
@@ -138,7 +138,7 @@ impl<'a> TryFrom<&'a str> for TableKeysOrderGroupKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]

--- a/extensions/tombi-extension-cargo/src/cargo_lock.rs
+++ b/extensions/tombi-extension-cargo/src/cargo_lock.rs
@@ -321,10 +321,7 @@ mod tests {
         );
 
         assert_eq!(dependency.name, "toml");
-        assert_eq!(
-            dependency.version.as_deref(),
-            Some("0.9.12+spec-1.1.0")
-        );
+        assert_eq!(dependency.version.as_deref(), Some("0.9.12+spec-1.1.0"));
     }
 
     #[test]

--- a/schemas/one-of-hover-discriminator-test.schema.json
+++ b/schemas/one-of-hover-discriminator-test.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "repos": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "repo": {
+                "const": "remote"
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "default": "remote-hook"
+                    }
+                  },
+                  "required": ["id"]
+                }
+              }
+            },
+            "required": ["repo", "hooks"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "repo": {
+                "const": "builtin"
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "default": "builtin-hook"
+                    }
+                  },
+                  "required": ["id"]
+                }
+              }
+            },
+            "required": ["repo", "hooks"]
+          }
+        ]
+      }
+    }
+  },
+  "required": ["repos"]
+}


### PR DESCRIPTION
## Summary

- fix oneOf hover selection to prefer the single schema branch that actually validates
- add a hover test covering discriminator-like oneOf behavior
- add a dedicated schema fixture for the new test
- update the schema completion test fixture list for the new schema file

## Testing

- cargo test -p tombi-lsp one_of_hover_prefers_single_valid_branch -- --nocapture
- cargo test -p tombi-lsp tombi_schemars_path_file_completion -- --nocapture