### PR TITLE
fix: Align LSP schema resolution with validation

### DIFF
--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -282,12 +282,23 @@ pub trait FindCompletionContents {
 }
 
 fn dedup_completion_contents(completion_items: Vec<CompletionContent>) -> Vec<CompletionContent> {
-    let mut seen_labels = tombi_hashmap::HashSet::new();
+    let mut deduped_items: tombi_hashmap::IndexMap<String, CompletionContent> =
+        tombi_hashmap::IndexMap::new();
 
-    completion_items
-        .into_iter()
-        .filter(|item| seen_labels.insert(item.label.clone()))
-        .collect()
+    for item in completion_items {
+        match deduped_items.entry(item.label.clone()) {
+            tombi_hashmap::map::Entry::Occupied(mut entry) => {
+                if item.priority < entry.get().priority {
+                    entry.insert(item);
+                }
+            }
+            tombi_hashmap::map::Entry::Vacant(entry) => {
+                entry.insert(item);
+            }
+        }
+    }
+
+    deduped_items.into_values().collect()
 }
 
 fn is_generic_literal_type_hint(completion_item: &CompletionContent) -> bool {

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -2,21 +2,22 @@ mod comment;
 mod schema_completion;
 mod value;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 pub use comment::get_document_comment_directive_completion_contents;
 use itertools::Itertools;
 use tombi_ast::{AstNode, AstToken, algo::ancestors_at_position};
 use tombi_config::TomlVersion;
 use tombi_document_tree::{IntoDocumentTreeAndErrors, TryIntoDocumentTree};
+use tombi_extension::CompletionContentPriority;
 use tombi_extension::{
     CommaHint, CommentContext, CompletionContent, CompletionEdit, CompletionHint,
 };
 use tombi_future::Boxable;
 use tombi_rg_tree::{NodeOrToken, TokenAtOffset};
 use tombi_schema_store::{
-    Accessor, AccessorKeyKind, CompositeSchema, CurrentSchema, KeyContext, SchemaDefinitions,
-    SchemaStore, SchemaUri, ValueSchema,
+    Accessor, AccessorKeyKind, AllOfSchema, AnyOfSchema, CompositeSchema, CurrentSchema,
+    KeyContext, OneOfSchema, SchemaDefinitions, SchemaStore, SchemaUri, ValueSchema,
 };
 use tombi_syntax::{Direction, SyntaxElement, SyntaxKind, SyntaxNode};
 
@@ -278,6 +279,117 @@ pub trait FindCompletionContents {
         schema_context: &'a tombi_schema_store::SchemaContext<'a>,
         completion_hint: Option<CompletionHint>,
     ) -> tombi_future::BoxFuture<'b, Vec<CompletionContent>>;
+}
+
+fn dedup_completion_contents(completion_items: Vec<CompletionContent>) -> Vec<CompletionContent> {
+    let mut seen_labels = tombi_hashmap::HashSet::new();
+
+    completion_items
+        .into_iter()
+        .filter(|item| seen_labels.insert(item.label.clone()))
+        .collect()
+}
+
+fn is_generic_literal_type_hint(completion_item: &CompletionContent) -> bool {
+    matches!(
+        completion_item.priority,
+        CompletionContentPriority::TypeHint
+            | CompletionContentPriority::TypeHintTrue
+            | CompletionContentPriority::TypeHintFalse
+    ) && completion_item.label != "\"\""
+        && completion_item.label != "''"
+}
+
+pub(super) async fn merge_adjacent_schema_completion_items(
+    position: tombi_text::Position,
+    keys: &[tombi_document_tree::Key],
+    accessors: &[Accessor],
+    current_schema: Option<&CurrentSchema<'_>>,
+    schema_context: &tombi_schema_store::SchemaContext<'_>,
+    completion_hint: Option<CompletionHint>,
+    base_completion_items: Vec<CompletionContent>,
+    one_of_schema: Option<&OneOfSchema>,
+    any_of_schema: Option<&AnyOfSchema>,
+    all_of_schema: Option<&AllOfSchema>,
+) -> Vec<CompletionContent> {
+    let Some(current_schema) = current_schema else {
+        return base_completion_items;
+    };
+
+    let mut adjacent_completion_items = Vec::new();
+
+    if let Some(one_of_schema) = one_of_schema {
+        adjacent_completion_items.extend(
+            value::find_one_of_completion_items(
+                &schema_completion::SchemaCompletion,
+                position,
+                keys,
+                accessors,
+                one_of_schema,
+                &CurrentSchema {
+                    value_schema: Arc::new(ValueSchema::OneOf(one_of_schema.clone())),
+                    schema_uri: current_schema.schema_uri.clone(),
+                    definitions: current_schema.definitions.clone(),
+                },
+                schema_context,
+                completion_hint,
+            )
+            .await,
+        );
+    }
+    if let Some(any_of_schema) = any_of_schema {
+        adjacent_completion_items.extend(
+            value::find_any_of_completion_items(
+                &schema_completion::SchemaCompletion,
+                position,
+                keys,
+                accessors,
+                any_of_schema,
+                &CurrentSchema {
+                    value_schema: Arc::new(ValueSchema::AnyOf(any_of_schema.clone())),
+                    schema_uri: current_schema.schema_uri.clone(),
+                    definitions: current_schema.definitions.clone(),
+                },
+                schema_context,
+                completion_hint,
+            )
+            .await,
+        );
+    }
+    if let Some(all_of_schema) = all_of_schema {
+        adjacent_completion_items.extend(
+            value::find_all_of_completion_items(
+                &schema_completion::SchemaCompletion,
+                position,
+                keys,
+                accessors,
+                all_of_schema,
+                &CurrentSchema {
+                    value_schema: Arc::new(ValueSchema::AllOf(all_of_schema.clone())),
+                    schema_uri: current_schema.schema_uri.clone(),
+                    definitions: current_schema.definitions.clone(),
+                },
+                schema_context,
+                completion_hint,
+            )
+            .await,
+        );
+    }
+
+    let has_concrete_adjacent_values = adjacent_completion_items.iter().any(|completion_item| {
+        !matches!(
+            completion_item.priority,
+            CompletionContentPriority::TypeHint
+                | CompletionContentPriority::TypeHintTrue
+                | CompletionContentPriority::TypeHintFalse
+        )
+    });
+
+    let mut completion_items = adjacent_completion_items;
+    completion_items.extend(base_completion_items.into_iter().filter(|completion_item| {
+        !has_concrete_adjacent_values || !is_generic_literal_type_hint(completion_item)
+    }));
+    dedup_completion_contents(completion_items)
 }
 
 pub trait CompletionCandidate {

--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -93,22 +93,21 @@ where
 
         let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
         let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
-        let fallback_completion_items = branch_results
-            .iter()
-            .flat_map(|(_, _, items)| items.iter().cloned())
-            .collect_vec();
-        for (branch_has_key, branch_is_valid, items) in branch_results {
+        for (branch_has_key, branch_is_valid, items) in &branch_results {
             if valid_branches {
-                if branch_is_valid {
-                    completion_items.extend(items);
+                if *branch_is_valid {
+                    completion_items.extend(items.iter().cloned());
                 }
-            } else if !narrow_branches || branch_has_key {
-                completion_items.extend(items);
+            } else if !narrow_branches || *branch_has_key {
+                completion_items.extend(items.iter().cloned());
             }
         }
 
         if completion_items.is_empty() {
-            completion_items = fallback_completion_items;
+            completion_items = branch_results
+                .into_iter()
+                .flat_map(|(_, _, items)| items)
+                .collect_vec();
         }
 
         let detail = any_of_schema

--- a/crates/tombi-lsp/src/completion/value/array.rs
+++ b/crates/tombi-lsp/src/completion/value/array.rs
@@ -14,8 +14,9 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit,
         comment::get_tombi_comment_directive_content_completion_contents,
-        schema_completion::SchemaCompletion,
+        merge_adjacent_schema_completion_items, schema_completion::SchemaCompletion,
     },
+    schema_resolver::resolve_array_item_schema,
 };
 
 impl FindCompletionContents for tombi_document_tree::Array {
@@ -86,16 +87,13 @@ impl FindCompletionContents for tombi_document_tree::Array {
                             }
                             if value.contains(position) {
                                 let accessor = Accessor::Index(index);
-                                if let Some(items) = &array_schema.items
-                                    && let Ok(Some(current_schema)) = items
-                                        .write()
-                                        .await
-                                        .resolve(
-                                            current_schema.schema_uri.clone(),
-                                            current_schema.definitions.clone(),
-                                            schema_context.store,
-                                        )
-                                        .await
+                                if let Some(current_schema) = resolve_array_item_schema(
+                                    index,
+                                    array_schema,
+                                    current_schema,
+                                    schema_context,
+                                )
+                                .await
                                 {
                                     return value
                                         .find_completion_contents(
@@ -112,19 +110,67 @@ impl FindCompletionContents for tombi_document_tree::Array {
                                         )
                                         .await;
                                 }
+
+                                if let Some(one_of_schema) = array_schema.one_of.as_deref() {
+                                    let completion_items = find_one_of_completion_items(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        one_of_schema,
+                                        current_schema,
+                                        schema_context,
+                                        completion_hint,
+                                    )
+                                    .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+
+                                if let Some(any_of_schema) = array_schema.any_of.as_deref() {
+                                    let completion_items = find_any_of_completion_items(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        any_of_schema,
+                                        current_schema,
+                                        schema_context,
+                                        completion_hint,
+                                    )
+                                    .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
+
+                                if let Some(all_of_schema) = array_schema.all_of.as_deref() {
+                                    let completion_items = find_all_of_completion_items(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        all_of_schema,
+                                        current_schema,
+                                        schema_context,
+                                        completion_hint,
+                                    )
+                                    .await;
+                                    if !completion_items.is_empty() {
+                                        return completion_items;
+                                    }
+                                }
                             }
                         }
 
-                        if let Some(items) = &array_schema.items
-                            && let Ok(Some(current_schema)) = items
-                                .write()
-                                .await
-                                .resolve(
-                                    current_schema.schema_uri.clone(),
-                                    current_schema.definitions.clone(),
-                                    schema_context.store,
-                                )
-                                .await
+                        if let Some(current_schema) = resolve_array_item_schema(
+                            new_item_index,
+                            array_schema,
+                            current_schema,
+                            schema_context,
+                        )
+                        .await
                         {
                             let mut completions = SchemaCompletion
                                 .find_completion_contents(
@@ -214,6 +260,55 @@ impl FindCompletionContents for tombi_document_tree::Array {
                             }
 
                             return completions;
+                        }
+
+                        if let Some(one_of_schema) = array_schema.one_of.as_deref() {
+                            let completion_items = find_one_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                one_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                            if !completion_items.is_empty() {
+                                return completion_items;
+                            }
+                        }
+                        if let Some(any_of_schema) = array_schema.any_of.as_deref() {
+                            let completion_items = find_any_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                any_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                            if !completion_items.is_empty() {
+                                return completion_items;
+                            }
+                        }
+                        if let Some(all_of_schema) = array_schema.all_of.as_deref() {
+                            let completion_items = find_all_of_completion_items(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                all_of_schema,
+                                current_schema,
+                                schema_context,
+                                completion_hint,
+                            )
+                            .await;
+                            if !completion_items.is_empty() {
+                                return completion_items;
+                            }
                         }
 
                         Vec::with_capacity(0)
@@ -368,7 +463,19 @@ impl FindCompletionContents for ArraySchema {
                         }
                     }
 
-                    completion_items
+                    merge_adjacent_schema_completion_items(
+                        position,
+                        keys,
+                        accessors,
+                        current_schema,
+                        _schema_context,
+                        completion_hint,
+                        completion_items,
+                        self.one_of.as_deref(),
+                        self.any_of.as_deref(),
+                        self.all_of.as_deref(),
+                    )
+                    .await
                 }
             }
         }

--- a/crates/tombi-lsp/src/completion/value/boolean.rs
+++ b/crates/tombi-lsp/src/completion/value/boolean.rs
@@ -7,6 +7,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -81,7 +82,19 @@ impl FindCompletionContents for BooleanSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -98,7 +111,19 @@ impl FindCompletionContents for BooleanSchema {
                     )
                 }));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(examples) = &self.examples {
@@ -123,7 +148,19 @@ impl FindCompletionContents for BooleanSchema {
                 completion_items = type_hint_boolean(position, schema_uri, completion_hint);
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                _schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/float.rs
+++ b/crates/tombi-lsp/src/completion/value/float.rs
@@ -8,6 +8,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -82,7 +83,19 @@ impl FindCompletionContents for FloatSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -99,7 +112,19 @@ impl FindCompletionContents for FloatSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -137,7 +162,19 @@ impl FindCompletionContents for FloatSchema {
                 completion_items.extend(type_hint_float(position, schema_uri, completion_hint));
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                _schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/integer.rs
+++ b/crates/tombi-lsp/src/completion/value/integer.rs
@@ -8,6 +8,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -82,7 +83,19 @@ impl FindCompletionContents for IntegerSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -99,7 +112,19 @@ impl FindCompletionContents for IntegerSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -137,7 +162,19 @@ impl FindCompletionContents for IntegerSchema {
                 completion_items.extend(type_hint_integer(position, schema_uri, completion_hint));
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                _schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/local_date.rs
+++ b/crates/tombi-lsp/src/completion/value/local_date.rs
@@ -9,6 +9,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -83,7 +84,19 @@ impl FindCompletionContents for LocalDateSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -100,7 +113,19 @@ impl FindCompletionContents for LocalDateSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -150,7 +175,19 @@ impl FindCompletionContents for LocalDateSchema {
                 }
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/completion/value/local_date_time.rs
@@ -11,6 +11,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -85,7 +86,19 @@ impl FindCompletionContents for LocalDateTimeSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -102,7 +115,19 @@ impl FindCompletionContents for LocalDateTimeSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -152,7 +177,19 @@ impl FindCompletionContents for LocalDateTimeSchema {
                 }
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/local_time.rs
+++ b/crates/tombi-lsp/src/completion/value/local_time.rs
@@ -9,6 +9,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -83,7 +84,19 @@ impl FindCompletionContents for LocalTimeSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -100,7 +113,19 @@ impl FindCompletionContents for LocalTimeSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -150,7 +175,19 @@ impl FindCompletionContents for LocalTimeSchema {
                 }
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/completion/value/offset_date_time.rs
@@ -11,6 +11,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
+        merge_adjacent_schema_completion_items,
     },
 };
 
@@ -85,7 +86,19 @@ impl FindCompletionContents for OffsetDateTimeSchema {
                     self.deprecated,
                 ));
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -102,7 +115,19 @@ impl FindCompletionContents for OffsetDateTimeSchema {
                     ));
                 }
 
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    keys,
+                    accessors,
+                    current_schema,
+                    schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(default) = &self.default {
@@ -152,7 +177,19 @@ impl FindCompletionContents for OffsetDateTimeSchema {
                 }
             }
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                keys,
+                accessors,
+                current_schema,
+                schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -97,22 +97,21 @@ where
 
         let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
         let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
-        let fallback_completion_items = branch_results
-            .iter()
-            .flat_map(|(_, _, items)| items.iter().cloned())
-            .collect_vec();
-        for (branch_has_key, branch_is_valid, items) in branch_results {
+        for (branch_has_key, branch_is_valid, items) in &branch_results {
             if valid_branches {
-                if branch_is_valid {
-                    completion_items.extend(items);
+                if *branch_is_valid {
+                    completion_items.extend(items.iter().cloned());
                 }
-            } else if !narrow_branches || branch_has_key {
-                completion_items.extend(items);
+            } else if !narrow_branches || *branch_has_key {
+                completion_items.extend(items.iter().cloned());
             }
         }
 
         if completion_items.is_empty() {
-            completion_items = fallback_completion_items;
+            completion_items = branch_results
+                .into_iter()
+                .flat_map(|(_, _, items)| items)
+                .collect_vec();
         }
 
         let detail = one_of_schema

--- a/crates/tombi-lsp/src/completion/value/string.rs
+++ b/crates/tombi-lsp/src/completion/value/string.rs
@@ -8,7 +8,7 @@ use crate::{
     completion::{
         CompletionContent, CompletionEdit, CompletionHint, FindCompletionContents,
         comment::get_tombi_comment_directive_content_completion_contents,
-        schema_completion::SchemaCompletion,
+        merge_adjacent_schema_completion_items, schema_completion::SchemaCompletion,
     },
 };
 
@@ -135,7 +135,19 @@ impl FindCompletionContents for StringSchema {
                     schema_uri,
                     self.deprecated,
                 ));
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    _keys,
+                    _accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(r#enum) = &self.r#enum {
@@ -151,7 +163,19 @@ impl FindCompletionContents for StringSchema {
                         self.deprecated,
                     ));
                 }
-                return completion_items;
+                return merge_adjacent_schema_completion_items(
+                    position,
+                    _keys,
+                    _accessors,
+                    current_schema,
+                    _schema_context,
+                    completion_hint,
+                    completion_items,
+                    self.one_of.as_deref(),
+                    self.any_of.as_deref(),
+                    self.all_of.as_deref(),
+                )
+                .await;
             }
 
             if let Some(examples) = &self.examples {
@@ -183,7 +207,19 @@ impl FindCompletionContents for StringSchema {
                     }),
             );
 
-            completion_items
+            merge_adjacent_schema_completion_items(
+                position,
+                _keys,
+                _accessors,
+                current_schema,
+                _schema_context,
+                completion_hint,
+                completion_items,
+                self.one_of.as_deref(),
+                self.any_of.as_deref(),
+                self.all_of.as_deref(),
+            )
+            .await
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -18,6 +18,7 @@ use crate::{
             one_of::find_one_of_completion_items, type_hint_value,
         },
     },
+    schema_resolver::resolve_table_unevaluated_property_schema,
 };
 
 impl FindCompletionContents for tombi_document_tree::Table {
@@ -395,22 +396,6 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                     }
                                 }
 
-                                if table_schema
-                                    .allows_any_additional_properties(schema_context.strict())
-                                {
-                                    return get_property_value_completion_contents(
-                                        value,
-                                        position,
-                                        key,
-                                        keys,
-                                        accessors,
-                                        None,
-                                        schema_context,
-                                        completion_hint,
-                                    )
-                                    .await;
-                                }
-
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {
                                     let completion_items =
                                         super::one_of::find_one_of_completion_items(
@@ -461,6 +446,56 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                     if !completion_items.is_empty() {
                                         return completion_items;
                                     }
+                                }
+
+                                if let Some(current_schema) =
+                                    resolve_table_unevaluated_property_schema(
+                                        table_schema,
+                                        current_schema,
+                                        schema_context,
+                                    )
+                                    .await
+                                {
+                                    let mut contents = get_property_value_completion_contents(
+                                        value,
+                                        position,
+                                        key,
+                                        keys,
+                                        accessors,
+                                        Some(&current_schema),
+                                        schema_context,
+                                        completion_hint,
+                                    )
+                                    .await;
+
+                                    if !contents.is_empty()
+                                        && current_schema.value_schema.deprecated().await
+                                            == Some(true)
+                                    {
+                                        for content in &mut contents {
+                                            if !content.in_comment {
+                                                content.deprecated = Some(true);
+                                            }
+                                        }
+                                    }
+
+                                    return contents;
+                                }
+
+                                if table_schema
+                                    .allows_any_additional_properties(schema_context.strict())
+                                {
+                                    return get_property_value_completion_contents(
+                                        value,
+                                        position,
+                                        key,
+                                        keys,
+                                        accessors,
+                                        None,
+                                        schema_context,
+                                        completion_hint,
+                                    )
+                                    .await;
                                 }
                             } else {
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {

--- a/crates/tombi-lsp/src/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/goto_type_definition.rs
@@ -8,7 +8,9 @@ use std::{borrow::Cow, ops::Deref};
 
 pub use comment::get_tombi_document_comment_directive_type_definition;
 use itertools::Itertools;
-use tombi_schema_store::{Accessor, CurrentSchema, SchemaUri};
+use tombi_schema_store::{
+    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaUri,
+};
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 
 use crate::{Backend, goto_definition::open_remote_file};
@@ -105,7 +107,7 @@ impl TypeDefinition {
     }
 }
 
-trait GetTypeDefinition {
+pub(super) trait GetTypeDefinition {
     fn get_type_definition<'a: 'b, 'b>(
         &'a self,
         position: tombi_text::Position,
@@ -114,6 +116,77 @@ trait GetTypeDefinition {
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
     ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>>;
+}
+
+pub(super) async fn adjacent_type_definition<
+    T: GetTypeDefinition
+        + Sync
+        + Send
+        + tombi_document_tree::ValueImpl
+        + tombi_validator::Validate
+        + std::fmt::Debug,
+>(
+    value: &T,
+    position: tombi_text::Position,
+    keys: &[tombi_document_tree::Key],
+    accessors: &[Accessor],
+    current_schema: Option<&CurrentSchema<'_>>,
+    schema_context: &tombi_schema_store::SchemaContext<'_>,
+    one_of_schema: Option<&OneOfSchema>,
+    any_of_schema: Option<&AnyOfSchema>,
+    all_of_schema: Option<&AllOfSchema>,
+) -> Option<TypeDefinition> {
+    let Some(current_schema) = current_schema else {
+        return None;
+    };
+
+    if let Some(one_of_schema) = one_of_schema
+        && let Some(type_definition) = one_of::get_one_of_type_definition(
+            value,
+            position,
+            keys,
+            accessors,
+            one_of_schema,
+            &current_schema.schema_uri,
+            &current_schema.definitions,
+            schema_context,
+        )
+        .await
+    {
+        return Some(type_definition);
+    }
+    if let Some(any_of_schema) = any_of_schema
+        && let Some(type_definition) = any_of::get_any_of_type_definition(
+            value,
+            position,
+            keys,
+            accessors,
+            any_of_schema,
+            &current_schema.schema_uri,
+            &current_schema.definitions,
+            schema_context,
+        )
+        .await
+    {
+        return Some(type_definition);
+    }
+    if let Some(all_of_schema) = all_of_schema
+        && let Some(type_definition) = all_of::get_all_of_type_definition(
+            value,
+            position,
+            keys,
+            accessors,
+            all_of_schema,
+            &current_schema.schema_uri,
+            &current_schema.definitions,
+            schema_context,
+        )
+        .await
+    {
+        return Some(type_definition);
+    }
+
+    None
 }
 
 pub(super) fn schema_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/array.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/array.rs
@@ -8,11 +8,12 @@ use tombi_schema_store::{Accessor, ArraySchema, CurrentSchema, ValueSchema};
 use crate::{
     comment_directive::get_array_comment_directive_content_with_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
+    schema_resolver::resolve_array_item_schema,
 };
 
 impl GetTypeDefinition for tombi_document_tree::Array {
@@ -73,15 +74,13 @@ impl GetTypeDefinition for tombi_document_tree::Array {
                             if value.contains(position) {
                                 let accessor = Accessor::Index(index);
 
-                                if let Some(items) = &array_schema.items
-                                    && let Ok(Some(current_schema)) =
-                                        tombi_schema_store::resolve_schema_item(
-                                            items,
-                                            current_schema.schema_uri.clone(),
-                                            current_schema.definitions.clone(),
-                                            schema_context.store,
-                                        )
-                                        .await
+                                if let Some(current_schema) = resolve_array_item_schema(
+                                    index,
+                                    array_schema,
+                                    current_schema,
+                                    schema_context,
+                                )
+                                .await
                                 {
                                     return value
                                         .get_type_definition(
@@ -96,6 +95,22 @@ impl GetTypeDefinition for tombi_document_tree::Array {
                                             schema_context,
                                         )
                                         .await;
+                                }
+
+                                if let Some(type_definition) = adjacent_type_definition(
+                                    self,
+                                    position,
+                                    keys,
+                                    accessors,
+                                    Some(current_schema),
+                                    schema_context,
+                                    array_schema.one_of.as_deref(),
+                                    array_schema.any_of.as_deref(),
+                                    array_schema.all_of.as_deref(),
+                                )
+                                .await
+                                {
+                                    return Some(type_definition);
                                 }
 
                                 return value

--- a/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
@@ -7,8 +7,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -46,7 +46,7 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Boolean(boolean_schema) => {
-                        boolean_schema
+                        let base_type_definition = boolean_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -54,7 +54,21 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            boolean_schema.one_of.as_deref(),
+                            boolean_schema.any_of.as_deref(),
+                            boolean_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/float.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/float.rs
@@ -7,8 +7,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -46,7 +46,7 @@ impl GetTypeDefinition for tombi_document_tree::Float {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::Float(float_schema) => {
-                        float_schema
+                        let base_type_definition = float_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -54,7 +54,21 @@ impl GetTypeDefinition for tombi_document_tree::Float {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            float_schema.one_of.as_deref(),
+                            float_schema.any_of.as_deref(),
+                            float_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
@@ -7,8 +7,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -52,7 +52,7 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                             return None;
                         }
 
-                        integer_schema
+                        let base_type_definition = integer_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -60,7 +60,21 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            integer_schema.one_of.as_deref(),
+                            integer_schema.any_of.as_deref(),
+                            integer_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
@@ -7,8 +7,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -46,7 +46,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::LocalDate(local_date_schema) => {
-                        local_date_schema
+                        let base_type_definition = local_date_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -54,7 +54,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_date_schema.one_of.as_deref(),
+                            local_date_schema.any_of.as_deref(),
+                            local_date_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
@@ -9,8 +9,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -48,7 +48,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::LocalDateTime(local_date_time_schema) => {
-                        local_date_time_schema
+                        let base_type_definition = local_date_time_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -56,7 +56,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_date_time_schema.one_of.as_deref(),
+                            local_date_time_schema.any_of.as_deref(),
+                            local_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
@@ -7,8 +7,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -46,7 +46,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::LocalTime(local_time_schema) => {
-                        local_time_schema
+                        let base_type_definition = local_time_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -54,7 +54,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_time_schema.one_of.as_deref(),
+                            local_time_schema.any_of.as_deref(),
+                            local_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
@@ -9,8 +9,8 @@ use tombi_schema_store::ValueSchema;
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -48,7 +48,7 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::OffsetDateTime(offset_date_time_schema) => {
-                        offset_date_time_schema
+                        let base_type_definition = offset_date_time_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -56,7 +56,21 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            offset_date_time_schema.one_of.as_deref(),
+                            offset_date_time_schema.any_of.as_deref(),
+                            offset_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/string.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/string.rs
@@ -3,12 +3,13 @@ use itertools::Itertools;
 use tombi_comment_directive::value::{StringCommonFormatRules, StringCommonLintRules};
 use tombi_future::Boxable;
 use tombi_schema_store::ValueSchema;
+use tombi_x_keyword::StringFormat;
 
 use crate::{
     comment_directive::get_key_table_value_comment_directive_content_and_schema_uri,
     goto_type_definition::{
-        GetTypeDefinition, TypeDefinition, all_of::get_all_of_type_definition,
-        any_of::get_any_of_type_definition,
+        GetTypeDefinition, TypeDefinition, adjacent_type_definition,
+        all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
@@ -46,7 +47,7 @@ impl GetTypeDefinition for tombi_document_tree::String {
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
                     ValueSchema::String(string_schema) => {
-                        string_schema
+                        let base_type_definition = string_schema
                             .get_type_definition(
                                 position,
                                 keys,
@@ -54,7 +55,129 @@ impl GetTypeDefinition for tombi_document_tree::String {
                                 Some(current_schema),
                                 schema_context,
                             )
-                            .await
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            string_schema.one_of.as_deref(),
+                            string_schema.any_of.as_deref(),
+                            string_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
+                    }
+                    ValueSchema::OffsetDateTime(offset_date_time_schema)
+                        if schema_context.has_string_format(StringFormat::DateTime) =>
+                    {
+                        let base_type_definition = offset_date_time_schema
+                            .get_type_definition(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            offset_date_time_schema.one_of.as_deref(),
+                            offset_date_time_schema.any_of.as_deref(),
+                            offset_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
+                    }
+                    ValueSchema::LocalDateTime(local_date_time_schema)
+                        if schema_context.has_string_format(StringFormat::DateTimeLocal) =>
+                    {
+                        let base_type_definition = local_date_time_schema
+                            .get_type_definition(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_date_time_schema.one_of.as_deref(),
+                            local_date_time_schema.any_of.as_deref(),
+                            local_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
+                    }
+                    ValueSchema::LocalDate(local_date_schema)
+                        if schema_context.has_string_format(StringFormat::Date) =>
+                    {
+                        let base_type_definition = local_date_schema
+                            .get_type_definition(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_date_schema.one_of.as_deref(),
+                            local_date_schema.any_of.as_deref(),
+                            local_date_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
+                    }
+                    ValueSchema::LocalTime(local_time_schema)
+                        if schema_context.has_string_format(StringFormat::TimeLocal) =>
+                    {
+                        let base_type_definition = local_time_schema
+                            .get_type_definition(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        adjacent_type_definition(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            local_time_schema.one_of.as_deref(),
+                            local_time_schema.any_of.as_deref(),
+                            local_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                        .or(base_type_definition)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -13,6 +13,7 @@ use crate::{
         comment::get_tombi_value_comment_directive_type_definition,
         one_of::get_one_of_type_definition,
     },
+    schema_resolver::resolve_table_unevaluated_property_schema,
 };
 
 impl GetTypeDefinition for tombi_document_tree::Table {
@@ -204,20 +205,6 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         });
                                 }
 
-                                let type_definition = value
-                                    .get_type_definition(
-                                        position,
-                                        &keys[1..],
-                                        &accessors,
-                                        None,
-                                        schema_context,
-                                    )
-                                    .await;
-
-                                if type_definition.is_some() {
-                                    return type_definition;
-                                }
-
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {
                                     if let Some(type_definition) = get_one_of_type_definition(
                                         self,
@@ -267,7 +254,34 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     }
                                 }
 
-                                None
+                                if let Some(current_schema) =
+                                    resolve_table_unevaluated_property_schema(
+                                        table_schema,
+                                        current_schema,
+                                        schema_context,
+                                    )
+                                    .await
+                                {
+                                    return value
+                                        .get_type_definition(
+                                            position,
+                                            &keys[1..],
+                                            &accessors,
+                                            Some(&current_schema),
+                                            schema_context,
+                                        )
+                                        .await;
+                                }
+
+                                value
+                                    .get_type_definition(
+                                        position,
+                                        &keys[1..],
+                                        &accessors,
+                                        None,
+                                        schema_context,
+                                    )
+                                    .await
                             } else {
                                 let mut schema_uri = current_schema.schema_uri.as_ref().clone();
                                 schema_uri.set_fragment(Some(&format!(

--- a/crates/tombi-lsp/src/hover.rs
+++ b/crates/tombi-lsp/src/hover.rs
@@ -13,7 +13,8 @@ use constraints::ValueConstraints;
 
 use tombi_extension::get_tombi_github_uri;
 use tombi_schema_store::{
-    Accessor, Accessors, CurrentSchema, SchemaUri, ValueType, get_schema_name,
+    Accessor, Accessors, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaUri,
+    ValueType, get_schema_name,
 };
 use tombi_text::{FromLsp, IntoLsp};
 
@@ -47,7 +48,7 @@ pub async fn get_hover_content(
     }
 }
 
-trait GetHoverContent {
+pub(super) trait GetHoverContent {
     fn get_hover_content<'a: 'b, 'b>(
         &'a self,
         position: tombi_text::Position,
@@ -56,6 +57,176 @@ trait GetHoverContent {
         current_schema: Option<&'a CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
     ) -> tombi_future::BoxFuture<'b, Option<HoverContent>>;
+}
+
+fn merge_optional_vec<T: PartialEq>(
+    base: Option<Vec<T>>,
+    adjacent: Option<Vec<T>>,
+) -> Option<Vec<T>> {
+    let mut values = base.unwrap_or_default();
+    for value in adjacent.unwrap_or_default() {
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+
+    (!values.is_empty()).then_some(values)
+}
+
+fn merge_constraints(
+    base: Option<ValueConstraints>,
+    adjacent: Option<ValueConstraints>,
+) -> Option<ValueConstraints> {
+    match (base, adjacent) {
+        (Some(mut base), Some(adjacent)) => {
+            base.r#enum = merge_optional_vec(base.r#enum, adjacent.r#enum);
+            base.default = base.default.or(adjacent.default);
+            base.examples = merge_optional_vec(base.examples, adjacent.examples);
+            base.minimum = base.minimum.or(adjacent.minimum);
+            base.maximum = base.maximum.or(adjacent.maximum);
+            base.exclusive_minimum = base.exclusive_minimum.or(adjacent.exclusive_minimum);
+            base.exclusive_maximum = base.exclusive_maximum.or(adjacent.exclusive_maximum);
+            base.multiple_of = base.multiple_of.or(adjacent.multiple_of);
+            base.min_length = base.min_length.or(adjacent.min_length);
+            base.max_length = base.max_length.or(adjacent.max_length);
+            base.format = base.format.or(adjacent.format);
+            base.pattern = base.pattern.or(adjacent.pattern);
+            base.min_items = base.min_items.or(adjacent.min_items);
+            base.max_items = base.max_items.or(adjacent.max_items);
+            base.unique_items = base.unique_items.or(adjacent.unique_items);
+            base.values_order = base.values_order.or(adjacent.values_order);
+            base.required_keys = merge_optional_vec(base.required_keys, adjacent.required_keys);
+            base.min_keys = base.min_keys.or(adjacent.min_keys);
+            base.max_keys = base.max_keys.or(adjacent.max_keys);
+            base.key_patterns = merge_optional_vec(base.key_patterns, adjacent.key_patterns);
+            base.additional_keys = base.additional_keys.or(adjacent.additional_keys);
+            base.pattern_keys |= adjacent.pattern_keys;
+            base.keys_order = base.keys_order.or(adjacent.keys_order);
+            base.array_values_order_by = base
+                .array_values_order_by
+                .or(adjacent.array_values_order_by);
+            Some(base)
+        }
+        (Some(base), None) => Some(base),
+        (None, Some(adjacent)) => Some(adjacent),
+        (None, None) => None,
+    }
+}
+
+fn merge_hover_value_content(
+    mut base: HoverValueContent,
+    adjacent: HoverValueContent,
+) -> HoverValueContent {
+    base.title = base.title.or(adjacent.title);
+    base.description = base.description.or(adjacent.description);
+    base.constraints = merge_constraints(base.constraints, adjacent.constraints);
+    base.schema_uri = base.schema_uri.or(adjacent.schema_uri);
+    base.range = base.range.or(adjacent.range);
+    base
+}
+
+fn merge_hover_content(
+    base: Option<HoverContent>,
+    adjacent: Option<HoverContent>,
+) -> Option<HoverContent> {
+    match (base, adjacent) {
+        (Some(HoverContent::Value(base)), Some(HoverContent::Value(adjacent))) => Some(
+            HoverContent::Value(merge_hover_value_content(base, adjacent)),
+        ),
+        (
+            Some(HoverContent::DirectiveContent(base)),
+            Some(HoverContent::DirectiveContent(adjacent)),
+        ) => Some(HoverContent::DirectiveContent(merge_hover_value_content(
+            base, adjacent,
+        ))),
+        (Some(HoverContent::Value(base)), Some(HoverContent::DirectiveContent(adjacent)))
+        | (Some(HoverContent::DirectiveContent(base)), Some(HoverContent::Value(adjacent))) => {
+            Some(HoverContent::Value(merge_hover_value_content(
+                base, adjacent,
+            )))
+        }
+        (Some(base), None) => Some(base),
+        (None, Some(adjacent)) => Some(adjacent),
+        (Some(base), Some(_)) => Some(base),
+        (None, None) => None,
+    }
+}
+
+pub(super) async fn merge_adjacent_hover_content<
+    T: GetHoverContent
+        + Sync
+        + Send
+        + tombi_document_tree::ValueImpl
+        + tombi_validator::Validate
+        + std::fmt::Debug,
+>(
+    value: &T,
+    position: tombi_text::Position,
+    keys: &[tombi_document_tree::Key],
+    accessors: &[Accessor],
+    current_schema: Option<&CurrentSchema<'_>>,
+    schema_context: &tombi_schema_store::SchemaContext<'_>,
+    base_hover_content: Option<HoverContent>,
+    one_of_schema: Option<&OneOfSchema>,
+    any_of_schema: Option<&AnyOfSchema>,
+    all_of_schema: Option<&AllOfSchema>,
+) -> Option<HoverContent> {
+    let Some(current_schema) = current_schema else {
+        return base_hover_content;
+    };
+
+    let mut hover_content = base_hover_content;
+
+    if let Some(one_of_schema) = one_of_schema {
+        hover_content = merge_hover_content(
+            hover_content,
+            one_of::get_one_of_hover_content(
+                value,
+                position,
+                keys,
+                accessors,
+                one_of_schema,
+                &current_schema.schema_uri,
+                &current_schema.definitions,
+                schema_context,
+            )
+            .await,
+        );
+    }
+    if let Some(any_of_schema) = any_of_schema {
+        hover_content = merge_hover_content(
+            hover_content,
+            any_of::get_any_of_hover_content(
+                value,
+                position,
+                keys,
+                accessors,
+                any_of_schema,
+                &current_schema.schema_uri,
+                &current_schema.definitions,
+                schema_context,
+            )
+            .await,
+        );
+    }
+    if let Some(all_of_schema) = all_of_schema {
+        hover_content = merge_hover_content(
+            hover_content,
+            all_of::get_all_of_hover_content(
+                value,
+                position,
+                keys,
+                accessors,
+                all_of_schema,
+                &current_schema.schema_uri,
+                &current_schema.definitions,
+                schema_context,
+            )
+            .await,
+        );
+    }
+
+    hover_content
 }
 
 #[derive(Debug, Clone)]

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -17,6 +17,7 @@ use crate::{
         display_value::DisplayValue,
         one_of::get_one_of_hover_content,
     },
+    schema_resolver::resolve_array_item_schema,
 };
 
 impl GetHoverContent for tombi_document_tree::Array {
@@ -75,15 +76,13 @@ impl GetHoverContent for tombi_document_tree::Array {
                             if value.contains(position) {
                                 let accessor = Accessor::Index(index);
 
-                                if let Some(items) = &array_schema.items
-                                    && let Ok(Some(current_schema)) =
-                                        tombi_schema_store::resolve_schema_item(
-                                            items,
-                                            current_schema.schema_uri.clone(),
-                                            current_schema.definitions.clone(),
-                                            schema_context.store,
-                                        )
-                                        .await
+                                if let Some(current_schema) = resolve_array_item_schema(
+                                    index,
+                                    array_schema,
+                                    current_schema,
+                                    schema_context,
+                                )
+                                .await
                                 {
                                     return match value
                                         .get_hover_content(
@@ -133,6 +132,57 @@ impl GetHoverContent for tombi_document_tree::Array {
                                             Some(HoverContent::DirectiveContent(hover_content))
                                         }
                                     };
+                                }
+
+                                if let Some(one_of_schema) = array_schema.one_of.as_deref() {
+                                    if let Some(hover_content) = get_one_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        one_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+
+                                if let Some(any_of_schema) = array_schema.any_of.as_deref() {
+                                    if let Some(hover_content) = get_any_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        any_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
+                                }
+
+                                if let Some(all_of_schema) = array_schema.all_of.as_deref() {
+                                    if let Some(hover_content) = get_all_of_hover_content(
+                                        self,
+                                        position,
+                                        keys,
+                                        accessors,
+                                        all_of_schema,
+                                        &current_schema.schema_uri,
+                                        &current_schema.definitions,
+                                        schema_context,
+                                    )
+                                    .await
+                                    {
+                                        return Some(hover_content);
+                                    }
                                 }
 
                                 return value

--- a/crates/tombi-lsp/src/hover/value/boolean.rs
+++ b/crates/tombi-lsp/src/hover/value/boolean.rs
@@ -11,6 +11,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -63,7 +64,19 @@ impl GetHoverContent for tombi_document_tree::Boolean {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            boolean_schema.one_of.as_deref(),
+                            boolean_schema.any_of.as_deref(),
+                            boolean_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/float.rs
+++ b/crates/tombi-lsp/src/hover/value/float.rs
@@ -11,6 +11,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -63,7 +64,19 @@ impl GetHoverContent for tombi_document_tree::Float {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            float_schema.one_of.as_deref(),
+                            float_schema.any_of.as_deref(),
+                            float_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/integer.rs
+++ b/crates/tombi-lsp/src/hover/value/integer.rs
@@ -11,6 +11,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -63,7 +64,19 @@ impl GetHoverContent for tombi_document_tree::Integer {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            integer_schema.one_of.as_deref(),
+                            integer_schema.any_of.as_deref(),
+                            integer_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/local_date.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date.rs
@@ -12,6 +12,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -58,7 +59,19 @@ impl GetHoverContent for tombi_document_tree::LocalDate {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_date_schema.one_of.as_deref(),
+                            local_date_schema.any_of.as_deref(),
+                            local_date_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date_time.rs
@@ -14,6 +14,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -60,7 +61,19 @@ impl GetHoverContent for tombi_document_tree::LocalDateTime {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_date_schema.one_of.as_deref(),
+                            local_date_schema.any_of.as_deref(),
+                            local_date_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date_time.rs
@@ -44,8 +44,8 @@ impl GetHoverContent for tombi_document_tree::LocalDateTime {
 
             if let Some(current_schema) = current_schema {
                 match current_schema.value_schema.as_ref() {
-                    ValueSchema::LocalDateTime(local_date_schema) => {
-                        let mut hover_content = local_date_schema
+                    ValueSchema::LocalDateTime(local_date_time_schema) => {
+                        let mut hover_content = local_date_time_schema
                             .get_hover_content(
                                 position,
                                 keys,
@@ -69,9 +69,9 @@ impl GetHoverContent for tombi_document_tree::LocalDateTime {
                             Some(current_schema),
                             schema_context,
                             hover_content,
-                            local_date_schema.one_of.as_deref(),
-                            local_date_schema.any_of.as_deref(),
-                            local_date_schema.all_of.as_deref(),
+                            local_date_time_schema.one_of.as_deref(),
+                            local_date_time_schema.any_of.as_deref(),
+                            local_date_time_schema.all_of.as_deref(),
                         )
                         .await
                     }

--- a/crates/tombi-lsp/src/hover/value/local_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_time.rs
@@ -12,6 +12,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -58,7 +59,19 @@ impl GetHoverContent for tombi_document_tree::LocalTime {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_time_schema.one_of.as_deref(),
+                            local_time_schema.any_of.as_deref(),
+                            local_time_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/offset_date_time.rs
@@ -14,6 +14,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -60,7 +61,19 @@ impl GetHoverContent for tombi_document_tree::OffsetDateTime {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            offset_date_time_schema.one_of.as_deref(),
+                            offset_date_time_schema.any_of.as_deref(),
+                            offset_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/string.rs
+++ b/crates/tombi-lsp/src/hover/value/string.rs
@@ -1,5 +1,6 @@
 use tombi_comment_directive::value::{StringCommonFormatRules, StringCommonLintRules};
 use tombi_schema_store::{Accessor, CurrentSchema, StringSchema, ValueSchema};
+use tombi_x_keyword::StringFormat;
 
 use crate::{
     HoverContent,
@@ -11,6 +12,7 @@ use crate::{
         comment::get_value_comment_directive_hover_content,
         constraints::{ValueConstraints, build_enum_values},
         display_value::DisplayValue,
+        merge_adjacent_hover_content,
         one_of::get_one_of_hover_content,
     },
 };
@@ -63,7 +65,151 @@ impl GetHoverContent for tombi_document_tree::String {
                             hover_value_content.range = Some(self.range());
                         }
 
-                        hover_content
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            string_schema.one_of.as_deref(),
+                            string_schema.any_of.as_deref(),
+                            string_schema.all_of.as_deref(),
+                        )
+                        .await
+                    }
+                    ValueSchema::OffsetDateTime(offset_date_time_schema)
+                        if schema_context.has_string_format(StringFormat::DateTime) =>
+                    {
+                        let mut hover_content = offset_date_time_schema
+                            .get_hover_content(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        if let Some(HoverContent::Value(hover_value_content)) =
+                            hover_content.as_mut()
+                        {
+                            hover_value_content.range = Some(self.range());
+                        }
+
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            offset_date_time_schema.one_of.as_deref(),
+                            offset_date_time_schema.any_of.as_deref(),
+                            offset_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                    }
+                    ValueSchema::LocalDateTime(local_date_time_schema)
+                        if schema_context.has_string_format(StringFormat::DateTimeLocal) =>
+                    {
+                        let mut hover_content = local_date_time_schema
+                            .get_hover_content(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        if let Some(HoverContent::Value(hover_value_content)) =
+                            hover_content.as_mut()
+                        {
+                            hover_value_content.range = Some(self.range());
+                        }
+
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_date_time_schema.one_of.as_deref(),
+                            local_date_time_schema.any_of.as_deref(),
+                            local_date_time_schema.all_of.as_deref(),
+                        )
+                        .await
+                    }
+                    ValueSchema::LocalDate(local_date_schema)
+                        if schema_context.has_string_format(StringFormat::Date) =>
+                    {
+                        let mut hover_content = local_date_schema
+                            .get_hover_content(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        if let Some(HoverContent::Value(hover_value_content)) =
+                            hover_content.as_mut()
+                        {
+                            hover_value_content.range = Some(self.range());
+                        }
+
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_date_schema.one_of.as_deref(),
+                            local_date_schema.any_of.as_deref(),
+                            local_date_schema.all_of.as_deref(),
+                        )
+                        .await
+                    }
+                    ValueSchema::LocalTime(local_time_schema)
+                        if schema_context.has_string_format(StringFormat::TimeLocal) =>
+                    {
+                        let mut hover_content = local_time_schema
+                            .get_hover_content(
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                            )
+                            .await;
+
+                        if let Some(HoverContent::Value(hover_value_content)) =
+                            hover_content.as_mut()
+                        {
+                            hover_value_content.range = Some(self.range());
+                        }
+
+                        merge_adjacent_hover_content(
+                            self,
+                            position,
+                            keys,
+                            accessors,
+                            Some(current_schema),
+                            schema_context,
+                            hover_content,
+                            local_time_schema.one_of.as_deref(),
+                            local_time_schema.any_of.as_deref(),
+                            local_time_schema.all_of.as_deref(),
+                        )
+                        .await
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         get_one_of_hover_content(

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -18,6 +18,7 @@ use crate::{
         constraints::{ValueConstraints, build_enum_values},
         one_of::get_one_of_hover_content,
     },
+    schema_resolver::resolve_table_unevaluated_property_schema,
 };
 
 impl GetHoverContent for tombi_document_tree::Table {
@@ -422,6 +423,57 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     {
                                         return Some(hover_content);
                                     }
+                                }
+
+                                if let Some(current_schema) =
+                                    resolve_table_unevaluated_property_schema(
+                                        table_schema,
+                                        current_schema,
+                                        schema_context,
+                                    )
+                                    .await
+                                {
+                                    let mut hover_content = value
+                                        .get_hover_content(
+                                            position,
+                                            &keys[1..],
+                                            &accessors
+                                                .iter()
+                                                .cloned()
+                                                .chain(std::iter::once(accessor.clone()))
+                                                .collect_vec(),
+                                            Some(&current_schema),
+                                            schema_context,
+                                        )
+                                        .await;
+
+                                    if let Some(HoverContent::Value(hover_value_content)) =
+                                        hover_content.as_mut()
+                                        && keys.len() == 1
+                                    {
+                                        if !value.contains(position) {
+                                            if let Some(title) = current_schema.value_schema.title()
+                                            {
+                                                hover_value_content.title = Some(title.to_string());
+                                            }
+                                            if let Some(description) =
+                                                current_schema.value_schema.description()
+                                            {
+                                                hover_value_content.description =
+                                                    Some(description.to_string());
+                                            }
+                                        }
+
+                                        if hover_value_content
+                                            .accessors
+                                            .last()
+                                            .map(|accessor| accessor.is_key())
+                                            .unwrap_or_default()
+                                        {
+                                            hover_value_content.value_type.set_nullable();
+                                        }
+                                    }
+                                    return hover_content;
                                 }
 
                                 value

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -8,6 +8,7 @@ mod document;
 mod goto_definition;
 mod goto_type_definition;
 mod hover;
+mod schema_resolver;
 mod semantic_tokens;
 
 pub mod handler {

--- a/crates/tombi-lsp/src/schema_resolver.rs
+++ b/crates/tombi-lsp/src/schema_resolver.rs
@@ -1,0 +1,64 @@
+use tombi_schema_store::{ArraySchema, CurrentSchema, SchemaContext, SchemaItem, TableSchema};
+
+async fn resolve_schema_item_owned(
+    schema_item: &SchemaItem,
+    current_schema: &CurrentSchema<'_>,
+    schema_context: &SchemaContext<'_>,
+) -> Option<CurrentSchema<'static>> {
+    tombi_schema_store::resolve_schema_item(
+        schema_item,
+        current_schema.schema_uri.clone(),
+        current_schema.definitions.clone(),
+        schema_context.store,
+    )
+    .await
+    .inspect_err(|err| log::warn!("{err}"))
+    .ok()
+    .flatten()
+    .map(CurrentSchema::into_owned)
+}
+
+pub(crate) async fn resolve_array_item_schema(
+    index: usize,
+    array_schema: &ArraySchema,
+    current_schema: &CurrentSchema<'_>,
+    schema_context: &SchemaContext<'_>,
+) -> Option<CurrentSchema<'static>> {
+    if let Some(prefix_items) = &array_schema.prefix_items {
+        if let Some(schema_item) = prefix_items.get(index) {
+            return resolve_schema_item_owned(schema_item, current_schema, schema_context).await;
+        }
+
+        if let Some(schema_item) = &array_schema.additional_items_schema {
+            return resolve_schema_item_owned(schema_item, current_schema, schema_context).await;
+        }
+
+        if array_schema.additional_items == Some(false) {
+            return None;
+        }
+
+        if let Some(schema_item) = &array_schema.items {
+            return resolve_schema_item_owned(schema_item, current_schema, schema_context).await;
+        }
+    } else if let Some(schema_item) = &array_schema.items {
+        return resolve_schema_item_owned(schema_item, current_schema, schema_context).await;
+    }
+
+    if let Some(schema_item) = &array_schema.unevaluated_items_schema {
+        return resolve_schema_item_owned(schema_item, current_schema, schema_context).await;
+    }
+
+    None
+}
+
+pub(crate) async fn resolve_table_unevaluated_property_schema(
+    table_schema: &TableSchema,
+    current_schema: &CurrentSchema<'_>,
+    schema_context: &SchemaContext<'_>,
+) -> Option<CurrentSchema<'static>> {
+    let Some(schema_item) = &table_schema.unevaluated_property_schema else {
+        return None;
+    };
+
+    resolve_schema_item_owned(schema_item, current_schema, schema_context).await
+}

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1,7 +1,9 @@
 use tombi_config::{JSON_SCHEMASTORE_CATALOG_URL, TOMBI_SCHEMASTORE_CATALOG_URL};
 use tombi_test_lib::{
-    adjacent_one_of_hover_test_schema_path, project_root_path, string_format_test_schema_path,
-    today_local_date, today_local_date_time, today_local_time, today_offset_date_time,
+    adjacent_applicators_test_schema_path, adjacent_one_of_additional_properties_test_schema_path,
+    adjacent_one_of_hover_test_schema_path, lsp_consistency_test_schema_path, project_root_path,
+    string_format_test_schema_path, today_local_date, today_local_date_time, today_local_time,
+    today_offset_date_time,
 };
 
 mod completion_labels {
@@ -632,6 +634,7 @@ mod completion_labels {
             ) -> Ok([
                 "additional-properties-branch-keys-test.schema.json",
                 "adjacent-applicators-test.schema.json",
+                "adjacent-one-of-additional-properties-test.schema.json",
                 "adjacent-one-of-hover-test.schema.json",
                 "anchor-dynamic-ref-test.schema.json",
                 "anchor-table-test.schema.json",
@@ -645,6 +648,7 @@ mod completion_labels {
                 "format-annotation-test.schema.json",
                 "format-assertion-vocab-test.schema.json",
                 "if-then-else-test.schema.json",
+                "lsp-consistency-test.schema.json",
                 "min-max-contains-test.schema.json",
                 "one-of-hover-discriminator-test.schema.json",
                 "partial-taskipy.schema.json",
@@ -730,6 +734,76 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_empty_inline_table_keys_completion(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [ {█} ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_empty_inline_table_keys_completion_with_space(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [ { █} ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_incomplete_inline_table_keys_completion(
+                r#"
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { █
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_builtin_hook_incomplete_inline_table_keys_completion_with_prek_context(
+                r#"
+                fail_fast = false
+
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { █
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_additional_properties_builtin_hook_incomplete_inline_table_keys_completion(
+                r#"
+                fail_fast = false
+
+                [[repos]]
+                repo = "builtin"
+                hooks = [
+                  { █
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_additional_properties_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
             async fn adjacent_one_of_builtin_hook_id_value_completion(
                 r#"
                 [[repos]]
@@ -740,6 +814,65 @@ mod completion_labels {
                 "#,
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
             ) -> Ok(["\"builtin-hook\"", "\"\"", "''"]);
+        }
+    }
+
+    mod adjacent_applicators_schema {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_all_of_offset_date_time_value_completion(
+                r#"
+                offset_date_time_all = █
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok(["2024-01-15T10:30:00Z"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_all_of_boolean_value_completion(
+                r#"
+                boolean_all = █
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok(["true"]);
+        }
+    }
+
+    mod consistency_schema {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn typed_extra_table_unevaluated_properties_inline_table_keys_completion(
+                r#"
+                [typed_extra_table]
+                extra = { █ }
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn typed_unevaluated_tuple_inline_table_keys_completion(
+                r#"
+                typed_unevaluated_tuple = [1, { █ }]
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(["id"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn typed_overflow_tuple_inline_table_keys_completion(
+                r#"
+                typed_overflow_tuple = [1, { █ }]
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(["id"]);
         }
     }
 

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -1,6 +1,9 @@
 mod goto_type_definition_tests {
     use super::*;
-    use tombi_test_lib::adjacent_one_of_hover_test_schema_path;
+    use tombi_test_lib::{
+        adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
+        lsp_consistency_test_schema_path,
+    };
 
     mod tombi_schema {
         use super::*;
@@ -180,6 +183,70 @@ mod goto_type_definition_tests {
                 SourcePath(adjacent_one_of_hover_test_schema_path()),
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
             ) -> Ok(adjacent_one_of_hover_test_schema_path());
+        );
+    }
+
+    mod adjacent_applicators_schema {
+        use super::*;
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn adjacent_all_of_offset_date_time_value(
+                r#"
+                offset_date_time_all = 2024-01-15T█10:30:00Z
+                "#,
+                SourcePath(adjacent_applicators_test_schema_path()),
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok(adjacent_applicators_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn adjacent_all_of_boolean_value(
+                r#"
+                boolean_all = tr█ue
+                "#,
+                SourcePath(adjacent_applicators_test_schema_path()),
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok(adjacent_applicators_test_schema_path());
+        );
+    }
+
+    mod consistency_schema {
+        use super::*;
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn typed_extra_table_unevaluated_properties_id_value(
+                r#"
+                [typed_extra_table]
+                extra = { id = "█value" }
+                "#,
+                SourcePath(lsp_consistency_test_schema_path()),
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(lsp_consistency_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn typed_unevaluated_tuple_id_value(
+                r#"
+                typed_unevaluated_tuple = [1, { id = "█value" }]
+                "#,
+                SourcePath(lsp_consistency_test_schema_path()),
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(lsp_consistency_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn typed_overflow_tuple_id_value(
+                r#"
+                typed_overflow_tuple = [1, { id = "█value" }]
+                "#,
+                SourcePath(lsp_consistency_test_schema_path()),
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(lsp_consistency_test_schema_path());
         );
     }
 

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
-    adjacent_one_of_hover_test_schema_path, cargo_feature_navigation_fixture_path,
-    cargo_schema_path, one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
+    adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
+    cargo_feature_navigation_fixture_path, cargo_schema_path, lsp_consistency_test_schema_path,
+    one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
 };
 
@@ -634,6 +635,82 @@ mod hover_keys_value {
         );
     }
 
+    mod adjacent_applicators_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn adjacent_all_of_offset_date_time_hover_merges_const(
+                r#"
+                offset_date_time_all = 2024-01-15T█10:30:00Z
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok({
+                "Keys": "offset_date_time_all",
+                "Value": "OffsetDateTime?",
+                "Enum": ["2024-01-15T10:30:00Z"]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn adjacent_all_of_boolean_hover_merges_const(
+                r#"
+                boolean_all = t█rue
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok({
+                "Keys": "boolean_all",
+                "Value": "Boolean?",
+                "Enum": ["true"]
+            });
+        );
+    }
+
+    mod consistency_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn typed_extra_table_unevaluated_properties_hover(
+                r#"
+                [typed_extra_table]
+                extra = { id = "█value" }
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok({
+                "Keys": "typed_extra_table.extra.id",
+                "Value": "String?"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn typed_unevaluated_tuple_hover(
+                r#"
+                typed_unevaluated_tuple = [1, { id = "█value" }]
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok({
+                "Keys": "typed_unevaluated_tuple[1].id",
+                "Value": "String?"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn typed_overflow_tuple_hover(
+                r#"
+                typed_overflow_tuple = [1, { id = "█value" }]
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok({
+                "Keys": "typed_overflow_tuple[1].id",
+                "Value": "String?"
+            });
+        );
+    }
+
     mod pyproject_schema {
         use super::*;
 
@@ -877,6 +954,7 @@ mod hover_keys_value {
             "Value": $value_type:expr
             $(, "Title": $title:expr)?
             $(, "Description": $description:expr)?
+            $(, "Enum": [$($enum_values:expr),* $(,)?])?
             $(, "Default": $default:expr)?
             $(, "Examples": [$($examples:expr),* $(,)?])?
             $(,)?
@@ -1113,6 +1191,19 @@ mod hover_keys_value {
                         hover_content.description.as_deref(),
                         expected_description.as_deref(),
                         "Description is not equal"
+                    );
+                )?
+                $(
+                    let expected_enum = vec![$($enum_values),*];
+                    pretty_assertions::assert_eq!(
+                        hover_content
+                            .constraints
+                            .as_ref()
+                            .and_then(|constraints| constraints.r#enum.as_ref())
+                            .map(|values| values.iter().map(ToString::to_string).collect::<Vec<_>>())
+                            .unwrap_or_default(),
+                        expected_enum,
+                        "Enum is not equal"
                     );
                 )?
                 $(

--- a/crates/tombi-schema-store/src/http_client.rs
+++ b/crates/tombi-schema-store/src/http_client.rs
@@ -23,7 +23,7 @@ mod gloo_net_client;
 #[cfg(all(feature = "gloo-net06", not(feature = "wasm")))]
 pub use gloo_net_client::HttpClient;
 
-#[cfg(feature = "surf2")]
+#[cfg(all(feature = "surf2", not(feature = "reqwest01")))]
 mod surf_client;
 #[cfg(all(feature = "surf2", not(feature = "reqwest01")))]
 pub use surf_client::HttpClient;

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -178,6 +178,18 @@ pub fn adjacent_one_of_hover_test_schema_path() -> PathBuf {
         .join("adjacent-one-of-hover-test.schema.json")
 }
 
+pub fn adjacent_one_of_additional_properties_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("adjacent-one-of-additional-properties-test.schema.json")
+}
+
+pub fn adjacent_applicators_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("adjacent-applicators-test.schema.json")
+}
+
 pub fn unevaluated_items_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")
@@ -194,4 +206,10 @@ pub fn unevaluated_properties_branch_additional_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")
         .join("unevaluated-properties-branch-additional-test.schema.json")
+}
+
+pub fn lsp_consistency_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("lsp-consistency-test.schema.json")
 }

--- a/schemas/adjacent-one-of-additional-properties-test.schema.json
+++ b/schemas/adjacent-one-of-additional-properties-test.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "fail_fast": {
+      "type": "boolean"
+    },
+    "repos": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Repo"
+      }
+    }
+  },
+  "required": ["repos"],
+  "additionalProperties": true,
+  "definitions": {
+    "Repo": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/RemoteRepo"
+        },
+        {
+          "$ref": "#/definitions/BuiltinRepo"
+        }
+      ],
+      "additionalProperties": true
+    },
+    "RemoteRepo": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "const": "remote"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RemoteHook"
+          }
+        }
+      },
+      "required": ["repo", "hooks"],
+      "additionalProperties": true
+    },
+    "BuiltinRepo": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "const": "builtin"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuiltinHook"
+          }
+        }
+      },
+      "required": ["repo", "hooks"],
+      "additionalProperties": true
+    },
+    "RemoteHook": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": true
+    },
+    "BuiltinHook": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/lsp-consistency-test.schema.json
+++ b/schemas/lsp-consistency-test.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LspConsistencyTest",
+  "type": "object",
+  "properties": {
+    "typed_extra_table": {
+      "type": "object",
+      "properties": {
+        "known": { "type": "string" }
+      },
+      "unevaluatedProperties": {
+        "type": "object",
+        "title": "ExtraTableEntry",
+        "properties": {
+          "id": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "typed_unevaluated_tuple": {
+      "type": "array",
+      "prefixItems": [{ "type": "integer" }],
+      "unevaluatedItems": {
+        "type": "object",
+        "title": "UnevaluatedTupleItem",
+        "properties": {
+          "id": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "typed_overflow_tuple": {
+      "type": "array",
+      "prefixItems": [{ "type": "integer" }],
+      "items": {
+        "type": "object",
+        "title": "OverflowTupleItem",
+        "properties": {
+          "id": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- align `hover`, `completion`, and `goto type definition` schema resolution with validation behavior
- fix adjacent `oneOf`/applicator lookups for nested table and array value handling
- add regression coverage for adjacent schema resolution and consistency cases

## Testing
- cargo test -p tombi-lsp --test test_hover
- cargo test -p tombi-lsp --test test_goto_type_definition
- cargo test -p tombi-lsp --test test_completion_labels