### PR TITLE
Add wildcard support for schemas root accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,6 +3536,7 @@ dependencies = [
  "tombi-hashmap",
  "tombi-text",
  "tombi-toml-text",
+ "tombi-toml-version",
 ]
 
 [[package]]

--- a/crates/tombi-accessor/Cargo.toml
+++ b/crates/tombi-accessor/Cargo.toml
@@ -11,6 +11,7 @@ itertools.workspace = true
 tombi-hashmap.workspace = true
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
+tombi-toml-version.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/tombi-accessor/src/lib.rs
+++ b/crates/tombi-accessor/src/lib.rs
@@ -1,5 +1,7 @@
 mod accessor;
+mod root_accessor;
 mod schema_accessor;
 
 pub use accessor::{Accessor, AccessorContext, AccessorKeyKind, Accessors, KeyContext};
+pub use root_accessor::{RootAccessor, RootAccessors};
 pub use schema_accessor::{SchemaAccessor, SchemaAccessors};

--- a/crates/tombi-accessor/src/root_accessor.rs
+++ b/crates/tombi-accessor/src/root_accessor.rs
@@ -35,6 +35,9 @@ impl RootAccessor {
                         index_str.push(chars[i]);
                         i += 1;
                     }
+                    if i >= chars.len() || chars[i] != ']' {
+                        return None;
+                    }
                     if index_str == "*" || index_str.parse::<usize>().is_ok() {
                         accessors.push(RootAccessor::Index);
                     } else {
@@ -218,6 +221,14 @@ mod tests {
             RootAccessor::Key("*".to_string()),
         ]);
         assert_eq!(format!("{accessors}"), r#"tool."*""#);
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case("items[*")]
+    #[case("items[foo]")]
+    fn test_root_accessor_parse_invalid(#[case] input: &str) {
+        assert_eq!(RootAccessor::parse(input), None);
     }
 
     #[test]

--- a/crates/tombi-accessor/src/root_accessor.rs
+++ b/crates/tombi-accessor/src/root_accessor.rs
@@ -1,0 +1,236 @@
+use itertools::Itertools;
+use tombi_toml_version::TomlVersion;
+
+use crate::Accessor;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RootAccessor {
+    Key(String),
+    AnyKey,
+    Index,
+}
+
+impl RootAccessor {
+    pub fn parse(path: &str) -> Option<Vec<RootAccessor>> {
+        let mut accessors = Vec::new();
+        let mut current_key = String::new();
+
+        if path.is_empty() {
+            return None;
+        }
+
+        let chars: Vec<char> = path.chars().collect();
+        let mut i = 0;
+
+        while i < chars.len() {
+            match chars[i] {
+                '[' => {
+                    if !current_key.is_empty() {
+                        accessors.push(parse_key_or_wildcard(current_key));
+                        current_key = String::new();
+                    }
+                    i += 1;
+                    let mut index_str = String::new();
+                    while i < chars.len() && chars[i] != ']' {
+                        index_str.push(chars[i]);
+                        i += 1;
+                    }
+                    if index_str == "*" || index_str.parse::<usize>().is_ok() {
+                        accessors.push(RootAccessor::Index);
+                    } else {
+                        return None;
+                    }
+                }
+                '\'' | '"' if current_key.is_empty() => {
+                    let (quoted_key, next_index) = parse_quoted_key(&chars, i)?;
+                    accessors.push(RootAccessor::Key(quoted_key));
+                    i = next_index;
+                }
+                '.' => {
+                    if !current_key.is_empty() {
+                        accessors.push(parse_key_or_wildcard(current_key));
+                        current_key = String::new();
+                    }
+                }
+                c => current_key.push(c),
+            }
+            i += 1;
+        }
+
+        if !current_key.is_empty() {
+            accessors.push(parse_key_or_wildcard(current_key));
+        }
+
+        Some(accessors)
+    }
+}
+
+impl PartialEq<Accessor> for RootAccessor {
+    fn eq(&self, other: &Accessor) -> bool {
+        match (self, other) {
+            (RootAccessor::Key(expected), Accessor::Key(actual)) => expected == actual,
+            (RootAccessor::AnyKey, Accessor::Key(_)) => true,
+            (RootAccessor::Index, Accessor::Index(_)) => true,
+            _ => false,
+        }
+    }
+}
+
+fn parse_key_or_wildcard(key: String) -> RootAccessor {
+    if key == "*" {
+        RootAccessor::AnyKey
+    } else {
+        RootAccessor::Key(key)
+    }
+}
+
+fn parse_quoted_key(chars: &[char], start: usize) -> Option<(String, usize)> {
+    let quote = chars[start];
+    let mut end = start + 1;
+    let mut escaped = false;
+
+    while end < chars.len() {
+        let current = chars[end];
+        if quote == '"' && current == '\\' && !escaped {
+            escaped = true;
+            end += 1;
+            continue;
+        }
+        if current == quote && !escaped {
+            let quoted = chars[start..=end].iter().collect::<String>();
+            let parsed = match quote {
+                '"' => tombi_toml_text::try_from_basic_string(&quoted, TomlVersion::V1_0_0).ok()?,
+                '\'' => tombi_toml_text::try_from_literal_string(&quoted).ok()?,
+                _ => return None,
+            };
+            return Some((parsed, end));
+        }
+        escaped = false;
+        end += 1;
+    }
+
+    None
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct RootAccessors(Vec<RootAccessor>);
+
+impl From<Vec<RootAccessor>> for RootAccessors {
+    fn from(accessors: Vec<RootAccessor>) -> Self {
+        Self(accessors)
+    }
+}
+
+impl From<&[RootAccessor]> for RootAccessors {
+    fn from(accessors: &[RootAccessor]) -> Self {
+        Self(accessors.to_vec())
+    }
+}
+
+impl std::fmt::Display for RootAccessors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(accessor) = iter.next() {
+            write!(f, "{accessor}")?;
+            for accessor in iter {
+                match accessor {
+                    RootAccessor::Key(_) | RootAccessor::AnyKey => write!(f, ".{accessor}")?,
+                    RootAccessor::Index => write!(f, "{accessor}")?,
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for RootAccessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RootAccessor::Key(key) => write!(f, "{}", tombi_toml_text::to_key_string(key)),
+            RootAccessor::AnyKey => write!(f, "*"),
+            RootAccessor::Index => write!(f, "[*]"),
+        }
+    }
+}
+
+impl From<&[Accessor]> for RootAccessors {
+    fn from(accessors: &[Accessor]) -> Self {
+        Self(
+            accessors
+                .iter()
+                .map(|accessor| match accessor {
+                    Accessor::Key(key) => RootAccessor::Key(key.clone()),
+                    Accessor::Index(_) => RootAccessor::Index,
+                })
+                .collect_vec(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case("tool.*", vec![
+        RootAccessor::Key("tool".to_string()),
+        RootAccessor::AnyKey,
+    ])]
+    #[case("tool.'*'", vec![
+        RootAccessor::Key("tool".to_string()),
+        RootAccessor::Key("*".to_string()),
+    ])]
+    #[case("tool.\"*\"", vec![
+        RootAccessor::Key("tool".to_string()),
+        RootAccessor::Key("*".to_string()),
+    ])]
+    #[case("\"a.b\".c", vec![
+        RootAccessor::Key("a.b".to_string()),
+        RootAccessor::Key("c".to_string()),
+    ])]
+    #[case("items[*].name", vec![
+        RootAccessor::Key("items".to_string()),
+        RootAccessor::Index,
+        RootAccessor::Key("name".to_string()),
+    ])]
+    fn test_root_accessor_parse(#[case] input: &str, #[case] expected: Vec<RootAccessor>) {
+        let result = RootAccessor::parse(input).unwrap();
+        pretty_assertions::assert_eq!(result, expected, "Failed for input: {}", input);
+    }
+
+    #[test]
+    fn test_root_accessors_display() {
+        let accessors = RootAccessors::from(vec![
+            RootAccessor::Key("tool".to_string()),
+            RootAccessor::AnyKey,
+            RootAccessor::Key("enabled".to_string()),
+        ]);
+        assert_eq!(format!("{accessors}"), "tool.*.enabled");
+    }
+
+    #[test]
+    fn test_root_accessors_display_literal_asterisk_key() {
+        let accessors = RootAccessors::from(vec![
+            RootAccessor::Key("tool".to_string()),
+            RootAccessor::Key("*".to_string()),
+        ]);
+        assert_eq!(format!("{accessors}"), r#"tool."*""#);
+    }
+
+    #[test]
+    fn test_root_accessor_matches() {
+        assert_eq!(RootAccessor::AnyKey, Accessor::Key("taskipy".to_string()));
+        assert_eq!(RootAccessor::Index, Accessor::Index(3));
+        assert_eq!(
+            RootAccessor::Key("tool".to_string()),
+            Accessor::Key("tool".to_string())
+        );
+        assert_ne!(
+            RootAccessor::Key("tool".to_string()),
+            Accessor::Key("other".to_string())
+        );
+    }
+}

--- a/crates/tombi-lsp/src/completion/comment.rs
+++ b/crates/tombi-lsp/src/completion/comment.rs
@@ -151,7 +151,7 @@ pub async fn get_tombi_comment_directive_content_completion_contents(
     let document_schema = comment_directive_document_schema(schema_store, schema_uri).await;
     let source_schema = tombi_schema_store::SourceSchema::new(
         Some(Arc::new(document_schema)),
-        tombi_hashmap::HashMap::with_capacity(0),
+        tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
     );

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -4,8 +4,8 @@ use futures::future::join_all;
 use itertools::Itertools;
 use tombi_future::{BoxFuture, Boxable};
 use tombi_schema_store::{
-    Accessor, CurrentSchema, FindSchemaCandidates, Referable, SchemaAccessor, SchemaStore,
-    TableSchema, ValueSchema, is_online_url,
+    Accessor, CurrentSchema, FindSchemaCandidates, Referable, RootAccessor, SchemaAccessor,
+    SchemaStore, TableSchema, ValueSchema, is_online_url, schema_pattern_matches_accessors,
 };
 
 use crate::{
@@ -645,59 +645,60 @@ impl FindCompletionContents for tombi_document_tree::Table {
 
                             if let Some(sub_schema_uri_map) = schema_context.sub_schema_uri_map {
                                 for (root_accessors, sub_schema_uri) in sub_schema_uri_map {
-                                    if let Some(SchemaAccessor::Key(last_key)) =
-                                        root_accessors.last()
+                                    if let Some(last_key) =
+                                        matching_subschema_completion_key(root_accessors, accessors)
                                     {
-                                        let head_accessors =
-                                            &root_accessors[..root_accessors.len() - 1];
-                                        if head_accessors == accessors
-                                            && let Ok(Some(document_schema)) = schema_context
-                                                .store
-                                                .try_get_document_schema(sub_schema_uri)
-                                                .await
-                                            && let Some(value_schema) =
-                                                &document_schema.value_schema
-                                        {
-                                            let (schema_candidates, errors) = value_schema
-                                                .find_schema_candidates(
-                                                    accessors,
-                                                    &document_schema.schema_uri,
-                                                    &document_schema.definitions,
-                                                    schema_context.store,
-                                                )
-                                                .await;
+                                        let Ok(Some(document_schema)) = schema_context
+                                            .store
+                                            .try_get_document_schema(sub_schema_uri)
+                                            .await
+                                        else {
+                                            continue;
+                                        };
+                                        let Some(value_schema) = &document_schema.value_schema
+                                        else {
+                                            continue;
+                                        };
 
-                                            for error in errors {
-                                                log::warn!("{}", error);
-                                            }
+                                        let (schema_candidates, errors) = value_schema
+                                            .find_schema_candidates(
+                                                accessors,
+                                                &document_schema.schema_uri,
+                                                &document_schema.definitions,
+                                                schema_context.store,
+                                            )
+                                            .await;
 
-                                            completion_contents.push(CompletionContent::new_key(
-                                                last_key,
-                                                position,
-                                                current_editing_key_range(keys, position),
-                                                value_schema
-                                                    .detail(
-                                                        &current_schema.schema_uri,
-                                                        &current_schema.definitions,
-                                                        schema_context.store,
-                                                        completion_hint,
-                                                    )
-                                                    .await,
-                                                value_schema
-                                                    .documentation(
-                                                        &current_schema.schema_uri,
-                                                        &current_schema.definitions,
-                                                        schema_context.store,
-                                                        completion_hint,
-                                                    )
-                                                    .await,
-                                                None,
-                                                Some(current_schema.schema_uri.as_ref()),
-                                                value_schema.deprecated().await,
-                                                completion_hint,
-                                                key_singleton_literal_label(&schema_candidates),
-                                            ));
+                                        for error in errors {
+                                            log::warn!("{}", error);
                                         }
+
+                                        completion_contents.push(CompletionContent::new_key(
+                                            last_key,
+                                            position,
+                                            current_editing_key_range(keys, position),
+                                            value_schema
+                                                .detail(
+                                                    &current_schema.schema_uri,
+                                                    &current_schema.definitions,
+                                                    schema_context.store,
+                                                    completion_hint,
+                                                )
+                                                .await,
+                                            value_schema
+                                                .documentation(
+                                                    &current_schema.schema_uri,
+                                                    &current_schema.definitions,
+                                                    schema_context.store,
+                                                    completion_hint,
+                                                )
+                                                .await,
+                                            None,
+                                            Some(current_schema.schema_uri.as_ref()),
+                                            value_schema.deprecated().await,
+                                            completion_hint,
+                                            key_singleton_literal_label(&schema_candidates),
+                                        ));
                                     }
                                 }
                             }
@@ -1321,6 +1322,17 @@ fn key_singleton_literal_label(schema_candidates: &[ValueSchema]) -> Option<Stri
     }
 }
 
+fn matching_subschema_completion_key<'a>(
+    root_accessors: &'a [RootAccessor],
+    accessors: &[Accessor],
+) -> Option<&'a str> {
+    let (RootAccessor::Key(last_key), head_accessors) = root_accessors.split_last()? else {
+        return None;
+    };
+
+    schema_pattern_matches_accessors(head_accessors, accessors).then_some(last_key.as_str())
+}
+
 fn current_editing_key_range(
     keys: &[tombi_document_tree::Key],
     position: tombi_text::Position,
@@ -1329,4 +1341,47 @@ fn current_editing_key_range(
         let range = key.range();
         (range.start <= position && position <= range.end).then_some(range)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use tombi_schema_store::{Accessor, RootAccessor};
+
+    use super::matching_subschema_completion_key;
+
+    #[test]
+    fn wildcard_subschema_root_matches_completion_parent_path() {
+        let root_accessors = vec![
+            RootAccessor::Key("tool".to_string()),
+            RootAccessor::AnyKey,
+            RootAccessor::Key("enabled".to_string()),
+        ];
+        let accessors = vec![
+            Accessor::Key("tool".to_string()),
+            Accessor::Key("taskipy".to_string()),
+        ];
+
+        assert_eq!(
+            matching_subschema_completion_key(&root_accessors, &accessors),
+            Some("enabled")
+        );
+    }
+
+    #[test]
+    fn wildcard_leaf_is_not_exposed_as_completion_key() {
+        let root_accessors = vec![
+            RootAccessor::Key("tool".to_string()),
+            RootAccessor::Key("taskipy".to_string()),
+            RootAccessor::AnyKey,
+        ];
+        let accessors = vec![
+            Accessor::Key("tool".to_string()),
+            Accessor::Key("taskipy".to_string()),
+        ];
+
+        assert_eq!(
+            matching_subschema_completion_key(&root_accessors, &accessors),
+            None
+        );
+    }
 }

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tombi_future::{BoxFuture, Boxable};
 use tombi_schema_store::{
     Accessor, CurrentSchema, FindSchemaCandidates, Referable, RootAccessor, SchemaAccessor,
-    SchemaStore, TableSchema, ValueSchema, is_online_url, schema_pattern_matches_accessors,
+    SchemaStore, TableSchema, ValueSchema, is_online_url,
 };
 
 use crate::{
@@ -1330,7 +1330,7 @@ fn matching_subschema_completion_key<'a>(
         return None;
     };
 
-    schema_pattern_matches_accessors(head_accessors, accessors).then_some(last_key.as_str())
+    (head_accessors == accessors).then_some(last_key.as_str())
 }
 
 fn current_editing_key_range(

--- a/crates/tombi-lsp/src/goto_type_definition/comment.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/comment.rs
@@ -62,7 +62,7 @@ pub async fn get_tombi_value_comment_directive_type_definition(
         Some(Arc::new(
             comment_directive_document_schema(schema_store, schema_uri).await,
         )),
-        tombi_hashmap::HashMap::with_capacity(0),
+        tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
     );

--- a/crates/tombi-lsp/src/hover/comment.rs
+++ b/crates/tombi-lsp/src/hover/comment.rs
@@ -134,7 +134,7 @@ async fn get_comment_directive_toml_content_hover_content(
             Some(Arc::new(
                 comment_directive_document_schema(schema_store, schema_uri).await,
             )),
-            tombi_hashmap::HashMap::with_capacity(0),
+            tombi_hashmap::IndexMap::with_capacity(0),
             Some(toml_version),
             None,
         );

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -46,7 +46,7 @@ pub use schema_cycle_guard::{SchemaCycleGuard, SchemaVisits};
 pub use source_schema::{SourceSchema, SubSchemaUriMap};
 pub use string_schema::StringSchema;
 pub use table_schema::{Dependency, TableKeysOrderGroup, TableSchema, XTombiTableKeysOrder};
-pub use tombi_accessor::{SchemaAccessor, SchemaAccessors};
+pub use tombi_accessor::{RootAccessor, RootAccessors, SchemaAccessor, SchemaAccessors};
 pub use tombi_uri::{CatalogUri, SchemaUri};
 pub use value_schema::*;
 
@@ -288,7 +288,7 @@ pub struct Schema {
     pub schema_uri: tombi_uri::SchemaUri,
     pub catalog_uri: Option<Arc<tombi_uri::CatalogUri>>,
     pub include: Vec<String>,
-    pub sub_root_keys: Option<Vec<SchemaAccessor>>,
+    pub sub_root_accessors: Option<Vec<RootAccessor>>,
 }
 
 pub trait FindSchemaCandidates {

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -1,10 +1,7 @@
-use itertools::Itertools;
 use tombi_severity_level::SeverityLevelDefaultWarn;
 use tombi_x_keyword::StringFormat;
 
 use crate::schema::schema_cycle_guard::SchemaVisits;
-
-use super::SchemaAccessor;
 
 pub struct SchemaContext<'a> {
     pub toml_version: tombi_config::TomlVersion,
@@ -40,8 +37,9 @@ impl SchemaContext<'_> {
         current_schema: Option<&crate::CurrentSchema<'_>>,
     ) -> Option<Result<std::sync::Arc<crate::DocumentSchema>, crate::Error>> {
         if let Some(sub_schema_uri_map) = self.sub_schema_uri_map
-            && let Some(sub_schema_uri) =
-                sub_schema_uri_map.get(&accessors.iter().map(SchemaAccessor::from).collect_vec())
+            && let Some((_, sub_schema_uri)) = sub_schema_uri_map
+                .iter()
+                .find(|(pattern, _)| pattern.as_slice() == accessors)
             && current_schema
                 .is_none_or(|current_schema| &*current_schema.schema_uri != sub_schema_uri)
         {

--- a/crates/tombi-schema-store/src/schema/source_schema.rs
+++ b/crates/tombi-schema-store/src/schema/source_schema.rs
@@ -5,9 +5,9 @@ use tombi_config::TomlVersion;
 use tombi_severity_level::SeverityLevelDefaultWarn;
 
 use super::{DocumentSchema, SchemaUri};
-use crate::{SchemaAccessor, SchemaAccessors};
+use crate::{RootAccessor, RootAccessors};
 
-pub type SubSchemaUriMap = tombi_hashmap::HashMap<Vec<SchemaAccessor>, SchemaUri>;
+pub type SubSchemaUriMap = tombi_hashmap::IndexMap<Vec<RootAccessor>, SchemaUri>;
 
 #[derive(Clone, Default)]
 pub struct SourceSchema {
@@ -57,7 +57,7 @@ impl std::fmt::Debug for SourceSchema {
             .sub_schema_uri_map
             .iter()
             .map(|(accessors, url)| {
-                format!("[{:?}]: {}", SchemaAccessors::from(accessors.clone()), url)
+                format!("[{:?}]: {}", RootAccessors::from(accessors.clone()), url)
             })
             .collect_vec()
             .join(", ");

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, ops::Deref, str::FromStr, sync::Arc};
 
 use crate::resolve_json_pointer;
 use crate::{
-    AllOfSchema, AnyOfSchema, CatalogUri, DocumentSchema, OneOfSchema, SchemaAccessor,
-    SchemaAccessors, SourceSchema, SubSchemaUriMap, ValueSchema, get_tombi_schemastore_content,
+    AllOfSchema, AnyOfSchema, CatalogUri, DocumentSchema, OneOfSchema, RootAccessor, RootAccessors,
+    SourceSchema, SubSchemaUriMap, ValueSchema, get_tombi_schemastore_content,
     http_client::HttpClient, json::JsonCatalog,
 };
 use itertools::{Either, Itertools};
@@ -198,7 +198,7 @@ impl SchemaStore {
                 catalog_uri: None,
                 include: schema.include().to_vec(),
                 toml_version: schema.toml_version(),
-                sub_root_keys: schema.root().and_then(SchemaAccessor::parse),
+                sub_root_accessors: schema.root().and_then(RootAccessor::parse),
             });
         }))
         .await;
@@ -340,7 +340,7 @@ impl SchemaStore {
                     catalog_uri: Some(catalog_uri.clone()),
                     include: schema.file_match,
                     toml_version: None,
-                    sub_root_keys: None,
+                    sub_root_accessors: None,
                 });
             }
         }
@@ -752,10 +752,12 @@ impl SchemaStore {
 
         let mut source_schema: Option<SourceSchema> = None;
         for matching_schema in matching_schemas {
-            // Skip if the same schema (by URL and sub_root_keys) is already loaded in source_schema
-            let already_loaded = match &matching_schema.sub_root_keys {
-                Some(sub_root_keys) => source_schema.as_ref().is_some_and(|source_schema| {
-                    source_schema.sub_schema_uri_map.contains_key(sub_root_keys)
+            // Skip if the same schema (by URL and sub_root_accessors) is already loaded in source_schema
+            let already_loaded = match &matching_schema.sub_root_accessors {
+                Some(sub_root_accessors) => source_schema.as_ref().is_some_and(|source_schema| {
+                    source_schema
+                        .sub_schema_uri_map
+                        .contains_key(sub_root_accessors)
                 }),
                 None => source_schema
                     .as_ref()
@@ -768,20 +770,25 @@ impl SchemaStore {
                 .try_get_document_schema(&matching_schema.schema_uri)
                 .await
             {
-                Ok(Some(document_schema)) => match &matching_schema.sub_root_keys {
-                    Some(sub_root_keys) => match source_schema {
+                Ok(Some(document_schema)) => match &matching_schema.sub_root_accessors {
+                    Some(sub_root_accessors) => match source_schema {
                         Some(ref mut source_schema) => {
-                            if !source_schema.sub_schema_uri_map.contains_key(sub_root_keys) {
+                            if !source_schema
+                                .sub_schema_uri_map
+                                .contains_key(sub_root_accessors)
+                            {
                                 source_schema.sub_schema_uri_map.insert(
-                                    sub_root_keys.clone(),
+                                    sub_root_accessors.clone(),
                                     document_schema.schema_uri.clone(),
                                 );
                             }
                         }
                         None => {
                             let mut sub_schema_uri_map = SubSchemaUriMap::default();
-                            sub_schema_uri_map
-                                .insert(sub_root_keys.clone(), document_schema.schema_uri.clone());
+                            sub_schema_uri_map.insert(
+                                sub_root_accessors.clone(),
+                                document_schema.schema_uri.clone(),
+                            );
                             let new_source = SourceSchema::new(
                                 None,
                                 sub_schema_uri_map,
@@ -871,7 +878,7 @@ impl SchemaStore {
                 for (accessors, schema_uri) in &source_schema.sub_schema_uri_map {
                     log::trace!(
                         "find sub schema {:?} from {}",
-                        SchemaAccessors::from(accessors.clone()),
+                        RootAccessors::from(accessors.clone()),
                         schema_uri
                     );
                 }
@@ -893,7 +900,7 @@ impl SchemaStore {
             catalog_uri: None,
             include,
             toml_version: options.toml_version,
-            sub_root_keys: None,
+            sub_root_accessors: None,
         };
 
         let mut schemas = self.schemas.write().await;

--- a/crates/tombi-validator/src/comment_directive/document.rs
+++ b/crates/tombi-validator/src/comment_directive/document.rs
@@ -42,7 +42,7 @@ pub async fn get_tombi_document_comment_directive_and_diagnostics(
 
         let source_schema = tombi_schema_store::SourceSchema::new(
             Some(Arc::new(document_schema)),
-            tombi_hashmap::HashMap::with_capacity(0),
+            tombi_hashmap::IndexMap::with_capacity(0),
             Some(toml_version),
             None,
         );

--- a/crates/tombi-validator/src/comment_directive/value.rs
+++ b/crates/tombi-validator/src/comment_directive/value.rs
@@ -407,7 +407,7 @@ pub async fn get_comment_directive_document_tree_and_diagnostics<'a>(
         Some(Arc::new(
             comment_directive_document_schema(schema_store, schema_uri).await,
         )),
-        tombi_hashmap::HashMap::with_capacity(0),
+        tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
     );

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -840,7 +840,7 @@ include = ["pyproject.toml"]
 deprecated = "warn"
 ```
 
-- `root`: The accessor path to apply the sub-schema (e.g., `"tools.tombi"`, `"items[0].name"`)
+- `root`: The accessor path to apply the sub-schema (e.g., `"tools.tombi"`, `"tool.*"`, `"tool.'*'"`, `"items[0].name"`). Use bare `*` for any key segment and `[*]` for any array element. If you need the literal key `*`, quote it as `'*'` or `"*"`.
 - `path`: The schema path (URL or local file path)
 - `include`: File match patterns to apply this schema (supports glob patterns)
 - `lint.rules.deprecated`(optional): Override the deprecated diagnostic level for this schema with `"off"`, `"warn"`, or `"error"`


### PR DESCRIPTION
This adds a dedicated RootAccessor type for `schemas[*].root` so wildcard matching can be implemented without changing existing SchemaAccessor behavior. Bare `*` now matches any key segment, `[*]` matches any array element, and quoted `"*"` or `'*'` keep the literal `*` key. Subschema resolution now preserves existing first-match-wins behavior while keeping root accessor order stable during lookup and completion. Updated comment-directive plumbing, completion handling, docs, and lockfile metadata to match the new root accessor path parsing.