### PR TITLE
break: change document-link sub-features to default-false

### DIFF
--- a/crates/tombi-config/src/extensions.rs
+++ b/crates/tombi-config/src/extensions.rs
@@ -218,7 +218,7 @@ impl From<&EnabledOnly> for Option<ToggleFeatureDefaultTrue> {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]

--- a/crates/tombi-config/src/extensions/cargo.rs
+++ b/crates/tombi-config/src/extensions/cargo.rs
@@ -35,7 +35,7 @@ extension_features! {
 
 #[cfg(all(test, feature = "serde"))]
 mod tests {
-    use crate::BoolDefaultTrue;
+    use crate::ToggleFeatureDefaultFalse;
     use crate::extensions::ToggleFeatureDefaultTrue;
 
     use super::{CargoDocumentLinkFeatureTree, CargoInlayHintFeatureTree};
@@ -52,7 +52,7 @@ mod tests {
         assert_eq!(
             features.workspace_value,
             Some(ToggleFeatureDefaultTrue {
-                enabled: Some(BoolDefaultTrue::from(false)),
+                enabled: Some(false.into()),
             })
         );
     }
@@ -63,7 +63,7 @@ mod tests {
             dependency_version: None,
             default_features: None,
             workspace_value: Some(ToggleFeatureDefaultTrue {
-                enabled: Some(BoolDefaultTrue::from(false)),
+                enabled: Some(false.into()),
             }),
         })
         .expect("workspace-value should serialize");
@@ -88,8 +88,8 @@ mod tests {
 
         assert_eq!(
             features.workspace,
-            Some(ToggleFeatureDefaultTrue {
-                enabled: Some(BoolDefaultTrue::from(false)),
+            Some(ToggleFeatureDefaultFalse {
+                enabled: Some(false.into()),
             })
         );
     }
@@ -98,8 +98,8 @@ mod tests {
     fn cargo_document_link_feature_tree_serializes_workspace_key() {
         let value = serde_json::to_value(CargoDocumentLinkFeatureTree {
             cargo_toml: None,
-            workspace: Some(ToggleFeatureDefaultTrue {
-                enabled: Some(BoolDefaultTrue::from(false)),
+            workspace: Some(ToggleFeatureDefaultFalse {
+                enabled: Some(false.into()),
             }),
             git: None,
             path: None,

--- a/crates/tombi-config/src/extensions/cargo/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/document_link.rs
@@ -1,4 +1,7 @@
-use crate::extensions::{EnabledOnly, ToggleFeatureDefaultTrue};
+use crate::{
+    ToggleFeatureDefaultFalse,
+    extensions::{EnabledOnly, ToggleFeatureDefaultTrue},
+};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -27,7 +30,7 @@ toggle_features! {
         /// # Cargo.toml document link feature
         ///
         /// Whether document links are created for `Cargo.toml` references.
-        pub cargo_toml: Option<ToggleFeatureDefaultTrue>,
+        pub cargo_toml: Option<ToggleFeatureDefaultFalse>,
 
         /// # crates.io document link feature
         ///
@@ -37,16 +40,16 @@ toggle_features! {
         /// # Git document link feature
         ///
         /// Whether document links are created for Git references.
-        pub git: Option<ToggleFeatureDefaultTrue>,
+        pub git: Option<ToggleFeatureDefaultFalse>,
 
         /// # Path document link feature
         ///
         /// Whether document links are created for filesystem paths.
-        pub path: Option<ToggleFeatureDefaultTrue>,
+        pub path: Option<ToggleFeatureDefaultFalse>,
 
         /// # Workspace document link feature
         ///
         /// Whether document links are created for `workspace = true` references.
-        pub workspace: Option<ToggleFeatureDefaultTrue>,
+        pub workspace: Option<ToggleFeatureDefaultFalse>,
     }
 }

--- a/crates/tombi-config/src/extensions/pyproject/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/pyproject/lsp/document_link.rs
@@ -1,4 +1,7 @@
-use crate::extensions::{EnabledOnly, ToggleFeatureDefaultTrue};
+use crate::{
+    ToggleFeatureDefaultFalse,
+    extensions::{EnabledOnly, ToggleFeatureDefaultTrue},
+};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -27,7 +30,7 @@ toggle_features! {
         /// # pyproject.toml document link feature
         ///
         /// Whether document links are created for `pyproject.toml` references.
-        pub pyproject_toml: Option<ToggleFeatureDefaultTrue>,
+        pub pyproject_toml: Option<ToggleFeatureDefaultFalse>,
 
         /// # PyPI document link feature
         ///

--- a/crates/tombi-config/src/extensions/tombi/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/tombi/lsp/document_link.rs
@@ -1,4 +1,4 @@
-use crate::extensions::{EnabledOnly, ToggleFeatureDefaultTrue};
+use crate::{ToggleFeatureDefaultFalse, extensions::EnabledOnly};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -27,6 +27,6 @@ toggle_features! {
         /// # Path document link feature
         ///
         /// Whether document links are created for filesystem paths.
-        pub path: Option<ToggleFeatureDefaultTrue>,
+        pub path: Option<ToggleFeatureDefaultFalse>,
     }
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled-bin/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled-bin/tombi.toml
@@ -1,2 +1,9 @@
 [extensions]
-"tombi-toml/cargo" = { lsp.document-link.cargo-toml.enabled = false }
+"tombi-toml/cargo" = {
+  lsp = {
+    document-link = {
+      cargo-toml.enabled = false,
+      path.enabled = true,
+    },
+  },
+}

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
@@ -1,2 +1,11 @@
 [extensions]
-"tombi-toml/cargo" = { lsp.document-link.cargo-toml.enabled = false }
+"tombi-toml/cargo" = {
+  lsp = {
+    document-link = {
+      cargo-toml.enabled = false,
+      path.enabled = true,
+      workspace.enabled = true,
+      git.enabled = true,
+    },
+  },
+}

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = ["member"]
+
+[workspace.dependencies]
+member = { path = "member" }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/member/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/member/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "member"
+version = "0.1.0"
+edition = "2024"

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/cargo" = {}

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test-git-disabled"
+version = "0.1.0"
+edition = "2024"

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/tombi.toml
@@ -3,8 +3,7 @@
   lsp = {
     document-link = {
       cargo-toml.enabled = true,
-      crates-io.enabled = false,
-      path.enabled = true,
+      git.enabled = false,
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
@@ -2,6 +2,7 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
+      cargo-toml.enabled = true,
       workspace.enabled = false,
       path.enabled = false,
     },

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
@@ -3,6 +3,7 @@
   lsp = {
     document-link = {
       cargo-toml.enabled = false,
+      workspace.enabled = true,
       path.enabled = false,
     },
   },

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/member/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/member/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "member"
+version = "0.1.0"

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "pyproject-document-link-default"
+version = "0.1.0"
+dependencies = [
+  "anyio>=4.0",
+  "member",
+]
+
+[tool.uv.workspace]
+members = ["member"]
+
+[tool.uv.sources]
+member = { workspace = true }

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/pyproject" = {}

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/tombi.toml
@@ -1,2 +1,9 @@
 [extensions]
-"tombi-toml/pyproject" = { lsp.document-link.pypi-org.enabled = false }
+"tombi-toml/pyproject" = {
+  lsp = {
+    document-link = {
+      pypi-org.enabled = false,
+      pyproject-toml.enabled = true,
+    },
+  },
+}

--- a/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-default/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-default/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/tombi" = {}

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -725,6 +725,42 @@ mod document_link_tests {
                 }
             ]));
         );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn cargo_git_dependency_links_disabled_by_git_setting(
+                r#"
+                [package]
+                name = "test"
+                version = "0.1.0"
+
+                [dependencies]
+                serde = { git = "https://github.com/serde-rs/serde" }
+                "#,
+                SourcePath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/Cargo.toml"
+                )),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://crates.io/crates/serde",
+                    range: 5:0..5:5,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CrateIo,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn cargo_default_features_produce_no_document_links(
+                r#"
+                [workspace.dependencies]
+                member = { path = "member" }
+                "#,
+                SourcePath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-default/Cargo.toml"
+                )),
+            ) -> Ok(None);
+        );
     }
 
     mod tombi_schema {
@@ -913,6 +949,48 @@ mod document_link_tests {
                     tooltip: "Open PyPI Package",
                 }
             ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn pyproject_default_features_disable_pyproject_toml_links(
+                r#"
+                [project]
+                dependencies = ["member", "anyio>=4.0"]
+
+                [tool.uv.workspace]
+                members = ["member"]
+
+                [tool.uv.sources]
+                member = { workspace = true }
+                "#,
+                SourcePath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-default/pyproject.toml"
+                )),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://pypi.org/project/anyio/",
+                    range: 1:27..1:37,
+                    tooltip: "Open PyPI Package",
+                }
+            ]));
+        );
+    }
+
+    mod tombi_schema_default {
+        use super::*;
+
+        test_document_link!(
+            #[tokio::test]
+            async fn tombi_default_features_produce_no_path_document_links(
+                r#"
+                [schema]
+                catalog = { path = "https://www.schemastore.org/api/json/catalog.json" }
+                "#,
+                SourcePath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-default/tombi.toml"
+                )),
+            ) -> Ok(None);
         );
     }
 }

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -1136,7 +1136,8 @@ mod tests {
     use tombi_document_tree::dig_keys;
 
     use crate::document_link::{
-        cargo_toml_document_link_enabled, dependency_key_tooltip, workspace_document_link_enabled,
+        cargo_toml_document_link_enabled, crates_io_document_link_enabled, dependency_key_tooltip,
+        git_document_link_enabled, path_document_link_enabled, workspace_document_link_enabled,
     };
 
     use super::{RegistryMap, document_link_for_dependency};
@@ -1151,10 +1152,12 @@ mod tests {
                     goto_declaration: None,
                     document_link: Some(tombi_config::CargoDocumentLinkFeatures::Features(
                         tombi_config::CargoDocumentLinkFeatureTree {
-                            cargo_toml: None,
+                            cargo_toml: Some(tombi_config::ToggleFeatureDefaultFalse {
+                                enabled: Some(true.into()),
+                            }),
                             workspace: None,
                             git: None,
-                            path: Some(tombi_config::ToggleFeatureDefaultTrue {
+                            path: Some(tombi_config::ToggleFeatureDefaultFalse {
                                 enabled: Some(false.into()),
                             }),
                             crates_io: None,
@@ -1177,12 +1180,16 @@ mod tests {
                     goto_declaration: None,
                     document_link: Some(tombi_config::CargoDocumentLinkFeatures::Features(
                         tombi_config::CargoDocumentLinkFeatureTree {
-                            cargo_toml: Some(tombi_config::ToggleFeatureDefaultTrue {
+                            cargo_toml: Some(tombi_config::ToggleFeatureDefaultFalse {
                                 enabled: Some(false.into()),
                             }),
-                            workspace: None,
+                            workspace: Some(tombi_config::ToggleFeatureDefaultFalse {
+                                enabled: Some(true.into()),
+                            }),
                             git: None,
-                            path: None,
+                            path: Some(tombi_config::ToggleFeatureDefaultFalse {
+                                enabled: Some(true.into()),
+                            }),
                             crates_io: None,
                         },
                     )),
@@ -1204,7 +1211,7 @@ mod tests {
                     document_link: Some(tombi_config::CargoDocumentLinkFeatures::Features(
                         tombi_config::CargoDocumentLinkFeatureTree {
                             cargo_toml: None,
-                            workspace: Some(tombi_config::ToggleFeatureDefaultTrue {
+                            workspace: Some(tombi_config::ToggleFeatureDefaultFalse {
                                 enabled: Some(false.into()),
                             }),
                             git: None,
@@ -1372,5 +1379,91 @@ version = "0.1.0"
         );
 
         assert!(tooltip.is_none());
+    }
+
+    fn default_link_features() -> tombi_config::CargoExtensionFeatures {
+        tombi_config::CargoExtensionFeatures::Features(tombi_config::CargoExtensionFeatureTree {
+            lsp: Some(tombi_config::CargoLspFeatures::Features(
+                tombi_config::CargoLspFeatureTree {
+                    completion: None,
+                    inlay_hint: None,
+                    goto_definition: None,
+                    goto_declaration: None,
+                    document_link: Some(tombi_config::CargoDocumentLinkFeatures::Features(
+                        tombi_config::CargoDocumentLinkFeatureTree {
+                            cargo_toml: None,
+                            workspace: None,
+                            git: None,
+                            path: None,
+                            crates_io: None,
+                        },
+                    )),
+                    hover: None,
+                    code_action: None,
+                },
+            )),
+        })
+    }
+
+    #[test]
+    fn default_features_disable_cargo_toml_document_link() {
+        let features = default_link_features();
+        assert!(!cargo_toml_document_link_enabled(Some(&features)));
+    }
+
+    #[test]
+    fn default_features_disable_git_document_link() {
+        let features = default_link_features();
+        assert!(!git_document_link_enabled(Some(&features)));
+    }
+
+    #[test]
+    fn default_features_disable_path_document_link() {
+        let features = default_link_features();
+        assert!(!path_document_link_enabled(Some(&features)));
+    }
+
+    #[test]
+    fn default_features_disable_workspace_document_link() {
+        let features = default_link_features();
+        assert!(!workspace_document_link_enabled(Some(&features)));
+    }
+
+    #[test]
+    fn default_features_keep_crates_io_document_link_enabled() {
+        let features = default_link_features();
+        assert!(crates_io_document_link_enabled(Some(&features)));
+    }
+
+    fn disabled_git_link_features() -> tombi_config::CargoExtensionFeatures {
+        tombi_config::CargoExtensionFeatures::Features(tombi_config::CargoExtensionFeatureTree {
+            lsp: Some(tombi_config::CargoLspFeatures::Features(
+                tombi_config::CargoLspFeatureTree {
+                    completion: None,
+                    inlay_hint: None,
+                    goto_definition: None,
+                    goto_declaration: None,
+                    document_link: Some(tombi_config::CargoDocumentLinkFeatures::Features(
+                        tombi_config::CargoDocumentLinkFeatureTree {
+                            cargo_toml: None,
+                            workspace: None,
+                            git: Some(tombi_config::ToggleFeatureDefaultFalse {
+                                enabled: Some(false.into()),
+                            }),
+                            path: None,
+                            crates_io: None,
+                        },
+                    )),
+                    hover: None,
+                    code_action: None,
+                },
+            )),
+        })
+    }
+
+    #[test]
+    fn git_document_link_disabled_by_setting() {
+        let features = disabled_git_link_features();
+        assert!(!git_document_link_enabled(Some(&features)));
     }
 }

--- a/tombi.toml
+++ b/tombi.toml
@@ -56,6 +56,7 @@ include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
       crates-io.enabled = true,
       git.enabled = true,
       path.enabled = true,
+      workspace.enabled = true,
     },
     goto-declaration = {
       dependency.enabled = true,


### PR DESCRIPTION
## Summary
- Switch cargo (`cargo-toml`, `git`, `path`, `workspace`), pyproject (`pyproject-toml`), and tombi (`path`) document-link sub-features from `ToggleFeatureDefaultTrue` to `ToggleFeatureDefaultFalse`, making them opt-in
- Add `Copy` derive to `ToggleFeatureDefaultFalse` to match `ToggleFeatureDefaultTrue`
- Add `workspace.enabled = true` to root `tombi.toml` document-link config
- Update test fixtures to explicitly enable features they depend on
- Add unit tests verifying default (unset) behavior for all affected sub-features
- Add LSP integration tests for git-disabled, cargo/pyproject/tombi default-unset scenarios

## Test plan
- [x] `cargo nextest run --package tombi-config` — 609 tests pass
- [x] `cargo nextest run --package tombi-extension-cargo` — 12 document_link tests pass (6 new)
- [x] `cargo nextest run --package tombi-lsp` — 44 document_link tests pass (4 new)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --workspace` no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)