### PR TITLE
fix: avoid LSP hangs when document source lock is contended

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -318,15 +318,16 @@ impl tower_lsp::LanguageServer for Backend {
         &self,
         params: CompletionParams,
     ) -> Result<Option<CompletionResponse>, tower_lsp::jsonrpc::Error> {
-        let document_source = self.document_sources.read().await;
-        let Some(document_source) = document_source.get(
-            &params
-                .text_document_position
-                .text_document
-                .uri
-                .clone()
-                .into(),
-        ) else {
+        let text_document_uri = params
+            .text_document_position
+            .text_document
+            .uri
+            .clone()
+            .into();
+        let Ok(document_sources) = self.document_sources.try_read() else {
+            return Ok(None);
+        };
+        let Some(document_source) = document_sources.get(&text_document_uri) else {
             return Ok(None);
         };
 
@@ -364,33 +365,37 @@ impl tower_lsp::LanguageServer for Backend {
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>, tower_lsp::jsonrpc::Error> {
-        let document_source = self.document_sources.read().await;
-        let Some(document_source) = document_source.get(
-            &params
-                .text_document_position_params
-                .text_document
-                .uri
-                .clone()
-                .into(),
-        ) else {
-            return Ok(None);
+        let text_document_uri = params
+            .text_document_position_params
+            .text_document
+            .uri
+            .clone()
+            .into();
+        let line_index = {
+            let Ok(document_sources) = self.document_sources.try_read() else {
+                return Ok(None);
+            };
+            let Some(document_source) = document_sources.get(&text_document_uri) else {
+                return Ok(None);
+            };
+            document_source.line_index_arc()
         };
-        let line_index = document_source.line_index();
 
         handle_hover(self, params)
             .await
-            .map(|response| response.map(|content| content.into_lsp(line_index)))
+            .map(|response| response.map(|content| content.into_lsp(line_index.as_ref())))
     }
 
     async fn inlay_hint(
         &self,
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>, tower_lsp::jsonrpc::Error> {
+        let text_document_uri = params.text_document.uri.clone().into();
         let line_index = {
-            let document_sources = self.document_sources.read().await;
-            let Some(document_source) =
-                document_sources.get(&params.text_document.uri.clone().into())
-            else {
+            let Ok(document_sources) = self.document_sources.try_read() else {
+                return Ok(None);
+            };
+            let Some(document_source) = document_sources.get(&text_document_uri) else {
                 return Ok(None);
             };
             document_source.line_index_arc()

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -71,7 +71,9 @@ pub async fn get_diagnostics_result(
     }
 
     let (text, version, toml_version, encoding_kind) = {
-        let document_sources = backend.document_sources.read().await;
+        let Ok(document_sources) = backend.document_sources.try_read() else {
+            return None;
+        };
         let document_source = document_sources.get(text_document_uri)?;
         (
             document_source.text_arc(),

--- a/crates/tombi-lsp/src/goto_definition.rs
+++ b/crates/tombi-lsp/src/goto_definition.rs
@@ -26,7 +26,7 @@ pub async fn into_definition_locations(
         }
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let document_sources = backend.document_sources.try_read().ok();
 
     let locations = definitions
         .into_iter()
@@ -34,10 +34,12 @@ pub async fn into_definition_locations(
             if let Some(remote_uri) = uri_set.get(&definition.uri) {
                 definition.uri = remote_uri.clone();
             }
-            let range = if let Some(document_source) = document_sources.get(&definition.uri) {
-                definition.range.into_lsp(document_source.line_index())
-            } else {
-                tombi_text::convert_range_to_lsp(definition.range)
+            let range = match document_sources
+                .as_ref()
+                .and_then(|ds| ds.get(&definition.uri))
+            {
+                Some(document_source) => definition.range.into_lsp(document_source.line_index()),
+                None => tombi_text::convert_range_to_lsp(definition.range),
             };
             tower_lsp::lsp_types::Location {
                 uri: definition.uri.into(),

--- a/crates/tombi-lsp/src/handler/code_action.rs
+++ b/crates/tombi-lsp/src/handler/code_action.rs
@@ -41,7 +41,9 @@ pub async fn handle_code_action(
         return Ok(None);
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(None);
     };

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -65,7 +65,9 @@ pub async fn handle_completion(
         return Ok(None);
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         log::trace!("document_source not found");
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/did_save.rs
+++ b/crates/tombi-lsp/src/handler/did_save.rs
@@ -29,7 +29,6 @@ pub async fn handle_did_save(backend: &Backend, params: DidSaveTextDocumentParam
 
             document.set_text(text, toml_version);
         };
-        drop(document_sources);
     };
 
     // Publish diagnostics for the saved document

--- a/crates/tombi-lsp/src/handler/document_link.rs
+++ b/crates/tombi-lsp/src/handler/document_link.rs
@@ -32,7 +32,9 @@ pub async fn handle_document_link(
         return Ok(None);
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(None);
     };

--- a/crates/tombi-lsp/src/handler/document_symbol.rs
+++ b/crates/tombi-lsp/src/handler/document_symbol.rs
@@ -16,7 +16,9 @@ pub async fn handle_document_symbol(
 
     let text_document_uri = text_document.uri.into();
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(None);
     };

--- a/crates/tombi-lsp/src/handler/folding_range.rs
+++ b/crates/tombi-lsp/src/handler/folding_range.rs
@@ -14,7 +14,9 @@ pub async fn handle_folding_range(
     let FoldingRangeParams { text_document, .. } = params;
     let text_document_uri = text_document.uri.into();
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(None);
     };

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -71,12 +71,21 @@ pub async fn handle_formatting(
         }
     }
 
-    let mut document_sources = backend.document_sources.write().await;
-    let Some(document_source) = document_sources.get_mut(&text_document_uri) else {
-        return Ok(None);
-    };
+    let (toml_version, document_text, line_index, version) = {
+        let Ok(document_sources) = backend.document_sources.try_read() else {
+            return Ok(None);
+        };
+        let Some(document_source) = document_sources.get(&text_document_uri) else {
+            return Ok(None);
+        };
 
-    let toml_version = document_source.toml_version;
+        (
+            document_source.toml_version,
+            document_source.text_arc(),
+            document_source.line_index_arc(),
+            document_source.version,
+        )
+    };
 
     // Get format options with override support
     let text_document_path = text_document_uri.to_file_path().ok();
@@ -98,18 +107,20 @@ pub async fn handle_formatting(
         Some(Either::Left(&text_document_uri)),
         &schema_store,
     )
-    .format(document_source.text())
+    .format(document_text.as_ref())
     .await
     {
         Ok(formatted) => {
-            if document_source.text() != formatted {
-                let edits = compute_text_edits(
-                    document_source.text(),
-                    &formatted,
-                    document_source.line_index(),
-                );
+            if document_text.as_ref() != formatted {
+                let edits =
+                    compute_text_edits(document_text.as_ref(), &formatted, line_index.as_ref());
                 log::debug!("{:?}", edits);
-                document_source.set_text(formatted, toml_version);
+                if let Ok(mut document_sources) = backend.document_sources.try_write()
+                    && let Some(document_source) = document_sources.get_mut(&text_document_uri)
+                    && document_source.text() == document_text.as_ref()
+                {
+                    document_source.set_text(formatted, toml_version);
+                }
 
                 return Ok(Some(edits));
             } else {
@@ -119,23 +130,22 @@ pub async fn handle_formatting(
                     .send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
                         uri: text_document_uri.into(),
                         diagnostics: Vec::with_capacity(0),
-                        version: document_source.version,
+                        version,
                     })
                     .await;
             }
         }
         Err(diagnostics) => {
             log::error!("Failed to format");
-            let line_index = document_source.line_index();
             backend
                 .client
                 .send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
                     uri: text_document_uri.into(),
                     diagnostics: diagnostics
                         .into_iter()
-                        .map(|diagnostic| diagnostic.into_lsp(line_index))
+                        .map(|diagnostic| diagnostic.into_lsp(line_index.as_ref()))
                         .collect_vec(),
-                    version: document_source.version,
+                    version,
                 })
                 .await;
         }

--- a/crates/tombi-lsp/src/handler/get_status.rs
+++ b/crates/tombi-lsp/src/handler/get_status.rs
@@ -34,66 +34,55 @@ pub async fn handle_get_status(
                 .text_document_toml_version_and_source(&text_document_uri, document_source.text())
                 .await;
 
-            // Get schema information
-            let schema = {
-                let root = document_source.ast();
+            let root = document_source.ast();
+            // resolve_source_schema_from_ast checks the comment directive first,
+            // then falls back to other methods.
+            let schema_uri = match schema_store
+                .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))
+                .await
+            {
+                Ok(Some(source_schema)) => source_schema
+                    .root_schema
+                    .as_ref()
+                    .map(|s| s.schema_uri.clone()),
+                _ => None,
+            };
 
-                // Get schema URI from resolve_source_schema_from_ast
-                // (internally checks comment directive first, then falls back to other methods)
-                let schema_uri = match schema_store
-                    .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))
-                    .await
-                {
-                    Ok(Some(source_schema)) => source_schema
-                        .root_schema
-                        .as_ref()
-                        .map(|s| s.schema_uri.clone()),
-                    _ => None,
-                };
-
-                // If schema URI is available, get detailed information
-                if let Some(schema_uri) = schema_uri {
-                    // First, search in list_schemas
-                    let schemas = schema_store.list_schemas().await;
-                    if let Some(schema) = schemas.iter().find(|s| s.schema_uri == schema_uri) {
-                        Some(SchemaStatus {
-                            title: schema.title.clone(),
-                            description: schema.description.clone(),
-                            uri: schema_uri,
-                        })
-                    } else {
-                        // If not found in list_schemas, get from DocumentSchema
-                        match schema_store.try_get_document_schema(&schema_uri).await {
-                            Ok(Some(doc_schema)) => {
-                                // Get title/description from DocumentSchema
-                                let (title, description) =
-                                    if let Some(value_schema) = &doc_schema.value_schema {
-                                        (
-                                            value_schema.title().map(|s| s.to_string()),
-                                            value_schema.description().map(|s| s.to_string()),
-                                        )
-                                    } else {
-                                        (None, None)
-                                    };
-                                Some(SchemaStatus {
-                                    title,
-                                    description,
-                                    uri: schema_uri,
-                                })
-                            }
-                            _ => {
-                                // Return URI only even if schema cannot be retrieved
-                                Some(SchemaStatus {
-                                    title: None,
-                                    description: None,
-                                    uri: schema_uri,
-                                })
-                            }
-                        }
-                    }
+            let schema = if let Some(schema_uri) = schema_uri {
+                let schemas = schema_store.list_schemas().await;
+                if let Some(schema) = schemas.iter().find(|s| s.schema_uri == schema_uri) {
+                    Some(SchemaStatus {
+                        title: schema.title.clone(),
+                        description: schema.description.clone(),
+                        uri: schema_uri,
+                    })
                 } else {
-                    None
+                    match schema_store.try_get_document_schema(&schema_uri).await {
+                        Ok(Some(doc_schema)) => {
+                            let (title, description) =
+                                if let Some(value_schema) = &doc_schema.value_schema {
+                                    (
+                                        value_schema.title().map(|s| s.to_string()),
+                                        value_schema.description().map(|s| s.to_string()),
+                                    )
+                                } else {
+                                    (None, None)
+                                };
+                            Some(SchemaStatus {
+                                title,
+                                description,
+                                uri: schema_uri,
+                            })
+                        }
+                        _ => Some(SchemaStatus {
+                            title: None,
+                            description: None,
+                            uri: schema_uri,
+                        }),
+                    }
                 }
+            } else {
+                None
             };
 
             (toml_version, source, schema)

--- a/crates/tombi-lsp/src/handler/get_toml_version.rs
+++ b/crates/tombi-lsp/src/handler/get_toml_version.rs
@@ -14,7 +14,12 @@ pub async fn handle_get_toml_version(
     let text_document_uri = uri.into();
 
     let (toml_version, source) = {
-        let document_sources = backend.document_sources.read().await;
+        let Ok(document_sources) = backend.document_sources.try_read() else {
+            return Ok(GetTomlVersionResponse {
+                toml_version: TomlVersion::default(),
+                source: TomlVersionSource::Default,
+            });
+        };
         if let Some(document_source) = document_sources.get(&text_document_uri) {
             backend
                 .text_document_toml_version_and_source(&text_document_uri, document_source.text())

--- a/crates/tombi-lsp/src/handler/goto_declaration.rs
+++ b/crates/tombi-lsp/src/handler/goto_declaration.rs
@@ -40,7 +40,9 @@ pub async fn handle_goto_declaration(
         return Ok(None);
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(None);
     };

--- a/crates/tombi-lsp/src/handler/goto_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_definition.rs
@@ -39,7 +39,9 @@ pub async fn handle_goto_definition(
         return Ok(Default::default());
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(Default::default());
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(Default::default());
     };

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -51,7 +51,9 @@ pub async fn handle_goto_type_definition(
         return Ok(Default::default());
     }
 
-    let document_sources = backend.document_sources.read().await;
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(Default::default());
+    };
     let Some(document_source) = document_sources.get(&text_document_uri) else {
         return Ok(Default::default());
     };

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -49,18 +49,21 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let Ok(document_sources) = backend.document_sources.try_read() else {
-        return Ok(None);
+    let (root, document_tree, toml_version, line_index) = {
+        let Ok(document_sources) = backend.document_sources.try_read() else {
+            return Ok(None);
+        };
+        let Some(document_source) = document_sources.get(&text_document_uri) else {
+            return Ok(None);
+        };
+        (
+            document_source.ast().clone(),
+            document_source.document_tree().clone(),
+            document_source.toml_version,
+            document_source.line_index().clone(),
+        )
     };
-    let Some(document_source) = document_sources.get(&text_document_uri) else {
-        return Ok(None);
-    };
-    let (root, document_tree, toml_version, position) = (
-        document_source.ast(),
-        document_source.document_tree(),
-        document_source.toml_version,
-        position.into_lsp(document_source.line_index()),
-    );
+    let position = position.into_lsp(&line_index);
 
     let source_schema = schema_store
         .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -49,19 +49,18 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let (root, document_tree, toml_version, position) = {
-        let document_sources = backend.document_sources.read().await;
-        let Some(document_source) = document_sources.get(&text_document_uri) else {
-            return Ok(None);
-        };
-
-        (
-            document_source.ast(),
-            document_source.document_tree(),
-            document_source.toml_version,
-            position.into_lsp(document_source.line_index()),
-        )
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
     };
+    let Some(document_source) = document_sources.get(&text_document_uri) else {
+        return Ok(None);
+    };
+    let (root, document_tree, toml_version, position) = (
+        document_source.ast(),
+        document_source.document_tree(),
+        document_source.toml_version,
+        position.into_lsp(document_source.line_index()),
+    );
 
     let source_schema = schema_store
         .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -49,21 +49,18 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let (root, document_tree, toml_version, line_index) = {
-        let Ok(document_sources) = backend.document_sources.try_read() else {
-            return Ok(None);
-        };
-        let Some(document_source) = document_sources.get(&text_document_uri) else {
-            return Ok(None);
-        };
-        (
-            document_source.ast().clone(),
-            document_source.document_tree().clone(),
-            document_source.toml_version,
-            document_source.line_index().clone(),
-        )
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
     };
-    let position = position.into_lsp(&line_index);
+    let Some(document_source) = document_sources.get(&text_document_uri) else {
+        return Ok(None);
+    };
+    let (root, document_tree, toml_version, position) = (
+        document_source.ast(),
+        document_source.document_tree(),
+        document_source.toml_version,
+        position.into_lsp(document_source.line_index()),
+    );
 
     let source_schema = schema_store
         .resolve_source_schema_from_ast(&root, Some(Either::Left(&text_document_uri)))

--- a/crates/tombi-lsp/src/handler/inlay_hint.rs
+++ b/crates/tombi-lsp/src/handler/inlay_hint.rs
@@ -26,17 +26,19 @@ pub async fn handle_inlay_hint(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    let Ok(document_sources) = backend.document_sources.try_read() else {
-        return Ok(None);
+    let (document_tree, toml_version, visible_range) = {
+        let Ok(document_sources) = backend.document_sources.try_read() else {
+            return Ok(None);
+        };
+        let Some(document_source) = document_sources.get(&text_document_uri) else {
+            return Ok(None);
+        };
+        (
+            document_source.document_tree(),
+            document_source.toml_version,
+            tombi_text::Range::from_lsp(range, document_source.line_index()),
+        )
     };
-    let Some(document_source) = document_sources.get(&text_document_uri) else {
-        return Ok(None);
-    };
-    let (document_tree, toml_version, visible_range) = (
-        document_source.document_tree(),
-        document_source.toml_version,
-        tombi_text::Range::from_lsp(range, document_source.line_index()),
-    );
 
     if config.cargo_inlay_hint_enabled() {
         if let Some(hints) = tombi_extension_cargo::inlay_hint(

--- a/crates/tombi-lsp/src/handler/inlay_hint.rs
+++ b/crates/tombi-lsp/src/handler/inlay_hint.rs
@@ -26,18 +26,17 @@ pub async fn handle_inlay_hint(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    let (document_tree, toml_version, visible_range) = {
-        let document_sources = backend.document_sources.read().await;
-        let Some(document_source) = document_sources.get(&text_document_uri) else {
-            return Ok(None);
-        };
-
-        (
-            document_source.document_tree(),
-            document_source.toml_version,
-            tombi_text::Range::from_lsp(range, document_source.line_index()),
-        )
+    let Ok(document_sources) = backend.document_sources.try_read() else {
+        return Ok(None);
     };
+    let Some(document_source) = document_sources.get(&text_document_uri) else {
+        return Ok(None);
+    };
+    let (document_tree, toml_version, visible_range) = (
+        document_source.document_tree(),
+        document_source.toml_version,
+        tombi_text::Range::from_lsp(range, document_source.line_index()),
+    );
 
     if config.cargo_inlay_hint_enabled() {
         if let Some(hints) = tombi_extension_cargo::inlay_hint(


### PR DESCRIPTION
## Summary
- replace blocking `document_sources.read().await` access with `try_read()` in LSP request handlers
- return early when the document source lock is contended instead of waiting and stalling the request path
- keep formatting updates guarded with a `try_write()` and a text equality check before mutating cached source

## Testing
- cargo test -p tombi-lsp --lib

Closes #1717