### PR TITLE
Deprecate `authors` field in `cargo.json`

### DIFF
--- a/www.schemastore.org/cargo.json
+++ b/www.schemastore.org/cargo.json
@@ -454,7 +454,7 @@
         },
         "authors": {
           "title": "Authors",
-          "description": "The `authors` field lists people or organizations that are considered the\n\"authors\" of the package. The exact meaning is open to interpretation — it may\nlist the original or primary authors, current maintainers, or owners of the\npackage. These names will be listed on the crate's page on\n[crates.io](https://crates.io). An optional email address may be included within angled\nbrackets at the end of each author.\n\n> **Note**: [crates.io](https://crates.io) requires at least one author to be listed.",
+          "description": "The `authors` field lists people or organizations that are considered the\n\"authors\" of the package. The exact meaning is open to interpretation — it may\nlist the original or primary authors, current maintainers, or owners of the\npackage. These names will be listed on the crate's page on\n[crates.io](https://crates.io). An optional email address may be included within angled\nbrackets at the end of each author.\n\n> **Note**: This field is deprecated.",
           "anyOf": [
             {
               "$ref": "#/definitions/Authors"


### PR DESCRIPTION
package.authors field in Cargo.toml is deprecated and is no longer required for publishing to crates.io.

- https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field
- https://releases.rs/docs/1.53.0/#:~:text=The%20authors%20field%20is%20no%20longer%20included%20in%20Cargo.toml%20for%20new%20projects.
- https://rust-lang.github.io/rfcs/3052-optional-authors-field.html

I'm sending this PR in parallel with https://github.com/SchemaStore/schemastore/pull/5566.