### PR TITLE
Fix missing default completion for composite schemas

### DIFF
--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -137,7 +137,7 @@ where
             }
         }
 
-        if !valid_branches && !narrow_branches {
+        if !narrow_branches {
             if let Some(default) = &any_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -137,7 +137,7 @@ where
             }
         }
 
-        if !narrow_branches {
+        if !narrow_branches && keys.is_empty() {
             if let Some(default) = &any_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -141,7 +141,7 @@ where
             }
         }
 
-        if !narrow_branches {
+        if !narrow_branches && keys.is_empty() {
             if let Some(default) = &one_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -141,7 +141,7 @@ where
             }
         }
 
-        if !valid_branches && !narrow_branches {
+        if !narrow_branches {
             if let Some(default) = &one_of_schema.default {
                 let default_label = default.to_string();
                 if let Some(completion_item) = completion_items

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -553,6 +553,20 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
+            async fn tombi_format_rules_array_bracket_space_width(
+                r#"
+                [format.rules]
+                array-bracket-space-width = █
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "0",
+                "42",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
             async fn tombi_lsp_comp(
                 r#"
                 [lsp]


### PR DESCRIPTION
## Summary
- keep top-level anyOf/oneOf defaults and examples visible unless branch narrowing is active
- restore the `0` default completion for `tombi.toml` format rules like `array-bracket-space-width`
- add an LSP completion test covering the `tombi.toml` regression

## Testing
- cargo test -p tombi-lsp tombi_format_rules_array_bracket_space_width --test test_completion_labels
- cargo test -p tombi-lsp tombi_lsp_completion --test test_completion_labels