### PR TITLE
fix: preserve recoverable branch completions

### DIFF
--- a/crates/tombi-lsp/src/completion/value.rs
+++ b/crates/tombi-lsp/src/completion/value.rs
@@ -2,6 +2,7 @@ mod all_of;
 mod any_of;
 mod array;
 mod boolean;
+mod branch_result;
 mod float;
 mod integer;
 mod local_date;

--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -1,12 +1,13 @@
-use itertools::Itertools;
 use tombi_extension::CompletionContentPriority;
 use tombi_future::Boxable;
-use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, ValueSchema};
+use tombi_schema_store::{Accessor, CurrentSchema};
 
 use crate::completion::{
     CompletionCandidate, CompletionContent, CompletionHint, FindCompletionContents,
     tombi_json_value_to_completion_default_item, tombi_json_value_to_completion_example_item,
 };
+
+use super::branch_result::collect_branch_completions;
 
 pub fn find_any_of_completion_items<'a: 'b, 'b, T>(
     value: &'a T,
@@ -29,12 +30,6 @@ where
     log::trace!("completion_hint = {:?}", completion_hint);
 
     async move {
-        let mut completion_items = Vec::new();
-
-        // Same branching narrow logic as oneOf: when completing the value of a single key, only
-        // consider branches that are a table containing that key; skip default/examples when narrow.
-        let first_key = (keys.len() == 1 && !keys[0].value.is_empty()).then(|| &keys[0].value);
-
         let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
             &any_of_schema.schemas,
             current_schema.schema_uri.clone(),
@@ -45,70 +40,19 @@ where
         )
         .await
         else {
-            return completion_items;
+            return Vec::new();
         };
 
-        let mut branch_results: Vec<(bool, bool, Vec<CompletionContent>)> = Vec::new();
-        for resolved_schema in &resolved_schemas {
-            let branch_has_key = if let Some(ref first_key) = first_key {
-                match resolved_schema.value_schema.as_ref() {
-                    ValueSchema::Table(table_schema) => table_schema
-                        .properties
-                        .read()
-                        .await
-                        .contains_key(&SchemaAccessor::Key(first_key.to_string())),
-                    _ => false,
-                }
-            } else {
-                false
-            };
-            let branch_is_valid = match value
-                .validate(accessors, Some(resolved_schema), schema_context)
-                .await
-            {
-                Ok(_) => true,
-                Err(tombi_validator::Error { diagnostics, .. })
-                    if diagnostics
-                        .iter()
-                        .all(tombi_diagnostic::Diagnostic::is_warning) =>
-                {
-                    true
-                }
-                _ => false,
-            };
-
-            let schema_completions = value
-                .find_completion_contents(
-                    position,
-                    keys,
-                    accessors,
-                    Some(resolved_schema),
-                    schema_context,
-                    completion_hint,
-                )
-                .await;
-
-            branch_results.push((branch_has_key, branch_is_valid, schema_completions));
-        }
-
-        let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
-        let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
-        for (branch_has_key, branch_is_valid, items) in &branch_results {
-            if valid_branches {
-                if *branch_is_valid {
-                    completion_items.extend(items.iter().cloned());
-                }
-            } else if !narrow_branches || *branch_has_key {
-                completion_items.extend(items.iter().cloned());
-            }
-        }
-
-        if completion_items.is_empty() {
-            completion_items = branch_results
-                .into_iter()
-                .flat_map(|(_, _, items)| items)
-                .collect_vec();
-        }
+        let (mut completion_items, narrow_branches) = collect_branch_completions(
+            value,
+            position,
+            keys,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+            completion_hint,
+        )
+        .await;
 
         let detail = any_of_schema
             .detail(

--- a/crates/tombi-lsp/src/completion/value/branch_result.rs
+++ b/crates/tombi-lsp/src/completion/value/branch_result.rs
@@ -1,0 +1,9 @@
+use crate::completion::CompletionContent;
+
+#[derive(Debug)]
+pub(super) struct BranchCompletionResult {
+    pub has_key: bool,
+    pub is_valid: bool,
+    pub is_recoverable: bool,
+    pub items: Vec<CompletionContent>,
+}

--- a/crates/tombi-lsp/src/completion/value/branch_result.rs
+++ b/crates/tombi-lsp/src/completion/value/branch_result.rs
@@ -1,4 +1,6 @@
-use crate::completion::CompletionContent;
+use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, ValueSchema};
+
+use crate::completion::{CompletionContent, CompletionHint, FindCompletionContents};
 
 #[derive(Debug)]
 pub(super) struct BranchCompletionResult {
@@ -6,4 +8,122 @@ pub(super) struct BranchCompletionResult {
     pub is_valid: bool,
     pub is_recoverable: bool,
     pub items: Vec<CompletionContent>,
+}
+
+impl BranchCompletionResult {
+    fn should_include_in_fallback(&self, valid_branches: bool, narrow_branches: bool) -> bool {
+        if valid_branches {
+            self.is_valid || self.is_recoverable
+        } else if narrow_branches {
+            self.has_key || self.is_recoverable
+        } else {
+            true
+        }
+    }
+}
+
+/// Evaluate each branch of a composite schema (oneOf/anyOf) and collect completion items.
+///
+/// Narrowing: when completing the value of a single key (e.g. `license = { file = "..." }`),
+/// only consider branches that are a table containing that key. Otherwise we would merge
+/// completions from all branches (e.g. file path and string variant like "MIT"). Requires
+/// exactly one non-empty key so we do not narrow when completing after a dot (e.g. `path.`
+/// yields `keys = ["path", ""]`). Only narrows when at least one branch has the key, so we
+/// never return `[]` by over-narrowing.
+///
+/// Returns the collected items and the `narrow_branches` flag for the caller to decide
+/// whether to include composite-level default/examples.
+pub(super) async fn collect_branch_completions<'a, T>(
+    value: &'a T,
+    position: tombi_text::Position,
+    keys: &'a [tombi_document_tree::Key],
+    accessors: &'a [Accessor],
+    resolved_schemas: &'a [CurrentSchema<'a>],
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+    completion_hint: Option<CompletionHint>,
+) -> (Vec<CompletionContent>, bool)
+where
+    T: FindCompletionContents + tombi_validator::Validate + Sync + Send + std::fmt::Debug,
+{
+    let first_key = (keys.len() == 1 && !keys[0].value.is_empty()).then(|| &keys[0].value);
+
+    let mut branch_results = Vec::new();
+    for resolved_schema in resolved_schemas {
+        let branch_has_key = if let Some(ref first_key) = first_key {
+            match resolved_schema.value_schema.as_ref() {
+                ValueSchema::Table(table_schema) => table_schema
+                    .properties
+                    .read()
+                    .await
+                    .contains_key(&SchemaAccessor::Key(first_key.to_string())),
+                _ => false,
+            }
+        } else {
+            false
+        };
+        let (branch_is_valid, branch_is_recoverable) = match value
+            .validate(accessors, Some(resolved_schema), schema_context)
+            .await
+        {
+            Ok(_) => (true, true),
+            Err(tombi_validator::Error { diagnostics, .. })
+                if diagnostics
+                    .iter()
+                    .all(tombi_diagnostic::Diagnostic::is_warning) =>
+            {
+                (true, true)
+            }
+            Err(tombi_validator::Error { diagnostics, .. }) => (
+                false,
+                diagnostics
+                    .iter()
+                    .all(|diagnostic| diagnostic.range().contains(position)),
+            ),
+        };
+
+        let schema_completions = value
+            .find_completion_contents(
+                position,
+                keys,
+                accessors,
+                Some(resolved_schema),
+                schema_context,
+                completion_hint,
+            )
+            .await;
+
+        branch_results.push(BranchCompletionResult {
+            has_key: branch_has_key,
+            is_valid: branch_is_valid,
+            is_recoverable: branch_is_recoverable,
+            items: schema_completions,
+        });
+    }
+
+    let valid_branches = branch_results.iter().any(|branch| branch.is_valid);
+    let narrow_branches = branch_results.iter().any(|branch| branch.has_key);
+
+    let mut completion_items = Vec::new();
+    for branch in &branch_results {
+        if valid_branches {
+            if branch.is_valid {
+                completion_items.extend(branch.items.iter().cloned());
+            }
+        } else if !narrow_branches || branch.has_key {
+            completion_items.extend(branch.items.iter().cloned());
+        }
+    }
+
+    // Fallback: if the precision-focused first pass yielded nothing, relax by also
+    // including branches whose validation errors are at the cursor — the user is still
+    // typing there, so that branch may become valid.
+    if completion_items.is_empty() {
+        completion_items = branch_results
+            .into_iter()
+            .filter(|branch| branch.should_include_in_fallback(valid_branches, narrow_branches))
+            .flat_map(|branch| branch.items)
+            .collect();
+    }
+
+    (completion_items, narrow_branches)
 }

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -1,12 +1,13 @@
-use itertools::Itertools;
 use tombi_extension::CompletionContentPriority;
 use tombi_future::Boxable;
-use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, ValueSchema};
+use tombi_schema_store::{Accessor, CurrentSchema};
 
 use crate::completion::{
     CompletionCandidate, CompletionContent, CompletionHint, FindCompletionContents,
     tombi_json_value_to_completion_default_item, tombi_json_value_to_completion_example_item,
 };
+
+use super::branch_result::collect_branch_completions;
 
 pub fn find_one_of_completion_items<'a: 'b, 'b, T>(
     value: &'a T,
@@ -29,16 +30,6 @@ where
     log::trace!("completion_hint = {:?}", completion_hint);
 
     async move {
-        let mut completion_items = Vec::new();
-
-        // When we are completing the value of a single key (e.g. license = { file = "..." }),
-        // only consider branches that are a table containing that key. Otherwise we would merge
-        // completions from all branches (e.g. file path and string variant like "MIT").
-        // Require exactly one key so we do not narrow when completing after a dot (e.g. "path."
-        // yields keys = ["path", ""]). Skip oneOf-level default/examples when narrowing.
-        // Only narrow when at least one branch has the key, so we never return [] by over-narrowing.
-        let first_key = (keys.len() == 1 && !keys[0].value.is_empty()).then(|| &keys[0].value);
-
         let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
             &one_of_schema.schemas,
             current_schema.schema_uri.clone(),
@@ -49,70 +40,19 @@ where
         )
         .await
         else {
-            return completion_items;
+            return Vec::new();
         };
 
-        let mut branch_results: Vec<(bool, bool, Vec<CompletionContent>)> = Vec::new();
-        for resolved_schema in &resolved_schemas {
-            let branch_has_key = if let Some(ref first_key) = first_key {
-                match resolved_schema.value_schema.as_ref() {
-                    ValueSchema::Table(table_schema) => table_schema
-                        .properties
-                        .read()
-                        .await
-                        .contains_key(&SchemaAccessor::Key(first_key.to_string())),
-                    _ => false,
-                }
-            } else {
-                false
-            };
-            let branch_is_valid = match value
-                .validate(accessors, Some(resolved_schema), schema_context)
-                .await
-            {
-                Ok(_) => true,
-                Err(tombi_validator::Error { diagnostics, .. })
-                    if diagnostics
-                        .iter()
-                        .all(tombi_diagnostic::Diagnostic::is_warning) =>
-                {
-                    true
-                }
-                _ => false,
-            };
-
-            let schema_completions = value
-                .find_completion_contents(
-                    position,
-                    keys,
-                    accessors,
-                    Some(resolved_schema),
-                    schema_context,
-                    completion_hint,
-                )
-                .await;
-
-            branch_results.push((branch_has_key, branch_is_valid, schema_completions));
-        }
-
-        let valid_branches = branch_results.iter().any(|(_, is_valid, _)| *is_valid);
-        let narrow_branches = branch_results.iter().any(|(has_key, _, _)| *has_key);
-        for (branch_has_key, branch_is_valid, items) in &branch_results {
-            if valid_branches {
-                if *branch_is_valid {
-                    completion_items.extend(items.iter().cloned());
-                }
-            } else if !narrow_branches || *branch_has_key {
-                completion_items.extend(items.iter().cloned());
-            }
-        }
-
-        if completion_items.is_empty() {
-            completion_items = branch_results
-                .into_iter()
-                .flat_map(|(_, _, items)| items)
-                .collect_vec();
-        }
+        let (mut completion_items, narrow_branches) = collect_branch_completions(
+            value,
+            position,
+            keys,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+            completion_hint,
+        )
+        .await;
 
         let detail = one_of_schema
             .detail(

--- a/crates/tombi-lsp/tests/fixtures/feature-toggle-one-of-test.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/feature-toggle-one-of-test.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "completion": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -553,6 +553,24 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
+            async fn tombi_extension_tombi_completion_variant_after_path_enabled(
+                r#"
+                [extensions]
+                "tombi-toml/tombi" = {
+                  lsp = {
+                    completion = {
+                      █
+                      path.enabled = true,
+                    },
+                  },
+                }
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
             async fn tombi_format_rules_array_bracket_space_width(
                 r#"
                 [format.rules]
@@ -2094,6 +2112,25 @@ mod completion_labels {
                 "favorite_color",
                 "number_of_pets",
             ]);
+        }
+    }
+
+    mod one_of_regression {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn one_of_variant_after_path_enabled(
+                r#"
+                completion = {
+                  █
+                  path.enabled = true,
+                }
+                "#,
+                SchemaPath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/feature-toggle-one-of-test.schema.json"
+                )),
+            ) -> Ok([]);
         }
     }
 


### PR DESCRIPTION
## Summary
- factor oneOf/anyOf branch completion selection into a shared helper
- keep branch completions available when a branch is only invalid at the current cursor position
- add regression tests for `path.enabled = true` variant completion behavior

## Why
When editing a partially complete inline table under a composite schema, validation can temporarily fail before the user finishes typing. The previous logic could drop all useful branch completions in that state.

## Validation
- `cargo test -p tombi-lsp --test test_completion_labels -- --nocapture`
