### PR TITLE
Add schema format rules and override handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "tombi-accessor",
  "tombi-severity-level",
  "tombi-toml-version",
  "tombi-uri",
@@ -3842,6 +3843,7 @@ dependencies = [
  "rstest",
  "schemars",
  "serde",
+ "serde_tombi",
  "textwrap",
  "tokio",
  "tombi-ast",
@@ -3855,6 +3857,7 @@ dependencies = [
  "tombi-text",
  "tombi-uri",
  "tombi-validator",
+ "tombi-x-keyword",
  "unicode-segmentation",
 ]
 
@@ -3997,6 +4000,7 @@ dependencies = [
  "tombi-ast",
  "tombi-cache",
  "tombi-comment-directive",
+ "tombi-comment-directive-serde",
  "tombi-comment-directive-store",
  "tombi-config",
  "tombi-date-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,7 +3667,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "tombi-accessor",
  "tombi-severity-level",
  "tombi-toml-version",
  "tombi-uri",
@@ -3857,7 +3856,6 @@ dependencies = [
  "tombi-text",
  "tombi-uri",
  "tombi-validator",
- "tombi-x-keyword",
  "unicode-segmentation",
 ]
 

--- a/crates/tombi-accessor/src/root_accessor.rs
+++ b/crates/tombi-accessor/src/root_accessor.rs
@@ -12,12 +12,12 @@ pub enum RootAccessor {
 
 impl RootAccessor {
     pub fn parse(path: &str) -> Option<Vec<RootAccessor>> {
+        if path.is_empty() {
+            return Some(Vec::new());
+        }
+
         let mut accessors = Vec::new();
         let mut current_key = String::new();
-
-        if path.is_empty() {
-            return None;
-        }
 
         let chars: Vec<char> = path.chars().collect();
         let mut i = 0;
@@ -50,14 +50,23 @@ impl RootAccessor {
                     i = next_index;
                 }
                 '.' => {
-                    if !current_key.is_empty() {
-                        accessors.push(parse_key_or_wildcard(current_key));
-                        current_key = String::new();
+                    if current_key.is_empty() {
+                        if i == 0 || chars[i - 1] == '.' {
+                            return None;
+                        }
+                        i += 1;
+                        continue;
                     }
+                    accessors.push(parse_key_or_wildcard(current_key));
+                    current_key = String::new();
                 }
                 c => current_key.push(c),
             }
             i += 1;
+        }
+
+        if chars.last() == Some(&'.') {
+            return None;
         }
 
         if !current_key.is_empty() {
@@ -178,6 +187,7 @@ mod tests {
     use super::*;
 
     #[rstest]
+    #[case("", vec![])]
     #[case("tool.*", vec![
         RootAccessor::Key("tool".to_string()),
         RootAccessor::AnyKey,
@@ -224,7 +234,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case("")]
+    #[case(".")]
     #[case("items[*")]
     #[case("items[foo]")]
     fn test_root_accessor_parse_invalid(#[case] input: &str) {

--- a/crates/tombi-ast-editor/src/edit/array.rs
+++ b/crates/tombi-ast-editor/src/edit/array.rs
@@ -5,9 +5,7 @@ use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use tombi_comment_directive::value::{ArrayCommonFormatRules, ArrayCommonLintRules};
 use tombi_comment_directive_serde::get_comment_directive_content;
 use tombi_future::{BoxFuture, Boxable};
-use tombi_schema_store::{
-    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, ValueSchema,
-};
+use tombi_schema_store::{Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, ValueSchema};
 use tombi_validator::Validate;
 
 use crate::rule::{array_comma_trailing_comment, array_values_order};
@@ -91,13 +89,6 @@ impl crate::Edit for tombi_ast::Array {
                     },
                 );
 
-            let array_schema_values_order = current_schema.and_then(|current_schema| {
-                if let ValueSchema::Array(array_schema) = current_schema.value_schema.as_ref() {
-                    array_schema.values_order.clone()
-                } else {
-                    None
-                }
-            });
             let mut nodes_iter = array_node.values().iter().enumerate();
             for group in self.value_with_comma_groups() {
                 let DanglingCommentGroupOr::ItemGroup(value_group) = group else {
@@ -117,7 +108,6 @@ impl crate::Edit for tombi_ast::Array {
                         accessors,
                         current_item_schema.as_ref(),
                         schema_context,
-                        array_schema_values_order.clone(),
                         comment_directive.clone(),
                     )
                     .await,

--- a/crates/tombi-ast-editor/src/edit/array.rs
+++ b/crates/tombi-ast-editor/src/edit/array.rs
@@ -5,7 +5,9 @@ use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use tombi_comment_directive::value::{ArrayCommonFormatRules, ArrayCommonLintRules};
 use tombi_comment_directive_serde::get_comment_directive_content;
 use tombi_future::{BoxFuture, Boxable};
-use tombi_schema_store::{Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, ValueSchema};
+use tombi_schema_store::{
+    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, ValueSchema,
+};
 use tombi_validator::Validate;
 
 use crate::rule::{array_comma_trailing_comment, array_values_order};

--- a/crates/tombi-ast-editor/src/edit/array.rs
+++ b/crates/tombi-ast-editor/src/edit/array.rs
@@ -108,7 +108,7 @@ impl crate::Edit for tombi_ast::Array {
                         nodes,
                         values_with_comma,
                         accessors,
-                        current_item_schema.as_ref(),
+                        current_schema,
                         schema_context,
                         comment_directive.clone(),
                     )

--- a/crates/tombi-ast-editor/src/edit/array_of_table.rs
+++ b/crates/tombi-ast-editor/src/edit/array_of_table.rs
@@ -63,6 +63,7 @@ impl crate::Edit for tombi_ast::ArrayOfTable {
                             changes.extend(
                                 table_keys_order(
                                     node,
+                                    &accessors,
                                     key_values,
                                     current_schema.as_ref(),
                                     schema_context,

--- a/crates/tombi-ast-editor/src/edit/inline_table.rs
+++ b/crates/tombi-ast-editor/src/edit/inline_table.rs
@@ -69,6 +69,7 @@ impl crate::Edit for tombi_ast::InlineTable {
                 changes.extend(
                     inline_table_keys_order(
                         node,
+                        accessors,
                         key_value_group.key_values_with_comma().collect_vec(),
                         current_schema,
                         schema_context,

--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -9,7 +9,6 @@ use tombi_syntax::SyntaxElement;
 
 use crate::node::make_dangling_comment_group_from_leading_comments;
 use crate::rule::root_table_keys_order;
-use crate::rule::{TableOrderOverride, TableOrderOverrides};
 use tombi_ast::{DanglingCommentGroupOr, GetHeaderAccessors};
 
 impl crate::Edit for tombi_ast::Root {
@@ -25,7 +24,12 @@ impl crate::Edit for tombi_ast::Root {
             let mut changes = vec![];
             let mut key_value_groups = vec![];
             let mut table_or_array_of_tables = vec![];
-            let mut table_order_overrides = TableOrderOverrides::default();
+
+            let mut table_order_overrides = schema_context
+                .overrides
+                .table_keys_order
+                .map(ToOwned::to_owned)
+                .unwrap_or_default();
 
             // Detect document comment directives.
             // If dangling comments exist, directives should already be there.
@@ -130,8 +134,11 @@ impl crate::Edit for tombi_ast::Root {
                             .unwrap_or(false);
                         let order = comment_directive.table_keys_order().map(Into::into);
                         if disabled || order.is_some() {
-                            table_order_overrides
-                                .insert(header_accessors, TableOrderOverride { disabled, order });
+                            table_order_overrides.insert_comment_directive_override(
+                                header_accessors,
+                                disabled,
+                                order,
+                            );
                         }
                     }
                 }

--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -130,7 +130,9 @@ impl crate::Edit for tombi_ast::Root {
 
                     if let Some(comment_directive) = comment_directive {
                         let (disabled, order) = (
-                            comment_directive.table_keys_order_disabled().unwrap_or(false),
+                            comment_directive
+                                .table_keys_order_disabled()
+                                .unwrap_or_default(),
                             comment_directive.table_keys_order().map(Into::into),
                         );
                         if disabled || order.is_some() {

--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -129,10 +129,10 @@ impl crate::Edit for tombi_ast::Root {
                     };
 
                     if let Some(comment_directive) = comment_directive {
-                        let disabled = comment_directive
-                            .table_keys_order_disabled()
-                            .unwrap_or(false);
-                        let order = comment_directive.table_keys_order().map(Into::into);
+                        let (disabled, order) = (
+                            comment_directive.table_keys_order_disabled().unwrap_or(false),
+                            comment_directive.table_keys_order().map(Into::into),
+                        );
                         if disabled || order.is_some() {
                             table_order_overrides.insert_comment_directive_override(
                                 header_accessors,

--- a/crates/tombi-ast-editor/src/edit/table.rs
+++ b/crates/tombi-ast-editor/src/edit/table.rs
@@ -63,6 +63,7 @@ impl crate::Edit for tombi_ast::Table {
                             changes.extend(
                                 table_keys_order(
                                     node,
+                                    &accessors,
                                     key_values,
                                     current_schema.as_ref(),
                                     schema_context,

--- a/crates/tombi-ast-editor/src/rule.rs
+++ b/crates/tombi-ast-editor/src/rule.rs
@@ -11,4 +11,3 @@ pub use inline_table_comma_trailing_comment::inline_table_comma_trailing_comment
 pub use inline_table_keys_order::inline_table_keys_order;
 pub use root_table_keys_order::root_table_keys_order;
 pub use table_keys_order::table_keys_order;
-pub use table_keys_order::{TableOrderOverride, TableOrderOverrides};

--- a/crates/tombi-ast-editor/src/rule/array_values_order.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order.rs
@@ -48,11 +48,13 @@ pub async fn array_values_order<'a>(
         .as_ref()
         .map(|comment_directive| {
             (
-                comment_directive.array_values_order_disabled().unwrap_or(false),
+                comment_directive
+                    .array_values_order_disabled()
+                    .unwrap_or_default(),
                 comment_directive.array_values_order().map(Into::into),
             )
         })
-        .unwrap_or((false, None));
+        .unwrap_or_default();
 
     if disabled {
         return Vec::with_capacity(0);
@@ -65,7 +67,11 @@ pub async fn array_values_order<'a>(
     });
 
     let values_order = schema_context
-        .array_values_order(accessors, current_schema, comment_directive_override.as_ref())
+        .array_values_order(
+            accessors,
+            current_schema,
+            comment_directive_override.as_ref(),
+        )
         .await;
 
     let Some(values_order) = values_order else {
@@ -77,7 +83,7 @@ pub async fn array_values_order<'a>(
     let is_last_comma = values_with_comma
         .last()
         .map(|(_, comma)| comma.is_some())
-        .unwrap_or(false);
+        .unwrap_or_default();
 
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(values_with_comma.first().unwrap().0.syntax().clone()),

--- a/crates/tombi-ast-editor/src/rule/array_values_order.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order.rs
@@ -200,28 +200,11 @@ async fn get_sorted_values_order_groups<'a>(
 ) -> Option<Vec<(tombi_ast::Value, Option<tombi_ast::Comma>)>> {
     let current_schema = current_schema?;
 
-    match (values_order_group, current_schema.value_schema.as_ref()) {
-        (
-            ArrayValuesOrderGroup::OneOf(group_orders),
-            ValueSchema::OneOf(OneOfSchema { schemas, .. }),
-        )
-        | (
-            ArrayValuesOrderGroup::AnyOf(group_orders),
-            ValueSchema::AnyOf(AnyOfSchema { schemas, .. }),
-        ) => {
+    match resolve_grouped_array_item_schemas(values_order_group, current_schema, accessors, schema_context)
+        .await
+    {
+        Some((group_orders, resolved_schemas)) => {
             let mut sorted_values_with_comma = Vec::with_capacity(values_with_comma.len());
-            let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
-                schemas,
-                current_schema.schema_uri.clone(),
-                current_schema.definitions.clone(),
-                schema_context.store,
-                &schema_context.schema_visits,
-                accessors,
-            )
-            .await
-            else {
-                return Some(values_with_comma);
-            };
 
             for (group_order, current_schema) in group_orders.iter().zip(resolved_schemas.iter()) {
                 let mut group_values_with_comma = Vec::new();
@@ -274,6 +257,68 @@ async fn get_sorted_values_order_groups<'a>(
     }
 }
 
+async fn resolve_grouped_array_item_schemas<'a>(
+    mut values_order_group: ArrayValuesOrderGroup,
+    current_schema: &'a CurrentSchema<'a>,
+    accessors: &'a [Accessor],
+    schema_context: &'a SchemaContext<'a>,
+) -> Option<(Vec<ArrayValuesOrder>, Vec<CurrentSchema<'static>>)> {
+    let mut current_schema = current_schema.clone().into_owned();
+
+    loop {
+        match (values_order_group, current_schema.value_schema.as_ref()) {
+            (
+                ArrayValuesOrderGroup::OneOf(group_orders),
+                ValueSchema::OneOf(OneOfSchema { schemas, .. }),
+            ) => {
+                return Some((
+                    group_orders,
+                    tombi_schema_store::resolve_and_collect_schemas(
+                        schemas,
+                        current_schema.schema_uri.clone(),
+                        current_schema.definitions.clone(),
+                        schema_context.store,
+                        &schema_context.schema_visits,
+                        accessors,
+                    )
+                    .await?,
+                ));
+            }
+            (
+                ArrayValuesOrderGroup::AnyOf(group_orders),
+                ValueSchema::AnyOf(AnyOfSchema { schemas, .. }),
+            ) => {
+                return Some((
+                    group_orders,
+                    tombi_schema_store::resolve_and_collect_schemas(
+                        schemas,
+                        current_schema.schema_uri.clone(),
+                        current_schema.definitions.clone(),
+                        schema_context.store,
+                        &schema_context.schema_visits,
+                        accessors,
+                    )
+                    .await?,
+                ));
+            }
+            (group, ValueSchema::Array(array_schema)) => {
+                let item_schema = array_schema.items.as_ref()?;
+                current_schema = tombi_schema_store::resolve_schema_item(
+                    item_schema,
+                    current_schema.schema_uri.clone(),
+                    current_schema.definitions.clone(),
+                    schema_context.store,
+                )
+                .await
+                .inspect_err(|err| log::warn!("{err}"))
+                .ok()??;
+                values_order_group = group;
+            }
+            _ => return None,
+        }
+    }
+}
+
 fn sort_array_values(
     sortable_values: SortableValues,
     values_order: ArrayValuesOrder,
@@ -305,8 +350,10 @@ fn try_array_values_order_by_from_item_schema<'a: 'b, 'b>(
     schema_context: &'a SchemaContext<'a>,
 ) -> BoxFuture<'b, Result<ArrayValuesOrderBy, SortFailReason>> {
     async move {
-        if let Some(current_schema) = current_schema {
-            match current_schema.value_schema.as_ref() {
+        let mut current_schema = current_schema.cloned().map(CurrentSchema::into_owned);
+
+        while let Some(schema) = current_schema {
+            match schema.value_schema.as_ref() {
                 ValueSchema::Table(TableSchema {
                     array_values_order_by: Some(array_values_order_by),
                     ..
@@ -318,8 +365,8 @@ fn try_array_values_order_by_from_item_schema<'a: 'b, 'b>(
                 | ValueSchema::OneOf(OneOfSchema { schemas, .. }) => {
                     if let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
                         schemas,
-                        current_schema.schema_uri.clone(),
-                        current_schema.definitions.clone(),
+                        schema.schema_uri.clone(),
+                        schema.definitions.clone(),
                         schema_context.store,
                         &schema_context.schema_visits,
                         accessors,
@@ -343,8 +390,26 @@ fn try_array_values_order_by_from_item_schema<'a: 'b, 'b>(
                         }
                     }
                 }
+                ValueSchema::Array(array_schema) => {
+                    let Some(item_schema) = array_schema.items.as_ref() else {
+                        break;
+                    };
+                    current_schema = tombi_schema_store::resolve_schema_item(
+                        item_schema,
+                        schema.schema_uri.clone(),
+                        schema.definitions.clone(),
+                        schema_context.store,
+                    )
+                    .await
+                    .inspect_err(|err| log::warn!("{err}"))
+                    .ok()
+                    .flatten();
+                    continue;
+                }
                 _ => {}
             }
+
+            break;
         }
 
         Err(SortFailReason::ArrayValuesOrderByRequired)

--- a/crates/tombi-ast-editor/src/rule/array_values_order.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order.rs
@@ -13,8 +13,8 @@ use tombi_comment_directive::value::{
 };
 use tombi_future::{BoxFuture, Boxable};
 use tombi_schema_store::{
-    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaContext, TableSchema,
-    ValueSchema, XTombiArrayValuesOrder,
+    Accessor, AllOfSchema, AnyOfSchema, ArrayOrderOverride, CurrentSchema, OneOfSchema,
+    SchemaContext, TableSchema, ValueSchema, XTombiArrayValuesOrder,
 };
 use tombi_syntax::SyntaxElement;
 use tombi_validator::Validate;
@@ -36,7 +36,6 @@ pub async fn array_values_order<'a>(
     accessors: &'a [Accessor],
     current_schema: Option<&'a CurrentSchema<'a>>,
     schema_context: &'a SchemaContext<'a>,
-    array_schema_values_order: Option<XTombiArrayValuesOrder>,
     comment_directive: Option<
         TombiValueDirectiveContent<ArrayCommonFormatRules, ArrayCommonLintRules>,
     >,
@@ -45,22 +44,29 @@ pub async fn array_values_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    if comment_directive
+    let (disabled, order) = comment_directive
         .as_ref()
-        .and_then(|content| content.array_values_order_disabled())
-        .unwrap_or(false)
-    {
+        .map(|comment_directive| {
+            (
+                comment_directive.array_values_order_disabled().unwrap_or(false),
+                comment_directive.array_values_order().map(Into::into),
+            )
+        })
+        .unwrap_or((false, None));
+
+    if disabled {
         return Vec::with_capacity(0);
     }
 
-    let order: Option<ArrayValuesOrder> = comment_directive
-        .as_ref()
-        .and_then(|comment_directive| comment_directive.array_values_order().map(Into::into));
+    let comment_directive_override = order.map(|order| ArrayOrderOverride {
+        target: Vec::new(),
+        disabled: false,
+        order: Some(order),
+    });
 
-    let values_order = match order {
-        Some(values_order) => Some(XTombiArrayValuesOrder::All(values_order)),
-        None => array_schema_values_order,
-    };
+    let values_order = schema_context
+        .array_values_order(accessors, current_schema, comment_directive_override.as_ref())
+        .await;
 
     let Some(values_order) = values_order else {
         return Vec::with_capacity(0);

--- a/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
@@ -22,17 +22,19 @@ pub async fn inline_table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    if comment_directive
+    let (disabled, order) = comment_directive
         .as_ref()
-        .and_then(|c| c.table_keys_order_disabled())
-        .unwrap_or(false)
-    {
+        .map(|comment_directive| {
+            (
+                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive.table_keys_order().map(Into::into),
+            )
+        })
+        .unwrap_or((false, None));
+
+    if disabled {
         return Vec::with_capacity(0);
     }
-
-    let order = comment_directive
-        .as_ref()
-        .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
 
     let mut changes = vec![];
 

--- a/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
@@ -10,6 +10,7 @@ use crate::rule::{inline_table_comma_trailing_comment, table_keys_order::get_sor
 
 pub async fn inline_table_keys_order<'a>(
     node: &'a tombi_document_tree::Value,
+    accessors: &'a [tombi_schema_store::Accessor],
     key_values_with_comma: Vec<(tombi_ast::KeyValue, Option<tombi_ast::Comma>)>,
     current_schema: Option<&'a CurrentSchema<'a>>,
     schema_context: &'a SchemaContext<'a>,
@@ -47,7 +48,7 @@ pub async fn inline_table_keys_order<'a>(
 
     let Some(mut sorted_key_values_with_comma) = get_sorted_accessors(
         node,
-        &[],
+        accessors,
         key_values_with_comma
             .into_iter()
             .map(|(kv, comma)| {

--- a/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/inline_table_keys_order.rs
@@ -26,11 +26,13 @@ pub async fn inline_table_keys_order<'a>(
         .as_ref()
         .map(|comment_directive| {
             (
-                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive
+                    .table_keys_order_disabled()
+                    .unwrap_or_default(),
                 comment_directive.table_keys_order().map(Into::into),
             )
         })
-        .unwrap_or((false, None));
+        .unwrap_or_default();
 
     if disabled {
         return Vec::with_capacity(0);
@@ -41,7 +43,7 @@ pub async fn inline_table_keys_order<'a>(
     let is_last_comma = key_values_with_comma
         .last()
         .map(|(_, comma)| comma.is_some())
-        .unwrap_or(false);
+        .unwrap_or_default();
 
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(key_values_with_comma.first().unwrap().0.syntax().clone()),

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -27,11 +27,13 @@ pub async fn root_table_keys_order<'a>(
         .as_ref()
         .map(|comment_directive| {
             (
-                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive
+                    .table_keys_order_disabled()
+                    .unwrap_or_default(),
                 comment_directive.table_keys_order().map(Into::into),
             )
         })
-        .unwrap_or((false, None));
+        .unwrap_or_default();
 
     if disabled {
         return Vec::with_capacity(0);

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -23,17 +23,19 @@ pub async fn root_table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    if comment_directive
+    let (disabled, order) = comment_directive
         .as_ref()
-        .and_then(|c| c.table_keys_order_disabled())
-        .unwrap_or(false)
-    {
+        .map(|comment_directive| {
+            (
+                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive.table_keys_order().map(Into::into),
+            )
+        })
+        .unwrap_or((false, None));
+
+    if disabled {
         return Vec::with_capacity(0);
     }
-
-    let order = comment_directive
-        .as_ref()
-        .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
 
     let mut changes = Vec::new();
     for key_value_group in key_value_groups {

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -4,10 +4,10 @@ use tombi_comment_directive::value::{
     TableCommonFormatRules, TableCommonLintRules, TombiValueDirectiveContent,
 };
 use tombi_document_tree::IntoDocumentTreeAndErrors;
-use tombi_schema_store::{CurrentSchema, SchemaContext};
+use tombi_schema_store::{CurrentSchema, SchemaContext, TableOrderOverrides};
 use tombi_syntax::SyntaxElement;
 
-use crate::rule::table_keys_order::{TableOrderOverrides, get_sorted_accessors, table_keys_order};
+use crate::rule::table_keys_order::{get_sorted_accessors, table_keys_order};
 
 pub async fn root_table_keys_order<'a>(
     key_value_groups: Vec<tombi_ast::KeyValueGroup>,
@@ -50,6 +50,7 @@ pub async fn root_table_keys_order<'a>(
                         .into_document_tree_and_errors(schema_context.toml_version)
                         .tree,
                 ),
+                &[],
                 key_values,
                 current_schema,
                 schema_context,

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -32,11 +32,13 @@ pub async fn table_keys_order<'a>(
         .as_ref()
         .map(|comment_directive| {
             (
-                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive
+                    .table_keys_order_disabled()
+                    .unwrap_or_default(),
                 comment_directive.table_keys_order().map(Into::into),
             )
         })
-        .unwrap_or((false, None));
+        .unwrap_or_default();
 
     if disabled {
         return Vec::with_capacity(0);
@@ -186,16 +188,15 @@ where
                     .or_else(|| schema_context.table_order_override(accessors));
                 let comment_directive_override =
                     order.map(|order| tombi_schema_store::TableOrderOverride {
-                    target: Vec::new(),
-                    disabled: false,
-                    order: Some(order),
-                });
+                        target: Vec::new(),
+                        disabled: false,
+                        order: Some(order),
+                    });
                 let table_order = schema_context
                     .table_keys_order(
                         accessors,
                         current_schema,
-                        table_override
-                            .or(comment_directive_override.as_ref()),
+                        table_override.or(comment_directive_override.as_ref()),
                     )
                     .await;
                 let table_schema = current_schema.and_then(|current_schema| {
@@ -209,7 +210,7 @@ where
                 let sorted_targets = if table_override
                     .as_ref()
                     .map(|override_order| override_order.disabled)
-                    .unwrap_or(false)
+                    .unwrap_or_default()
                 {
                     sort_targets_map.into_iter().collect_vec()
                 } else {

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -243,7 +243,7 @@ where
                                     targets,
                                     Some(&current_schema),
                                     schema_context,
-                                    None,
+                                    order,
                                     table_order_overrides,
                                 )
                                 .await?,
@@ -273,7 +273,7 @@ where
                                     targets,
                                     Some(&current_schema),
                                     schema_context,
-                                    None,
+                                    order,
                                     table_order_overrides,
                                 )
                                 .await?,
@@ -293,7 +293,7 @@ where
                             targets,
                             None,
                             schema_context,
-                            None,
+                            order,
                             table_order_overrides,
                         )
                         .await?,
@@ -333,7 +333,7 @@ where
                                 targets,
                                 Some(&current_schema),
                                 schema_context,
-                                None,
+                                order,
                                 table_order_overrides,
                             )
                             .await?,
@@ -355,7 +355,7 @@ where
                             targets,
                             None,
                             schema_context,
-                            None,
+                            order,
                             table_order_overrides,
                         )
                         .await?,

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -28,17 +28,19 @@ pub async fn table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    if comment_directive
+    let (disabled, order) = comment_directive
         .as_ref()
-        .and_then(|c| c.table_keys_order_disabled())
-        .unwrap_or(false)
-    {
+        .map(|comment_directive| {
+            (
+                comment_directive.table_keys_order_disabled().unwrap_or(false),
+                comment_directive.table_keys_order().map(Into::into),
+            )
+        })
+        .unwrap_or((false, None));
+
+    if disabled {
         return Vec::with_capacity(0);
     }
-
-    let order = comment_directive
-        .as_ref()
-        .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
 
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(key_values.first().unwrap().syntax().clone()),
@@ -182,14 +184,18 @@ where
                 let table_override = table_order_overrides
                     .and_then(|overrides| overrides.get(accessors))
                     .or_else(|| schema_context.table_order_override(accessors));
+                let comment_directive_override =
+                    order.map(|order| tombi_schema_store::TableOrderOverride {
+                    target: Vec::new(),
+                    disabled: false,
+                    order: Some(order),
+                });
                 let table_order = schema_context
                     .table_keys_order(
                         accessors,
                         current_schema,
                         table_override
-                            .as_ref()
-                            .map(|override_item| (override_item.disabled, override_item.order))
-                            .or_else(|| order.map(|order| (false, Some(order)))),
+                            .or(comment_directive_override.as_ref()),
                     )
                     .await;
                 let table_schema = current_schema.and_then(|current_schema| {

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -7,23 +7,16 @@ use tombi_comment_directive::value::{
 };
 use tombi_future::{BoxFuture, Boxable};
 use tombi_schema_store::{
-    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaContext, TableSchema,
-    ValueSchema, XTombiTableKeysOrder,
+    Accessor, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaContext,
+    TableOrderOverrides, TableSchema, ValueSchema, XTombiTableKeysOrder,
 };
 use tombi_syntax::SyntaxElement;
 use tombi_validator::Validate;
 use tombi_x_keyword::{TableKeysOrder, TableKeysOrderGroupKind};
 
-#[derive(Debug, Clone, Copy)]
-pub struct TableOrderOverride {
-    pub disabled: bool,
-    pub order: Option<TableKeysOrder>,
-}
-
-pub type TableOrderOverrides = tombi_hashmap::HashMap<Vec<Accessor>, TableOrderOverride>;
-
 pub async fn table_keys_order<'a>(
     value: &'a tombi_document_tree::Value,
+    accessors: &'a [tombi_schema_store::Accessor],
     key_values: Vec<tombi_ast::KeyValue>,
     current_schema: Option<&'a CurrentSchema<'a>>,
     schema_context: &'a SchemaContext<'a>,
@@ -54,7 +47,7 @@ pub async fn table_keys_order<'a>(
 
     let Some(sorted_key_values) = get_sorted_accessors(
         value,
-        &[],
+        accessors,
         key_values
             .into_iter()
             .map(|kv| {
@@ -134,13 +127,26 @@ where
                                 .await
                                 .is_ok()
                             {
+                                let resolved_order = if order.is_some() {
+                                    order
+                                } else if schema_context
+                                    .table_keys_order_enabled(
+                                        accessors,
+                                        current_schema.schema_uri.as_ref(),
+                                    )
+                                    .await
+                                {
+                                    *keys_order
+                                } else {
+                                    None
+                                };
                                 return get_sorted_accessors(
                                     value,
                                     accessors,
                                     targets.clone(),
                                     Some(current_schema),
                                     schema_context,
-                                    order.or(*keys_order),
+                                    resolved_order,
                                     table_order_overrides,
                                 )
                                 .await;
@@ -173,17 +179,19 @@ where
                     .iter()
                     .all(|(accessor, _)| matches!(accessor, Accessor::Key(_))) =>
             {
-                let table_override =
-                    table_order_overrides.and_then(|overrides| overrides.get(accessors));
-                let table_order_override = table_override.and_then(|override_order| {
-                    if override_order.disabled {
-                        None
-                    } else {
-                        override_order.order
-                    }
-                });
-                let table_order =
-                    get_table_keys_order(table_order_override.or(order), current_schema);
+                let table_override = table_order_overrides
+                    .and_then(|overrides| overrides.get(accessors))
+                    .or_else(|| schema_context.table_order_override(accessors));
+                let table_order = schema_context
+                    .table_keys_order(
+                        accessors,
+                        current_schema,
+                        table_override
+                            .as_ref()
+                            .map(|override_item| (override_item.disabled, override_item.order))
+                            .or_else(|| order.map(|order| (false, Some(order)))),
+                    )
+                    .await;
                 let table_schema = current_schema.and_then(|current_schema| {
                     if let ValueSchema::Table(table_schema) = current_schema.value_schema.as_ref() {
                         Some(table_schema)
@@ -193,6 +201,7 @@ where
                 });
 
                 let sorted_targets = if table_override
+                    .as_ref()
                     .map(|override_order| override_order.disabled)
                     .unwrap_or(false)
                 {
@@ -227,7 +236,7 @@ where
                                     targets,
                                     Some(&current_schema),
                                     schema_context,
-                                    order,
+                                    None,
                                     table_order_overrides,
                                 )
                                 .await?,
@@ -257,7 +266,7 @@ where
                                     targets,
                                     Some(&current_schema),
                                     schema_context,
-                                    order,
+                                    None,
                                     table_order_overrides,
                                 )
                                 .await?,
@@ -277,7 +286,7 @@ where
                             targets,
                             None,
                             schema_context,
-                            order,
+                            None,
                             table_order_overrides,
                         )
                         .await?,
@@ -317,7 +326,7 @@ where
                                 targets,
                                 Some(&current_schema),
                                 schema_context,
-                                order,
+                                None,
                                 table_order_overrides,
                             )
                             .await?,
@@ -339,7 +348,7 @@ where
                             targets,
                             None,
                             schema_context,
-                            order,
+                            None,
                             table_order_overrides,
                         )
                         .await?,
@@ -396,23 +405,6 @@ async fn sort_targets<T>(
         }
     };
     targets
-}
-
-fn get_table_keys_order(
-    order: Option<TableKeysOrder>,
-    current_schema: Option<&CurrentSchema>,
-) -> Option<XTombiTableKeysOrder> {
-    match order {
-        Some(order) => Some(XTombiTableKeysOrder::All(order)),
-        None => {
-            if let Some(current_schema) = current_schema
-                && let ValueSchema::Table(table_schema) = current_schema.value_schema.as_ref()
-            {
-                return table_schema.keys_order.clone();
-            }
-            None
-        }
-    }
 }
 
 async fn sort_table_targets<T>(

--- a/crates/tombi-ast/src/impls/array.rs
+++ b/crates/tombi-ast/src/impls/array.rs
@@ -121,7 +121,7 @@ impl crate::Array {
                     .last()
                     .map(|(_, comma)| comma.is_some()),
             })
-            .unwrap_or(false)
+            .unwrap_or_default()
     }
 
     #[inline]

--- a/crates/tombi-ast/src/impls/inline_table.rs
+++ b/crates/tombi-ast/src/impls/inline_table.rs
@@ -111,7 +111,7 @@ impl crate::InlineTable {
                     .last()
                     .map(|(_, comma)| comma.is_some()),
             })
-            .unwrap_or(false)
+            .unwrap_or_default()
     }
 
     #[inline]

--- a/crates/tombi-comment-directive/src/value.rs
+++ b/crates/tombi-comment-directive/src/value.rs
@@ -388,7 +388,7 @@ pub struct ErrorRuleOptions {
 
 impl From<&WarnRuleOptions> for SeverityLevelDefaultWarn {
     fn from(value: &WarnRuleOptions) -> Self {
-        if value.disabled.unwrap_or(false) {
+        if value.disabled.unwrap_or_default() {
             SeverityLevel::Off.into()
         } else {
             Self::default()
@@ -398,7 +398,7 @@ impl From<&WarnRuleOptions> for SeverityLevelDefaultWarn {
 
 impl From<&ErrorRuleOptions> for SeverityLevelDefaultError {
     fn from(value: &ErrorRuleOptions) -> Self {
-        if value.disabled.unwrap_or(false) {
+        if value.disabled.unwrap_or_default() {
             SeverityLevel::Off.into()
         } else {
             Self::default()

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
-tombi-accessor.workspace = true
 tombi-severity-level.workspace = true
 tombi-toml-version.workspace = true
 tombi-uri.workspace = true

--- a/crates/tombi-config/Cargo.toml
+++ b/crates/tombi-config/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
+tombi-accessor.workspace = true
 tombi-severity-level.workspace = true
 tombi-toml-version.workspace = true
 tombi-uri.workspace = true
@@ -24,6 +25,7 @@ default = ["serde"]
 jsonschema = [
   "dep:schemars",
   "serde",
+  "tombi-x-keyword/jsonschema",
   "tombi-severity-level/jsonschema",
   "tombi-toml-version/jsonschema",
 ]

--- a/crates/tombi-config/src/lib.rs
+++ b/crates/tombi-config/src/lib.rs
@@ -18,9 +18,10 @@ pub use lint::*;
 pub use overrides::*;
 pub use schema::SchemaOverviewOptions;
 pub use schema::{
-    RootSchema, SchemaFormatOptions, SchemaFormatRules, SchemaItem, SchemaLintOptions,
-    SchemaLintRules, SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
-    SchemaTableKeysOrderRule, SubSchema, Target,
+    RootSchema, SchemaArrayValuesOrderRule, SchemaFormatOptions, SchemaFormatRules, SchemaItem,
+    SchemaLintOptions, SchemaLintRules, SchemaOverrideArrayValuesOrderRule,
+    SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
+    SchemaOverrideTableKeysOrderRule, SchemaTableKeysOrderRule, SubSchema, Target,
 };
 pub use server::{LspCompletion, LspDiagnostic, LspOptions};
 pub use tombi_severity_level::SeverityLevel;

--- a/crates/tombi-config/src/lib.rs
+++ b/crates/tombi-config/src/lib.rs
@@ -17,7 +17,11 @@ pub use level::ConfigLevel;
 pub use lint::*;
 pub use overrides::*;
 pub use schema::SchemaOverviewOptions;
-pub use schema::{RootSchema, SchemaItem, SchemaLintOptions, SchemaLintRules, SubSchema};
+pub use schema::{
+    RootSchema, SchemaFormatOptions, SchemaFormatRules, SchemaItem, SchemaLintOptions,
+    SchemaLintRules, SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
+    SchemaTableKeysOrderRule, SubSchema, Target,
+};
 pub use server::{LspCompletion, LspDiagnostic, LspOptions};
 pub use tombi_severity_level::SeverityLevel;
 pub use tombi_toml_version::TomlVersion;

--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -1,6 +1,6 @@
 use tombi_severity_level::SeverityLevelDefaultWarn;
 use tombi_toml_version::TomlVersion;
-use tombi_x_keyword::TableKeysOrder;
+use tombi_x_keyword::{ArrayValuesOrder, TableKeysOrder};
 
 use crate::{
     BoolDefaultTrue, JSON_SCHEMASTORE_CATALOG_URL, SchemaCatalogPath, TOMBI_SCHEMASTORE_CATALOG_URL,
@@ -279,8 +279,23 @@ pub struct SchemaFormatOptions {
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending)))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SchemaFormatRules {
+    /// # Whether schema-defined array values ordering is enabled
+    pub array_values_order: Option<SchemaArrayValuesOrderRule>,
+
     /// # Whether schema-defined table key ordering is enabled
     pub table_keys_order: Option<SchemaTableKeysOrderRule>,
+}
+
+/// # Schema-defined array values ordering
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaArrayValuesOrderRule {
+    /// # Whether schema-defined array values ordering is enabled
+    pub enabled: Option<BoolDefaultTrue>,
 }
 
 /// # Schema-defined table key ordering
@@ -352,6 +367,9 @@ pub struct SchemaOverrideFormatOptions {
 #[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending)))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SchemaOverrideFormatRules {
+    /// # Override array values ordering for matched roots
+    pub array_values_order: Option<ArrayValuesOrder>,
+
     /// # Override table key ordering for matched roots
     pub table_keys_order: Option<TableKeysOrder>,
 }

--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -1,5 +1,6 @@
 use tombi_severity_level::SeverityLevelDefaultWarn;
 use tombi_toml_version::TomlVersion;
+use tombi_x_keyword::TableKeysOrder;
 
 use crate::{
     BoolDefaultTrue, JSON_SCHEMASTORE_CATALOG_URL, SchemaCatalogPath, TOMBI_SCHEMASTORE_CATALOG_URL,
@@ -129,6 +130,20 @@ impl SchemaItem {
             Self::Sub(item) => item.deprecated_lint_level(),
         }
     }
+
+    pub fn format(&self) -> Option<&SchemaFormatOptions> {
+        match self {
+            Self::Root(item) => item.format.as_ref(),
+            Self::Sub(item) => item.format.as_ref(),
+        }
+    }
+
+    pub fn overrides(&self) -> Option<&Vec<SchemaOverrideItem>> {
+        match self {
+            Self::Root(item) => item.overrides.as_ref(),
+            Self::Sub(item) => item.overrides.as_ref(),
+        }
+    }
 }
 
 /// # The schema for the root table
@@ -154,6 +169,12 @@ pub struct RootSchema {
 
     /// # Schema-specific lint options
     pub lint: Option<SchemaLintOptions>,
+
+    /// # Schema-specific format options
+    pub format: Option<SchemaFormatOptions>,
+
+    /// # Schema-specific overrides
+    pub overrides: Option<Vec<SchemaOverrideItem>>,
 }
 
 impl RootSchema {
@@ -190,6 +211,12 @@ pub struct SubSchema {
 
     /// # Schema-specific lint options
     pub lint: Option<SchemaLintOptions>,
+
+    /// # Schema-specific format options
+    pub format: Option<SchemaFormatOptions>,
+
+    /// # Schema-specific overrides
+    pub overrides: Option<Vec<SchemaOverrideItem>>,
 }
 
 impl SubSchema {
@@ -230,6 +257,103 @@ pub struct SchemaLintRules {
     ///
     /// Override the deprecated diagnostic level for this schema.
     pub deprecated: Option<SeverityLevelDefaultWarn>,
+}
+
+/// # Schema-specific format options
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaFormatOptions {
+    /// # Schema-specific format rules
+    pub rules: Option<SchemaFormatRules>,
+}
+
+/// # Schema-specific format rules
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaFormatRules {
+    /// # Whether schema-defined table key ordering is enabled
+    pub table_keys_order: Option<SchemaTableKeysOrderRule>,
+}
+
+/// # Schema-defined table key ordering
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaTableKeysOrderRule {
+    /// # Whether schema-defined table key ordering is enabled
+    pub enabled: Option<BoolDefaultTrue>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct Target(String);
+
+impl std::ops::Deref for Target {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&str> for Target {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+/// # Schema-specific override item
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaOverrideItem {
+    /// # Accessor pattern(s) to override
+    ///
+    /// Use `""` to target the root table.
+    #[cfg_attr(feature = "jsonschema", schemars(length(min = 1)))]
+    pub targets: Vec<Target>,
+
+    /// # Format options to override
+    pub format: Option<SchemaOverrideFormatOptions>,
+}
+
+/// # Schema-specific override format options
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Schema)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaOverrideFormatOptions {
+    /// # Schema-specific override format rules
+    pub rules: Option<SchemaOverrideFormatRules>,
+}
+
+/// # Schema-specific override format rules
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(extend("x-tombi-table-keys-order" = tombi_x_keyword::TableKeysOrder::Ascending)))]
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SchemaOverrideFormatRules {
+    /// # Override table key ordering for matched roots
+    pub table_keys_order: Option<TableKeysOrder>,
 }
 
 #[cfg(test)]

--- a/crates/tombi-config/src/schema.rs
+++ b/crates/tombi-config/src/schema.rs
@@ -368,10 +368,62 @@ pub struct SchemaOverrideFormatOptions {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SchemaOverrideFormatRules {
     /// # Override array values ordering for matched roots
-    pub array_values_order: Option<ArrayValuesOrder>,
+    pub array_values_order: Option<SchemaOverrideArrayValuesOrderRule>,
 
     /// # Override table key ordering for matched roots
-    pub table_keys_order: Option<TableKeysOrder>,
+    pub table_keys_order: Option<SchemaOverrideTableKeysOrderRule>,
+}
+
+/// # Override array values ordering for matched roots
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum SchemaOverrideArrayValuesOrderRule {
+    Order(ArrayValuesOrder),
+    Rule(SchemaArrayValuesOrderRule),
+}
+
+impl SchemaOverrideArrayValuesOrderRule {
+    pub fn enabled(&self) -> Option<BoolDefaultTrue> {
+        match self {
+            Self::Order(_) => None,
+            Self::Rule(rule) => rule.enabled,
+        }
+    }
+
+    pub fn order(&self) -> Option<ArrayValuesOrder> {
+        match self {
+            Self::Order(order) => Some(order.clone()),
+            Self::Rule(_) => None,
+        }
+    }
+}
+
+/// # Override table key ordering for matched roots
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum SchemaOverrideTableKeysOrderRule {
+    Order(TableKeysOrder),
+    Rule(SchemaTableKeysOrderRule),
+}
+
+impl SchemaOverrideTableKeysOrderRule {
+    pub fn enabled(&self) -> Option<BoolDefaultTrue> {
+        match self {
+            Self::Order(_) => None,
+            Self::Rule(rule) => rule.enabled,
+        }
+    }
+
+    pub fn order(&self) -> Option<TableKeysOrder> {
+        match self {
+            Self::Order(order) => Some(order.clone()),
+            Self::Rule(_) => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -30,7 +30,6 @@ serde_tombi.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tombi-test-lib.workspace = true
-tombi-x-keyword.workspace = true
 
 [features]
 jsonschema = ["dep:schemars", "serde"]

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -26,9 +26,11 @@ unicode-segmentation.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
+serde_tombi.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tombi-test-lib.workspace = true
+tombi-x-keyword.workspace = true
 
 [features]
 jsonschema = ["dep:schemars", "serde"]

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -69,7 +69,7 @@ impl<'a> Formatter<'a> {
 
         if let Some(tombi_document_comment_directive) = &tombi_document_comment_directive
             && let Some(format) = &tombi_document_comment_directive.format
-            && format.disabled.unwrap_or(false)
+            && format.disabled.unwrap_or_default()
         {
             match self.source_uri_or_path.map(|path| match path {
                 Either::Left(url) => url.to_string(),

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -121,31 +121,18 @@ impl<'a> Formatter<'a> {
             Either::Right(path) => Some(path.to_path_buf()),
         });
 
-        let root = tombi_ast_editor::Editor::new(
-            root,
-            source_path.as_deref(),
-            &tombi_schema_store::SchemaContext {
-                toml_version: self.toml_version,
-                root_schema: source_schema
-                    .as_ref()
-                    .and_then(|schema| schema.root_schema.as_deref()),
-                sub_schema_uri_map: source_schema
-                    .as_ref()
-                    .map(|schema| &schema.sub_schema_uri_map),
-                deprecated_lint_level: source_schema
-                    .as_ref()
-                    .and_then(|schema| schema.deprecated_lint_level),
-                schema_visits: Default::default(),
-                store: self.schema_store,
-                strict: tombi_document_comment_directive
-                    .as_ref()
-                    .and_then(|directive| {
-                        directive.schema.as_ref().and_then(|schema| schema.strict)
-                    }),
-            },
-        )
-        .edit()
-        .await;
+        let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
+            self.toml_version,
+            source_schema.as_ref(),
+            self.schema_store,
+            tombi_document_comment_directive
+                .as_ref()
+                .and_then(|directive| directive.schema.as_ref().and_then(|schema| schema.strict)),
+        );
+
+        let root = tombi_ast_editor::Editor::new(root, source_path.as_deref(), &schema_context)
+            .edit()
+            .await;
 
         log::trace!("TOML AST after editing: {:#?}", root);
 

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -41,6 +41,9 @@ macro_rules! test_format {
                 pub toml_version: TomlVersion,
                 pub options: FormatOptions,
                 pub schema_path: Option<std::path::PathBuf>,
+                pub source_path: Option<std::path::PathBuf>,
+                pub config_toml: Option<String>,
+                pub test_files: Vec<(std::path::PathBuf, String)>,
             }
 
             #[allow(unused)]
@@ -70,6 +73,40 @@ macro_rules! test_format {
                 }
             }
 
+            #[allow(unused)]
+            pub struct SourcePath(pub std::path::PathBuf);
+
+            impl ApplyTestArg for SourcePath {
+                fn apply(self, args: &mut TestArgs) {
+                    args.source_path = Some(self.0);
+                }
+            }
+
+            #[allow(unused)]
+            pub struct Config<T>(pub T);
+
+            impl<T> ApplyTestArg for Config<T>
+            where
+                T: Into<String>,
+            {
+                fn apply(self, args: &mut TestArgs) {
+                    args.config_toml = Some(self.0.into());
+                }
+            }
+
+            #[allow(unused)]
+            pub struct TestFile<P, C>(pub P, pub C);
+
+            impl<P, C> ApplyTestArg for TestFile<P, C>
+            where
+                P: Into<std::path::PathBuf>,
+                C: Into<String>,
+            {
+                fn apply(self, args: &mut TestArgs) {
+                    args.test_files.push((self.0.into(), self.1.into()));
+                }
+            }
+
             #[allow(unused_mut)]
             let mut args = TestArgs::default();
             $(
@@ -78,8 +115,45 @@ macro_rules! test_format {
 
             // Initialize schema store
             let schema_store = SchemaStore::new();
+            let temp_dir = if args.config_toml.is_some() || !args.test_files.is_empty() || args.source_path.is_some() {
+                let temp_dir = std::env::temp_dir().join(format!(
+                    "tombi_formatter_test_{}_{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .expect("time should be after unix epoch")
+                        .as_nanos()
+                ));
+                std::fs::create_dir_all(&temp_dir).expect("failed to create test temp dir");
 
-            if let Some(schema_path) = &args.schema_path {
+                for (path, content) in &args.test_files {
+                    let file_path = temp_dir.join(path);
+                    if let Some(parent) = file_path.parent() {
+                        std::fs::create_dir_all(parent).expect("failed to create test file parent");
+                    }
+                    std::fs::write(&file_path, dedent(content)).expect("failed to write test file");
+                }
+
+                Some(temp_dir)
+            } else {
+                None
+            };
+
+            if let Some(config_toml) = args.config_toml.as_ref() {
+                let config_path = temp_dir
+                    .as_ref()
+                    .expect("temp dir should exist for config")
+                    .join(tombi_config::TOMBI_TOML_FILENAME);
+                std::fs::write(&config_path, dedent(config_toml))
+                    .expect("failed to write test config");
+                let config = serde_tombi::config::try_from_path(&config_path)
+                    .expect("failed to parse test config")
+                    .expect("test config should exist");
+                schema_store
+                    .load_config(&config, Some(&config_path))
+                    .await
+                    .expect("failed to load test config");
+            } else if let Some(schema_path) = &args.schema_path {
                 let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_path.as_path())
                     .expect("failed to convert test schema path to schema uri");
                 schema_store
@@ -92,7 +166,17 @@ macro_rules! test_format {
             }
 
             // Initialize formatter
-            let source_path = tombi_test_lib::project_root_path().join("test.toml");
+            let default_source_path = tombi_test_lib::project_root_path().join("test.toml");
+            let source_path = args
+                .source_path
+                .as_ref()
+                .map(|path| {
+                    temp_dir
+                        .as_ref()
+                        .map(|temp_dir| temp_dir.join(path))
+                        .unwrap_or_else(|| path.clone())
+                })
+                .unwrap_or(default_source_path);
             let formatter = Formatter::new(
                 args.toml_version,
                 &args.options,
@@ -124,6 +208,10 @@ macro_rules! test_format {
                 expected,
                 "Formatting should be equal to expected"
             );
+
+            if let Some(temp_dir) = temp_dir {
+                let _ = std::fs::remove_dir_all(temp_dir);
+            }
         }
     };
 
@@ -147,6 +235,9 @@ macro_rules! test_format {
                 pub toml_version: TomlVersion,
                 pub options: FormatOptions,
                 pub schema_path: Option<std::path::PathBuf>,
+                pub source_path: Option<std::path::PathBuf>,
+                pub config_toml: Option<String>,
+                pub test_files: Vec<(std::path::PathBuf, String)>,
             }
 
             #[allow(unused)]
@@ -176,6 +267,40 @@ macro_rules! test_format {
                 }
             }
 
+            #[allow(unused)]
+            pub struct SourcePath(pub std::path::PathBuf);
+
+            impl ApplyTestArg for SourcePath {
+                fn apply(self, config: &mut TestArgs) {
+                    config.source_path = Some(self.0);
+                }
+            }
+
+            #[allow(unused)]
+            pub struct Config<T>(pub T);
+
+            impl<T> ApplyTestArg for Config<T>
+            where
+                T: Into<String>,
+            {
+                fn apply(self, config: &mut TestArgs) {
+                    config.config_toml = Some(self.0.into());
+                }
+            }
+
+            #[allow(unused)]
+            pub struct TestFile<P, C>(pub P, pub C);
+
+            impl<P, C> ApplyTestArg for TestFile<P, C>
+            where
+                P: Into<std::path::PathBuf>,
+                C: Into<String>,
+            {
+                fn apply(self, args: &mut TestArgs) {
+                    args.test_files.push((self.0.into(), self.1.into()));
+                }
+            }
+
             #[allow(unused_mut)]
             let mut config = TestArgs::default();
             $(
@@ -184,8 +309,46 @@ macro_rules! test_format {
 
             // Initialize schema store
             let schema_store = SchemaStore::new();
+            let temp_dir = if config.config_toml.is_some() || !config.test_files.is_empty() || config.source_path.is_some() {
+                let temp_dir = std::env::temp_dir().join(format!(
+                    "tombi_formatter_test_{}_{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .expect("time should be after unix epoch")
+                        .as_nanos()
+                ));
+                std::fs::create_dir_all(&temp_dir).expect("failed to create test temp dir");
 
-            if let Some(schema_path) = config.schema_path {
+                for (path, content) in &config.test_files {
+                    let file_path = temp_dir.join(path);
+                    if let Some(parent) = file_path.parent() {
+                        std::fs::create_dir_all(parent).expect("failed to create test file parent");
+                    }
+                    std::fs::write(&file_path, textwrap::dedent(content))
+                        .expect("failed to write test file");
+                }
+
+                Some(temp_dir)
+            } else {
+                None
+            };
+
+            if let Some(config_toml) = config.config_toml.as_ref() {
+                let config_path = temp_dir
+                    .as_ref()
+                    .expect("temp dir should exist for config")
+                    .join(tombi_config::TOMBI_TOML_FILENAME);
+                std::fs::write(&config_path, textwrap::dedent(config_toml))
+                    .expect("failed to write test config");
+                let test_config = serde_tombi::config::try_from_path(&config_path)
+                    .expect("failed to parse test config")
+                    .expect("test config should exist");
+                schema_store
+                    .load_config(&test_config, Some(&config_path))
+                    .await
+                    .expect("failed to load test config");
+            } else if let Some(schema_path) = config.schema_path {
                 let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_path)
                     .expect("failed to convert test schema path to schema uri");
                 schema_store
@@ -198,7 +361,17 @@ macro_rules! test_format {
             }
 
             // Initialize formatter
-            let source_path = tombi_test_lib::project_root_path().join("test.toml");
+            let default_source_path = tombi_test_lib::project_root_path().join("test.toml");
+            let source_path = config
+                .source_path
+                .as_ref()
+                .map(|path| {
+                    temp_dir
+                        .as_ref()
+                        .map(|temp_dir| temp_dir.join(path))
+                        .unwrap_or_else(|| path.clone())
+                })
+                .unwrap_or(default_source_path);
             let formatter = Formatter::new(
                 config.toml_version,
                 &config.options,
@@ -213,6 +386,10 @@ macro_rules! test_format {
                 Err(errors) => {
                     pretty_assertions::assert_ne!(errors, vec![]);
                 }
+            }
+
+            if let Some(temp_dir) = temp_dir {
+                let _ = std::fs::remove_dir_all(temp_dir);
             }
         }
     };

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -509,6 +509,126 @@ mod table_keys_order {
                 "#
             )
         }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_format_rules_root_schema_override_only(
+                r#"
+                [tool.tombi.format.rules]
+                trailing-comment-alignment = true
+                key-value-equals-sign-alignment = true
+                inline-table-brace-space-width = 0
+                indent-table-key-value-pairs = true
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.table-keys-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.format.rules"], format.rules.table-keys-order = "ascending" }
+                    ]
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.table-keys-order.enabled = false
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.format.rules]
+                indent-table-key-value-pairs = true
+                inline-table-brace-space-width = 0
+                key-value-equals-sign-alignment = true
+                trailing-comment-alignment = true
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_format_rules_subschema_override_only(
+                r#"
+                [tool.tombi.format.rules]
+                trailing-comment-alignment = true
+                key-value-equals-sign-alignment = true
+                inline-table-brace-space-width = 0
+                indent-table-key-value-pairs = true
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    format.rules.table-keys-order.enabled = false
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.table-keys-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.format.rules"], format.rules.table-keys-order = "descending" }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.format.rules]
+                trailing-comment-alignment = true
+                key-value-equals-sign-alignment = true
+                inline-table-brace-space-width = 0
+                indent-table-key-value-pairs = true
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_format_rules_root_override_precedes_subschema_override(
+                r#"
+                [tool.tombi.format.rules]
+                trailing-comment-alignment = true
+                key-value-equals-sign-alignment = true
+                inline-table-brace-space-width = 0
+                indent-table-key-value-pairs = true
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.table-keys-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.format.rules"], format.rules.table-keys-order = "ascending" }
+                    ]
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.table-keys-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.format.rules"], format.rules.table-keys-order = "descending" }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.format.rules]
+                indent-table-key-value-pairs = true
+                inline-table-brace-space-width = 0
+                key-value-equals-sign-alignment = true
+                trailing-comment-alignment = true
+                "#
+            )
+        }
     }
 
     mod cargo {
@@ -872,6 +992,90 @@ mod table_keys_order {
                 [[schemas]]
                 path = "schemas/type-test.schema.json"
                 include = ["type-test.toml"]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tombi_schema_table_keys_order_disabled_keeps_user_order_in_schema_item(
+                r#"
+                files.include = []
+                lint.rules.key-empty = "warn"
+                toml-version = "v1.0.0"
+                "#,
+                SourcePath(std::path::PathBuf::from(".tombi.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                    format.rules.table-keys-order.enabled = false
+                    "#
+                ),
+            ) -> Ok(source)
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tombi_schema_table_keys_order_ascending_user_order_in_schema_item(
+                r#"
+                toml-version = "v1.0.0"
+                files.include = []
+                lint.rules.key-empty = "warn"
+                "#,
+                SourcePath(std::path::PathBuf::from(".tombi.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                    overrides = [
+                        { targets = [""], format.rules.table-keys-order = "ascending" }
+                    ]
+                   "#
+                ),
+            ) -> Ok(
+                r#"
+                files.include = []
+                lint.rules.key-empty = "warn"
+                toml-version = "v1.0.0"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tombi_schema_table_keys_order_override_schema_item_table_order(
+                r#"
+                [[schemas]]
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                path = "tombi://www.schemastore.org/tombi.json"
+                overrides = [
+                    { targets = ["schemas[*]"], }
+                ]
+                "#,
+                SourcePath(std::path::PathBuf::from(".tombi.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                    overrides = [
+                      { targets = ["schemas[*]"],  }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [
+                    {
+                    targets = ["schemas[*]"],
+                    }
+                ]
                 "#
             )
         }
@@ -1782,5 +1986,127 @@ mod table_keys_order {
                 "#
             )
         }
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn test_schema_format_disable_does_not_apply_schema_order_from_referenced_tables(
+            r#"
+            [b]
+            zed = 1
+            uv = 2
+
+            [a]
+            zed = 3
+            uv = 4
+            "#,
+            SourcePath(std::path::PathBuf::from("test.toml")),
+            TestFile(
+                "schema.json",
+                r#"
+                {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "$ref": "child-schema.json"
+                    },
+                    "b": {
+                      "$ref": "child-schema.json"
+                    }
+                  }
+                }
+                "#
+            ),
+            TestFile(
+                "child-schema.json",
+                r#"
+                {
+                  "type": "object",
+                  "x-tombi-table-keys-order": "schema",
+                  "properties": {
+                    "uv": { "type": "integer" },
+                    "zed": { "type": "integer" }
+                  }
+                }
+                "#
+            ),
+            Config(
+                r#"
+                [[schemas]]
+                path = "./schema.json"
+                include = ["*.toml"]
+                format.rules.table-keys-order.enabled = false
+                "#
+            ),
+        ) -> Ok(
+            r#"
+            [b]
+            zed = 1
+            uv = 2
+
+            [a]
+            zed = 3
+            uv = 4
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn test_schema_override_has_priority_over_schema_format_disable(
+            r#"
+            [b]
+            zed = 1
+            uv = 2
+
+            [a]
+            zed = 3
+            uv = 4
+            "#,
+            SourcePath(std::path::PathBuf::from("test.toml")),
+            TestFile(
+                "schema.json",
+                r#"
+                {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": "object",
+                      "properties": {
+                        "uv": { "type": "integer" },
+                        "zed": { "type": "integer" }
+                      }
+                    },
+                    "b": {
+                      "type": "object",
+                      "properties": {
+                        "uv": { "type": "integer" },
+                        "zed": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+                "#
+            ),
+            Config(r#"
+                [[schemas]]
+                path = "./schema.json"
+                include = ["*.toml"]
+                format.rules.table-keys-order.enabled = false
+                overrides = [
+                  { targets = [""], format.rules.table-keys-order = "schema" }
+                ]
+            "#),
+        ) -> Ok(
+            r#"
+            [a]
+            zed = 3
+            uv = 4
+
+            [b]
+            zed = 1
+            uv = 2
+            "#
+        )
     }
 }

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -1274,9 +1274,9 @@ mod table_keys_order {
                 path = "tombi://www.schemastore.org/tombi.json"
                 include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
                 overrides = [
-                    {
+                  {
                     targets = ["schemas[*]"],
-                    }
+                  }
                 ]
                 "#
             )

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -512,6 +512,208 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
+            async fn test_dependency_groups_array_values_order_disabled_keeps_user_order(
+                r#"
+                [project]
+                name = "tombi"
+                version = "1.0.0"
+                requires-python = ">=3.10"
+                dependencies = []
+
+                [dependency-groups]
+                dev = [
+                  { include-group = "stub" },
+                  "pytest>=8.3.3",
+                  { include-group = "ci" },
+                  "ruff>=0.7.4",
+                ]
+                ci = [
+                  "ruff>=0.7.4",
+                  "pytest-ci>=0.0.0",
+                ]
+                stub = [
+                  "pytest-stub>=1.1.0",
+                ]
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.array-values-order.enabled = false
+                    "#
+                ),
+            ) -> Ok(source)
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_dependency_groups_array_values_order_override_ascending(
+                r#"
+                [project]
+                name = "tombi"
+                version = "1.0.0"
+                requires-python = ">=3.10"
+                dependencies = []
+
+                [dependency-groups]
+                dev = [
+                  { include-group = "stub" },
+                  "pytest>=8.3.3",
+                  { include-group = "ci" },
+                  "ruff>=0.7.4",
+                ]
+                ci = [
+                  "ruff>=0.7.4",
+                  "pytest-ci>=0.0.0",
+                ]
+                stub = [
+                  "pytest-stub>=1.1.0",
+                ]
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.array-values-order.enabled = false
+                    overrides = [
+                      { targets = ["dependency-groups.dev"], format.rules.array-values-order = "ascending" }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [project]
+                name = "tombi"
+                version = "1.0.0"
+                requires-python = ">=3.10"
+                dependencies = []
+
+                [dependency-groups]
+                dev = [
+                  { include-group = "ci" },
+                  "pytest>=8.3.3",
+                  "ruff>=0.7.4",
+                  { include-group = "stub" },
+                ]
+                ci = [
+                  "ruff>=0.7.4",
+                  "pytest-ci>=0.0.0",
+                ]
+                stub = [
+                  "pytest-stub>=1.1.0",
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_files_exclude_root_schema_array_override_only(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/cache", "**/uv.lock", "**/dist"]
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.array-values-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.files.exclude"], format.rules.array-values-order = "ascending" }
+                    ]
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.array-values-order.enabled = false
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/cache", "**/dist", "**/uv.lock"]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_files_exclude_subschema_array_override_only(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/cache", "**/uv.lock", "**/dist"]
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    format.rules.array-values-order.enabled = false
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.array-values-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.files.exclude"], format.rules.array-values-order = "descending" }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/uv.lock", "**/dist", "**/cache"]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_tool_tombi_files_exclude_root_array_override_precedes_subschema_override(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/cache", "**/uv.lock", "**/dist"]
+                "#,
+                SourcePath(std::path::PathBuf::from("pyproject.toml")),
+                Config(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/pyproject.json"
+                    include = ["pyproject.toml"]
+                    format.rules.array-values-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.files.exclude"], format.rules.array-values-order = "ascending" }
+                    ]
+
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/tombi.json"
+                    include = ["pyproject.toml"]
+                    root = "tool.tombi"
+                    format.rules.array-values-order.enabled = false
+                    overrides = [
+                      { targets = ["tool.tombi.files.exclude"], format.rules.array-values-order = "descending" }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [tool.tombi.files]
+                exclude = ["**/cache", "**/dist", "**/uv.lock"]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_tool_tombi_format_rules_root_schema_override_only(
                 r#"
                 [tool.tombi.format.rules]

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -117,25 +117,16 @@ impl<'a> Linter<'a> {
 
             log::trace!("document_tree: {:#?}", document_tree);
 
-            let schema_context = tombi_schema_store::SchemaContext {
-                toml_version: self.toml_version,
-                root_schema: source_schema
-                    .as_ref()
-                    .and_then(|source_schema| source_schema.root_schema.as_deref()),
-                sub_schema_uri_map: source_schema
-                    .as_ref()
-                    .map(|source_schema| &source_schema.sub_schema_uri_map),
-                deprecated_lint_level: source_schema
-                    .as_ref()
-                    .and_then(|source_schema| source_schema.deprecated_lint_level),
-                schema_visits: Default::default(),
-                store: self.schema_store,
-                strict: tombi_document_comment_directive
+            let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
+                self.toml_version,
+                source_schema.as_ref(),
+                self.schema_store,
+                tombi_document_comment_directive
                     .as_ref()
                     .and_then(|directive| {
                         directive.schema.as_ref().and_then(|schema| schema.strict)
                     }),
-            };
+            );
 
             if let Err(diagnostics) =
                 tombi_validator::validate(document_tree, source_schema.as_ref(), &schema_context)

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -68,7 +68,7 @@ impl<'a> Linter<'a> {
 
         if let Some(tombi_document_comment_directive) = &tombi_document_comment_directive
             && let Some(lint) = &tombi_document_comment_directive.lint
-            && lint.disabled.unwrap_or(false)
+            && lint.disabled.unwrap_or_default()
         {
             // Only skip linting if there are no validation errors
             if self.diagnostics.is_empty() {

--- a/crates/tombi-linter/src/rule/dotted_keys_out_of_order.rs
+++ b/crates/tombi-linter/src/rule/dotted_keys_out_of_order.rs
@@ -43,7 +43,7 @@ async fn check_dotted_keys_out_of_order(
     if comment_directive
         .as_ref()
         .and_then(|comment_directive| comment_directive.table_keys_order_disabled())
-        .unwrap_or(false)
+        .unwrap_or_default()
     {
         return;
     }

--- a/crates/tombi-linter/src/rule/tables_out_of_order.rs
+++ b/crates/tombi-linter/src/rule/tables_out_of_order.rs
@@ -18,7 +18,7 @@ impl Rule<tombi_ast::Root> for TablesOutOfOrderRule {
         if comment_directive
             .as_ref()
             .and_then(|comment_directive| comment_directive.table_keys_order_disabled())
-            .unwrap_or(false)
+            .unwrap_or_default()
         {
             return;
         }

--- a/crates/tombi-linter/tests/integration/cargo_schema.rs
+++ b/crates/tombi-linter/tests/integration/cargo_schema.rs
@@ -104,6 +104,8 @@ fn deprecated_schema_config(deprecated_level: Option<SeverityLevel>) -> tombi_co
                     )),
                 }),
             }),
+            format: None,
+            overrides: None,
         },
     )]);
     config
@@ -128,6 +130,8 @@ fn deprecated_sub_schema_config(deprecated_level: Option<SeverityLevel>) -> tomb
                     )),
                 }),
             }),
+            format: None,
+            overrides: None,
         },
     )]);
     config

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["fs", "io-std", "rt-multi-thread"] }
 tombi-ast.workspace = true
 tombi-cache.workspace = true
 tombi-comment-directive.workspace = true
+tombi-comment-directive-serde.workspace = true
 tombi-comment-directive-store.workspace = true
 tombi-config.workspace = true
 tombi-date-time.workspace = true

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -96,7 +96,7 @@ pub fn extract_keys_and_hint(
     comment_context: Option<&CommentContext>,
 ) -> Option<(Vec<tombi_document_tree::Key>, Option<CompletionHint>)> {
     let mut keys: Vec<tombi_document_tree::Key> = vec![];
-    let mut completion_hint = None;
+    let mut completion_hint = get_comma_completion_hint(root.syntax(), position);
     let is_tombi_value_comment_directive =
         matches!(comment_context, Some(CommentContext::ValueDirective(_)));
 
@@ -780,7 +780,13 @@ fn get_leading_comma(node: &SyntaxNode, position: tombi_text::Position) -> Optio
     }
     if let Some(sibling) = node
         .siblings_with_tokens(Direction::Prev)
-        .find(|node_or_token| !node_or_token.range().contains(position))
+        .find(|node_or_token| {
+            !node_or_token.range().contains(position)
+                && !matches!(
+                    node_or_token.kind(),
+                    SyntaxKind::WHITESPACE | SyntaxKind::LINE_BREAK
+                )
+        })
         && sibling.kind() == SyntaxKind::COMMA
     {
         return Some(CommaHint {
@@ -790,8 +796,83 @@ fn get_leading_comma(node: &SyntaxNode, position: tombi_text::Position) -> Optio
     None
 }
 
+fn get_comma_completion_hint(
+    root: &SyntaxNode,
+    position: tombi_text::Position,
+) -> Option<CompletionHint> {
+    let (prev_token, next_token) = match root.token_at_position(position) {
+        TokenAtOffset::Single(token) => {
+            let prev_token = if is_trivia(token.kind()) {
+                token.prev_token()
+            } else {
+                Some(token.clone())
+            };
+            let next_token = if is_trivia(token.kind()) {
+                token.next_token()
+            } else {
+                Some(token)
+            };
+            (prev_token, next_token)
+        }
+        TokenAtOffset::Between(left, right) => (Some(left), Some(right)),
+        TokenAtOffset::None => (None, None),
+    };
+
+    let leading_comma = prev_token
+        .and_then(|token| prev_non_trivia_token(&token).or(Some(token)))
+        .filter(|token| token.kind() == SyntaxKind::COMMA)
+        .map(|token| CommaHint {
+            range: token.range(),
+        });
+    let trailing_comma = next_token
+        .and_then(|token| next_non_trivia_token(&token).or(Some(token)))
+        .filter(|token| token.kind() == SyntaxKind::COMMA)
+        .map(|token| CommaHint {
+            range: token.range(),
+        });
+
+    (leading_comma.is_some() || trailing_comma.is_some()).then_some(CompletionHint::Comma {
+        leading_comma,
+        trailing_comma,
+    })
+}
+
+fn is_trivia(kind: SyntaxKind) -> bool {
+    matches!(kind, SyntaxKind::WHITESPACE | SyntaxKind::LINE_BREAK)
+}
+
+fn prev_non_trivia_token(token: &tombi_syntax::SyntaxToken) -> Option<tombi_syntax::SyntaxToken> {
+    let mut current = Some(token.clone());
+    while let Some(token) = current {
+        if !is_trivia(token.kind()) {
+            return Some(token);
+        }
+        current = token.prev_token();
+    }
+    None
+}
+
+fn next_non_trivia_token(token: &tombi_syntax::SyntaxToken) -> Option<tombi_syntax::SyntaxToken> {
+    let mut current = Some(token.clone());
+    while let Some(token) = current {
+        if !is_trivia(token.kind()) {
+            return Some(token);
+        }
+        current = token.next_token();
+    }
+    None
+}
+
 fn get_trailing_comma(node: &SyntaxNode, position: tombi_text::Position) -> Option<CommaHint> {
-    if let Some(sibling) = node.siblings_with_tokens(Direction::Next).next() {
+    if let Some(sibling) = node
+        .siblings_with_tokens(Direction::Next)
+        .find(|node_or_token| {
+            !matches!(
+                node_or_token.kind(),
+                SyntaxKind::WHITESPACE | SyntaxKind::LINE_BREAK
+            )
+        })
+    {
         match sibling.kind() {
             SyntaxKind::COMMA => {
                 // Case like:

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -17,9 +17,13 @@ use tombi_future::Boxable;
 use tombi_rg_tree::{NodeOrToken, TokenAtOffset};
 use tombi_schema_store::{
     Accessor, AccessorKeyKind, AllOfSchema, AnyOfSchema, CompositeSchema, CurrentSchema,
-    KeyContext, OneOfSchema, SchemaDefinitions, SchemaStore, SchemaUri, ValueSchema,
+    KeyContext, OneOfSchema, SchemaAccessor, SchemaDefinitions, SchemaStore, SchemaUri,
+    ValueSchema,
 };
 use tombi_syntax::{Direction, SyntaxElement, SyntaxKind, SyntaxNode};
+
+use crate::completion::schema_completion::SchemaCompletion;
+use crate::schema_resolver::resolve_array_item_schema;
 
 pub fn get_comment_context(
     root: &tombi_ast::Root,
@@ -267,6 +271,139 @@ pub async fn find_completion_contents_with_tree(
                 .next()
         })
         .collect()
+}
+
+pub async fn find_completion_contents_with_accessors(
+    position: tombi_text::Position,
+    accessors: &[Accessor],
+    schema_context: &tombi_schema_store::SchemaContext<'_>,
+    completion_hint: Option<CompletionHint>,
+) -> Vec<CompletionContent> {
+    let Some(document_schema) = schema_context.root_schema else {
+        return Vec::new();
+    };
+    let Some(root_value_schema) = document_schema.value_schema.as_ref() else {
+        return Vec::new();
+    };
+
+    let Some(current_schema) = resolve_schema_with_accessors(
+        CurrentSchema {
+            value_schema: root_value_schema.clone(),
+            schema_uri: Cow::Owned(document_schema.schema_uri.clone()),
+            definitions: Cow::Owned(document_schema.definitions.clone()),
+        },
+        accessors,
+        schema_context,
+    )
+    .await
+    else {
+        return Vec::new();
+    };
+
+    dedup_completion_contents(
+        SchemaCompletion
+            .find_completion_contents(
+                position,
+                &[],
+                &[],
+                Some(&current_schema),
+                schema_context,
+                completion_hint,
+            )
+            .await,
+    )
+}
+
+fn resolve_schema_with_accessors<'a: 'b, 'b>(
+    current_schema: CurrentSchema<'static>,
+    accessors: &'a [Accessor],
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> tombi_future::BoxFuture<'b, Option<CurrentSchema<'static>>> {
+    async move {
+        let Some((accessor, remaining_accessors)) = accessors.split_first() else {
+            return Some(current_schema);
+        };
+
+        let composite_schemas = match current_schema.value_schema.as_ref() {
+            ValueSchema::OneOf(schema) => Some(schema.schemas.clone()),
+            ValueSchema::AnyOf(schema) => Some(schema.schemas.clone()),
+            ValueSchema::AllOf(schema) => Some(schema.schemas.clone()),
+            _ => None,
+        };
+        if let Some(schemas) = composite_schemas {
+            return resolve_composite_schema_with_accessors(
+                &schemas,
+                current_schema,
+                accessors,
+                schema_context,
+            )
+            .await;
+        }
+
+        match (accessor, current_schema.value_schema.as_ref()) {
+            (Accessor::Key(_), ValueSchema::Table(table_schema)) => {
+                let next_schema = table_schema
+                    .resolve_property_schema(
+                        &SchemaAccessor::from(accessor),
+                        current_schema.schema_uri.clone(),
+                        current_schema.definitions.clone(),
+                        schema_context.store,
+                    )
+                    .await
+                    .inspect_err(|err| log::warn!("{err}"))
+                    .ok()
+                    .flatten()?
+                    .into_owned();
+                resolve_schema_with_accessors(next_schema, remaining_accessors, schema_context)
+                    .await
+            }
+            (Accessor::Index(index), ValueSchema::Array(array_schema)) => {
+                let next_schema = resolve_array_item_schema(
+                    *index,
+                    array_schema,
+                    &current_schema,
+                    schema_context,
+                )
+                .await?
+                .into_owned();
+                resolve_schema_with_accessors(next_schema, remaining_accessors, schema_context)
+                    .await
+            }
+            _ => None,
+        }
+    }
+    .boxed()
+}
+
+fn resolve_composite_schema_with_accessors<'a: 'b, 'b>(
+    schemas: &'a tombi_schema_store::ReferableValueSchemas,
+    current_schema: CurrentSchema<'static>,
+    accessors: &'a [Accessor],
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> tombi_future::BoxFuture<'b, Option<CurrentSchema<'static>>> {
+    async move {
+        let schema_visits = tombi_schema_store::SchemaVisits::default();
+        let collected = tombi_schema_store::resolve_and_collect_schemas(
+            schemas,
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            schema_context.store,
+            &schema_visits,
+            accessors,
+        )
+        .await?;
+
+        for schema in collected {
+            if let Some(resolved) =
+                resolve_schema_with_accessors(schema.into_owned(), accessors, schema_context).await
+            {
+                return Some(resolved);
+            }
+        }
+
+        None
+    }
+    .boxed()
 }
 
 pub trait FindCompletionContents {

--- a/crates/tombi-lsp/src/completion/comment.rs
+++ b/crates/tombi-lsp/src/completion/comment.rs
@@ -155,6 +155,7 @@ pub async fn get_tombi_comment_directive_content_completion_contents(
         Some(toml_version),
         None,
         true,
+        true,
     );
     let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
         toml_version,

--- a/crates/tombi-lsp/src/completion/comment.rs
+++ b/crates/tombi-lsp/src/completion/comment.rs
@@ -154,16 +154,14 @@ pub async fn get_tombi_comment_directive_content_completion_contents(
         tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
+        true,
     );
-    let schema_context = tombi_schema_store::SchemaContext {
+    let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
         toml_version,
-        root_schema: source_schema.root_schema.as_deref(),
-        sub_schema_uri_map: None,
-        deprecated_lint_level: None,
-        schema_visits: Default::default(),
-        store: schema_store,
-        strict: None,
-    };
+        Some(&source_schema),
+        schema_store,
+        None,
+    );
 
     Some(
         find_completion_contents_with_tree(

--- a/crates/tombi-lsp/src/completion/value/array.rs
+++ b/crates/tombi-lsp/src/completion/value/array.rs
@@ -185,7 +185,16 @@ impl FindCompletionContents for tombi_document_tree::Array {
                                     schema_context,
                                     if self.kind() == ArrayKind::Array {
                                         if new_item_index == 0 {
+                                            let has_separator_before_next_value = self
+                                                .values()
+                                                .first()
+                                                .is_some_and(|next_value| {
+                                                    position.line < next_value.range().start.line
+                                                        && position.column
+                                                            < next_value.range().start.column
+                                                });
                                             let add_trailing_comma = if self.is_empty()
+                                                || has_separator_before_next_value
                                                 || matches!(
                                                     completion_hint,
                                                     Some(CompletionHint::Comma {

--- a/crates/tombi-lsp/src/completion/value/branch_result.rs
+++ b/crates/tombi-lsp/src/completion/value/branch_result.rs
@@ -12,10 +12,10 @@ pub(super) struct BranchCompletionResult {
 
 impl BranchCompletionResult {
     fn should_include_in_fallback(&self, valid_branches: bool, narrow_branches: bool) -> bool {
-        if valid_branches {
-            self.is_valid || self.is_recoverable
-        } else if narrow_branches {
+        if narrow_branches {
             self.has_key || self.is_recoverable
+        } else if valid_branches {
+            self.is_valid || self.is_recoverable
         } else {
             true
         }
@@ -105,11 +105,15 @@ where
 
     let mut completion_items = Vec::new();
     for branch in &branch_results {
-        if valid_branches {
+        if narrow_branches {
+            if branch.has_key {
+                completion_items.extend(branch.items.iter().cloned());
+            }
+        } else if valid_branches {
             if branch.is_valid {
                 completion_items.extend(branch.items.iter().cloned());
             }
-        } else if !narrow_branches || branch.has_key {
+        } else {
             completion_items.extend(branch.items.iter().cloned());
         }
     }

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -643,14 +643,14 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                 }
                             }
 
-                            if let Some(sub_schema_uri_map) = schema_context.sub_schema_uri_map {
-                                for (root_accessors, sub_schema_uri) in sub_schema_uri_map {
+                            if let Some(sub_schema_map) = schema_context.sub_schema_map {
+                                for (root_accessors, sub_schema) in sub_schema_map {
                                     if let Some(last_key) =
                                         matching_subschema_completion_key(root_accessors, accessors)
                                     {
                                         let Ok(Some(document_schema)) = schema_context
                                             .store
-                                            .try_get_document_schema(sub_schema_uri)
+                                            .try_get_document_schema(&sub_schema.schema_uri)
                                             .await
                                         else {
                                             continue;

--- a/crates/tombi-lsp/src/goto_type_definition/comment.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/comment.rs
@@ -65,17 +65,15 @@ pub async fn get_tombi_value_comment_directive_type_definition(
         tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
+        true,
     );
 
-    let schema_context = tombi_schema_store::SchemaContext {
-        toml_version: TOMBI_COMMENT_DIRECTIVE_TOML_VERSION,
-        root_schema: source_schema.root_schema.as_deref(),
-        sub_schema_uri_map: None,
-        deprecated_lint_level: None,
-        schema_visits: Default::default(),
-        store: schema_store,
-        strict: None,
-    };
+    let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
+        TOMBI_COMMENT_DIRECTIVE_TOML_VERSION,
+        Some(&source_schema),
+        schema_store,
+        None,
+    );
 
     get_type_definition(&document_tree, position_in_content, &keys, &schema_context).await
 }

--- a/crates/tombi-lsp/src/goto_type_definition/comment.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/comment.rs
@@ -66,6 +66,7 @@ pub async fn get_tombi_value_comment_directive_type_definition(
         Some(toml_version),
         None,
         true,
+        true,
     );
 
     let schema_context = tombi_schema_store::SchemaContext::from_source_schema(

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -83,10 +83,6 @@ pub async fn handle_completion(
         .ok()
         .flatten();
 
-    let root_schema = source_schema
-        .as_ref()
-        .and_then(|schema| schema.root_schema.as_deref());
-
     // Skip completion if the trigger character is a whitespace or if there is no schema.
     if let Some(CompletionContext {
         trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
@@ -98,7 +94,11 @@ pub async fn handle_completion(
         let pos_line = position.line as usize;
         if pos_line > 0
             && let Some(prev_line) = &document_source.text().lines().nth(pos_line - 1)
-            && (prev_line.trim().is_empty() || root_schema.is_none())
+            && (prev_line.trim().is_empty()
+                || source_schema
+                    .as_ref()
+                    .and_then(|schema| schema.root_schema.as_deref())
+                    .is_none())
         {
             log::trace!("completion skipped due to consecutive line breaks");
             return Ok(None);
@@ -145,19 +145,12 @@ pub async fn handle_completion(
                 return Ok(Some(Vec::with_capacity(0)));
             };
 
-            let schema_context = tombi_schema_store::SchemaContext {
+            let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
                 toml_version,
-                root_schema,
-                sub_schema_uri_map: source_schema
-                    .as_ref()
-                    .map(|schema| &schema.sub_schema_uri_map),
-                deprecated_lint_level: source_schema
-                    .as_ref()
-                    .and_then(|schema| schema.deprecated_lint_level),
-                schema_visits: Default::default(),
-                store: &schema_store,
-                strict: None,
-            };
+                source_schema.as_ref(),
+                &schema_store,
+                None,
+            );
 
             completion_items.extend(
                 find_completion_contents_with_tree(

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -8,7 +8,8 @@ use tower_lsp::lsp_types::{
 use crate::{
     backend,
     completion::{
-        extract_keys_and_hint, find_completion_contents_with_tree, get_comment_context,
+        extract_keys_and_hint, find_completion_contents_with_accessors,
+        find_completion_contents_with_tree, get_comment_context,
         get_document_comment_directive_completion_contents,
     },
     config_manager::ConfigSchemaStore,
@@ -152,16 +153,38 @@ pub async fn handle_completion(
                 None,
             );
 
-            completion_items.extend(
-                find_completion_contents_with_tree(
-                    &document_tree,
-                    position,
-                    &keys,
-                    &schema_context,
-                    completion_hint,
-                )
-                .await,
-            );
+            let mut schema_completion_items = find_completion_contents_with_tree(
+                &document_tree,
+                position,
+                &keys,
+                &schema_context,
+                completion_hint,
+            )
+            .await;
+
+            if schema_completion_items.is_empty()
+                && matches!(completion_hint, Some(CompletionHint::DotTrigger { .. }))
+            {
+                let accessors =
+                    tombi_document_tree::get_accessors(&document_tree, &keys, position);
+                // `get_accessors` appends `Accessor::Index` entries when `position` is
+                // inside an array value, so more accessors than keys means we have a
+                // deeper context that the tree-based completion didn't reach.
+                if accessors.len() > keys.len() {
+                    let accessor_completion_items = find_completion_contents_with_accessors(
+                        position,
+                        &accessors,
+                        &schema_context,
+                        completion_hint,
+                    )
+                    .await;
+                    if !accessor_completion_items.is_empty() {
+                        schema_completion_items = accessor_completion_items;
+                    }
+                }
+            }
+
+            completion_items.extend(schema_completion_items);
 
             (keys, completion_hint)
         }

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -92,17 +92,12 @@ pub async fn handle_goto_type_definition(
             &document_source.document_tree(),
             position,
             &keys,
-            &SchemaContext {
+            &SchemaContext::from_source_schema(
                 toml_version,
-                root_schema: source_schema
-                    .as_ref()
-                    .and_then(|s| s.root_schema.as_deref()),
-                sub_schema_uri_map: source_schema.as_ref().map(|s| &s.sub_schema_uri_map),
-                deprecated_lint_level: source_schema.as_ref().and_then(|s| s.deprecated_lint_level),
-                schema_visits: Default::default(),
-                store: &schema_store,
-                strict: None,
-            },
+                source_schema.as_ref(),
+                &schema_store,
+                None,
+            ),
         )
         .await
         {

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -90,17 +90,12 @@ pub async fn handle_hover(
         &document_tree,
         position,
         &keys,
-        &SchemaContext {
+        &SchemaContext::from_source_schema(
             toml_version,
-            root_schema: source_schema
-                .as_ref()
-                .and_then(|s| s.root_schema.as_deref()),
-            sub_schema_uri_map: source_schema.as_ref().map(|s| &s.sub_schema_uri_map),
-            deprecated_lint_level: source_schema.as_ref().and_then(|s| s.deprecated_lint_level),
-            schema_visits: Default::default(),
-            store: &schema_store,
-            strict: None,
-        },
+            source_schema.as_ref(),
+            &schema_store,
+            None,
+        ),
     )
     .await;
 

--- a/crates/tombi-lsp/src/hover/comment.rs
+++ b/crates/tombi-lsp/src/hover/comment.rs
@@ -137,17 +137,15 @@ async fn get_comment_directive_toml_content_hover_content(
             tombi_hashmap::IndexMap::with_capacity(0),
             Some(toml_version),
             None,
+            true,
         );
 
-        let schema_context = tombi_schema_store::SchemaContext {
+        let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
             toml_version,
-            root_schema: source_schema.root_schema.as_deref(),
-            sub_schema_uri_map: None,
-            deprecated_lint_level: None,
-            schema_visits: Default::default(),
-            store: schema_store,
-            strict: None,
-        };
+            Some(&source_schema),
+            schema_store,
+            None,
+        );
 
         if let Some(hover_content) = get_hover_content(
             &directive_ast

--- a/crates/tombi-lsp/src/hover/comment.rs
+++ b/crates/tombi-lsp/src/hover/comment.rs
@@ -138,6 +138,7 @@ async fn get_comment_directive_toml_content_hover_content(
             Some(toml_version),
             None,
             true,
+            true,
         );
 
         let schema_context = tombi_schema_store::SchemaContext::from_source_schema(

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -138,7 +138,7 @@ impl std::fmt::Display for ValueConstraints {
             write!(f, "Max Values: `{max_items}`\n\n")?;
         }
 
-        if self.unique_items.unwrap_or(false) {
+        if self.unique_items.unwrap_or_default() {
             write!(f, "Unique Values: `true`\n\n")?;
         }
 
@@ -186,7 +186,7 @@ impl std::fmt::Display for ValueConstraints {
             }
         }
 
-        if self.additional_keys.unwrap_or(false) {
+        if self.additional_keys.unwrap_or_default() {
             write!(f, "Additional Keys: `true`\n\n")?;
         }
 

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -100,7 +100,7 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         .required
                                         .as_ref()
                                         .map(|r| r.contains(&key.value))
-                                        .unwrap_or(false);
+                                        .unwrap_or_default();
 
                                     if let Ok(Some(current_schema)) = table_schema
                                         .resolve_property_schema(
@@ -709,7 +709,7 @@ fn comment_directive_table_keys_order(
     let (disabled, order) = (
         comment_directive
             .table_keys_order_disabled()
-            .unwrap_or(false),
+            .unwrap_or_default(),
         comment_directive.table_keys_order().map(Into::into),
     );
 

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -564,7 +564,7 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         .table_keys_order(
                                             accessors,
                                             Some(current_schema),
-                                            comment_directive_table_keys_order(self),
+                                            comment_directive_table_keys_order(self).as_ref(),
                                         )
                                         .await;
                                 }
@@ -700,18 +700,24 @@ impl GetHoverContent for tombi_document_tree::Table {
 
 fn comment_directive_table_keys_order(
     table: &tombi_document_tree::Table,
-) -> Option<(bool, Option<tombi_x_keyword::TableKeysOrder>)> {
+) -> Option<tombi_schema_store::TableOrderOverride> {
     let comment_directive = get_comment_directive_content::<
         TableCommonFormatRules,
         TableCommonLintRules,
     >(table.comment_directives()?.cloned())?;
 
-    let disabled = comment_directive
-        .table_keys_order_disabled()
-        .unwrap_or(false);
-    let order = comment_directive.table_keys_order().map(Into::into);
+    let (disabled, order) = (
+        comment_directive
+            .table_keys_order_disabled()
+            .unwrap_or(false),
+        comment_directive.table_keys_order().map(Into::into),
+    );
 
-    (disabled || order.is_some()).then_some((disabled, order))
+    (disabled || order.is_some()).then_some(tombi_schema_store::TableOrderOverride {
+        target: Vec::new(),
+        disabled,
+        order,
+    })
 }
 
 impl GetHoverContent for TableSchema {

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
+use tombi_comment_directive::value::{TableCommonFormatRules, TableCommonLintRules};
+use tombi_comment_directive_serde::get_comment_directive_content;
 
 use tombi_future::Boxable;
 use tombi_schema_store::{
@@ -556,6 +558,16 @@ impl GetHoverContent for tombi_document_tree::Table {
                                 hover_content.as_mut()
                             {
                                 hover_value_content.range = Some(self.range());
+                                if let Some(constraints) = hover_value_content.constraints.as_mut()
+                                {
+                                    constraints.keys_order = schema_context
+                                        .table_keys_order(
+                                            accessors,
+                                            Some(current_schema),
+                                            comment_directive_table_keys_order(self),
+                                        )
+                                        .await;
+                                }
                             } else {
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {
                                     if let Some(hover_content) = get_one_of_hover_content(
@@ -684,6 +696,22 @@ impl GetHoverContent for tombi_document_tree::Table {
         }
         .boxed()
     }
+}
+
+fn comment_directive_table_keys_order(
+    table: &tombi_document_tree::Table,
+) -> Option<(bool, Option<tombi_x_keyword::TableKeysOrder>)> {
+    let comment_directive = get_comment_directive_content::<
+        TableCommonFormatRules,
+        TableCommonLintRules,
+    >(table.comment_directives()?.cloned())?;
+
+    let disabled = comment_directive
+        .table_keys_order_disabled()
+        .unwrap_or(false);
+    let order = comment_directive.table_keys_order().map(Into::into);
+
+    (disabled || order.is_some()).then_some((disabled, order))
 }
 
 impl GetHoverContent for TableSchema {

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -1154,7 +1154,9 @@ mod completion_edit {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -87,6 +87,90 @@ mod completion_edit {
                 "#
             );
         }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_inline_table_dot(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.█ }]
+                "#,
+                Select("rules"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules }]
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_inline_table_dot(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format = { rules.█ } }]
+                "#,
+                Select("table-keys-order"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format = { rules.table-keys-order } }]
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_table_keys_order_dot(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.table-keys-order.█ }]
+                "#,
+                Select("enabled"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.table-keys-order.enabled }]
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_array_values_order_dot(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.array-values-order.█ }]
+                "#,
+                Select("enabled"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.array-values-order.enabled }]
+                "#
+            );
+        }
     }
 
     mod cargo_schema {
@@ -1089,6 +1173,7 @@ mod completion_edit {
                     select: Option<String>,
                     source_file_path: Option<std::path::PathBuf>,
                     schema_file_path: Option<std::path::PathBuf>,
+                    completion_context: Option<tower_lsp::lsp_types::CompletionContext>,
                     backend_options: tombi_lsp::backend::Options,
                 }
 
@@ -1127,6 +1212,12 @@ mod completion_edit {
                 impl ApplyTestArg for tombi_lsp::backend::Options {
                     fn apply(self, args: &mut TestArgs) {
                         args.backend_options = self;
+                    }
+                }
+
+                impl ApplyTestArg for tower_lsp::lsp_types::CompletionContext {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.completion_context = Some(self);
                     }
                 }
 
@@ -1245,7 +1336,7 @@ mod completion_edit {
                         partial_result_params: PartialResultParams {
                             partial_result_token: None,
                         },
-                        context: None,
+                        context: args.completion_context,
                     },
                 )
                 .await

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -706,6 +706,414 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
+            async fn tombi_schemars_override_format_inline_table_dot_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "rules",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_inline_table_dot_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "array-values-order",
+                "table-keys-order",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_table_keys_order_dot_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.table-keys-order.█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "\"ascending\"",
+                "\"descending\"",
+                "\"schema\"",
+                "\"version-sort\"",
+                "enabled",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schemars_override_format_rules_array_values_order_dot_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.array-values-order.█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "\"ascending\"",
+                "\"descending\"",
+                "\"version-sort\"",
+                "enabled",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schemars_override_targets_equal_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                ".",
+                "=",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_format_dot_trigger_character_completion(
+                r#"
+                # Tombi config for this project.
+                #
+                # This file is for checking if the JsonSchema is correct.
+                #
+
+                toml-version = "v1.0.0"
+
+                [files]
+                exclude = [
+                  "editors/intellij/src/test/testData/*",
+                ]
+
+                [format]
+                [format.rules]
+
+                [lint]
+                [lint.rules]
+                key-empty = "warn"
+
+                [lsp]
+                code-action.enabled = true
+
+                [schema]
+                enabled = true
+                catalog = {
+                  paths = [
+                    "tombi://www.schemastore.org/api/json/catalog.json",
+                    "https://www.schemastore.org/api/json/catalog.json",
+                  ],
+                }
+
+                [[schemas]]
+                path = "schemas/type-test.schema.json"
+                include = ["type-test.toml"]
+
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.█ }]
+
+                [extensions]
+                "tombi-toml/cargo" = {
+                  lsp = {
+                    completion = {
+                      dependency-feature.enabled = true,
+                    },
+                  }
+                }
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::TRIGGER_CHARACTER,
+                    trigger_character: Some(".".to_string()),
+                },
+            ) -> Ok([
+                "rules",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_format_rules_dot_trigger_character_completion(
+                r#"
+                toml-version = "v1.0.0"
+
+                [files]
+                exclude = [
+                  "editors/intellij/src/test/testData/*",
+                ]
+
+                [format]
+                [format.rules]
+
+                [lint]
+                [lint.rules]
+                key-empty = "warn"
+
+                [lsp]
+                code-action.enabled = true
+
+                [schema]
+                enabled = true
+                catalog = {
+                  paths = [
+                    "tombi://www.schemastore.org/api/json/catalog.json",
+                    "https://www.schemastore.org/api/json/catalog.json",
+                  ],
+                }
+
+                [[schemas]]
+                path = "schemas/type-test.schema.json"
+                include = ["type-test.toml"]
+
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::TRIGGER_CHARACTER,
+                    trigger_character: Some(".".to_string()),
+                },
+            ) -> Ok([
+                "array-values-order",
+                "table-keys-order",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_format_rules_dot_before_equal_trigger_character_completion(
+                r#"
+                toml-version = "v1.0.0"
+
+                [files]
+                exclude = [
+                  "editors/intellij/src/test/testData/*",
+                ]
+
+                [format]
+                [format.rules]
+
+                [lint]
+                [lint.rules]
+                key-empty = "warn"
+
+                [lsp]
+                code-action.enabled = true
+
+                [schema]
+                enabled = true
+                catalog = {
+                  paths = [
+                    "tombi://www.schemastore.org/api/json/catalog.json",
+                    "https://www.schemastore.org/api/json/catalog.json",
+                  ],
+                }
+
+                [[schemas]]
+                path = "schemas/type-test.schema.json"
+                include = ["type-test.toml"]
+
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules.█ = "" }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::TRIGGER_CHARACTER,
+                    trigger_character: Some(".".to_string()),
+                },
+            ) -> Ok([
+                "array-values-order",
+                "table-keys-order",
+                "{}",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_format_rules_missing_equal_invoked_completion(
+                r#"
+                toml-version = "v1.0.0"
+
+                [files]
+                exclude = [
+                  "editors/intellij/src/test/testData/*",
+                ]
+
+                [format]
+                [format.rules]
+
+                [lint]
+                [lint.rules]
+                key-empty = "warn"
+
+                [lsp]
+                code-action.enabled = true
+
+                [schema]
+                enabled = true
+                catalog = {
+                  paths = [
+                    "tombi://www.schemastore.org/api/json/catalog.json",
+                    "https://www.schemastore.org/api/json/catalog.json",
+                  ],
+                }
+
+                [[schemas]]
+                path = "schemas/type-test.schema.json"
+                include = ["type-test.toml"]
+
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = [""], format.rules█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                ".",
+                "=",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_targets_invoked_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                ".",
+                "=",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_targets_value_invoked_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = █ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                "[]",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_targets_value_with_next_section_invoked_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets = █ }]
+
+                [extensions]
+                "tombi-toml/cargo" = {}
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                "[]",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_targets_missing_equal_invoked_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets█ }]
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                ".",
+                "=",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn current_real_tombi_override_targets_missing_equal_with_next_section_invoked_completion(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                overrides = [{ targets█ }]
+
+                [extensions]
+                "tombi-toml/cargo" = {}
+                "#,
+                SchemaPath(tombi_schema_path()),
+                tower_lsp::lsp_types::CompletionContext {
+                    trigger_kind: tower_lsp::lsp_types::CompletionTriggerKind::INVOKED,
+                    trigger_character: None,
+                },
+            ) -> Ok([
+                ".",
+                "=",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
             async fn tombi_toml_version_v1_0_0_comment_directive(
                 r#"
                 toml-version = "v1.0.0" # tombi:█
@@ -2488,6 +2896,7 @@ mod completion_labels {
                     source_file_path: Option<std::path::PathBuf>,
                     schema_file_path: Option<std::path::PathBuf>,
                     subschemas: Vec<SubSchema>,
+                    completion_context: Option<tower_lsp::lsp_types::CompletionContext>,
                     backend_options: tombi_lsp::backend::Options,
                 }
 
@@ -2529,6 +2938,12 @@ mod completion_labels {
                 impl ApplyTestArg for tombi_lsp::backend::Options {
                     fn apply(self, args: &mut TestArgs) {
                         args.backend_options = self;
+                    }
+                }
+
+                impl ApplyTestArg for tower_lsp::lsp_types::CompletionContext {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.completion_context = Some(self);
                     }
                 }
 
@@ -2664,7 +3079,7 @@ mod completion_labels {
                         partial_result_params: PartialResultParams {
                             partial_result_token: None,
                         },
-                        context: None,
+                        context: args.completion_context,
                     },
                 )
                 .await

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -635,7 +635,9 @@ mod completion_labels {
                 "include",
                 "path",
                 "root",
+                "format",
                 "lint",
+                "overrides",
                 "toml-version",
             ]);
         }
@@ -2553,7 +2555,9 @@ mod completion_labels {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
@@ -2572,6 +2576,8 @@ mod completion_labels {
                         include: vec!["*.toml".to_string()],
                         root: subschema.root.to_string(),
                         lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -303,7 +303,9 @@ macro_rules! test_diagnostic {
                             toml_version: None,
                             path: schema_uri.to_string(),
                             include: vec!["*.toml".to_string()],
-                        lint: None,
+                            lint: None,
+                            format: None,
+                            overrides: None,
                         }),
                     ]);
                     editor_config
@@ -608,7 +610,9 @@ macro_rules! test_diagnostic_file {
                             toml_version: None,
                             path: schema_uri.to_string(),
                             include: vec!["*.toml".to_string()],
-                        lint: None,
+                            lint: None,
+                            format: None,
+                            overrides: None,
                         }),
                     ]);
                     editor_config

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -804,6 +804,9 @@ mod document_link_tests {
             #[tokio::test]
             async fn tombi_schema_catalog_path_disabled_by_extensions(
                 r#"
+                [extensions]
+                "tombi-toml/tombi" = { lsp.document-link.path.enabled = false }
+
                 [schema]
                 catalog = { paths = ["https://www.schemastore.org/api/json/catalog.json"] }
                 "#,
@@ -1115,7 +1118,9 @@ macro_rules! test_document_link {
                     toml_version: None,
                     path: schema_uri.to_string(),
                     include: vec!["*.toml".to_string()],
-                lint: None,
+                    lint: None,
+                    format: None,
+                    overrides: None,
                 }));
             }
 
@@ -1134,6 +1139,8 @@ macro_rules! test_document_link {
                     include: vec!["*.toml".to_string()],
                     root: subschema.root.clone(),
                     lint: None,
+                    format: None,
+                    overrides: None,
                 }));
             }
 

--- a/crates/tombi-lsp/tests/test_goto_declaration.rs
+++ b/crates/tombi-lsp/tests/test_goto_declaration.rs
@@ -369,7 +369,9 @@ mod goto_declaration_tests {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
@@ -388,6 +390,8 @@ mod goto_declaration_tests {
                         include: vec!["*.toml".to_string()],
                         root: subschema.root.clone(),
                         lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -904,7 +904,9 @@ mod goto_definition_tests {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
@@ -923,6 +925,8 @@ mod goto_definition_tests {
                         include: vec!["*.toml".to_string()],
                         root: subschema.root.clone(),
                         lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -688,7 +688,9 @@ mod goto_type_definition_tests {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
@@ -707,6 +709,8 @@ mod goto_type_definition_tests {
                         include: vec!["*.toml".to_string()],
                         root: subschema.root.clone(),
                         lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -955,6 +955,8 @@ mod hover_keys_value {
         ) -> Ok({
             "Keys": $keys:expr,
             "Value": $value_type:expr
+            $(, "Schema": $has_schema:expr)?
+            $(, "Keys Order": $keys_order:expr)?
             $(, "Title": $title:expr)?
             $(, "Description": $description:expr)?
             $(, "Enum": [$($enum_values:expr),* $(,)?])?
@@ -983,6 +985,9 @@ mod hover_keys_value {
                 struct TestArgs {
                     source_file_path: Option<std::path::PathBuf>,
                     schema_file_path: Option<std::path::PathBuf>,
+                    inline_schema: Option<String>,
+                    config_file_path: Option<std::path::PathBuf>,
+                    config_text: Option<String>,
                     subschemas: Vec<SubSchemaPath>,
                     backend_options: tombi_lsp::backend::Options,
                 }
@@ -1002,11 +1007,38 @@ mod hover_keys_value {
                 }
 
                 #[allow(unused)]
+                struct Schema(String);
+
+                impl ApplyTestArg for Schema {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.inline_schema = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
                 struct SchemaPath(std::path::PathBuf);
 
                 impl ApplyTestArg for SchemaPath {
                     fn apply(self, args: &mut TestArgs) {
                         args.schema_file_path = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct Config(String);
+
+                impl ApplyTestArg for Config {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.config_text = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct ConfigPath(std::path::PathBuf);
+
+                impl ApplyTestArg for ConfigPath {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.config_file_path = Some(self.0);
                     }
                 }
 
@@ -1053,7 +1085,9 @@ mod hover_keys_value {
                         toml_version: None,
                         path: schema_uri.to_string(),
                         include: vec!["*.toml".to_string()],
-                    lint: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
@@ -1072,18 +1106,23 @@ mod hover_keys_value {
                         include: vec!["*.toml".to_string()],
                         root: subschema.root.clone(),
                         lint: None,
+                        format: None,
+                        overrides: None,
                     }));
                 }
 
-                let current_dir = std::env::current_dir().expect("failed to get current directory");
-                let temp_dir = if let Some(source_path) = args.source_file_path.as_ref() {
-                    source_path.parent().ok_or("failed to get parent directory")?
-                } else {
-                    current_dir.as_path()
+                let temp_dir = tempfile::tempdir()?;
+                let temp_dir_path = temp_dir.path();
+                let resolve_path = |path: &std::path::Path| {
+                    if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        temp_dir_path.join(path)
+                    }
                 };
                 let Ok(temp_file) = tempfile::NamedTempFile::with_suffix_in(
                     ".toml",
-                    temp_dir,
+                    temp_dir_path,
                 ) else {
                     return Err("failed to create a temporary file for the test data".into());
                 };
@@ -1105,11 +1144,70 @@ mod hover_keys_value {
                 let line_index =
                 tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
 
-                let source_path = args.source_file_path.as_deref().unwrap_or(temp_file.path());
+                let source_path_buf = args
+                    .source_file_path
+                    .as_ref()
+                    .map(|path| resolve_path(path))
+                    .unwrap_or_else(|| temp_file.path().to_path_buf());
+                let should_write_source_file = args
+                    .source_file_path
+                    .as_ref()
+                    .is_some_and(|path| !path.is_absolute());
+                if should_write_source_file {
+                    if let Some(parent) = source_path_buf.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    if source_path_buf != temp_file.path() {
+                        std::fs::write(&source_path_buf, &toml_text)?;
+                    }
+                }
+                let source_path = source_path_buf.as_path();
+
+                if let Some(schema_text) = args.inline_schema.as_ref() {
+                    let schema_file_path = temp_dir_path.join("schema.json");
+                    std::fs::write(&schema_file_path, textwrap::dedent(schema_text).trim())?;
+                    args.schema_file_path = Some(schema_file_path);
+                }
+
+                if let Some(config_text) = args.config_text.as_ref() {
+                    let config_path = args
+                        .config_file_path
+                        .as_ref()
+                        .map(|path| resolve_path(path))
+                        .unwrap_or_else(|| temp_dir_path.join("tombi.toml"));
+                    let should_write_config_file = args
+                        .config_file_path
+                        .as_ref()
+                        .is_none_or(|path| !path.is_absolute());
+                    if should_write_config_file {
+                        if let Some(parent) = config_path.parent() {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        std::fs::write(&config_path, textwrap::dedent(config_text).trim())?;
+                    }
+                    args.config_file_path = Some(config_path);
+                }
 
                 let Ok(toml_file_url) = Url::from_file_path(source_path) else {
                     return Err("failed to convert file path to URL".into());
                 };
+
+                if let Some(config_file_path) = args.config_file_path.as_ref() {
+                    let config_content = std::fs::read_to_string(config_file_path)?;
+                    let tombi_config =
+                        serde_tombi::config::from_str(&config_content, config_file_path)?;
+                    backend
+                        .config_manager
+                        .update_config_with_path(tombi_config, config_file_path)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "failed to update config {}: {}",
+                                config_file_path.display(),
+                                e
+                            )
+                        })?;
+                }
 
                 if !schema_items.is_empty() {
                     let config_schema_store = backend
@@ -1172,7 +1270,13 @@ mod hover_keys_value {
 
                 log::debug!("hover_content: {:#?}", hover_content);
 
-                if args.schema_file_path.is_some() {
+                if let Some(expected_has_schema) = None::<bool> $(.or(Some($has_schema)))? {
+                    pretty_assertions::assert_eq!(
+                        hover_content.schema_uri.is_some(),
+                        expected_has_schema,
+                        "Schema presence is not equal"
+                    );
+                } else if args.schema_file_path.is_some() {
                     assert!(hover_content.schema_uri.is_some(), "The hover target is not defined in the schema.");
                 } else {
                     assert!(hover_content.schema_uri.is_none(), "The hover target is defined in the schema.");
@@ -1180,6 +1284,22 @@ mod hover_keys_value {
 
                 pretty_assertions::assert_eq!(hover_content.accessors.to_string(), $keys, "Keys are not equal");
                 pretty_assertions::assert_eq!(hover_content.value_type.to_string(), $value_type, "Value type are not equal");
+                $(
+                    let expected_keys_order = $keys_order.map(ToString::to_string);
+                    let actual_keys_order = hover_content
+                        .constraints
+                        .as_ref()
+                        .and_then(|constraints| constraints.keys_order.as_ref())
+                        .map(|keys_order| match keys_order {
+                            tombi_schema_store::XTombiTableKeysOrder::All(order) => order.to_string(),
+                            tombi_schema_store::XTombiTableKeysOrder::Groups(groups) => groups
+                                .iter()
+                                .map(|group| format!("{}={}", group.target, group.order))
+                                .collect::<Vec<_>>()
+                                .join(","),
+                        });
+                    pretty_assertions::assert_eq!(actual_keys_order, expected_keys_order, "Keys order is not equal");
+                )?
                 $(
                     let expected_title = $title;
                     pretty_assertions::assert_eq!(
@@ -1238,5 +1358,145 @@ mod hover_keys_value {
                 Ok(())
             }
         }
+    }
+
+    mod hover_table_keys_order {
+        use super::*;
+
+        const NESTED_TABLE_SCHEMA: &str = r#"
+        {
+          "type": "object",
+          "properties": {
+            "nested": {
+              "type": "object",
+              "x-tombi-table-keys-order": "ascending",
+              "properties": {
+                "a": { "type": "integer" },
+                "b": { "type": "integer" }
+              }
+            }
+          }
+        }
+        "#;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn hides_json_schema_keys_order_when_schema_format_is_disabled(
+                r#"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                Schema(NESTED_TABLE_SCHEMA.to_string()),
+                Config(r#"
+                [[schemas]]
+                path = "schema.json"
+                include = ["*.toml"]
+                format.rules.table-keys-order.enabled = false
+                "#.to_string()),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": None::<&str>
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn prefers_schema_override_over_json_schema_keys_order(
+                r#"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                Schema(NESTED_TABLE_SCHEMA.to_string()),
+                Config(r#"
+                [[schemas]]
+                path = "schema.json"
+                include = ["*.toml"]
+                overrides = [
+                  { targets = ["nested"], format.rules.table-keys-order = "descending" }
+                ]
+                "#.to_string()),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": Some("descending")
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn prefers_schema_override_when_schema_format_is_disabled(
+                r#"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                Schema(NESTED_TABLE_SCHEMA.to_string()),
+                Config(r#"
+                [[schemas]]
+                path = "schema.json"
+                include = ["*.toml"]
+                format.rules.table-keys-order.enabled = false
+                overrides = [
+                  { targets = ["nested"], format.rules.table-keys-order = "descending" }
+                ]
+                "#.to_string()),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": Some("descending")
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn prefers_comment_directive_over_schema_override_and_json_schema_keys_order(
+                r#"
+                # tombi: format.rules.table-keys-order = "descending"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                Schema(NESTED_TABLE_SCHEMA.to_string()),
+                Config(r#"
+                [[schemas]]
+                path = "schema.json"
+                include = ["*.toml"]
+                overrides = [
+                  { targets = ["nested"], format.rules.table-keys-order = "ascending" }
+                ]
+                "#.to_string()),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": Some("descending")
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn current_tombi_config_disables_json_schema_keys_order_in_hover(
+                r#"
+                schema.catalog.paths = ["https://www.schemastore.org/api/json/catalog.json"]
+
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+
+                [[schemas█]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+                format.rules.table-keys-order.enabled = false
+                "#,
+                SourcePath(std::path::PathBuf::from("tombi.toml")),
+            ) -> Ok({
+                "Keys": "schemas[1]",
+                "Value": "Table",
+                "Schema": true,
+                "Keys Order": None::<&str>
+            });
+        );
     }
 }

--- a/crates/tombi-parser/src/lib.rs
+++ b/crates/tombi-parser/src/lib.rs
@@ -270,4 +270,30 @@ macro_rules! test_parser {
         }
     };
 
+    {#[test] fn $name:ident($source:expr) -> Err(|$parsed:ident, $root:ident| -> $assert_expr:expr)} => {
+        #[test]
+        fn $name() {
+            tombi_test_lib::init_log();
+
+            let $parsed = $crate::parse(textwrap::dedent($source).trim());
+
+            log::debug!("syntax_node: {:#?}", $parsed.syntax_node());
+
+            assert!(
+                !$parsed.errors.is_empty(),
+                "Err(|parsed, root| -> ...) expected parse errors, but there were none"
+            );
+
+            use tombi_ast::AstNode as _;
+            let $root = tombi_ast::Root::cast($parsed.syntax_node())
+                .expect("parse result must contain ROOT syntax node");
+
+            assert!(
+                $assert_expr,
+                "Err(|parsed, root| -> ...) assertion failed: {}",
+                stringify!($assert_expr)
+            );
+        }
+    };
+
 }

--- a/crates/tombi-parser/src/parse/array.rs
+++ b/crates/tombi-parser/src/parse/array.rs
@@ -21,7 +21,10 @@ impl Parse for tombi_ast::Array {
         trailing_comment(p);
 
         loop {
-            while p.eat(LINE_BREAK) {}
+            let mut line_break_count = 0;
+            while p.eat(LINE_BREAK) {
+                line_break_count += 1;
+            }
 
             Vec::<tombi_ast::DanglingCommentGroup>::parse(p);
 
@@ -29,9 +32,7 @@ impl Parse for tombi_ast::Array {
             if p.nth_at_ts(n, TS_ARRAY_END) {
                 break;
             }
-            if p.nth_at_ts(n, TS_NEXT_SECTION)
-                && (p.recovered_to_next_section() || !matches!(p.previous(), T![,] | T!['[']))
-            {
+            if line_break_count >= 2 && p.nth_at_ts(n, TS_NEXT_SECTION) {
                 p.mark_recovered_to_next_section();
                 break;
             }

--- a/crates/tombi-parser/src/parse/array.rs
+++ b/crates/tombi-parser/src/parse/array.rs
@@ -5,7 +5,7 @@ use crate::{
     parse::Parse,
     parser::Parser,
     support::{leading_comments, peek_leading_comments, trailing_comment},
-    token_set::TS_ARRAY_END,
+    token_set::{TS_ARRAY_END, TS_NEXT_SECTION},
 };
 
 impl Parse for tombi_ast::Array {
@@ -27,6 +27,12 @@ impl Parse for tombi_ast::Array {
 
             let n = peek_leading_comments(p);
             if p.nth_at_ts(n, TS_ARRAY_END) {
+                break;
+            }
+            if p.nth_at_ts(n, TS_NEXT_SECTION)
+                && (p.recovered_to_next_section() || !matches!(p.previous(), T![,] | T!['[']))
+            {
+                p.mark_recovered_to_next_section();
                 break;
             }
 

--- a/crates/tombi-parser/src/parse/array_of_table.rs
+++ b/crates/tombi-parser/src/parse/array_of_table.rs
@@ -44,6 +44,9 @@ impl Parse for tombi_ast::ArrayOfTable {
             tombi_ast::KeyValueGroup::parse(p);
 
             if !p.at_ts(TS_LINE_END) {
+                if p.at_ts(TS_NEXT_SECTION) {
+                    break;
+                }
                 invalid_line(p, ExpectedLineBreak);
             }
         }

--- a/crates/tombi-parser/src/parse/inline_table.rs
+++ b/crates/tombi-parser/src/parse/inline_table.rs
@@ -5,7 +5,7 @@ use crate::{
     parse::Parse,
     parser::Parser,
     support::{leading_comments, peek_leading_comments, trailing_comment},
-    token_set::TS_INLINE_TABLE_END,
+    token_set::{TS_INLINE_TABLE_END, TS_NEXT_SECTION},
 };
 
 impl Parse for tombi_ast::InlineTable {
@@ -27,6 +27,12 @@ impl Parse for tombi_ast::InlineTable {
 
             let n = peek_leading_comments(p);
             if p.nth_at_ts(n, TS_INLINE_TABLE_END) {
+                break;
+            }
+            if p.nth_at_ts(n, TS_NEXT_SECTION)
+                && (p.recovered_to_next_section() || !matches!(p.previous(), T![,] | T!['{']))
+            {
+                p.mark_recovered_to_next_section();
                 break;
             }
 
@@ -233,6 +239,33 @@ mod test {
                 }
             }
         )
+    }
+
+    test_parser! {
+        #[test]
+        fn recovers_to_next_section_after_invalid_inline_table_value(
+            r#"
+            [[schemas]]
+            overrides = [{ targets }]
+
+            [extensions]
+            "tombi-toml/cargo" = {}
+            "#
+        ) -> Err(|parsed, root| -> {
+            parsed.errors.iter().any(|error| matches!(
+                error.kind(),
+                ExpectedEqual | ExpectedValue | ExpectedBraceEnd
+            )) && root
+                .table_or_array_of_tables()
+                .any(|item| match item {
+                    tombi_ast::TableOrArrayOfTable::Table(table) => table
+                        .header()
+                        .and_then(|keys| keys.keys().next())
+                        .and_then(|key| key.token())
+                        .is_some_and(|token| token.text() == "extensions"),
+                    tombi_ast::TableOrArrayOfTable::ArrayOfTable(_) => false,
+                })
+        })
     }
 
     test_parser! {

--- a/crates/tombi-parser/src/parse/inline_table.rs
+++ b/crates/tombi-parser/src/parse/inline_table.rs
@@ -21,7 +21,10 @@ impl Parse for tombi_ast::InlineTable {
         trailing_comment(p);
 
         loop {
-            while p.eat(LINE_BREAK) {}
+            let mut line_break_count = 0;
+            while p.eat(LINE_BREAK) {
+                line_break_count += 1;
+            }
 
             Vec::<tombi_ast::DanglingCommentGroup>::parse(p);
 
@@ -29,9 +32,7 @@ impl Parse for tombi_ast::InlineTable {
             if p.nth_at_ts(n, TS_INLINE_TABLE_END) {
                 break;
             }
-            if p.nth_at_ts(n, TS_NEXT_SECTION)
-                && (p.recovered_to_next_section() || !matches!(p.previous(), T![,] | T!['{']))
-            {
+            if line_break_count >= 2 && p.nth_at_ts(n, TS_NEXT_SECTION) {
                 p.mark_recovered_to_next_section();
                 break;
             }
@@ -265,6 +266,26 @@ mod test {
                         .is_some_and(|token| token.text() == "extensions"),
                     tombi_ast::TableOrArrayOfTable::ArrayOfTable(_) => false,
                 })
+        })
+    }
+
+    test_parser! {
+        #[test]
+        fn incomplete_inline_table_in_array_recovers_at_array_end(
+            r#"
+            key = [
+              {
+            ]
+            "#
+        ) -> Err(|parsed, root| -> {
+            parsed.errors.iter().any(|error| matches!(error.kind(), ExpectedEqual | ExpectedBraceEnd))
+                && root
+                    .key_value_groups()
+                    .find_map(|group| group.into_item_group())
+                    .and_then(|group| group.key_values().next())
+                    .and_then(|key_value| key_value.value())
+                    .and_then(|value| tombi_ast::Array::cast(value.syntax().clone()))
+                    .is_some()
         })
     }
 

--- a/crates/tombi-parser/src/parse/key_value_with_comma_group.rs
+++ b/crates/tombi-parser/src/parse/key_value_with_comma_group.rs
@@ -4,7 +4,7 @@ use crate::{
     parse::{Parse, is_group_separator},
     parser::Parser,
     support::peek_leading_comments,
-    token_set::{TS_INLINE_TABLE_END, TS_KEY_FIRST},
+    token_set::{TS_INLINE_TABLE_END, TS_KEY_FIRST, TS_NEXT_SECTION},
 };
 
 impl Parse for tombi_ast::KeyValueWithCommaGroup {
@@ -23,9 +23,14 @@ impl Parse for tombi_ast::KeyValueWithCommaGroup {
                 tombi_ast::Comma::parse(p);
             } else if p.nth_at_ts(n, TS_INLINE_TABLE_END) {
                 break;
+            } else if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
+                break;
             }
 
             let n = peek_leading_comments(p);
+            if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
+                break;
+            }
             if !p.nth_at_ts(n, TS_KEY_FIRST) {
                 break;
             }

--- a/crates/tombi-parser/src/parse/root.rs
+++ b/crates/tombi-parser/src/parse/root.rs
@@ -488,7 +488,7 @@ mod test {
             parsed
                 .errors
                 .iter()
-                .any(|error| error.kind() == ExpectedBracketEnd)
+                .any(|error| error.kind() == ExpectedValue)
                 && root.table_or_array_of_tables().any(|item| match item {
                     tombi_ast::TableOrArrayOfTable::Table(table) => table
                         .header()

--- a/crates/tombi-parser/src/parse/root.rs
+++ b/crates/tombi-parser/src/parse/root.rs
@@ -25,6 +25,9 @@ impl Parse for tombi_ast::Root {
             tombi_ast::KeyValueGroup::parse(p);
 
             if !p.at_ts(TS_LINE_END) {
+                if p.at_ts(TS_NEXT_SECTION) {
+                    break;
+                }
                 invalid_line(p, ExpectedLineBreak);
             }
         }
@@ -65,7 +68,7 @@ fn unknwon_line(p: &mut Parser<'_>) {
 
 #[cfg(test)]
 mod test {
-    use crate::test_parser;
+    use crate::{ErrorKind::*, test_parser};
 
     test_parser! {
         #[test]
@@ -467,5 +470,60 @@ mod test {
                 }
             }
         )
+    }
+
+    test_parser! {
+        #[test]
+        fn recovers_to_next_section_after_invalid_array_value(
+            r#"
+            [[schemas]]
+            path = "tombi://www.schemastore.org/tombi.json"
+            include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+            overrides = [targets=]
+
+            [extensions]
+            "tombi-toml/cargo" = {}
+            "#
+        ) -> Err(|parsed, root| -> {
+            parsed
+                .errors
+                .iter()
+                .any(|error| error.kind() == ExpectedBracketEnd)
+                && root.table_or_array_of_tables().any(|item| match item {
+                    tombi_ast::TableOrArrayOfTable::Table(table) => table
+                        .header()
+                        .and_then(|keys| keys.keys().next())
+                        .and_then(|key| key.token())
+                        .is_some_and(|token| token.text() == "extensions"),
+                    tombi_ast::TableOrArrayOfTable::ArrayOfTable(_) => false,
+                })
+        })
+    }
+
+    test_parser! {
+        #[test]
+        fn recovers_to_next_section_after_invalid_inline_table_item(
+            r#"
+            [[schemas]]
+            path = "tombi://www.schemastore.org/tombi.json"
+            include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+            overrides = [{ targets }]
+
+            [extensions]
+            "tombi-toml/cargo" = {}
+            "#
+        ) -> Err(|parsed, root| -> {
+            parsed.errors.iter().any(|error| matches!(
+                error.kind(),
+                ExpectedEqual | ExpectedValue | ExpectedBraceEnd
+            )) && root.table_or_array_of_tables().any(|item| match item {
+                tombi_ast::TableOrArrayOfTable::Table(table) => table
+                    .header()
+                    .and_then(|keys| keys.keys().next())
+                    .and_then(|key| key.token())
+                    .is_some_and(|token| token.text() == "extensions"),
+                tombi_ast::TableOrArrayOfTable::ArrayOfTable(_) => false,
+            })
+        })
     }
 }

--- a/crates/tombi-parser/src/parse/table.rs
+++ b/crates/tombi-parser/src/parse/table.rs
@@ -44,6 +44,9 @@ impl Parse for tombi_ast::Table {
             tombi_ast::KeyValueGroup::parse(p);
 
             if !p.at_ts(TS_LINE_END) {
+                if p.at_ts(TS_NEXT_SECTION) {
+                    break;
+                }
                 invalid_line(p, ExpectedLineBreak);
             }
         }
@@ -274,7 +277,7 @@ mod test {
 
             table
                 .map(|table| table.dangling_comment_groups().count() == 0 && table.key_value_groups().count() == 1)
-                .unwrap_or(false)
+                .unwrap_or_default()
         })
     }
 

--- a/crates/tombi-parser/src/parse/value.rs
+++ b/crates/tombi-parser/src/parse/value.rs
@@ -3,7 +3,11 @@ use tombi_syntax::{SyntaxKind::*, T};
 use super::Parse;
 use crate::parse::key::eat_keys;
 use crate::support::{leading_comments, peek_leading_comments, trailing_comment};
-use crate::{ErrorKind::*, parser::Parser, token_set::TS_COMMEMT_OR_LINE_END};
+use crate::{
+    ErrorKind::*,
+    parser::Parser,
+    token_set::TS_VALUE_RECOVERY_END,
+};
 
 impl Parse for tombi_ast::Value {
     fn parse(p: &mut Parser<'_>) {
@@ -69,7 +73,7 @@ fn parse_invalid_value(p: &mut Parser<'_>, n: usize) {
 
     let start_range = p.current_range();
     let mut end_range = start_range;
-    while !p.at_ts(TS_COMMEMT_OR_LINE_END) {
+    while !p.at_ts(TS_VALUE_RECOVERY_END) {
         end_range = p.current_range();
         p.bump_any();
     }

--- a/crates/tombi-parser/src/parse/value_with_comma_group.rs
+++ b/crates/tombi-parser/src/parse/value_with_comma_group.rs
@@ -4,7 +4,7 @@ use crate::{
     parse::{Parse, is_group_separator},
     parser::Parser,
     support::peek_leading_comments,
-    token_set::{TS_ARRAY_END, TS_VALUE_FIRST},
+    token_set::{TS_ARRAY_END, TS_NEXT_SECTION, TS_VALUE_FIRST},
 };
 
 impl Parse for tombi_ast::ValueWithCommaGroup {
@@ -23,9 +23,14 @@ impl Parse for tombi_ast::ValueWithCommaGroup {
                 tombi_ast::Comma::parse(p);
             } else if p.nth_at_ts(n, TS_ARRAY_END) {
                 break;
+            } else if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
+                break;
             }
 
             let n = peek_leading_comments(p);
+            if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
+                break;
+            }
             if !p.nth_at_ts(n, TS_VALUE_FIRST) {
                 break;
             }

--- a/crates/tombi-parser/src/parse/value_with_comma_group.rs
+++ b/crates/tombi-parser/src/parse/value_with_comma_group.rs
@@ -4,7 +4,7 @@ use crate::{
     parse::{Parse, is_group_separator},
     parser::Parser,
     support::peek_leading_comments,
-    token_set::{TS_ARRAY_END, TS_NEXT_SECTION, TS_VALUE_FIRST},
+    token_set::{TS_ARRAY_END, TS_VALUE_FIRST},
 };
 
 impl Parse for tombi_ast::ValueWithCommaGroup {
@@ -23,14 +23,9 @@ impl Parse for tombi_ast::ValueWithCommaGroup {
                 tombi_ast::Comma::parse(p);
             } else if p.nth_at_ts(n, TS_ARRAY_END) {
                 break;
-            } else if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
-                break;
             }
 
             let n = peek_leading_comments(p);
-            if p.recovered_to_next_section() && p.nth_at_ts(n, TS_NEXT_SECTION) {
-                break;
-            }
             if !p.nth_at_ts(n, TS_VALUE_FIRST) {
                 break;
             }

--- a/crates/tombi-parser/src/parser.rs
+++ b/crates/tombi-parser/src/parser.rs
@@ -10,6 +10,7 @@ pub(crate) struct Parser<'t> {
     source: &'t str,
     input_tokens: &'t [tombi_lexer::Token],
     pos: usize,
+    recovered_to_next_section: bool,
     pub tokens: Vec<tombi_lexer::Token>,
     pub(crate) events: Vec<crate::Event>,
 }
@@ -20,6 +21,7 @@ impl<'t> Parser<'t> {
             source,
             input_tokens,
             pos: 0, // Start from the beginning to preserve leading trivia
+            recovered_to_next_section: false,
             tokens: Vec::new(),
             events: Vec::new(),
         }
@@ -52,6 +54,28 @@ impl<'t> Parser<'t> {
             pos -= 1;
         }
         self.input_tokens[pos].range()
+    }
+
+    #[inline]
+    pub(crate) fn previous(&self) -> SyntaxKind {
+        if self.pos == 0 {
+            return EOF;
+        }
+        let mut pos = self.pos - 1;
+        while pos > 0 && self.input_tokens[pos].kind().is_trivia() {
+            pos -= 1;
+        }
+        self.input_tokens[pos].kind()
+    }
+
+    #[inline]
+    pub(crate) fn recovered_to_next_section(&self) -> bool {
+        self.recovered_to_next_section
+    }
+
+    #[inline]
+    pub(crate) fn mark_recovered_to_next_section(&mut self) {
+        self.recovered_to_next_section = true;
     }
 
     fn nth_index(&self, n: usize) -> usize {
@@ -185,6 +209,7 @@ impl<'t> Parser<'t> {
 
     pub(crate) fn bump_float_key(&mut self) {
         debug_assert!(self.nth(0) == FLOAT);
+        self.recovered_to_next_section = false;
         let token = self.nth_token(0);
         let text = &self.source[token.span()];
 
@@ -282,6 +307,7 @@ impl<'t> Parser<'t> {
     }
 
     fn do_bump(&mut self, kind: SyntaxKind, n_raw_tokens: u8) {
+        self.recovered_to_next_section = false;
         self.push_event(Event::Token { kind, n_raw_tokens });
         let nth_index = self.nth_index((n_raw_tokens) as usize);
         self.tokens.extend(&self.input_tokens[self.pos..nth_index]);

--- a/crates/tombi-parser/src/parser.rs
+++ b/crates/tombi-parser/src/parser.rs
@@ -57,18 +57,6 @@ impl<'t> Parser<'t> {
     }
 
     #[inline]
-    pub(crate) fn previous(&self) -> SyntaxKind {
-        if self.pos == 0 {
-            return EOF;
-        }
-        let mut pos = self.pos - 1;
-        while pos > 0 && self.input_tokens[pos].kind().is_trivia() {
-            pos -= 1;
-        }
-        self.input_tokens[pos].kind()
-    }
-
-    #[inline]
     pub(crate) fn recovered_to_next_section(&self) -> bool {
         self.recovered_to_next_section
     }

--- a/crates/tombi-parser/src/token_set.rs
+++ b/crates/tombi-parser/src/token_set.rs
@@ -1,9 +1,10 @@
 use tombi_syntax::{SyntaxKind, SyntaxKind::*, T};
 
 pub(crate) const TS_LINE_END: TokenSet = TokenSet::new(&[LINE_BREAK, EOF]);
-pub(crate) const TS_COMMEMT_OR_LINE_END: TokenSet = TokenSet::new(&[COMMENT, LINE_BREAK, EOF]);
+pub(crate) const TS_VALUE_RECOVERY_END: TokenSet =
+    TokenSet::new(&[COMMENT, LINE_BREAK, T![,], T![']'], T!['}'], EOF]);
 pub(crate) const TS_NEXT_SECTION: TokenSet = TokenSet::new(&[T!['['], T!("[["), EOF]);
-pub(crate) const TS_INLINE_TABLE_END: TokenSet = TokenSet::new(&[T!['}'], EOF]);
+pub(crate) const TS_INLINE_TABLE_END: TokenSet = TokenSet::new(&[T!['}'], T![']'], EOF]);
 pub(crate) const TS_ARRAY_END: TokenSet = TokenSet::new(&[T![']'], EOF]);
 pub(crate) const TS_VALUE_FIRST: TokenSet = TokenSet::new(&[
     BASIC_STRING,

--- a/crates/tombi-regex/src/lib.rs
+++ b/crates/tombi-regex/src/lib.rs
@@ -63,7 +63,7 @@ impl Regex {
     pub fn is_match(&self, text: &str) -> bool {
         #[cfg(all(not(feature = "regex"), feature = "fancy-regex"))]
         {
-            self.0.is_match(text).unwrap_or(false)
+            self.0.is_match(text).unwrap_or_default()
         }
 
         #[cfg(feature = "regex")]

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -430,6 +430,8 @@ pub struct Schema {
     pub catalog_uri: Option<Arc<tombi_uri::CatalogUri>>,
     pub include: Vec<String>,
     pub sub_root_accessors: Option<Vec<RootAccessor>>,
+    pub explicit_array_values_order_enabled: Option<bool>,
+    pub explicit_table_keys_order_enabled: Option<bool>,
     pub array_values_order_enabled: bool,
     pub table_keys_order_enabled: bool,
     pub overrides: SchemaOverrides,

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -51,11 +51,64 @@ pub use tombi_uri::{CatalogUri, SchemaUri};
 pub use value_schema::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TableOrderOverride {
+pub struct OrderOverride<T> {
     pub target: Vec<RootAccessor>,
     pub disabled: bool,
-    pub order: Option<tombi_x_keyword::TableKeysOrder>,
+    pub order: Option<T>,
 }
+
+pub type ArrayOrderOverride = OrderOverride<tombi_x_keyword::ArrayValuesOrder>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArrayOrderOverrides(Vec<ArrayOrderOverride>);
+
+impl ArrayOrderOverrides {
+    pub fn push_schema_override(
+        &mut self,
+        target: Vec<RootAccessor>,
+        disabled: bool,
+        order: Option<tombi_x_keyword::ArrayValuesOrder>,
+    ) {
+        self.0.push(ArrayOrderOverride {
+            target,
+            disabled,
+            order,
+        });
+    }
+
+    pub fn get(&self, accessors: &[Accessor]) -> Option<&ArrayOrderOverride> {
+        self.0.iter().find(|override_item| {
+            override_item.target.len() == accessors.len()
+                && override_item
+                    .target
+                    .iter()
+                    .zip(accessors)
+                    .all(|(expected, actual)| expected == actual)
+        })
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, ArrayOrderOverride> {
+        self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<Vec<ArrayOrderOverride>> for ArrayOrderOverrides {
+    fn from(value: Vec<ArrayOrderOverride>) -> Self {
+        Self(value)
+    }
+}
+
+impl FromIterator<ArrayOrderOverride> for ArrayOrderOverrides {
+    fn from_iter<T: IntoIterator<Item = ArrayOrderOverride>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+pub type TableOrderOverride = OrderOverride<tombi_x_keyword::TableKeysOrder>;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TableOrderOverrides(Vec<TableOrderOverride>);
@@ -134,6 +187,7 @@ impl FromIterator<TableOrderOverride> for TableOrderOverrides {
 
 #[derive(Debug, Clone, Default)]
 pub struct SchemaOverrides {
+    pub array_values_order: ArrayOrderOverrides,
     pub table_keys_order: TableOrderOverrides,
 }
 
@@ -376,6 +430,7 @@ pub struct Schema {
     pub catalog_uri: Option<Arc<tombi_uri::CatalogUri>>,
     pub include: Vec<String>,
     pub sub_root_accessors: Option<Vec<RootAccessor>>,
+    pub array_values_order_enabled: bool,
     pub table_keys_order_enabled: bool,
     pub overrides: SchemaOverrides,
 }

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -41,14 +41,101 @@ pub use referable_schema::{
     CurrentSchema, Referable, is_online_url, resolve_and_collect_schemas, resolve_json_pointer,
     resolve_schema_item,
 };
-pub use schema_context::SchemaContext;
+pub use schema_context::{SchemaContext, SchemaContextOverrides};
 pub use schema_cycle_guard::{SchemaCycleGuard, SchemaVisits};
-pub use source_schema::{SourceSchema, SubSchemaUriMap};
+pub use source_schema::{SourceSchema, SourceSubSchema, SourceSubSchemaMap};
 pub use string_schema::StringSchema;
 pub use table_schema::{Dependency, TableKeysOrderGroup, TableSchema, XTombiTableKeysOrder};
 pub use tombi_accessor::{RootAccessor, RootAccessors, SchemaAccessor, SchemaAccessors};
 pub use tombi_uri::{CatalogUri, SchemaUri};
 pub use value_schema::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableOrderOverride {
+    pub target: Vec<RootAccessor>,
+    pub disabled: bool,
+    pub order: Option<tombi_x_keyword::TableKeysOrder>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TableOrderOverrides(Vec<TableOrderOverride>);
+
+impl TableOrderOverrides {
+    pub fn push_schema_override(
+        &mut self,
+        target: Vec<RootAccessor>,
+        disabled: bool,
+        order: Option<tombi_x_keyword::TableKeysOrder>,
+    ) {
+        self.0.push(TableOrderOverride {
+            target,
+            disabled,
+            order,
+        });
+    }
+
+    pub fn insert_comment_directive_override(
+        &mut self,
+        accessors: Vec<Accessor>,
+        disabled: bool,
+        order: Option<tombi_x_keyword::TableKeysOrder>,
+    ) {
+        self.0.insert(
+            0,
+            TableOrderOverride {
+                target: accessors
+                    .into_iter()
+                    .map(|accessor| match accessor {
+                        Accessor::Key(key) => RootAccessor::Key(key),
+                        Accessor::Index(_) => RootAccessor::Index,
+                    })
+                    .collect(),
+                disabled,
+                order,
+            },
+        );
+    }
+
+    pub fn get(&self, accessors: &[Accessor]) -> Option<&TableOrderOverride> {
+        self.0.iter().find(|override_item| {
+            override_item.target.len() == accessors.len()
+                && override_item
+                    .target
+                    .iter()
+                    .zip(accessors)
+                    .all(|(expected, actual)| expected == actual)
+        })
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, TableOrderOverride> {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<Vec<TableOrderOverride>> for TableOrderOverrides {
+    fn from(value: Vec<TableOrderOverride>) -> Self {
+        Self(value)
+    }
+}
+
+impl FromIterator<TableOrderOverride> for TableOrderOverrides {
+    fn from_iter<T: IntoIterator<Item = TableOrderOverride>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SchemaOverrides {
+    pub table_keys_order: TableOrderOverrides,
+}
 
 pub type SchemaProperties =
     Arc<tokio::sync::RwLock<tombi_hashmap::IndexMap<SchemaAccessor, PropertySchema>>>;
@@ -289,6 +376,8 @@ pub struct Schema {
     pub catalog_uri: Option<Arc<tombi_uri::CatalogUri>>,
     pub include: Vec<String>,
     pub sub_root_accessors: Option<Vec<RootAccessor>>,
+    pub table_keys_order_enabled: bool,
+    pub overrides: SchemaOverrides,
 }
 
 pub trait FindSchemaCandidates {

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -92,6 +92,15 @@ impl SchemaContext<'_> {
 
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
+        let root_explicit = if let Some(root_schema) = self.root_schema {
+            let mut root_schema_uri = root_schema.schema_uri.clone();
+            root_schema_uri.set_fragment(None);
+            self.store
+                .explicit_table_keys_order_enabled_for_schema(&root_schema_uri, None)
+                .await
+        } else {
+            None
+        };
 
         if self.root_schema.is_some_and(|root_schema| {
             let mut root_schema_uri = root_schema.schema_uri.clone();
@@ -121,6 +130,17 @@ impl SchemaContext<'_> {
                 })
         });
 
+        let explicit = self
+            .store
+            .explicit_table_keys_order_enabled_for_schema(&normalized, sub_root_accessors)
+            .await;
+        if let Some(explicit) = explicit {
+            return explicit;
+        }
+        if let Some(root_explicit) = root_explicit {
+            return root_explicit;
+        }
+
         self.store
             .table_keys_order_enabled_for_schema(&normalized, sub_root_accessors)
             .await
@@ -144,6 +164,15 @@ impl SchemaContext<'_> {
 
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
+        let root_explicit = if let Some(root_schema) = self.root_schema {
+            let mut root_schema_uri = root_schema.schema_uri.clone();
+            root_schema_uri.set_fragment(None);
+            self.store
+                .explicit_array_values_order_enabled_for_schema(&root_schema_uri, None)
+                .await
+        } else {
+            None
+        };
 
         if self.root_schema.is_some_and(|root_schema| {
             let mut root_schema_uri = root_schema.schema_uri.clone();
@@ -172,6 +201,17 @@ impl SchemaContext<'_> {
                     .then_some(sub_root_accessors.as_slice())
                 })
         });
+
+        let explicit = self
+            .store
+            .explicit_array_values_order_enabled_for_schema(&normalized, sub_root_accessors)
+            .await;
+        if let Some(explicit) = explicit {
+            return explicit;
+        }
+        if let Some(root_explicit) = root_explicit {
+            return root_explicit;
+        }
 
         self.store
             .array_values_order_enabled_for_schema(&normalized, sub_root_accessors)

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -1,14 +1,16 @@
 use tombi_severity_level::SeverityLevelDefaultWarn;
-use tombi_x_keyword::{StringFormat, TableKeysOrder};
+use tombi_x_keyword::StringFormat;
 
 use crate::schema::schema_cycle_guard::SchemaVisits;
 use crate::{
-    Accessor, CurrentSchema, SchemaUri, TableOrderOverride, TableOrderOverrides, ValueSchema,
+    Accessor, ArrayOrderOverride, ArrayOrderOverrides, CurrentSchema, SchemaUri,
+    TableOrderOverride, TableOrderOverrides, ValueSchema, XTombiArrayValuesOrder,
     XTombiTableKeysOrder,
 };
 
 #[derive(Default)]
 pub struct SchemaContextOverrides<'a> {
+    pub array_values_order: Option<&'a ArrayOrderOverrides>,
     pub table_keys_order: Option<&'a TableOrderOverrides>,
 }
 
@@ -36,6 +38,7 @@ impl SchemaContext<'_> {
             sub_schema_map: source_schema.map(|schema| &schema.sub_schema_map),
             deprecated_lint_level: source_schema.and_then(|schema| schema.deprecated_lint_level),
             overrides: SchemaContextOverrides {
+                array_values_order: source_schema.map(|schema| &schema.overrides.array_values_order),
                 table_keys_order: source_schema.map(|schema| &schema.overrides.table_keys_order),
             },
             schema_visits: Default::default(),
@@ -56,6 +59,7 @@ impl SchemaContext<'_> {
             sub_schema_map: self.sub_schema_map,
             deprecated_lint_level: self.deprecated_lint_level,
             overrides: SchemaContextOverrides {
+                array_values_order: self.overrides.array_values_order,
                 table_keys_order: self.overrides.table_keys_order,
             },
             schema_visits: self.schema_visits.clone(),
@@ -124,28 +128,113 @@ impl SchemaContext<'_> {
             .and_then(|overrides| overrides.get(accessors))
     }
 
-    pub async fn table_keys_order(
+    pub async fn array_values_order_enabled(
+        &self,
+        accessors: &[Accessor],
+        schema_uri: &SchemaUri,
+    ) -> bool {
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        if self.root_schema.is_some_and(|root_schema| {
+            let mut root_schema_uri = root_schema.schema_uri.clone();
+            root_schema_uri.set_fragment(None);
+            root_schema_uri == normalized
+        }) {
+            return self
+                .store
+                .array_values_order_enabled_for_schema(&normalized, None)
+                .await
+                .unwrap_or(true);
+        }
+
+        let sub_root_accessors = self.sub_schema_map.and_then(|sub_schema_map| {
+            sub_schema_map
+                .iter()
+                .find_map(|(sub_root_accessors, sub_schema)| {
+                    let mut sub_schema_uri = sub_schema.schema_uri.clone();
+                    sub_schema_uri.set_fragment(None);
+                    (sub_schema_uri == normalized
+                        && sub_root_accessors.len() <= accessors.len()
+                        && sub_root_accessors
+                            .iter()
+                            .zip(accessors.iter())
+                            .all(|(expected, actual)| expected == actual))
+                    .then_some(sub_root_accessors.as_slice())
+                })
+        });
+
+        self.store
+            .array_values_order_enabled_for_schema(&normalized, sub_root_accessors)
+            .await
+            .unwrap_or(true)
+    }
+
+    pub fn array_order_override(&self, accessors: &[Accessor]) -> Option<&ArrayOrderOverride> {
+        self.overrides
+            .array_values_order
+            .and_then(|overrides| overrides.get(accessors))
+    }
+
+    pub async fn array_values_order(
         &self,
         accessors: &[Accessor],
         current_schema: Option<&CurrentSchema<'_>>,
-        local_override: Option<(bool, Option<TableKeysOrder>)>,
-    ) -> Option<XTombiTableKeysOrder> {
-        if let Some((disabled, order)) = local_override {
-            if disabled {
+        comment_directive_override: Option<&ArrayOrderOverride>,
+    ) -> Option<XTombiArrayValuesOrder> {
+        if let Some(comment_directive_override) = comment_directive_override {
+            if comment_directive_override.disabled {
                 return None;
             }
-            if let Some(order) = order {
-                return Some(XTombiTableKeysOrder::All(order));
+            if let Some(order) = comment_directive_override.order {
+                return Some(XTombiArrayValuesOrder::All(order));
             }
         }
 
-        if let Some(schema_override) = self.table_order_override(accessors) {
+        if let Some(schema_override) = self.array_order_override(accessors) {
             if schema_override.disabled {
                 return None;
             }
             if let Some(order) = schema_override.order {
-                return Some(XTombiTableKeysOrder::All(order));
+                return Some(XTombiArrayValuesOrder::All(order));
             }
+        }
+
+        let current_schema = current_schema?;
+        self.array_values_order_enabled(accessors, current_schema.schema_uri.as_ref())
+            .await
+            .then_some(())
+            .and_then(|_| match current_schema.value_schema.as_ref() {
+                ValueSchema::Array(array_schema) => array_schema.values_order.clone(),
+                _ => None,
+            })
+    }
+
+    pub async fn table_keys_order(
+        &self,
+        accessors: &[Accessor],
+        current_schema: Option<&CurrentSchema<'_>>,
+        comment_directive_override: Option<&TableOrderOverride>,
+    ) -> Option<XTombiTableKeysOrder> {
+        let (disabled, order) = comment_directive_override
+            .map(|override_item| (override_item.disabled, override_item.order))
+            .unwrap_or((false, None));
+        if disabled {
+            return None;
+        }
+        if let Some(order) = order {
+            return Some(XTombiTableKeysOrder::All(order));
+        }
+
+        let (disabled, order) = self
+            .table_order_override(accessors)
+            .map(|override_item| (override_item.disabled, override_item.order))
+            .unwrap_or((false, None));
+        if disabled {
+            return None;
+        }
+        if let Some(order) = order {
+            return Some(XTombiTableKeysOrder::All(order));
         }
 
         let current_schema = current_schema?;

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -38,7 +38,8 @@ impl SchemaContext<'_> {
             sub_schema_map: source_schema.map(|schema| &schema.sub_schema_map),
             deprecated_lint_level: source_schema.and_then(|schema| schema.deprecated_lint_level),
             overrides: SchemaContextOverrides {
-                array_values_order: source_schema.map(|schema| &schema.overrides.array_values_order),
+                array_values_order: source_schema
+                    .map(|schema| &schema.overrides.array_values_order),
                 table_keys_order: source_schema.map(|schema| &schema.overrides.table_keys_order),
             },
             schema_visits: Default::default(),
@@ -85,6 +86,10 @@ impl SchemaContext<'_> {
         accessors: &[Accessor],
         schema_uri: &SchemaUri,
     ) -> bool {
+        if let Some(override_item) = self.table_order_override(accessors) {
+            return !override_item.disabled;
+        }
+
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
 
@@ -133,6 +138,10 @@ impl SchemaContext<'_> {
         accessors: &[Accessor],
         schema_uri: &SchemaUri,
     ) -> bool {
+        if let Some(override_item) = self.array_order_override(accessors) {
+            return !override_item.disabled;
+        }
+
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
 
@@ -218,7 +227,7 @@ impl SchemaContext<'_> {
     ) -> Option<XTombiTableKeysOrder> {
         let (disabled, order) = comment_directive_override
             .map(|override_item| (override_item.disabled, override_item.order))
-            .unwrap_or((false, None));
+            .unwrap_or_default();
         if disabled {
             return None;
         }
@@ -229,7 +238,7 @@ impl SchemaContext<'_> {
         let (disabled, order) = self
             .table_order_override(accessors)
             .map(|override_item| (override_item.disabled, override_item.order))
-            .unwrap_or((false, None));
+            .unwrap_or_default();
         if disabled {
             return None;
         }

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -1,22 +1,67 @@
 use tombi_severity_level::SeverityLevelDefaultWarn;
-use tombi_x_keyword::StringFormat;
+use tombi_x_keyword::{StringFormat, TableKeysOrder};
 
 use crate::schema::schema_cycle_guard::SchemaVisits;
+use crate::{
+    Accessor, CurrentSchema, SchemaUri, TableOrderOverride, TableOrderOverrides, ValueSchema,
+    XTombiTableKeysOrder,
+};
+
+#[derive(Default)]
+pub struct SchemaContextOverrides<'a> {
+    pub table_keys_order: Option<&'a TableOrderOverrides>,
+}
 
 pub struct SchemaContext<'a> {
     pub toml_version: tombi_config::TomlVersion,
     pub root_schema: Option<&'a crate::DocumentSchema>,
-    pub sub_schema_uri_map: Option<&'a crate::SubSchemaUriMap>,
+    pub sub_schema_map: Option<&'a crate::SourceSubSchemaMap>,
     pub deprecated_lint_level: Option<SeverityLevelDefaultWarn>,
+    pub overrides: SchemaContextOverrides<'a>,
     pub schema_visits: SchemaVisits,
     pub store: &'a crate::SchemaStore,
     pub strict: Option<bool>,
 }
 
 impl SchemaContext<'_> {
+    pub fn from_source_schema<'a>(
+        toml_version: tombi_config::TomlVersion,
+        source_schema: Option<&'a crate::SourceSchema>,
+        store: &'a crate::SchemaStore,
+        strict: Option<bool>,
+    ) -> SchemaContext<'a> {
+        SchemaContext {
+            toml_version,
+            root_schema: source_schema.and_then(|schema| schema.root_schema.as_deref()),
+            sub_schema_map: source_schema.map(|schema| &schema.sub_schema_map),
+            deprecated_lint_level: source_schema.and_then(|schema| schema.deprecated_lint_level),
+            overrides: SchemaContextOverrides {
+                table_keys_order: source_schema.map(|schema| &schema.overrides.table_keys_order),
+            },
+            schema_visits: Default::default(),
+            store,
+            strict,
+        }
+    }
+
     #[inline]
     pub fn strict(&self) -> bool {
         self.strict.unwrap_or_else(|| self.store.strict())
+    }
+
+    pub fn with_strict(&self, strict: Option<bool>) -> SchemaContext<'_> {
+        SchemaContext {
+            toml_version: self.toml_version,
+            root_schema: self.root_schema,
+            sub_schema_map: self.sub_schema_map,
+            deprecated_lint_level: self.deprecated_lint_level,
+            overrides: SchemaContextOverrides {
+                table_keys_order: self.overrides.table_keys_order,
+            },
+            schema_visits: self.schema_visits.clone(),
+            store: self.store,
+            strict,
+        }
     }
 
     #[inline]
@@ -31,21 +76,103 @@ impl SchemaContext<'_> {
         self.deprecated_lint_level
     }
 
+    pub async fn table_keys_order_enabled(
+        &self,
+        accessors: &[Accessor],
+        schema_uri: &SchemaUri,
+    ) -> bool {
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        if self.root_schema.is_some_and(|root_schema| {
+            let mut root_schema_uri = root_schema.schema_uri.clone();
+            root_schema_uri.set_fragment(None);
+            root_schema_uri == normalized
+        }) {
+            return self
+                .store
+                .table_keys_order_enabled_for_schema(&normalized, None)
+                .await
+                .unwrap_or(true);
+        }
+
+        let sub_root_accessors = self.sub_schema_map.and_then(|sub_schema_map| {
+            sub_schema_map
+                .iter()
+                .find_map(|(sub_root_accessors, sub_schema)| {
+                    let mut sub_schema_uri = sub_schema.schema_uri.clone();
+                    sub_schema_uri.set_fragment(None);
+                    (sub_schema_uri == normalized
+                        && sub_root_accessors.len() <= accessors.len()
+                        && sub_root_accessors
+                            .iter()
+                            .zip(accessors.iter())
+                            .all(|(expected, actual)| expected == actual))
+                    .then_some(sub_root_accessors.as_slice())
+                })
+        });
+
+        self.store
+            .table_keys_order_enabled_for_schema(&normalized, sub_root_accessors)
+            .await
+            .unwrap_or(true)
+    }
+
+    pub fn table_order_override(&self, accessors: &[Accessor]) -> Option<&TableOrderOverride> {
+        self.overrides
+            .table_keys_order
+            .and_then(|overrides| overrides.get(accessors))
+    }
+
+    pub async fn table_keys_order(
+        &self,
+        accessors: &[Accessor],
+        current_schema: Option<&CurrentSchema<'_>>,
+        local_override: Option<(bool, Option<TableKeysOrder>)>,
+    ) -> Option<XTombiTableKeysOrder> {
+        if let Some((disabled, order)) = local_override {
+            if disabled {
+                return None;
+            }
+            if let Some(order) = order {
+                return Some(XTombiTableKeysOrder::All(order));
+            }
+        }
+
+        if let Some(schema_override) = self.table_order_override(accessors) {
+            if schema_override.disabled {
+                return None;
+            }
+            if let Some(order) = schema_override.order {
+                return Some(XTombiTableKeysOrder::All(order));
+            }
+        }
+
+        let current_schema = current_schema?;
+        self.table_keys_order_enabled(accessors, current_schema.schema_uri.as_ref())
+            .await
+            .then_some(())
+            .and_then(|_| match current_schema.value_schema.as_ref() {
+                ValueSchema::Table(table_schema) => table_schema.keys_order.clone(),
+                _ => None,
+            })
+    }
+
     pub async fn get_subschema(
         &self,
         accessors: &[crate::Accessor],
         current_schema: Option<&crate::CurrentSchema<'_>>,
     ) -> Option<Result<std::sync::Arc<crate::DocumentSchema>, crate::Error>> {
-        if let Some(sub_schema_uri_map) = self.sub_schema_uri_map
-            && let Some((_, sub_schema_uri)) = sub_schema_uri_map
+        if let Some(sub_schema_map) = self.sub_schema_map
+            && let Some((_, sub_schema)) = sub_schema_map
                 .iter()
                 .find(|(pattern, _)| pattern.as_slice() == accessors)
             && current_schema
-                .is_none_or(|current_schema| &*current_schema.schema_uri != sub_schema_uri)
+                .is_none_or(|current_schema| &*current_schema.schema_uri != &sub_schema.schema_uri)
         {
             return self
                 .store
-                .try_get_document_schema(sub_schema_uri)
+                .try_get_document_schema(&sub_schema.schema_uri)
                 .await
                 .transpose();
         }

--- a/crates/tombi-schema-store/src/schema/source_schema.rs
+++ b/crates/tombi-schema-store/src/schema/source_schema.rs
@@ -11,6 +11,7 @@ pub struct SourceSchema {
     pub root_schema: Option<Arc<DocumentSchema>>,
     pub sub_schema_map: SourceSubSchemaMap,
     pub deprecated_lint_level: Option<SeverityLevelDefaultWarn>,
+    pub array_values_order_enabled: bool,
     pub table_keys_order_enabled: bool,
     pub overrides: SchemaOverrides,
     /// TOML version override from `[[schemas]]` config entry.
@@ -32,11 +33,13 @@ impl SourceSchema {
         sub_schema_map: SourceSubSchemaMap,
         toml_version: Option<TomlVersion>,
         deprecated_lint_level: Option<SeverityLevelDefaultWarn>,
+        array_values_order_enabled: bool,
         table_keys_order_enabled: bool,
     ) -> Self {
         Self {
             root_schema,
             sub_schema_map,
+            array_values_order_enabled,
             deprecated_lint_level,
             table_keys_order_enabled,
             overrides: Default::default(),

--- a/crates/tombi-schema-store/src/schema/source_schema.rs
+++ b/crates/tombi-schema-store/src/schema/source_schema.rs
@@ -1,36 +1,45 @@
 use std::sync::Arc;
 
-use itertools::Itertools;
 use tombi_config::TomlVersion;
 use tombi_severity_level::SeverityLevelDefaultWarn;
 
-use super::{DocumentSchema, SchemaUri};
-use crate::{RootAccessor, RootAccessors};
+use super::{DocumentSchema, SchemaOverrides, SchemaUri, TableOrderOverride};
+use crate::RootAccessor;
 
-pub type SubSchemaUriMap = tombi_hashmap::IndexMap<Vec<RootAccessor>, SchemaUri>;
-
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SourceSchema {
     pub root_schema: Option<Arc<DocumentSchema>>,
-    pub sub_schema_uri_map: SubSchemaUriMap,
+    pub sub_schema_map: SourceSubSchemaMap,
     pub deprecated_lint_level: Option<SeverityLevelDefaultWarn>,
+    pub table_keys_order_enabled: bool,
+    pub overrides: SchemaOverrides,
     /// TOML version override from `[[schemas]]` config entry.
     ///
     /// Use [`toml_version()`](Self::toml_version) to get the resolved value.
     toml_version: Option<TomlVersion>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceSubSchema {
+    pub schema_uri: SchemaUri,
+}
+
+pub type SourceSubSchemaMap = tombi_hashmap::IndexMap<Vec<RootAccessor>, SourceSubSchema>;
+
 impl SourceSchema {
     pub fn new(
         root_schema: Option<Arc<DocumentSchema>>,
-        sub_schema_uri_map: SubSchemaUriMap,
+        sub_schema_map: SourceSubSchemaMap,
         toml_version: Option<TomlVersion>,
         deprecated_lint_level: Option<SeverityLevelDefaultWarn>,
+        table_keys_order_enabled: bool,
     ) -> Self {
         Self {
             root_schema,
-            sub_schema_uri_map,
+            sub_schema_map,
             deprecated_lint_level,
+            table_keys_order_enabled,
+            overrides: Default::default(),
             toml_version,
         }
     }
@@ -45,25 +54,16 @@ impl SourceSchema {
                 .and_then(|root| root.toml_version())
         })
     }
-}
 
-impl std::fmt::Debug for SourceSchema {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let root_schema_uri = self
-            .root_schema
-            .as_ref()
-            .map(|schema| schema.schema_uri.to_string());
-        let sub_schema_uri_map = self
-            .sub_schema_uri_map
-            .iter()
-            .map(|(accessors, url)| {
-                format!("[{:?}]: {}", RootAccessors::from(accessors.clone()), url)
-            })
-            .collect_vec()
-            .join(", ");
-        write!(
-            f,
-            "SourceSchema {{ root_schema: {root_schema_uri:?}, sub_schema_uri_map: {sub_schema_uri_map:?} }}"
-        )
+    pub fn push_table_order_override(
+        &mut self,
+        target: Vec<RootAccessor>,
+        table_order_override: TableOrderOverride,
+    ) {
+        self.overrides.table_keys_order.push_schema_override(
+            target,
+            table_order_override.disabled,
+            table_order_override.order,
+        );
     }
 }

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -2,9 +2,10 @@ use std::{borrow::Cow, ops::Deref, str::FromStr, sync::Arc};
 
 use crate::resolve_json_pointer;
 use crate::{
-    AllOfSchema, AnyOfSchema, CatalogUri, DocumentSchema, OneOfSchema, RootAccessor, RootAccessors,
-    SourceSchema, SourceSubSchema, SourceSubSchemaMap, TableOrderOverride, ValueSchema,
-    get_tombi_schemastore_content, http_client::HttpClient, json::JsonCatalog,
+    AllOfSchema, AnyOfSchema, ArrayOrderOverride, CatalogUri, DocumentSchema, OneOfSchema,
+    RootAccessor, RootAccessors, SourceSchema, SourceSubSchema, SourceSubSchemaMap,
+    TableOrderOverride, ValueSchema, get_tombi_schemastore_content, http_client::HttpClient,
+    json::JsonCatalog,
 };
 use itertools::{Either, Itertools};
 use tokio::sync::RwLock;
@@ -199,6 +200,13 @@ impl SchemaStore {
                 include: schema.include().to_vec(),
                 toml_version: schema.toml_version(),
                 sub_root_accessors: schema.root().and_then(RootAccessor::parse),
+                array_values_order_enabled: schema
+                    .format()
+                    .and_then(|format| format.rules.as_ref())
+                    .and_then(|rules| rules.array_values_order.as_ref())
+                    .and_then(|rule| rule.enabled)
+                    .unwrap_or_default()
+                    .value(),
                 table_keys_order_enabled: schema
                     .format()
                     .and_then(|format| format.rules.as_ref())
@@ -207,6 +215,35 @@ impl SchemaStore {
                     .unwrap_or_default()
                     .value(),
                 overrides: crate::SchemaOverrides {
+                    array_values_order: schema
+                        .overrides()
+                        .into_iter()
+                        .flatten()
+                        .flat_map(|override_item| {
+                            let Some(order) = override_item
+                                .format
+                                .as_ref()
+                                .and_then(|format| format.rules.as_ref())
+                                .and_then(|rules| rules.array_values_order)
+                            else {
+                                return Vec::new();
+                            };
+
+                            override_item
+                                .targets
+                                .iter()
+                                .filter_map(|target| {
+                                    RootAccessor::parse(target).map(|root_accessors| {
+                                        ArrayOrderOverride {
+                                            target: root_accessors,
+                                            disabled: false,
+                                            order: Some(order),
+                                        }
+                                    })
+                                })
+                                .collect()
+                        })
+                        .collect(),
                     table_keys_order: schema
                         .overrides()
                         .into_iter()
@@ -379,6 +416,7 @@ impl SchemaStore {
                     include: schema.file_match,
                     toml_version: None,
                     sub_root_accessors: None,
+                    array_values_order_enabled: true,
                     table_keys_order_enabled: true,
                     overrides: Default::default(),
                 });
@@ -693,6 +731,7 @@ impl SchemaStore {
             sub_schema_map,
             toml_version,
             deprecated_lint_level,
+            array_values_order_enabled,
             table_keys_order_enabled,
         ) = if let Some(source_schema) = source_schema {
             let toml_version = source_schema.toml_version();
@@ -701,10 +740,11 @@ impl SchemaStore {
                 source_schema.sub_schema_map,
                 toml_version,
                 source_schema.deprecated_lint_level,
+                source_schema.array_values_order_enabled,
                 source_schema.table_keys_order_enabled,
             )
         } else {
-            (None, Default::default(), None, None, true)
+            (None, Default::default(), None, None, true, true)
         };
 
         Ok(Some(SourceSchema::new(
@@ -714,6 +754,7 @@ impl SchemaStore {
             sub_schema_map,
             toml_version,
             deprecated_lint_level,
+            array_values_order_enabled,
             table_keys_order_enabled,
         )))
     }
@@ -837,8 +878,17 @@ impl SchemaStore {
                     }
                     if let Some(existing) = source_schema.as_mut() {
                         if matching_schema.sub_root_accessors.is_none() {
+                            existing.array_values_order_enabled =
+                                matching_schema.array_values_order_enabled;
                             existing.table_keys_order_enabled =
                                 matching_schema.table_keys_order_enabled;
+                        }
+                        for override_item in matching_schema.overrides.array_values_order.iter() {
+                            existing.overrides.array_values_order.push_schema_override(
+                                override_item.target.clone(),
+                                override_item.disabled,
+                                override_item.order,
+                            );
                         }
                         for override_item in matching_schema.overrides.table_keys_order.iter() {
                             existing.push_table_order_override(
@@ -884,6 +934,7 @@ impl SchemaStore {
                                 matching_schema.toml_version,
                                 matching_schema.deprecated_lint_level,
                                 true,
+                                true,
                             );
                             source_schema = Some(new_source);
                         }
@@ -900,6 +951,7 @@ impl SchemaStore {
                                     sub_schema_map,
                                     toml_version,
                                     matching_schema.deprecated_lint_level,
+                                    matching_schema.array_values_order_enabled,
                                     matching_schema.table_keys_order_enabled,
                                 );
                                 existing.overrides = overrides;
@@ -911,6 +963,7 @@ impl SchemaStore {
                                 Default::default(),
                                 matching_schema.toml_version,
                                 matching_schema.deprecated_lint_level,
+                                matching_schema.array_values_order_enabled,
                                 matching_schema.table_keys_order_enabled,
                             );
                             source_schema = Some(new_source);
@@ -933,7 +986,15 @@ impl SchemaStore {
 
             if let Some(existing) = source_schema.as_mut() {
                 if matching_schema.sub_root_accessors.is_none() {
+                    existing.array_values_order_enabled = matching_schema.array_values_order_enabled;
                     existing.table_keys_order_enabled = matching_schema.table_keys_order_enabled;
+                }
+                for override_item in matching_schema.overrides.array_values_order.iter() {
+                    existing.overrides.array_values_order.push_schema_override(
+                        override_item.target.clone(),
+                        override_item.disabled,
+                        override_item.order,
+                    );
                 }
                 for override_item in matching_schema.overrides.table_keys_order.iter() {
                     existing.push_table_order_override(
@@ -1006,6 +1067,7 @@ impl SchemaStore {
             include,
             toml_version: options.toml_version,
             sub_root_accessors: None,
+            array_values_order_enabled: true,
             table_keys_order_enabled: true,
             overrides: Default::default(),
         };
@@ -1048,6 +1110,32 @@ impl SchemaStore {
                     }
             })
             .map(|schema| schema.table_keys_order_enabled)
+    }
+
+    pub(crate) async fn array_values_order_enabled_for_schema(
+        &self,
+        schema_uri: &SchemaUri,
+        sub_root_accessors: Option<&[RootAccessor]>,
+    ) -> Option<bool> {
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        self.schemas
+            .read()
+            .await
+            .iter()
+            .rev()
+            .find(|schema| {
+                let mut candidate_uri = schema.schema_uri.clone();
+                candidate_uri.set_fragment(None);
+                candidate_uri == normalized
+                    && match (&schema.sub_root_accessors, sub_root_accessors) {
+                        (None, None) => true,
+                        (Some(candidate), Some(target)) => candidate.as_slice() == target,
+                        _ => false,
+                    }
+            })
+            .map(|schema| schema.array_values_order_enabled)
     }
 }
 
@@ -1344,6 +1432,7 @@ mod tests {
             lint: None,
             format: Some(SchemaFormatOptions {
                 rules: Some(SchemaFormatRules {
+                    array_values_order: None,
                     table_keys_order: Some(SchemaTableKeysOrderRule {
                         enabled: Some(false.into()),
                     }),
@@ -1354,6 +1443,7 @@ mod tests {
                     targets: vec![Target::from("")],
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
+                            array_values_order: None,
                             table_keys_order: Some(TableKeysOrder::Ascending),
                         }),
                     }),
@@ -1362,6 +1452,7 @@ mod tests {
                     targets: vec![Target::from("tool.uv"), Target::from("tool")],
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
+                            array_values_order: None,
                             table_keys_order: Some(TableKeysOrder::Descending),
                         }),
                     }),
@@ -1446,6 +1537,7 @@ mod tests {
                     targets: vec![Target::from("tool")],
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
+                            array_values_order: None,
                             table_keys_order: Some(TableKeysOrder::Ascending),
                         }),
                     }),
@@ -1518,6 +1610,7 @@ mod tests {
                 lint: None,
                 format: Some(SchemaFormatOptions {
                     rules: Some(SchemaFormatRules {
+                        array_values_order: None,
                         table_keys_order: Some(SchemaTableKeysOrderRule {
                             enabled: Some(false.into()),
                         }),
@@ -1535,6 +1628,7 @@ mod tests {
                     targets: vec![Target::from("")],
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
+                            array_values_order: None,
                             table_keys_order: Some(TableKeysOrder::Descending),
                         }),
                     }),
@@ -1625,6 +1719,7 @@ mod tests {
                 lint: None,
                 format: Some(SchemaFormatOptions {
                     rules: Some(SchemaFormatRules {
+                        array_values_order: None,
                         table_keys_order: Some(SchemaTableKeysOrderRule {
                             enabled: Some(false.into()),
                         }),

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -191,6 +191,19 @@ impl SchemaStore {
 
             log::debug!("Load schema from config: {}", schema_uri);
 
+            let explicit_array_values_order_enabled = schema
+                .format()
+                .and_then(|format| format.rules.as_ref())
+                .and_then(|rules| rules.array_values_order.as_ref())
+                .and_then(|rule| rule.enabled)
+                .map(|enabled| enabled.value());
+            let explicit_table_keys_order_enabled = schema
+                .format()
+                .and_then(|format| format.rules.as_ref())
+                .and_then(|rules| rules.table_keys_order.as_ref())
+                .and_then(|rule| rule.enabled)
+                .map(|enabled| enabled.value());
+
             self.schemas.write().await.push(crate::Schema {
                 title: None,
                 description: None,
@@ -200,20 +213,10 @@ impl SchemaStore {
                 include: schema.include().to_vec(),
                 toml_version: schema.toml_version(),
                 sub_root_accessors: schema.root().and_then(RootAccessor::parse),
-                array_values_order_enabled: schema
-                    .format()
-                    .and_then(|format| format.rules.as_ref())
-                    .and_then(|rules| rules.array_values_order.as_ref())
-                    .and_then(|rule| rule.enabled)
-                    .unwrap_or_default()
-                    .value(),
-                table_keys_order_enabled: schema
-                    .format()
-                    .and_then(|format| format.rules.as_ref())
-                    .and_then(|rules| rules.table_keys_order.as_ref())
-                    .and_then(|rule| rule.enabled)
-                    .unwrap_or_default()
-                    .value(),
+                explicit_array_values_order_enabled,
+                explicit_table_keys_order_enabled,
+                array_values_order_enabled: explicit_array_values_order_enabled.unwrap_or(true),
+                table_keys_order_enabled: explicit_table_keys_order_enabled.unwrap_or(true),
                 overrides: crate::SchemaOverrides {
                     array_values_order: schema
                         .overrides()
@@ -420,6 +423,8 @@ impl SchemaStore {
                     include: schema.file_match,
                     toml_version: None,
                     sub_root_accessors: None,
+                    explicit_array_values_order_enabled: None,
+                    explicit_table_keys_order_enabled: None,
                     array_values_order_enabled: true,
                     table_keys_order_enabled: true,
                     overrides: Default::default(),
@@ -1072,6 +1077,8 @@ impl SchemaStore {
             include,
             toml_version: options.toml_version,
             sub_root_accessors: None,
+            explicit_array_values_order_enabled: None,
+            explicit_table_keys_order_enabled: None,
             array_values_order_enabled: true,
             table_keys_order_enabled: true,
             overrides: Default::default(),
@@ -1096,12 +1103,18 @@ impl SchemaStore {
         schema_uri: &SchemaUri,
         sub_root_accessors: Option<&[RootAccessor]>,
     ) -> Option<bool> {
+        if let Some(explicit) = self
+            .explicit_table_keys_order_enabled_for_schema(schema_uri, sub_root_accessors)
+            .await
+        {
+            return Some(explicit);
+        }
+
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
 
-        self.schemas
-            .read()
-            .await
+        let schemas = self.schemas.read().await;
+        schemas
             .iter()
             .rev()
             .find(|schema| {
@@ -1117,7 +1130,7 @@ impl SchemaStore {
             .map(|schema| schema.table_keys_order_enabled)
     }
 
-    pub(crate) async fn array_values_order_enabled_for_schema(
+    pub(crate) async fn explicit_table_keys_order_enabled_for_schema(
         &self,
         schema_uri: &SchemaUri,
         sub_root_accessors: Option<&[RootAccessor]>,
@@ -1125,9 +1138,42 @@ impl SchemaStore {
         let mut normalized = schema_uri.clone();
         normalized.set_fragment(None);
 
-        self.schemas
-            .read()
+        let schemas = self.schemas.read().await;
+        schemas
+            .iter()
+            .rev()
+            .find(|schema| {
+                let mut candidate_uri = schema.schema_uri.clone();
+                candidate_uri.set_fragment(None);
+                candidate_uri == normalized
+                    && match (&schema.sub_root_accessors, sub_root_accessors) {
+                        (None, None) => true,
+                        (Some(candidate), Some(target)) => candidate.as_slice() == target,
+                        _ => false,
+                    }
+                    && schema.catalog_uri.is_none()
+                    && schema.explicit_table_keys_order_enabled.is_some()
+            })
+            .and_then(|schema| schema.explicit_table_keys_order_enabled)
+    }
+
+    pub(crate) async fn array_values_order_enabled_for_schema(
+        &self,
+        schema_uri: &SchemaUri,
+        sub_root_accessors: Option<&[RootAccessor]>,
+    ) -> Option<bool> {
+        if let Some(explicit) = self
+            .explicit_array_values_order_enabled_for_schema(schema_uri, sub_root_accessors)
             .await
+        {
+            return Some(explicit);
+        }
+
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        let schemas = self.schemas.read().await;
+        schemas
             .iter()
             .rev()
             .find(|schema| {
@@ -1141,6 +1187,30 @@ impl SchemaStore {
                     }
             })
             .map(|schema| schema.array_values_order_enabled)
+    }
+
+    pub(crate) async fn explicit_array_values_order_enabled_for_schema(
+        &self,
+        schema_uri: &SchemaUri,
+        sub_root_accessors: Option<&[RootAccessor]>,
+    ) -> Option<bool> {
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        let schemas = self.schemas.read().await;
+        schemas.iter().rev().find(|schema| {
+            let mut candidate_uri = schema.schema_uri.clone();
+            candidate_uri.set_fragment(None);
+            candidate_uri == normalized
+                && match (&schema.sub_root_accessors, sub_root_accessors) {
+                    (None, None) => true,
+                    (Some(candidate), Some(target)) => candidate.as_slice() == target,
+                    _ => false,
+                }
+                && schema.catalog_uri.is_none()
+                && schema.explicit_array_values_order_enabled.is_some()
+        })
+        .and_then(|schema| schema.explicit_array_values_order_enabled)
     }
 }
 
@@ -1279,9 +1349,9 @@ mod tests {
     use crate::{CatalogUri, RootAccessor, ValueSchema};
     use tombi_config::{
         Config, RootSchema, SchemaFormatOptions, SchemaFormatRules, SchemaItem,
-        SchemaOverrideArrayValuesOrderRule, SchemaOverrideFormatOptions, SchemaOverrideFormatRules,
-        SchemaOverrideItem, SchemaOverrideTableKeysOrderRule, SchemaOverviewOptions,
-        SchemaTableKeysOrderRule, SubSchema, Target,
+        SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
+        SchemaOverrideTableKeysOrderRule, SchemaOverviewOptions, SchemaTableKeysOrderRule,
+        SubSchema, Target,
     };
     use tombi_uri::SchemaUri;
     use tombi_x_keyword::TableKeysOrder;

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -73,7 +73,7 @@ impl SchemaStore {
 
     /// Offline mode
     pub fn offline(&self) -> bool {
-        self.options.offline.unwrap_or(false)
+        self.options.offline.unwrap_or_default()
     }
 
     /// Cache options
@@ -220,11 +220,11 @@ impl SchemaStore {
                         .into_iter()
                         .flatten()
                         .flat_map(|override_item| {
-                            let Some(order) = override_item
+                            let Some(rule) = override_item
                                 .format
                                 .as_ref()
                                 .and_then(|format| format.rules.as_ref())
-                                .and_then(|rules| rules.array_values_order)
+                                .and_then(|rules| rules.array_values_order.clone())
                             else {
                                 return Vec::new();
                             };
@@ -236,8 +236,10 @@ impl SchemaStore {
                                     RootAccessor::parse(target).map(|root_accessors| {
                                         ArrayOrderOverride {
                                             target: root_accessors,
-                                            disabled: false,
-                                            order: Some(order),
+                                            disabled: rule
+                                                .enabled()
+                                                .is_some_and(|enabled| !enabled.value()),
+                                            order: rule.order(),
                                         }
                                     })
                                 })
@@ -249,11 +251,11 @@ impl SchemaStore {
                         .into_iter()
                         .flatten()
                         .flat_map(|override_item| {
-                            let Some(order) = override_item
+                            let Some(rule) = override_item
                                 .format
                                 .as_ref()
                                 .and_then(|format| format.rules.as_ref())
-                                .and_then(|rules| rules.table_keys_order)
+                                .and_then(|rules| rules.table_keys_order.clone())
                             else {
                                 return Vec::new();
                             };
@@ -265,8 +267,10 @@ impl SchemaStore {
                                     RootAccessor::parse(target).map(|root_accessors| {
                                         TableOrderOverride {
                                             target: root_accessors,
-                                            disabled: false,
-                                            order: Some(order),
+                                            disabled: rule
+                                                .enabled()
+                                                .is_some_and(|enabled| !enabled.value()),
+                                            order: rule.order(),
                                         }
                                     })
                                 })
@@ -986,7 +990,8 @@ impl SchemaStore {
 
             if let Some(existing) = source_schema.as_mut() {
                 if matching_schema.sub_root_accessors.is_none() {
-                    existing.array_values_order_enabled = matching_schema.array_values_order_enabled;
+                    existing.array_values_order_enabled =
+                        matching_schema.array_values_order_enabled;
                     existing.table_keys_order_enabled = matching_schema.table_keys_order_enabled;
                 }
                 for override_item in matching_schema.overrides.array_values_order.iter() {
@@ -1158,7 +1163,7 @@ fn matches_schema_include(
                     || (path_for_matching != absolute_source_path
                         && glob_pat.matches_path(absolute_source_path))
             })
-            .unwrap_or(false)
+            .unwrap_or_default()
     })
 }
 
@@ -1274,8 +1279,9 @@ mod tests {
     use crate::{CatalogUri, RootAccessor, ValueSchema};
     use tombi_config::{
         Config, RootSchema, SchemaFormatOptions, SchemaFormatRules, SchemaItem,
-        SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
-        SchemaOverviewOptions, SchemaTableKeysOrderRule, SubSchema, Target,
+        SchemaOverrideArrayValuesOrderRule, SchemaOverrideFormatOptions, SchemaOverrideFormatRules,
+        SchemaOverrideItem, SchemaOverrideTableKeysOrderRule, SchemaOverviewOptions,
+        SchemaTableKeysOrderRule, SubSchema, Target,
     };
     use tombi_uri::SchemaUri;
     use tombi_x_keyword::TableKeysOrder;
@@ -1444,7 +1450,9 @@ mod tests {
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
                             array_values_order: None,
-                            table_keys_order: Some(TableKeysOrder::Ascending),
+                            table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(
+                                TableKeysOrder::Ascending,
+                            )),
                         }),
                     }),
                 },
@@ -1453,7 +1461,9 @@ mod tests {
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
                             array_values_order: None,
-                            table_keys_order: Some(TableKeysOrder::Descending),
+                            table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(
+                                TableKeysOrder::Descending,
+                            )),
                         }),
                     }),
                 },
@@ -1538,7 +1548,9 @@ mod tests {
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
                             array_values_order: None,
-                            table_keys_order: Some(TableKeysOrder::Ascending),
+                            table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(
+                                TableKeysOrder::Ascending,
+                            )),
                         }),
                     }),
                 }]),
@@ -1629,7 +1641,9 @@ mod tests {
                     format: Some(SchemaOverrideFormatOptions {
                         rules: Some(SchemaOverrideFormatRules {
                             array_values_order: None,
-                            table_keys_order: Some(TableKeysOrder::Descending),
+                            table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(
+                                TableKeysOrder::Descending,
+                            )),
                         }),
                     }),
                 }]),

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, ops::Deref, str::FromStr, sync::Arc};
 use crate::resolve_json_pointer;
 use crate::{
     AllOfSchema, AnyOfSchema, CatalogUri, DocumentSchema, OneOfSchema, RootAccessor, RootAccessors,
-    SourceSchema, SubSchemaUriMap, ValueSchema, get_tombi_schemastore_content,
-    http_client::HttpClient, json::JsonCatalog,
+    SourceSchema, SourceSubSchema, SourceSubSchemaMap, TableOrderOverride, ValueSchema,
+    get_tombi_schemastore_content, http_client::HttpClient, json::JsonCatalog,
 };
 use itertools::{Either, Itertools};
 use tokio::sync::RwLock;
@@ -199,6 +199,44 @@ impl SchemaStore {
                 include: schema.include().to_vec(),
                 toml_version: schema.toml_version(),
                 sub_root_accessors: schema.root().and_then(RootAccessor::parse),
+                table_keys_order_enabled: schema
+                    .format()
+                    .and_then(|format| format.rules.as_ref())
+                    .and_then(|rules| rules.table_keys_order.as_ref())
+                    .and_then(|rule| rule.enabled)
+                    .unwrap_or_default()
+                    .value(),
+                overrides: crate::SchemaOverrides {
+                    table_keys_order: schema
+                        .overrides()
+                        .into_iter()
+                        .flatten()
+                        .flat_map(|override_item| {
+                            let Some(order) = override_item
+                                .format
+                                .as_ref()
+                                .and_then(|format| format.rules.as_ref())
+                                .and_then(|rules| rules.table_keys_order)
+                            else {
+                                return Vec::new();
+                            };
+
+                            override_item
+                                .targets
+                                .iter()
+                                .filter_map(|target| {
+                                    RootAccessor::parse(target).map(|root_accessors| {
+                                        TableOrderOverride {
+                                            target: root_accessors,
+                                            disabled: false,
+                                            order: Some(order),
+                                        }
+                                    })
+                                })
+                                .collect()
+                        })
+                        .collect(),
+                },
             });
         }))
         .await;
@@ -341,6 +379,8 @@ impl SchemaStore {
                     include: schema.file_match,
                     toml_version: None,
                     sub_root_accessors: None,
+                    table_keys_order_enabled: true,
+                    overrides: Default::default(),
                 });
             }
         }
@@ -648,26 +688,33 @@ impl SchemaStore {
             None
         };
 
-        let (root_schema, sub_schema_uri_map, toml_version, deprecated_lint_level) =
-            if let Some(source_schema) = source_schema {
-                let toml_version = source_schema.toml_version();
-                (
-                    source_schema.root_schema,
-                    source_schema.sub_schema_uri_map,
-                    toml_version,
-                    source_schema.deprecated_lint_level,
-                )
-            } else {
-                (None, Default::default(), None, None)
-            };
+        let (
+            root_schema,
+            sub_schema_map,
+            toml_version,
+            deprecated_lint_level,
+            table_keys_order_enabled,
+        ) = if let Some(source_schema) = source_schema {
+            let toml_version = source_schema.toml_version();
+            (
+                source_schema.root_schema,
+                source_schema.sub_schema_map,
+                toml_version,
+                source_schema.deprecated_lint_level,
+                source_schema.table_keys_order_enabled,
+            )
+        } else {
+            (None, Default::default(), None, None, true)
+        };
 
         Ok(Some(SourceSchema::new(
             self.try_get_document_schema(schema_uri)
                 .await?
                 .or(root_schema),
-            sub_schema_uri_map,
+            sub_schema_map,
             toml_version,
             deprecated_lint_level,
+            table_keys_order_enabled,
         )))
     }
 
@@ -752,19 +799,57 @@ impl SchemaStore {
 
         let mut source_schema: Option<SourceSchema> = None;
         for matching_schema in matching_schemas {
-            // Skip if the same schema (by URL and sub_root_accessors) is already loaded in source_schema
-            let already_loaded = match &matching_schema.sub_root_accessors {
-                Some(sub_root_accessors) => source_schema.as_ref().is_some_and(|source_schema| {
-                    source_schema
-                        .sub_schema_uri_map
-                        .contains_key(sub_root_accessors)
-                }),
+            enum SchemaLoadState {
+                NotLoaded,
+                SameSchemaLoaded,
+                DifferentSchemaLoaded,
+            }
+
+            let load_state = match &matching_schema.sub_root_accessors {
+                Some(sub_root_accessors) => source_schema
+                    .as_ref()
+                    .and_then(|source_schema| source_schema.sub_schema_map.get(sub_root_accessors))
+                    .map(|sub_schema| {
+                        if sub_schema.schema_uri == matching_schema.schema_uri {
+                            SchemaLoadState::SameSchemaLoaded
+                        } else {
+                            SchemaLoadState::DifferentSchemaLoaded
+                        }
+                    })
+                    .unwrap_or(SchemaLoadState::NotLoaded),
                 None => source_schema
                     .as_ref()
-                    .is_some_and(|source_schema| source_schema.root_schema.is_some()),
+                    .and_then(|source_schema| source_schema.root_schema.as_ref())
+                    .map(|root_schema| {
+                        if root_schema.schema_uri == matching_schema.schema_uri {
+                            SchemaLoadState::SameSchemaLoaded
+                        } else {
+                            SchemaLoadState::DifferentSchemaLoaded
+                        }
+                    })
+                    .unwrap_or(SchemaLoadState::NotLoaded),
             };
-            if already_loaded {
-                continue;
+            match load_state {
+                SchemaLoadState::DifferentSchemaLoaded => continue,
+                SchemaLoadState::SameSchemaLoaded => {
+                    if matching_schema.catalog_uri.is_some() {
+                        continue;
+                    }
+                    if let Some(existing) = source_schema.as_mut() {
+                        if matching_schema.sub_root_accessors.is_none() {
+                            existing.table_keys_order_enabled =
+                                matching_schema.table_keys_order_enabled;
+                        }
+                        for override_item in matching_schema.overrides.table_keys_order.iter() {
+                            existing.push_table_order_override(
+                                override_item.target.clone(),
+                                override_item.clone(),
+                            );
+                        }
+                    }
+                    continue;
+                }
+                SchemaLoadState::NotLoaded => {}
             }
             match self
                 .try_get_document_schema(&matching_schema.schema_uri)
@@ -774,26 +859,31 @@ impl SchemaStore {
                     Some(sub_root_accessors) => match source_schema {
                         Some(ref mut source_schema) => {
                             if !source_schema
-                                .sub_schema_uri_map
+                                .sub_schema_map
                                 .contains_key(sub_root_accessors)
                             {
-                                source_schema.sub_schema_uri_map.insert(
+                                source_schema.sub_schema_map.insert(
                                     sub_root_accessors.clone(),
-                                    document_schema.schema_uri.clone(),
+                                    SourceSubSchema {
+                                        schema_uri: document_schema.schema_uri.clone(),
+                                    },
                                 );
                             }
                         }
                         None => {
-                            let mut sub_schema_uri_map = SubSchemaUriMap::default();
-                            sub_schema_uri_map.insert(
+                            let mut sub_schema_map = SourceSubSchemaMap::default();
+                            sub_schema_map.insert(
                                 sub_root_accessors.clone(),
-                                document_schema.schema_uri.clone(),
+                                SourceSubSchema {
+                                    schema_uri: document_schema.schema_uri.clone(),
+                                },
                             );
                             let new_source = SourceSchema::new(
                                 None,
-                                sub_schema_uri_map,
+                                sub_schema_map,
                                 matching_schema.toml_version,
                                 matching_schema.deprecated_lint_level,
+                                true,
                             );
                             source_schema = Some(new_source);
                         }
@@ -803,14 +893,16 @@ impl SchemaStore {
                             if existing.root_schema.is_none() {
                                 let toml_version =
                                     existing.toml_version().or(matching_schema.toml_version);
-                                let sub_schema_uri_map =
-                                    std::mem::take(&mut existing.sub_schema_uri_map);
+                                let sub_schema_map = std::mem::take(&mut existing.sub_schema_map);
+                                let overrides = std::mem::take(&mut existing.overrides);
                                 *existing = SourceSchema::new(
                                     Some(document_schema),
-                                    sub_schema_uri_map,
+                                    sub_schema_map,
                                     toml_version,
                                     matching_schema.deprecated_lint_level,
+                                    matching_schema.table_keys_order_enabled,
                                 );
+                                existing.overrides = overrides;
                             }
                         }
                         None => {
@@ -819,6 +911,7 @@ impl SchemaStore {
                                 Default::default(),
                                 matching_schema.toml_version,
                                 matching_schema.deprecated_lint_level,
+                                matching_schema.table_keys_order_enabled,
                             );
                             source_schema = Some(new_source);
                         }
@@ -834,6 +927,18 @@ impl SchemaStore {
                     log::warn!(
                         "Failed to get document schema for {url}: {err}",
                         url = matching_schema.schema_uri,
+                    );
+                }
+            }
+
+            if let Some(existing) = source_schema.as_mut() {
+                if matching_schema.sub_root_accessors.is_none() {
+                    existing.table_keys_order_enabled = matching_schema.table_keys_order_enabled;
+                }
+                for override_item in matching_schema.overrides.table_keys_order.iter() {
+                    existing.push_table_order_override(
+                        override_item.target.clone(),
+                        override_item.clone(),
                     );
                 }
             }
@@ -875,11 +980,11 @@ impl SchemaStore {
                 if let Some(root_schema) = &source_schema.root_schema {
                     log::trace!("find root schema from {}", root_schema.schema_uri);
                 }
-                for (accessors, schema_uri) in &source_schema.sub_schema_uri_map {
+                for (accessors, sub_schema) in &source_schema.sub_schema_map {
                     log::trace!(
                         "find sub schema {:?} from {}",
                         RootAccessors::from(accessors.clone()),
-                        schema_uri
+                        sub_schema.schema_uri
                     );
                 }
             }
@@ -901,6 +1006,8 @@ impl SchemaStore {
             include,
             toml_version: options.toml_version,
             sub_root_accessors: None,
+            table_keys_order_enabled: true,
+            overrides: Default::default(),
         };
 
         let mut schemas = self.schemas.write().await;
@@ -915,6 +1022,32 @@ impl SchemaStore {
 
     pub async fn list_schemas(&self) -> Vec<crate::Schema> {
         self.schemas.read().await.clone()
+    }
+
+    pub(crate) async fn table_keys_order_enabled_for_schema(
+        &self,
+        schema_uri: &SchemaUri,
+        sub_root_accessors: Option<&[RootAccessor]>,
+    ) -> Option<bool> {
+        let mut normalized = schema_uri.clone();
+        normalized.set_fragment(None);
+
+        self.schemas
+            .read()
+            .await
+            .iter()
+            .rev()
+            .find(|schema| {
+                let mut candidate_uri = schema.schema_uri.clone();
+                candidate_uri.set_fragment(None);
+                candidate_uri == normalized
+                    && match (&schema.sub_root_accessors, sub_root_accessors) {
+                        (None, None) => true,
+                        (Some(candidate), Some(target)) => candidate.as_slice() == target,
+                        _ => false,
+                    }
+            })
+            .map(|schema| schema.table_keys_order_enabled)
     }
 }
 
@@ -1040,6 +1173,7 @@ fn canonicalize_path_for_matching(path: &std::path::Path) -> std::path::PathBuf 
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
         path::{Path, PathBuf},
         str::FromStr,
         time::Duration,
@@ -1049,8 +1183,14 @@ mod tests {
         SchemaStore, load_catalog_from_cache_ignoring_ttl,
         load_json_schema_from_cache_ignoring_ttl, matches_schema_include,
     };
-    use crate::{CatalogUri, ValueSchema};
+    use crate::{CatalogUri, RootAccessor, ValueSchema};
+    use tombi_config::{
+        Config, RootSchema, SchemaFormatOptions, SchemaFormatRules, SchemaItem,
+        SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
+        SchemaOverviewOptions, SchemaTableKeysOrderRule, SubSchema, Target,
+    };
     use tombi_uri::SchemaUri;
+    use tombi_x_keyword::TableKeysOrder;
 
     fn temp_cache_path(test_name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
@@ -1162,6 +1302,356 @@ mod tests {
         ));
 
         let _ = std::fs::remove_file(schema_path);
+    }
+
+    #[tokio::test]
+    async fn load_config_applies_schema_table_order_settings() {
+        let test_root = std::env::temp_dir().join(format!(
+            "tombi_schema_format_rules_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&test_root).unwrap();
+
+        let schema_path = test_root.join("schema.json");
+        fs::write(
+            &schema_path,
+            r#"{
+                "type": "object",
+                "x-tombi-table-keys-order": "descending",
+                "properties": {
+                    "a": { "type": "integer" },
+                    "b": { "type": "integer" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let source_path = test_root.join("test.toml");
+        fs::write(&source_path, "b = 1\na = 2\n").unwrap();
+
+        let config_path = test_root.join("tombi.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let mut config = Config::default();
+        config.schemas = Some(vec![SchemaItem::Root(RootSchema {
+            toml_version: None,
+            path: String::from("schema.json"),
+            include: vec![String::from("test.toml")],
+            lint: None,
+            format: Some(SchemaFormatOptions {
+                rules: Some(SchemaFormatRules {
+                    table_keys_order: Some(SchemaTableKeysOrderRule {
+                        enabled: Some(false.into()),
+                    }),
+                }),
+            }),
+            overrides: Some(vec![
+                SchemaOverrideItem {
+                    targets: vec![Target::from("")],
+                    format: Some(SchemaOverrideFormatOptions {
+                        rules: Some(SchemaOverrideFormatRules {
+                            table_keys_order: Some(TableKeysOrder::Ascending),
+                        }),
+                    }),
+                },
+                SchemaOverrideItem {
+                    targets: vec![Target::from("tool.uv"), Target::from("tool")],
+                    format: Some(SchemaOverrideFormatOptions {
+                        rules: Some(SchemaOverrideFormatRules {
+                            table_keys_order: Some(TableKeysOrder::Descending),
+                        }),
+                    }),
+                },
+            ]),
+        })]);
+
+        let store = SchemaStore::new();
+        store
+            .load_config(&config, Some(&config_path))
+            .await
+            .unwrap();
+
+        let source_schema = store
+            .resolve_source_schema_from_path(&source_path)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(source_schema.table_keys_order_enabled, false);
+        assert_eq!(
+            source_schema.overrides.table_keys_order,
+            crate::TableOrderOverrides::from(vec![
+                crate::TableOrderOverride {
+                    target: vec![],
+                    disabled: false,
+                    order: Some(TableKeysOrder::Ascending),
+                },
+                crate::TableOrderOverride {
+                    target: vec![
+                        RootAccessor::Key(String::from("tool")),
+                        RootAccessor::Key(String::from("uv")),
+                    ],
+                    disabled: false,
+                    order: Some(TableKeysOrder::Descending),
+                },
+                crate::TableOrderOverride {
+                    target: vec![RootAccessor::Key(String::from("tool"))],
+                    disabled: false,
+                    order: Some(TableKeysOrder::Descending),
+                },
+            ])
+        );
+
+        fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolve_source_schema_preserves_subschema_overrides_when_root_schema_is_loaded_later()
+    {
+        let test_root = std::env::temp_dir().join(format!(
+            "tombi_schema_override_preserve_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&test_root).unwrap();
+
+        let root_schema_path = test_root.join("root-schema.json");
+        fs::write(&root_schema_path, r#"{ "type": "object" }"#).unwrap();
+
+        let sub_schema_path = test_root.join("sub-schema.json");
+        fs::write(&sub_schema_path, r#"{ "type": "object" }"#).unwrap();
+
+        let source_path = test_root.join("test.toml");
+        fs::write(&source_path, "[tool]\na = 1\n").unwrap();
+
+        let config_path = test_root.join("tombi.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let mut config = Config::default();
+        config.schemas = Some(vec![
+            SchemaItem::Sub(SubSchema {
+                path: String::from("sub-schema.json"),
+                include: vec![String::from("test.toml")],
+                root: String::from("tool"),
+                lint: None,
+                format: None,
+                overrides: Some(vec![SchemaOverrideItem {
+                    targets: vec![Target::from("tool")],
+                    format: Some(SchemaOverrideFormatOptions {
+                        rules: Some(SchemaOverrideFormatRules {
+                            table_keys_order: Some(TableKeysOrder::Ascending),
+                        }),
+                    }),
+                }]),
+            }),
+            SchemaItem::Root(RootSchema {
+                toml_version: None,
+                path: String::from("root-schema.json"),
+                include: vec![String::from("test.toml")],
+                lint: None,
+                format: None,
+                overrides: None,
+            }),
+        ]);
+
+        let store = SchemaStore::new();
+        store
+            .load_config(&config, Some(&config_path))
+            .await
+            .unwrap();
+
+        let source_schema = store
+            .resolve_source_schema_from_path(&source_path)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            source_schema.overrides.table_keys_order,
+            crate::TableOrderOverrides::from(vec![crate::TableOrderOverride {
+                target: vec![RootAccessor::Key(String::from("tool"))],
+                disabled: false,
+                order: Some(TableKeysOrder::Ascending),
+            }])
+        );
+
+        fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolve_source_schema_does_not_merge_format_settings_from_different_root_schema() {
+        let test_root = std::env::temp_dir().join(format!(
+            "tombi_schema_root_conflict_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&test_root).unwrap();
+
+        let first_schema_path = test_root.join("first-schema.json");
+        fs::write(&first_schema_path, r#"{ "type": "object" }"#).unwrap();
+
+        let second_schema_path = test_root.join("second-schema.json");
+        fs::write(&second_schema_path, r#"{ "type": "object" }"#).unwrap();
+
+        let source_path = test_root.join("test.toml");
+        fs::write(&source_path, "a = 1\n").unwrap();
+
+        let config_path = test_root.join("tombi.toml");
+        fs::write(&config_path, "").unwrap();
+
+        let mut config = Config::default();
+        config.schemas = Some(vec![
+            SchemaItem::Root(RootSchema {
+                toml_version: None,
+                path: String::from("first-schema.json"),
+                include: vec![String::from("test.toml")],
+                lint: None,
+                format: Some(SchemaFormatOptions {
+                    rules: Some(SchemaFormatRules {
+                        table_keys_order: Some(SchemaTableKeysOrderRule {
+                            enabled: Some(false.into()),
+                        }),
+                    }),
+                }),
+                overrides: None,
+            }),
+            SchemaItem::Root(RootSchema {
+                toml_version: None,
+                path: String::from("second-schema.json"),
+                include: vec![String::from("test.toml")],
+                lint: None,
+                format: None,
+                overrides: Some(vec![SchemaOverrideItem {
+                    targets: vec![Target::from("")],
+                    format: Some(SchemaOverrideFormatOptions {
+                        rules: Some(SchemaOverrideFormatRules {
+                            table_keys_order: Some(TableKeysOrder::Descending),
+                        }),
+                    }),
+                }]),
+            }),
+        ]);
+
+        let store = SchemaStore::new();
+        store
+            .load_config(&config, Some(&config_path))
+            .await
+            .unwrap();
+
+        let source_schema = store
+            .resolve_source_schema_from_path(&source_path)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            source_schema
+                .root_schema
+                .as_ref()
+                .and_then(|schema| schema.schema_uri.to_file_path().ok())
+                .and_then(|path| path.canonicalize().ok()),
+            Some(first_schema_path.canonicalize().unwrap())
+        );
+        assert!(!source_schema.table_keys_order_enabled);
+        assert!(source_schema.overrides.table_keys_order.is_empty());
+
+        fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolve_source_schema_prefers_config_table_order_settings_over_catalog_defaults() {
+        let test_root = std::env::temp_dir().join(format!(
+            "tombi_schema_catalog_precedence_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&test_root).unwrap();
+
+        let source_path = test_root.join("tombi.toml");
+        fs::write(
+            &source_path,
+            r#"
+            [[schemas]]
+            include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+            path = "tombi://www.schemastore.org/tombi.json"
+
+            [[schemas]]
+            path = "tombi://www.schemastore.org/tombi.json"
+            include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
+            format.rules.table-keys-order.enabled = false
+            overrides = [
+              { targets = [""] }
+            ]
+            "#,
+        )
+        .unwrap();
+
+        let mut config = Config::default();
+        config.schema = Some(SchemaOverviewOptions::default());
+        config.schemas = Some(vec![
+            SchemaItem::Root(RootSchema {
+                toml_version: None,
+                path: String::from("tombi://www.schemastore.org/tombi.json"),
+                include: vec![
+                    String::from(".tombi.toml"),
+                    String::from("tombi.toml"),
+                    String::from("tombi/config.toml"),
+                ],
+                lint: None,
+                format: None,
+                overrides: None,
+            }),
+            SchemaItem::Root(RootSchema {
+                toml_version: None,
+                path: String::from("tombi://www.schemastore.org/tombi.json"),
+                include: vec![
+                    String::from(".tombi.toml"),
+                    String::from("tombi.toml"),
+                    String::from("tombi/config.toml"),
+                ],
+                lint: None,
+                format: Some(SchemaFormatOptions {
+                    rules: Some(SchemaFormatRules {
+                        table_keys_order: Some(SchemaTableKeysOrderRule {
+                            enabled: Some(false.into()),
+                        }),
+                    }),
+                }),
+                overrides: Some(vec![SchemaOverrideItem {
+                    targets: vec![Target::from("")],
+                    format: None,
+                }]),
+            }),
+        ]);
+
+        let store = SchemaStore::new();
+        store
+            .load_config(&config, Some(&source_path))
+            .await
+            .unwrap();
+
+        let source_schema = store
+            .resolve_source_schema_from_path(&source_path)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(!source_schema.table_keys_order_enabled);
+
+        fs::remove_dir_all(test_root).unwrap();
     }
 
     #[tokio::test]

--- a/crates/tombi-validator/src/comment_directive/document.rs
+++ b/crates/tombi-validator/src/comment_directive/document.rs
@@ -46,6 +46,7 @@ pub async fn get_tombi_document_comment_directive_and_diagnostics(
             Some(toml_version),
             None,
             true,
+            true,
         );
 
         let schema_context = tombi_schema_store::SchemaContext::from_source_schema(

--- a/crates/tombi-validator/src/comment_directive/document.rs
+++ b/crates/tombi-validator/src/comment_directive/document.rs
@@ -45,17 +45,15 @@ pub async fn get_tombi_document_comment_directive_and_diagnostics(
             tombi_hashmap::IndexMap::with_capacity(0),
             Some(toml_version),
             None,
+            true,
         );
 
-        let schema_context = tombi_schema_store::SchemaContext {
+        let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
             toml_version,
-            root_schema: source_schema.root_schema.as_deref(),
-            sub_schema_uri_map: None,
-            deprecated_lint_level: None,
-            schema_visits: Default::default(),
-            store: schema_store,
-            strict: None,
-        };
+            Some(&source_schema),
+            schema_store,
+            None,
+        );
 
         for tombi_ast::TombiDocumentCommentDirective {
             content,

--- a/crates/tombi-validator/src/comment_directive/value.rs
+++ b/crates/tombi-validator/src/comment_directive/value.rs
@@ -410,17 +410,15 @@ pub async fn get_comment_directive_document_tree_and_diagnostics<'a>(
         tombi_hashmap::IndexMap::with_capacity(0),
         Some(toml_version),
         None,
+        true,
     );
 
-    let schema_context = tombi_schema_store::SchemaContext {
+    let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
         toml_version,
-        root_schema: source_schema.root_schema.as_deref(),
-        sub_schema_uri_map: None,
-        deprecated_lint_level: None,
-        schema_visits: Default::default(),
-        store: schema_store,
-        strict: None,
-    };
+        Some(&source_schema),
+        schema_store,
+        None,
+    );
 
     for tombi_ast::TombiValueCommentDirective {
         content,

--- a/crates/tombi-validator/src/comment_directive/value.rs
+++ b/crates/tombi-validator/src/comment_directive/value.rs
@@ -411,6 +411,7 @@ pub async fn get_comment_directive_document_tree_and_diagnostics<'a>(
         Some(toml_version),
         None,
         true,
+        true,
     );
 
     let schema_context = tombi_schema_store::SchemaContext::from_source_schema(

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -240,7 +240,7 @@ fn handle_unused_noqa<'a>(
     if common_rules
         .and_then(|rules| rules.unused_noqa.as_ref())
         .and_then(|rules| rules.disabled)
-        .unwrap_or(false)
+        .unwrap_or_default()
     {
         return;
     }

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -357,7 +357,7 @@ async fn validate_array(
         };
 
         for (index, value) in array_value.values().iter().enumerate() {
-            if evaluated.get(index).copied().unwrap_or(false) {
+            if evaluated.get(index).copied().unwrap_or_default() {
                 continue;
             }
             evaluated[index] = true;

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -557,15 +557,7 @@ async fn validate_table(
                         // the parent table schema. Running strict mode here against the
                         // partial dependency schema causes false-positive additional key
                         // diagnostics for valid keys defined by the parent schema.
-                        let dependency_schema_context = tombi_schema_store::SchemaContext {
-                            toml_version: schema_context.toml_version,
-                            root_schema: schema_context.root_schema,
-                            sub_schema_uri_map: schema_context.sub_schema_uri_map,
-                            deprecated_lint_level: schema_context.deprecated_lint_level,
-                            schema_visits: schema_context.schema_visits.clone(),
-                            store: schema_context.store,
-                            strict: Some(false),
-                        };
+                        let dependency_schema_context = schema_context.with_strict(Some(false));
 
                         if let Err(crate::Error { diagnostics, .. }) = table_value
                             .validate(accessors, Some(&dep_schema), &dependency_schema_context)
@@ -619,15 +611,7 @@ async fn validate_table(
             .inspect_err(|err| log::warn!("{err}"))
             {
                 // See the rationale in the `Dependency::Schema` branch above.
-                let dependency_schema_context = tombi_schema_store::SchemaContext {
-                    toml_version: schema_context.toml_version,
-                    root_schema: schema_context.root_schema,
-                    sub_schema_uri_map: schema_context.sub_schema_uri_map,
-                    deprecated_lint_level: schema_context.deprecated_lint_level,
-                    schema_visits: schema_context.schema_visits.clone(),
-                    store: schema_context.store,
-                    strict: Some(false),
-                };
+                let dependency_schema_context = schema_context.with_strict(Some(false));
 
                 if let Err(crate::Error { diagnostics, .. }) = table_value
                     .validate(accessors, Some(&dep_schema), &dependency_schema_context)

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -10,6 +10,7 @@ pub const X_TOMBI_ADDITIONAL_KEY_LABEL: &str = "x-tombi-additional-key-label";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum ArrayValuesOrder {
     Ascending,
     Descending,

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -74,6 +74,7 @@ impl PartialEq<ArrayValuesOrderBy> for String {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum TableKeysOrder {
     Ascending,
     Descending,

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -11,7 +11,7 @@ use tombi_config::{
 /// Therefore, [crate::config::from_str], which does not use schema_store and is not async, is called to prevent stack overflow.
 ///
 /// This function is not public and is only used internally.
-pub(crate) fn from_str(
+pub fn from_str(
     toml_text: &str,
     config_path: &std::path::Path,
 ) -> Result<Config, crate::de::Error> {

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -944,6 +944,27 @@
               "type": "null"
             }
           ]
+        },
+        "format": {
+          "title": "Schema-specific format options",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaFormatOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "overrides": {
+          "title": "Schema-specific overrides",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaOverrideItem"
+          }
         }
       },
       "additionalProperties": false,
@@ -992,6 +1013,144 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "schema"
     },
+    "SchemaFormatOptions": {
+      "title": "Schema-specific format options",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "title": "Schema-specific format rules",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaFormatRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "schema"
+    },
+    "SchemaFormatRules": {
+      "title": "Schema-specific format rules",
+      "type": "object",
+      "properties": {
+        "table-keys-order": {
+          "title": "Whether schema-defined table key ordering is enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaTableKeysOrderRule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
+    "SchemaTableKeysOrderRule": {
+      "title": "Schema-defined table key ordering",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Whether schema-defined table key ordering is enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "schema"
+    },
+    "SchemaOverrideItem": {
+      "title": "Schema-specific override item",
+      "type": "object",
+      "properties": {
+        "targets": {
+          "title": "Accessor pattern(s) to override",
+          "description": "Use `\"\"` to target the root table.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Target"
+          },
+          "minItems": 1
+        },
+        "format": {
+          "title": "Format options to override",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaOverrideFormatOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "targets"
+      ],
+      "x-tombi-table-keys-order": "schema"
+    },
+    "Target": {
+      "type": "string"
+    },
+    "SchemaOverrideFormatOptions": {
+      "title": "Schema-specific override format options",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "title": "Schema-specific override format rules",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaOverrideFormatRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "schema"
+    },
+    "SchemaOverrideFormatRules": {
+      "title": "Schema-specific override format rules",
+      "type": "object",
+      "properties": {
+        "table-keys-order": {
+          "title": "Override table key ordering for matched roots",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TableKeysOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "ascending"
+    },
+    "TableKeysOrder": {
+      "type": "string",
+      "enum": [
+        "ascending",
+        "descending",
+        "schema",
+        "version-sort"
+      ]
+    },
     "SubSchema": {
       "title": "The schema for the sub value",
       "type": "object",
@@ -1028,6 +1187,27 @@
               "type": "null"
             }
           ]
+        },
+        "format": {
+          "title": "Schema-specific format options",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaFormatOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "overrides": {
+          "title": "Schema-specific overrides",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemaOverrideItem"
+          }
         }
       },
       "additionalProperties": false,
@@ -1230,17 +1410,17 @@
         "enabled": {
           "title": "Enable feature",
           "description": "Whether this feature is enabled.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/BoolDefaultTrue"
-            },
-            {
-              "type": "null"
             }
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "enabled"
+      ]
     },
     "CargoExtensionFeatureTree": {
       "type": "object",
@@ -1550,7 +1730,7 @@
           "description": "Whether document links are created for `Cargo.toml` references.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -1574,7 +1754,7 @@
           "description": "Whether document links are created for Git references.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -1586,7 +1766,7 @@
           "description": "Whether document links are created for filesystem paths.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -1598,7 +1778,7 @@
           "description": "Whether document links are created for `workspace = true` references.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -1608,6 +1788,28 @@
       },
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
+    },
+    "ToggleFeatureDefaultFalse": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable feature",
+          "description": "Whether this nested feature is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultFalse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "BoolDefaultFalse": {
+      "type": "boolean",
+      "default": false
     },
     "CargoHoverFeatures": {
       "anyOf": [
@@ -1963,7 +2165,7 @@
           "description": "Whether document links are created for `pyproject.toml` references.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -2140,7 +2342,7 @@
           "description": "Configure Tombi hover features.",
           "anyOf": [
             {
-              "$ref": "#/definitions/EnabledOnly"
+              "$ref": "#/definitions/TombiHoverFeatures"
             },
             {
               "type": "null"
@@ -2229,7 +2431,7 @@
           "description": "Whether document links are created for filesystem paths.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+              "$ref": "#/definitions/ToggleFeatureDefaultFalse"
             },
             {
               "type": "null"
@@ -2239,6 +2441,20 @@
       },
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
+    },
+    "TombiHoverFeatures": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EnabledOnly"
+        },
+        {
+          "$ref": "#/definitions/TombiHoverFeatureTree"
+        }
+      ]
+    },
+    "TombiHoverFeatureTree": {
+      "type": "object",
+      "additionalProperties": false
     }
   }
 }

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -1036,6 +1036,17 @@
       "title": "Schema-specific format rules",
       "type": "object",
       "properties": {
+        "array-values-order": {
+          "title": "Whether schema-defined array values ordering is enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaArrayValuesOrderRule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "table-keys-order": {
           "title": "Whether schema-defined table key ordering is enabled",
           "anyOf": [
@@ -1050,6 +1061,25 @@
       },
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
+    },
+    "SchemaArrayValuesOrderRule": {
+      "title": "Schema-defined array values ordering",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Whether schema-defined array values ordering is enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "schema"
     },
     "SchemaTableKeysOrderRule": {
       "title": "Schema-defined table key ordering",
@@ -1127,6 +1157,17 @@
       "title": "Schema-specific override format rules",
       "type": "object",
       "properties": {
+        "array-values-order": {
+          "title": "Override array values ordering for matched roots",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ArrayValuesOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "table-keys-order": {
           "title": "Override table key ordering for matched roots",
           "anyOf": [
@@ -1141,6 +1182,14 @@
       },
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
+    },
+    "ArrayValuesOrder": {
+      "type": "string",
+      "enum": [
+        "ascending",
+        "descending",
+        "version-sort"
+      ]
     },
     "TableKeysOrder": {
       "type": "string",

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -1164,6 +1164,9 @@
               "$ref": "#/definitions/ArrayValuesOrder"
             },
             {
+              "$ref": "#/definitions/SchemaArrayValuesOrderRule"
+            },
+            {
               "type": "null"
             }
           ]
@@ -1173,6 +1176,9 @@
           "anyOf": [
             {
               "$ref": "#/definitions/TableKeysOrder"
+            },
+            {
+              "$ref": "#/definitions/SchemaTableKeysOrderRule"
             },
             {
               "type": "null"


### PR DESCRIPTION
This adds schema-level format rules and per-target overrides for table key ordering and array value ordering, including generated schema updates. It threads those settings through the schema store, formatter, parser, validator, and accessor handling so ordering behavior can be resolved consistently from schema context and comment directives. It also updates LSP completion, hover, and goto-type-definition behavior to use the new schema context and adds broad regression coverage for formatter, schema resolution, and editor features. Existing workspace changes in this branch are included as part of this PR.