### PR TITLE
Abort did_open background tasks on LSP shutdown

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -45,6 +45,7 @@ pub struct Backend {
     #[allow(dead_code)]
     pub client: tower_lsp::Client,
     pub capabilities: Arc<tokio::sync::RwLock<BackendCapabilities>>,
+    pub background_tasks: Arc<std::sync::Mutex<Vec<tokio::task::AbortHandle>>>,
     pub document_sources:
         Arc<tokio::sync::RwLock<tombi_hashmap::HashMap<tombi_uri::Uri, DocumentSource>>>,
     pub config_manager: Arc<ConfigManager>,
@@ -88,8 +89,31 @@ impl Backend {
                 encoding_kind: EncodingKind::default(),
                 diagnostic_mode: DiagnosticMode::Push,
             })),
+            background_tasks: Default::default(),
             document_sources: Default::default(),
             config_manager: Arc::new(ConfigManager::new(options)),
+        }
+    }
+
+    pub fn register_background_task(
+        &self,
+        task: &tokio::task::JoinHandle<impl Send + 'static>,
+    ) {
+        let mut background_tasks = self
+            .background_tasks
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        background_tasks.push(task.abort_handle());
+    }
+
+    pub fn abort_background_tasks(&self) {
+        let mut background_tasks = self
+            .background_tasks
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+
+        for task in background_tasks.drain(..) {
+            task.abort();
         }
     }
 
@@ -245,6 +269,12 @@ impl Backend {
     }
 }
 
+impl Drop for Backend {
+    fn drop(&mut self) {
+        self.abort_background_tasks();
+    }
+}
+
 #[tower_lsp::async_trait]
 impl tower_lsp::LanguageServer for Backend {
     async fn initialize(
@@ -259,7 +289,7 @@ impl tower_lsp::LanguageServer for Backend {
     }
 
     async fn shutdown(&self) -> Result<(), tower_lsp::jsonrpc::Error> {
-        handle_shutdown().await
+        handle_shutdown(self).await
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -103,6 +103,7 @@ impl Backend {
             .background_tasks
             .lock()
             .unwrap_or_else(|error| error.into_inner());
+        background_tasks.retain(|task| !task.is_finished());
         background_tasks.push(task.abort_handle());
     }
 

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -65,6 +65,7 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
     backend.push_diagnostics(text_document_uri).await;
 
     if let Some(handle) = cache_warming_handle {
+        backend.register_background_task(&handle);
         let client = backend.client.clone();
         let refresh_task = tokio::spawn(async move {
             let Ok(should_refresh_inlay_hint) = handle.await else {

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -66,7 +66,7 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
 
     if let Some(handle) = cache_warming_handle {
         let client = backend.client.clone();
-        tokio::spawn(async move {
+        let refresh_task = tokio::spawn(async move {
             let Ok(should_refresh_inlay_hint) = handle.await else {
                 return;
             };
@@ -75,5 +75,6 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
                 log::debug!("Failed to request warmed inlay hint refresh: {err}");
             }
         });
+        backend.register_background_task(&refresh_task);
     }
 }

--- a/crates/tombi-lsp/src/handler/shutdown.rs
+++ b/crates/tombi-lsp/src/handler/shutdown.rs
@@ -1,5 +1,8 @@
-pub async fn handle_shutdown() -> Result<(), tower_lsp::jsonrpc::Error> {
+use crate::Backend;
+
+pub async fn handle_shutdown(backend: &Backend) -> Result<(), tower_lsp::jsonrpc::Error> {
     log::info!("handle_shutdown");
+    backend.abort_background_tasks();
 
     Ok(())
 }

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -1353,6 +1353,8 @@ mod completion_edit {
                     }
                 }
 
+                backend.abort_background_tasks();
+
                 pretty_assertions::assert_eq!(new_text, textwrap::dedent($expected).trim());
 
                 Ok(())

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -70,20 +70,21 @@ pub async fn did_open(
             return false;
         }
 
+        let should_refresh_inlay_hint = !urls.awaited.is_empty();
+
         if !urls.background.is_empty() {
-            let background_urls = urls.background;
             let background_cache_options = cache_options.clone();
+            let background_urls = urls.background;
             tokio::spawn(async move {
                 warm_urls(background_urls, offline, background_cache_options).await;
             });
         }
 
-        if urls.awaited.is_empty() {
-            return false;
+        if !urls.awaited.is_empty() {
+            warm_urls(urls.awaited, offline, cache_options).await;
         }
 
-        warm_urls(urls.awaited, offline, cache_options).await;
-        true
+        should_refresh_inlay_hint
     });
 
     Ok(Some(handle))

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -71,18 +71,22 @@ pub async fn did_open(
         }
 
         let should_refresh_inlay_hint = !urls.awaited.is_empty();
+        let awaited_urls = urls.awaited;
+        let background_urls = urls.background;
+        let background_cache_options = cache_options.clone();
 
-        if !urls.background.is_empty() {
-            let background_cache_options = cache_options.clone();
-            let background_urls = urls.background;
-            tokio::spawn(async move {
-                warm_urls(background_urls, offline, background_cache_options).await;
-            });
-        }
-
-        if !urls.awaited.is_empty() {
-            warm_urls(urls.awaited, offline, cache_options).await;
-        }
+        tokio::join!(
+            async move {
+                if !background_urls.is_empty() {
+                    warm_urls(background_urls, offline, background_cache_options).await;
+                }
+            },
+            async move {
+                if !awaited_urls.is_empty() {
+                    warm_urls(awaited_urls, offline, cache_options).await;
+                }
+            }
+        );
 
         should_refresh_inlay_hint
     });


### PR DESCRIPTION
## Summary
- track background refresh tasks spawned from LSP `did_open`
- abort tracked tasks during shutdown and backend drop to avoid leaks
- only request inlay hint refresh when Cargo cache warming actually awaited URLs

## Testing
- cargo test -p tombi-extension-cargo keeps_did_open_caches_bounded
- cargo test -p tombi-extension-cargo did_open_ignores_non_cargo_documents
- cargo test -p tombi-lsp shutdown -- --nocapture