### PR TITLE
Fix adjacent applicator schema lookups in LSP

### DIFF
--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use tombi_extension::CompletionContentPriority;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, ValueSchema};
@@ -67,7 +68,9 @@ where
             {
                 Ok(_) => true,
                 Err(tombi_validator::Error { diagnostics, .. })
-                    if diagnostics.iter().all(tombi_diagnostic::Diagnostic::is_warning) =>
+                    if diagnostics
+                        .iter()
+                        .all(tombi_diagnostic::Diagnostic::is_warning) =>
                 {
                     true
                 }
@@ -90,6 +93,10 @@ where
 
         let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
         let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
+        let fallback_completion_items = branch_results
+            .iter()
+            .flat_map(|(_, _, items)| items.iter().cloned())
+            .collect_vec();
         for (branch_has_key, branch_is_valid, items) in branch_results {
             if valid_branches {
                 if branch_is_valid {
@@ -98,6 +105,10 @@ where
             } else if !narrow_branches || branch_has_key {
                 completion_items.extend(items);
             }
+        }
+
+        if completion_items.is_empty() {
+            completion_items = fallback_completion_items;
         }
 
         let detail = any_of_schema

--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -47,7 +47,7 @@ where
             return completion_items;
         };
 
-        let mut branch_results: Vec<(bool, Vec<CompletionContent>)> = Vec::new();
+        let mut branch_results: Vec<(bool, bool, Vec<CompletionContent>)> = Vec::new();
         for resolved_schema in &resolved_schemas {
             let branch_has_key = if let Some(ref first_key) = first_key {
                 match resolved_schema.value_schema.as_ref() {
@@ -61,6 +61,18 @@ where
             } else {
                 false
             };
+            let branch_is_valid = match value
+                .validate(accessors, Some(resolved_schema), schema_context)
+                .await
+            {
+                Ok(_) => true,
+                Err(tombi_validator::Error { diagnostics, .. })
+                    if diagnostics.iter().all(tombi_diagnostic::Diagnostic::is_warning) =>
+                {
+                    true
+                }
+                _ => false,
+            };
 
             let schema_completions = value
                 .find_completion_contents(
@@ -73,12 +85,17 @@ where
                 )
                 .await;
 
-            branch_results.push((branch_has_key, schema_completions));
+            branch_results.push((branch_has_key, branch_is_valid, schema_completions));
         }
 
-        let narrow_branches = branch_results.iter().any(|(has_key, _)| *has_key);
-        for (branch_has_key, items) in branch_results {
-            if !narrow_branches || branch_has_key {
+        let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
+        let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
+        for (branch_has_key, branch_is_valid, items) in branch_results {
+            if valid_branches {
+                if branch_is_valid {
+                    completion_items.extend(items);
+                }
+            } else if !narrow_branches || branch_has_key {
                 completion_items.extend(items);
             }
         }
@@ -110,7 +127,7 @@ where
             }
         }
 
-        if !narrow_branches {
+        if !valid_branches && !narrow_branches {
             if let Some(default) = &any_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use tombi_extension::CompletionContentPriority;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, ValueSchema};
@@ -71,7 +72,9 @@ where
             {
                 Ok(_) => true,
                 Err(tombi_validator::Error { diagnostics, .. })
-                    if diagnostics.iter().all(tombi_diagnostic::Diagnostic::is_warning) =>
+                    if diagnostics
+                        .iter()
+                        .all(tombi_diagnostic::Diagnostic::is_warning) =>
                 {
                     true
                 }
@@ -94,6 +97,10 @@ where
 
         let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
         let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
+        let fallback_completion_items = branch_results
+            .iter()
+            .flat_map(|(_, _, items)| items.iter().cloned())
+            .collect_vec();
         for (branch_has_key, branch_is_valid, items) in branch_results {
             if valid_branches {
                 if branch_is_valid {
@@ -102,6 +109,10 @@ where
             } else if !narrow_branches || branch_has_key {
                 completion_items.extend(items);
             }
+        }
+
+        if completion_items.is_empty() {
+            completion_items = fallback_completion_items;
         }
 
         let detail = one_of_schema

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -51,7 +51,7 @@ where
             return completion_items;
         };
 
-        let mut branch_results: Vec<(bool, Vec<CompletionContent>)> = Vec::new();
+        let mut branch_results: Vec<(bool, bool, Vec<CompletionContent>)> = Vec::new();
         for resolved_schema in &resolved_schemas {
             let branch_has_key = if let Some(ref first_key) = first_key {
                 match resolved_schema.value_schema.as_ref() {
@@ -65,6 +65,18 @@ where
             } else {
                 false
             };
+            let branch_is_valid = match value
+                .validate(accessors, Some(resolved_schema), schema_context)
+                .await
+            {
+                Ok(_) => true,
+                Err(tombi_validator::Error { diagnostics, .. })
+                    if diagnostics.iter().all(tombi_diagnostic::Diagnostic::is_warning) =>
+                {
+                    true
+                }
+                _ => false,
+            };
 
             let schema_completions = value
                 .find_completion_contents(
@@ -77,12 +89,17 @@ where
                 )
                 .await;
 
-            branch_results.push((branch_has_key, schema_completions));
+            branch_results.push((branch_has_key, branch_is_valid, schema_completions));
         }
 
-        let narrow_branches = branch_results.iter().any(|(has_key, _)| *has_key);
-        for (branch_has_key, items) in branch_results {
-            if !narrow_branches || branch_has_key {
+        let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
+        let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
+        for (branch_has_key, branch_is_valid, items) in branch_results {
+            if valid_branches {
+                if branch_is_valid {
+                    completion_items.extend(items);
+                }
+            } else if !narrow_branches || branch_has_key {
                 completion_items.extend(items);
             }
         }
@@ -114,7 +131,7 @@ where
             }
         }
 
-        if !narrow_branches {
+        if !valid_branches && !narrow_branches {
             if let Some(default) = &one_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -103,46 +103,6 @@ impl FindCompletionContents for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
-                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                            return super::one_of::find_one_of_completion_items(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                one_of_schema,
-                                current_schema,
-                                schema_context,
-                                completion_hint,
-                            )
-                            .await;
-                        }
-                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                            return super::any_of::find_any_of_completion_items(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                any_of_schema,
-                                current_schema,
-                                schema_context,
-                                completion_hint,
-                            )
-                            .await;
-                        }
-                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                            return super::all_of::find_all_of_completion_items(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                all_of_schema,
-                                current_schema,
-                                schema_context,
-                                completion_hint,
-                            )
-                            .await;
-                        }
-
                         let mut completion_contents = Vec::new();
 
                         if let Some(key) = keys.first() {
@@ -450,6 +410,110 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                     )
                                     .await;
                                 }
+
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    let completion_items =
+                                        super::one_of::find_one_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            one_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    let completion_items =
+                                        super::any_of::find_any_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            any_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    let completion_items =
+                                        super::all_of::find_all_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            all_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                            } else {
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    let completion_items =
+                                        super::one_of::find_one_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            one_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    let completion_items =
+                                        super::any_of::find_any_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            any_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    let completion_items =
+                                        super::all_of::find_all_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            all_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
                             }
                         } else {
                             let schema_accessors = table_schema
@@ -638,6 +702,60 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                     value_schema.deprecated().await,
                                     completion_hint,
                                 ));
+                            }
+
+                            if completion_contents.is_empty() {
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    let completion_items =
+                                        super::one_of::find_one_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            one_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    let completion_items =
+                                        super::any_of::find_any_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            any_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    let completion_items =
+                                        super::all_of::find_all_of_completion_items(
+                                            self,
+                                            position,
+                                            keys,
+                                            accessors,
+                                            all_of_schema,
+                                            current_schema,
+                                            schema_context,
+                                            completion_hint,
+                                        )
+                                        .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
                             }
                         }
                         completion_contents

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -103,6 +103,46 @@ impl FindCompletionContents for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
+                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                            return super::one_of::find_one_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                one_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                        }
+                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                            return super::any_of::find_any_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                any_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                        }
+                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                            return super::all_of::find_all_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                all_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                        }
+
                         let mut completion_contents = Vec::new();
 
                         if let Some(key) = keys.first() {

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -69,6 +69,46 @@ impl GetTypeDefinition for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
+                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                            return get_one_of_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                one_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                            return get_any_of_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                any_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                            return get_all_of_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                all_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+
                         if let Some(key) = keys.first() {
                             if let Some(value) = self.get(key) {
                                 let accessor = Accessor::Key(key.value.clone());

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -69,46 +69,6 @@ impl GetTypeDefinition for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
-                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                            return get_one_of_type_definition(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                one_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                            return get_any_of_type_definition(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                any_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                            return get_all_of_type_definition(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                all_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-
                         if let Some(key) = keys.first() {
                             if let Some(value) = self.get(key) {
                                 let accessor = Accessor::Key(key.value.clone());
@@ -244,7 +204,7 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         });
                                 }
 
-                                value
+                                let type_definition = value
                                     .get_type_definition(
                                         position,
                                         &keys[1..],
@@ -252,7 +212,62 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         None,
                                         schema_context,
                                     )
+                                    .await;
+
+                                if type_definition.is_some() {
+                                    return type_definition;
+                                }
+
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    if let Some(type_definition) = get_one_of_type_definition(
+                                        self,
+                                        position,
+                                        keys,
+                                        &accessors,
+                                        one_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
                                     .await
+                                    {
+                                        return Some(type_definition);
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    if let Some(type_definition) = get_any_of_type_definition(
+                                        self,
+                                        position,
+                                        keys,
+                                        &accessors,
+                                        any_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(type_definition);
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    if let Some(type_definition) = get_all_of_type_definition(
+                                        self,
+                                        position,
+                                        keys,
+                                        &accessors,
+                                        all_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(type_definition);
+                                    }
+                                }
+
+                                None
                             } else {
                                 let mut schema_uri = current_schema.schema_uri.as_ref().clone();
                                 schema_uri.set_fragment(Some(&format!(
@@ -270,7 +285,7 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                 })
                             }
                         } else {
-                            table_schema
+                            let type_definition = table_schema
                                 .get_type_definition(
                                     position,
                                     keys,
@@ -278,7 +293,62 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     Some(current_schema),
                                     schema_context,
                                 )
+                                .await;
+
+                            if type_definition.is_some() {
+                                return type_definition;
+                            }
+
+                            if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                if let Some(type_definition) = get_one_of_type_definition(
+                                    self,
+                                    position,
+                                    keys,
+                                    accessors,
+                                    one_of_schema,
+                                    &current_schema.schema_uri,
+                                    &current_schema.definitions,
+                                    schema_context,
+                                )
                                 .await
+                                {
+                                    return Some(type_definition);
+                                }
+                            }
+                            if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                if let Some(type_definition) = get_any_of_type_definition(
+                                    self,
+                                    position,
+                                    keys,
+                                    accessors,
+                                    any_of_schema,
+                                    &current_schema.schema_uri,
+                                    &current_schema.definitions,
+                                    schema_context,
+                                )
+                                .await
+                                {
+                                    return Some(type_definition);
+                                }
+                            }
+                            if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                if let Some(type_definition) = get_all_of_type_definition(
+                                    self,
+                                    position,
+                                    keys,
+                                    accessors,
+                                    all_of_schema,
+                                    &current_schema.schema_uri,
+                                    &current_schema.definitions,
+                                    schema_context,
+                                )
+                                .await
+                                {
+                                    return Some(type_definition);
+                                }
+                            }
+
+                            None
                         }
                     }
                     ValueSchema::OneOf(one_of_schema) => {

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -72,6 +72,46 @@ impl GetHoverContent for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
+                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                            return get_one_of_hover_content(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                one_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                            return get_any_of_hover_content(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                any_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                            return get_all_of_hover_content(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                all_of_schema,
+                                &current_schema.schema_uri,
+                                &current_schema.definitions,
+                                schema_context,
+                            )
+                            .await;
+                        }
+
                         if let Some(key) = keys.first() {
                             if let Some(value) = self.get(key) {
                                 let accessor = Accessor::Key(key.value.clone());

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -72,46 +72,6 @@ impl GetHoverContent for tombi_document_tree::Table {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Table(table_schema) => {
-                        if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                            return get_one_of_hover_content(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                one_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-                        if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                            return get_any_of_hover_content(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                any_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-                        if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                            return get_all_of_hover_content(
-                                self,
-                                position,
-                                keys,
-                                accessors,
-                                all_of_schema,
-                                &current_schema.schema_uri,
-                                &current_schema.definitions,
-                                schema_context,
-                            )
-                            .await;
-                        }
-
                         if let Some(key) = keys.first() {
                             if let Some(value) = self.get(key) {
                                 let accessor = Accessor::Key(key.value.clone());
@@ -415,6 +375,55 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     return hover_content;
                                 }
 
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    if let Some(hover_content) = get_one_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        one_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    if let Some(hover_content) = get_any_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        any_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    if let Some(hover_content) = get_all_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        all_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+
                                 value
                                     .get_hover_content(
                                         position,
@@ -429,6 +438,55 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     )
                                     .await
                             } else {
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    if let Some(hover_content) = get_one_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        one_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    if let Some(hover_content) = get_any_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        any_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    if let Some(hover_content) = get_all_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        all_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+
                                 None
                             }
                         } else {
@@ -446,6 +504,55 @@ impl GetHoverContent for tombi_document_tree::Table {
                                 hover_content.as_mut()
                             {
                                 hover_value_content.range = Some(self.range());
+                            } else {
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
+                                    if let Some(hover_content) = get_one_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        one_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
+                                    if let Some(hover_content) = get_any_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        any_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                    if let Some(hover_content) = get_all_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        all_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
                             }
 
                             hover_content

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -632,6 +632,7 @@ mod completion_labels {
             ) -> Ok([
                 "additional-properties-branch-keys-test.schema.json",
                 "adjacent-applicators-test.schema.json",
+                "adjacent-one-of-hover-test.schema.json",
                 "anchor-dynamic-ref-test.schema.json",
                 "anchor-table-test.schema.json",
                 "array-const-enum-test.schema.json",

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1,7 +1,7 @@
 use tombi_config::{JSON_SCHEMASTORE_CATALOG_URL, TOMBI_SCHEMASTORE_CATALOG_URL};
 use tombi_test_lib::{
-    project_root_path, string_format_test_schema_path, today_local_date, today_local_date_time,
-    today_local_time, today_offset_date_time,
+    adjacent_one_of_hover_test_schema_path, project_root_path, string_format_test_schema_path,
+    today_local_date, today_local_date_time, today_local_time, today_offset_date_time,
 };
 
 mod completion_labels {
@@ -721,6 +721,24 @@ mod completion_labels {
             ) -> Ok([
                 "schemas/type-test.schema.json",
             ]);
+        }
+    }
+
+    mod adjacent_one_of_schema {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_id_value_completion(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { id = █ }
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["\"builtin-hook\"", "\"\"", "''"]);
         }
     }
 

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -1,5 +1,6 @@
 mod goto_type_definition_tests {
     use super::*;
+    use tombi_test_lib::adjacent_one_of_hover_test_schema_path;
 
     mod tombi_schema {
         use super::*;
@@ -147,6 +148,38 @@ mod goto_type_definition_tests {
                 SourcePath(pyproject_schema_path()),
                 SchemaPath(pyproject_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-document-directive.json");
+        );
+    }
+
+    mod adjacent_one_of_schema {
+        use super::*;
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hooks_key(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                ho█oks = []
+                "#,
+                SourcePath(adjacent_one_of_hover_test_schema_path()),
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(adjacent_one_of_hover_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_id_value(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SourcePath(adjacent_one_of_hover_test_schema_path()),
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(adjacent_one_of_hover_test_schema_path());
         );
     }
 

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
+    adjacent_one_of_hover_test_schema_path,
     cargo_feature_navigation_fixture_path, cargo_schema_path,
     one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
@@ -597,6 +598,39 @@ mod hover_keys_value {
             ) -> Ok({
                 "Keys": "repos[0]",
                 "Value": "Table"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn adjacent_one_of_hover_prefers_valid_branch_property_schema(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                ho█oks = []
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos[0].hooks",
+                "Value": "Array"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn adjacent_one_of_hover_prefers_valid_branch_nested_item_schema(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos[0].hooks[0].id",
+                "Value": "String",
+                "Default": "\"builtin-hook\""
             });
         );
     }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,9 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
-    adjacent_one_of_hover_test_schema_path,
-    cargo_feature_navigation_fixture_path, cargo_schema_path,
-    one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
+    adjacent_one_of_hover_test_schema_path, cargo_feature_navigation_fixture_path,
+    cargo_schema_path, one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
 };
 

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -172,6 +172,12 @@ pub fn one_of_hover_discriminator_test_schema_path() -> PathBuf {
         .join("one-of-hover-discriminator-test.schema.json")
 }
 
+pub fn adjacent_one_of_hover_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("adjacent-one-of-hover-test.schema.json")
+}
+
 pub fn unevaluated_items_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")

--- a/schemas/adjacent-one-of-hover-test.schema.json
+++ b/schemas/adjacent-one-of-hover-test.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "repos": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Repo"
+      }
+    }
+  },
+  "required": ["repos"],
+  "definitions": {
+    "Repo": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/RemoteRepo"
+        },
+        {
+          "$ref": "#/definitions/BuiltinRepo"
+        }
+      ]
+    },
+    "RemoteRepo": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "const": "remote"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteHook"
+          }
+        }
+      },
+      "required": ["repo", "hooks"]
+    },
+    "BuiltinRepo": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "const": "builtin"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuiltinHook"
+          }
+        }
+      },
+      "required": ["repo", "hooks"]
+    },
+    "RemoteHook": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "default": "remote-hook"
+        }
+      },
+      "required": ["id"]
+    },
+    "BuiltinHook": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "default": "builtin-hook"
+        }
+      },
+      "required": ["id"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fix hover resolution for table schemas that carry adjacent `oneOf`/`anyOf`/`allOf` applicators
- apply the same traversal to completion and goto type definition
- add regression coverage for adjacent applicator branch narrowing on table properties and nested items

## Testing
- cargo test -p tombi-lsp one_of_hover --test test_hover
- cargo test -p tombi-lsp adjacent_one_of_builtin_hook_id_value_completion --test test_completion_labels
- cargo test -p tombi-lsp adjacent_one_of_builtin_ --test test_goto_type_definition