### PR TITLE
Fix issue 1719 unevaluatedProperties handling

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/README.md
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/README.md
@@ -1,0 +1,14 @@
+# Issue #1719: `allOf` and `unevaluatedProperties` on open
+
+This fixture reproduces issue #1719:
+https://github.com/tombi-toml/tombi/issues/1719
+
+## Problem
+
+When a TOML file references a local draft 2020-12 schema via `#:schema`, Tombi
+incorrectly reports `Unevaluated property "x" is not allowed` on startup even
+though `x` is defined through `allOf`.
+
+## Expected Behavior
+
+`test.toml` should not produce diagnostics immediately after `didOpen`.

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/test.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/test.toml
@@ -1,0 +1,5 @@
+#:schema ./test_schema.json
+
+[a]
+b = 1
+x = 2

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/test_schema.json
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/test_schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
+  "title": "Test Schema",
+  "type": "object",
+  "properties": {
+    "a": {
+      "$ref": "#/definitions/type1"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "shared": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "integer"
+        }
+      }
+    },
+    "type1": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/shared"
+        }
+      ],
+      "properties": {
+        "b": {
+          "type": "integer"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties/tombi.toml
@@ -1,0 +1,3 @@
+[[schemas]]
+path = "./test_schema.json"
+include = ["test.toml"]

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/README.md
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/README.md
@@ -1,0 +1,4 @@
+# Issue #1719: schema directive only
+
+This fixture matches the issue report more closely by relying only on
+`#:schema ./test_schema.json` and not using `tombi.toml`.

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/test.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/test.toml
@@ -1,0 +1,5 @@
+#:schema ./test_schema.json
+
+[a]
+b = 1
+x = 2

--- a/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/test_schema.json
+++ b/crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/test_schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
+  "title": "Test Schema",
+  "type": "object",
+  "properties": {
+    "a": {
+      "$ref": "#/definitions/type1"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "shared": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "integer"
+        }
+      }
+    },
+    "type1": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/shared"
+        }
+      ],
+      "properties": {
+        "b": {
+          "type": "integer"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -112,6 +112,48 @@ mod diagnostic {
             ]);
         );
     }
+
+    /// Test for issue #1719: local schema with `allOf` + `unevaluatedProperties`
+    /// https://github.com/tombi-toml/tombi/issues/1719
+    mod issue_1719_all_of_unevaluated_properties {
+        use tombi_test_lib::project_root_path;
+
+        use super::*;
+        use std::path::PathBuf;
+
+        fn fixture_path() -> PathBuf {
+            project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/issue-1719-all-of-unevaluated-properties")
+        }
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn test_toml_has_no_false_unevaluated_property_error_on_open(
+                SourcePath(fixture_path().join("test.toml")),
+                ConfigPath(fixture_path().join("tombi.toml")),
+            ) -> Ok([]);
+        );
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn test_toml_has_no_false_unevaluated_property_error_with_schema_directive_only(
+                SourcePath(
+                    project_root_path().join(
+                        "crates/tombi-lsp/tests/fixtures/issue-1719-schema-directive-only/test.toml"
+                    )
+                ),
+            ) -> Ok([]);
+        );
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn first_pull_diagnostic_after_open_has_no_false_unevaluated_property(
+                SourcePath(fixture_path().join("test.toml")),
+                ConfigPath(fixture_path().join("tombi.toml")),
+                LspDiagnosticMode(tombi_lsp::backend::DiagnosticMode::Pull),
+            ) -> Ok([]);
+        );
+    }
 }
 
 // Unified test macro
@@ -154,6 +196,7 @@ macro_rules! test_diagnostic {
             source_text: Option<String>,
             schema_file_path: Option<std::path::PathBuf>,
             config_file_path: Option<std::path::PathBuf>,
+            diagnostic_mode: Option<tombi_lsp::backend::DiagnosticMode>,
             backend_options: tombi_lsp::backend::Options,
         }
 
@@ -198,6 +241,15 @@ macro_rules! test_diagnostic {
             }
         }
 
+        #[allow(unused)]
+        struct LspDiagnosticMode(tombi_lsp::backend::DiagnosticMode);
+
+        impl ApplyTestArg for LspDiagnosticMode {
+            fn apply(self, args: &mut TestArgs) {
+                args.diagnostic_mode = Some(self.0);
+            }
+        }
+
         impl ApplyTestArg for tombi_lsp::backend::Options {
             fn apply(self, args: &mut TestArgs) {
                 args.backend_options = self;
@@ -213,6 +265,10 @@ macro_rules! test_diagnostic {
         });
 
         let backend = service.inner();
+
+        if let Some(diagnostic_mode) = args.diagnostic_mode {
+            backend.capabilities.write().await.diagnostic_mode = diagnostic_mode;
+        }
 
         // Load config file if specified
         if let Some(config_file_path) = args.config_file_path.as_ref() {
@@ -441,6 +497,7 @@ macro_rules! test_diagnostic_file {
             source_text: Option<String>,
             schema_file_path: Option<std::path::PathBuf>,
             config_file_path: Option<std::path::PathBuf>,
+            diagnostic_mode: Option<tombi_lsp::backend::DiagnosticMode>,
             backend_options: tombi_lsp::backend::Options,
         }
 
@@ -485,6 +542,15 @@ macro_rules! test_diagnostic_file {
             }
         }
 
+        #[allow(unused)]
+        struct LspDiagnosticMode(tombi_lsp::backend::DiagnosticMode);
+
+        impl ApplyTestArg for LspDiagnosticMode {
+            fn apply(self, config: &mut TestArgs) {
+                config.diagnostic_mode = Some(self.0);
+            }
+        }
+
         impl ApplyTestArg for tombi_lsp::backend::Options {
             fn apply(self, config: &mut TestArgs) {
                 config.backend_options = self;
@@ -504,6 +570,10 @@ macro_rules! test_diagnostic_file {
         });
 
         let backend = service.inner();
+
+        if let Some(diagnostic_mode) = config.diagnostic_mode {
+            backend.capabilities.write().await.diagnostic_mode = diagnostic_mode;
+        }
 
         // Load config file if specified
         if let Some(config_file_path) = config.config_file_path.as_ref() {

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -283,7 +283,7 @@ macro_rules! test_diagnostic {
                 .update_config_with_path(tombi_config, config_file_path)
                 .await
                 .map_err(|e| format!("Failed to load config file {}: {}", config_file_path.display(), e))?;
-        } else if let Some(schema_file_path) = config.schema_file_path.as_ref() {
+        } else if let Some(schema_file_path) = args.schema_file_path.as_ref() {
             // Fallback to schema path if no config file
             let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
                 .expect(
@@ -312,7 +312,7 @@ macro_rules! test_diagnostic {
         }
 
         // Determine source based on config
-        let (toml_text, toml_file_url) = if let Some(source_text) = config.source_text {
+        let (toml_text, toml_file_url) = if let Some(source_text) = args.source_text {
             // Use inline text via SourceText
             use std::io::Write;
 
@@ -320,7 +320,7 @@ macro_rules! test_diagnostic {
 
             let current_dir = std::env::current_dir().expect("failed to get current directory");
             // If ConfigPath is specified, use its parent directory for temp file
-            let temp_dir = if let Some(config_path) = config.config_file_path.as_ref() {
+            let temp_dir = if let Some(config_path) = args.config_file_path.as_ref() {
                 config_path.parent().ok_or("failed to get parent directory")?
             } else {
                 current_dir.as_path()
@@ -343,7 +343,7 @@ macro_rules! test_diagnostic {
             (toml_text, toml_file_url)
         } else {
             // Use file path via SourcePath
-            let source_path = config.source_file_path.as_ref()
+            let source_path = args.source_file_path.as_ref()
                 .expect("SourcePath or SourceText must be provided");
             let toml_text = std::fs::read_to_string(source_path)
                 .map_err(|e| format!("Failed to read source file {}: {}", source_path.display(), e))?;

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -1036,28 +1036,31 @@ fn collect_evaluated_properties_from_referable_schemas<'a>(
 ) -> BoxFuture<'a, crate::EvaluatedLocations> {
     async move {
         let mut result = crate::EvaluatedLocations::new();
-        for schema_item in applicator.schemas().read().await.iter() {
-            if let Ok(Some(schema)) = schema_item
-                .to_current_schema(
-                    current_schema.schema_uri.clone(),
-                    current_schema.definitions.clone(),
-                    schema_context.store,
+        let Some(schemas) = tombi_schema_store::resolve_and_collect_schemas(
+            applicator.schemas(),
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            schema_context.store,
+            &schema_context.schema_visits,
+            accessors,
+        )
+        .await
+        else {
+            return result;
+        };
+
+        for schema in &schemas {
+            result.merge_from(
+                collect_evaluated_properties_from_value_schema(
+                    table_value,
+                    accessors,
+                    schema.value_schema.as_ref(),
+                    schema,
+                    schema_context,
+                    visited_schema_values,
                 )
-                .await
-                .inspect_err(|err| log::warn!("{err}"))
-            {
-                result.merge_from(
-                    collect_evaluated_properties_from_value_schema(
-                        table_value,
-                        accessors,
-                        schema.value_schema.as_ref(),
-                        &schema,
-                        schema_context,
-                        visited_schema_values,
-                    )
-                    .await,
-                );
-            }
+                .await,
+            );
         }
         result
     }


### PR DESCRIPTION
## Summary
Fix evaluated-property collection for referenced schemas inside applicators so `allOf` + `unevaluatedProperties` does not report false diagnostics.
Add LSP regression fixtures and tests for issue #1719 covering config-based, schema-directive-only, and pull-diagnostic startup flows.

## Testing
cargo test -p tombi-lsp issue_1719_all_of_unevaluated_properties -- --nocapture
cargo test -p tombi-validator collect_evaluated_properties_from_referable_schemas -- --nocapture