### PR TITLE
test: use config text in formatter schema tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,6 +3842,7 @@ dependencies = [
  "rstest",
  "schemars",
  "serde",
+ "serde_tombi",
  "textwrap",
  "tokio",
  "tombi-ast",

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -26,6 +26,7 @@ unicode-segmentation.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
+serde_tombi.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tombi-test-lib.workspace = true

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! test_format {
             pub struct TestArgs {
                 pub toml_version: TomlVersion,
                 pub options: FormatOptions,
-                pub config: Option<tombi_config::Config>,
+                pub config_text: Option<String>,
                 pub schema_path: Option<std::path::PathBuf>,
                 pub source_path: Option<std::path::PathBuf>,
             }
@@ -62,13 +62,13 @@ macro_rules! test_format {
                 }
             }
 
-            /// Set full config for the test case.
+            /// Set full config TOML text for the test case.
             #[allow(unused)]
-            pub struct Config(pub tombi_config::Config);
+            pub struct ConfigText<T: Into<String>>(pub T);
 
-            impl ApplyTestArg for Config {
+            impl<T: Into<String>> ApplyTestArg for ConfigText<T> {
                 fn apply(self, args: &mut TestArgs) {
-                    args.config = Some(self.0);
+                    args.config_text = Some(textwrap::dedent(&self.0.into()).trim().to_string());
                 }
             }
 
@@ -101,9 +101,12 @@ macro_rules! test_format {
             // Initialize schema store
             let schema_store = SchemaStore::new();
 
-            if let Some(config) = &args.config {
+            if let Some(config_text) = &args.config_text {
+                let config: tombi_config::Config = serde_tombi::from_str_async(config_text)
+                    .await
+                    .expect("failed to parse formatter test config text");
                 schema_store
-                    .load_config(config, None)
+                    .load_config(&config, None)
                     .await
                     .expect("failed to load formatter test config");
             } else if let Some(schema_path) = &args.schema_path {
@@ -179,7 +182,7 @@ macro_rules! test_format {
             pub struct TestArgs {
                 pub toml_version: TomlVersion,
                 pub options: FormatOptions,
-                pub config: Option<tombi_config::Config>,
+                pub config_text: Option<String>,
                 pub schema_path: Option<std::path::PathBuf>,
                 pub source_path: Option<std::path::PathBuf>,
             }
@@ -201,13 +204,13 @@ macro_rules! test_format {
                 }
             }
 
-            /// Set full config for the test case.
+            /// Set full config TOML text for the test case.
             #[allow(unused)]
-            pub struct Config(pub tombi_config::Config);
+            pub struct ConfigText<T: Into<String>>(pub T);
 
-            impl ApplyTestArg for Config {
-                fn apply(self, config: &mut TestArgs) {
-                    config.config = Some(self.0);
+            impl<T: Into<String>> ApplyTestArg for ConfigText<T> {
+                fn apply(self, args: &mut TestArgs) {
+                    args.config_text = Some(textwrap::dedent(&self.0.into()).trim().to_string());
                 }
             }
 
@@ -240,9 +243,12 @@ macro_rules! test_format {
             // Initialize schema store
             let schema_store = SchemaStore::new();
 
-            if let Some(config_value) = &config.config {
+            if let Some(config_text) = &config.config_text {
+                let config_value: tombi_config::Config = serde_tombi::from_str_async(config_text)
+                    .await
+                    .expect("failed to parse formatter test config text");
                 schema_store
-                    .load_config(config_value, None)
+                    .load_config(&config_value, None)
                     .await
                     .expect("failed to load formatter test config");
             } else if let Some(schema_path) = config.schema_path {

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -512,35 +512,9 @@ mod table_keys_order {
     }
 
     mod cargo {
-        use tombi_config::{
-            Config, RootSchema, SchemaArrayValuesOrderRule, SchemaFormatOptions,
-            SchemaFormatRules, SchemaItem, SchemaTableKeysOrderRule,
-        };
         use tombi_test_lib::cargo_schema_path;
 
         use super::*;
-
-        fn cargo_schema_rules_disabled_config() -> Config {
-            let mut config = Config::default();
-            config.schemas = Some(vec![SchemaItem::Root(RootSchema {
-                toml_version: None,
-                path: "tombi://json.schemastore.org/cargo.json".to_string(),
-                include: vec!["Cargo.toml".to_string()],
-                lint: None,
-                format: Some(SchemaFormatOptions {
-                    rules: Some(SchemaFormatRules {
-                        array_values_order: Some(SchemaArrayValuesOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                        table_keys_order: Some(SchemaTableKeysOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                    }),
-                }),
-                overrides: None,
-            })]);
-            config
-        }
 
         test_format! {
             #[tokio::test]
@@ -861,7 +835,17 @@ mod table_keys_order {
                 deprecated = "warn"
                 aarch64_softfloat_neon = "warn"
                 "#,
-                Config(cargo_schema_rules_disabled_config()),
+                ConfigText(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://json.schemastore.org/cargo.json"
+                    include = ["Cargo.toml"]
+                    [schemas.format.rules.array-values-order]
+                    enabled = false
+                    [schemas.format.rules.table-keys-order]
+                    enabled = false
+                    "#
+                ),
                 SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
             ) -> Ok(
                 r#"
@@ -1831,34 +1815,7 @@ mod table_keys_order {
 }
 
 mod schema_format_rules {
-    use tombi_config::{
-        Config, RootSchema, SchemaArrayValuesOrderRule, SchemaFormatOptions, SchemaFormatRules,
-        SchemaItem, SchemaTableKeysOrderRule,
-    };
     use tombi_formatter::{Formatter, test_format};
-    use tombi_test_lib::pyproject_schema_path;
-
-    fn pyproject_schema_rules_disabled_config() -> Config {
-        let mut config = Config::default();
-        config.schemas = Some(vec![SchemaItem::Root(RootSchema {
-            toml_version: None,
-            path: pyproject_schema_path().to_string_lossy().into_owned(),
-            include: vec!["*.toml".to_string()],
-            lint: None,
-            format: Some(SchemaFormatOptions {
-                rules: Some(SchemaFormatRules {
-                    array_values_order: Some(SchemaArrayValuesOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                    table_keys_order: Some(SchemaTableKeysOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                }),
-            }),
-            overrides: None,
-        })]);
-        config
-    }
 
     test_format! {
         #[tokio::test]
@@ -1871,7 +1828,17 @@ mod schema_format_rules {
             description = "A test project"
             requires-python = ">=3.10"
             "#,
-            Config(pyproject_schema_rules_disabled_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+                "#,
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -1886,87 +1853,7 @@ mod schema_format_rules {
 }
 
 mod schema_overrides {
-    use tombi_config::{
-        ArrayValuesOrder, Config, RootSchema, SchemaArrayValuesOrderRule, SchemaFormatOptions,
-        SchemaFormatRules, SchemaItem, SchemaOverrideArrayValuesOrderRule,
-        SchemaOverrideFormatOptions, SchemaOverrideFormatRules, SchemaOverrideItem,
-        SchemaOverrideTableKeysOrderRule, SchemaTableKeysOrderRule, SubSchema, TableKeysOrder,
-    };
     use tombi_formatter::{Formatter, test_format};
-    use tombi_test_lib::{pyproject_schema_path, tombi_schema_path};
-
-    fn pyproject_schema_overrides_config() -> Config {
-        let mut config = Config::default();
-        config.schemas = Some(vec![SchemaItem::Root(RootSchema {
-            toml_version: None,
-            path: pyproject_schema_path().to_string_lossy().into_owned(),
-            include: vec!["*.toml".to_string()],
-            lint: None,
-            format: Some(SchemaFormatOptions {
-                rules: Some(SchemaFormatRules {
-                    array_values_order: Some(SchemaArrayValuesOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                    table_keys_order: Some(SchemaTableKeysOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                }),
-            }),
-            overrides: Some(vec![
-                SchemaOverrideItem {
-                    targets: vec!["project".into()],
-                    format: Some(SchemaOverrideFormatOptions {
-                        rules: Some(SchemaOverrideFormatRules {
-                            array_values_order: None,
-                            table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(
-                                TableKeysOrder::Schema,
-                            )),
-                        }),
-                    }),
-                    lint: None,
-                },
-                SchemaOverrideItem {
-                    targets: vec!["dependency-groups.dev".into()],
-                    format: Some(SchemaOverrideFormatOptions {
-                        rules: Some(SchemaOverrideFormatRules {
-                            array_values_order: Some(SchemaOverrideArrayValuesOrderRule::Order(
-                                ArrayValuesOrder::Ascending,
-                            )),
-                            table_keys_order: None,
-                        }),
-                    }),
-                    lint: None,
-                },
-            ]),
-        })]);
-        config
-    }
-
-    fn pyproject_schema_override_disable_project_config() -> Config {
-        let mut config = Config::default();
-        config.schemas = Some(vec![SchemaItem::Root(RootSchema {
-            toml_version: None,
-            path: pyproject_schema_path().to_string_lossy().into_owned(),
-            include: vec!["*.toml".to_string()],
-            lint: None,
-            format: None,
-            overrides: Some(vec![SchemaOverrideItem {
-                targets: vec!["project".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: None,
-                        table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Rule(
-                            SchemaTableKeysOrderRule {
-                                enabled: Some(false.into()),
-                            },
-                        )),
-                    }),
-                }),
-                lint: None,
-            }]),
-        })]);
-        config
-    }
 
     test_format! {
         #[tokio::test]
@@ -1978,7 +1865,24 @@ mod schema_overrides {
             description = "A test project"
             requires-python = ">=3.10"
             "#,
-            Config(pyproject_schema_overrides_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order = "schema"
+
+                [[schemas.overrides]]
+                targets = ["dependency-groups.dev"]
+                format.rules.array-values-order = "ascending"
+                "#,
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -2000,7 +1904,25 @@ mod schema_overrides {
             description = "A test project"
             requires-python = ">=3.10"
             "#,
-            Config(pyproject_schema_overrides_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order = "schema"
+
+                [[schemas.overrides]]
+                targets = ["dependency-groups.dev"]
+                format.rules.array-values-order = "ascending"
+                "#,
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -2013,9 +1935,9 @@ mod schema_overrides {
     }
 
     test_format! {
-        #[tokio::test]
-        async fn test_schema_overrides_reenable_array_values_order_for_matched_target(
-            r#"
+    #[tokio::test]
+    async fn test_schema_overrides_reenable_array_values_order_for_matched_target(
+        r#"
             [project]
             name = "tombi"
             version = "1.0.0"
@@ -2028,7 +1950,24 @@ mod schema_overrides {
               "pytest>=8.3.3",
             ]
             "#,
-            Config(pyproject_schema_overrides_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order = "schema"
+
+                [[schemas.overrides]]
+                targets = ["dependency-groups.dev"]
+                format.rules.array-values-order = "ascending"
+                "#
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -2062,7 +2001,25 @@ mod schema_overrides {
               "pytest>=8.3.3",
             ]
             "#,
-            Config(pyproject_schema_overrides_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order = "schema"
+
+                [[schemas.overrides]]
+                targets = ["dependency-groups.dev"]
+                format.rules.array-values-order = "ascending"
+                "#
+            )
         ) -> Ok(
             r#"
             [project]
@@ -2090,7 +2047,17 @@ mod schema_overrides {
             description = "A test project"
             requires-python = ">=3.10"
             "#,
-            Config(pyproject_schema_override_disable_project_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order.enabled = false
+                "#,
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -2100,179 +2067,6 @@ mod schema_overrides {
             requires-python = ">=3.10"
             "#
         )
-    }
-
-    fn pyproject_schema_override_reenable_without_order_config() -> Config {
-        let mut config = Config::default();
-        config.schemas = Some(vec![SchemaItem::Root(RootSchema {
-            toml_version: None,
-            path: pyproject_schema_path().to_string_lossy().into_owned(),
-            include: vec!["*.toml".to_string()],
-            lint: None,
-            format: Some(SchemaFormatOptions {
-                rules: Some(SchemaFormatRules {
-                    array_values_order: Some(SchemaArrayValuesOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                    table_keys_order: Some(SchemaTableKeysOrderRule {
-                        enabled: Some(false.into()),
-                    }),
-                }),
-            }),
-            overrides: Some(vec![SchemaOverrideItem {
-                targets: vec!["project".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: None,
-                        table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Rule(
-                            SchemaTableKeysOrderRule {
-                                enabled: Some(true.into()),
-                            },
-                        )),
-                    }),
-                }),
-                lint: None,
-            }]),
-        })]);
-        config
-    }
-
-    fn pyproject_with_tombi_subschema_table_config(
-        root_override_order: Option<TableKeysOrder>,
-        subschema_override_order: Option<TableKeysOrder>,
-    ) -> Config {
-        let root_overrides = root_override_order.map(|order| {
-            vec![SchemaOverrideItem {
-                targets: vec!["tool.tombi.format.rules".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: None,
-                        table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(order)),
-                    }),
-                }),
-                lint: None,
-            }]
-        });
-        let subschema_overrides = subschema_override_order.map(|order| {
-            vec![SchemaOverrideItem {
-                targets: vec!["tool.tombi.format.rules".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: None,
-                        table_keys_order: Some(SchemaOverrideTableKeysOrderRule::Order(order)),
-                    }),
-                }),
-                lint: None,
-            }]
-        });
-
-        let mut config = Config::default();
-        config.schemas = Some(vec![
-            SchemaItem::Root(RootSchema {
-                toml_version: None,
-                path: pyproject_schema_path().to_string_lossy().into_owned(),
-                include: vec!["*.toml".to_string()],
-                lint: None,
-                format: Some(SchemaFormatOptions {
-                    rules: Some(SchemaFormatRules {
-                        array_values_order: Some(SchemaArrayValuesOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                        table_keys_order: Some(SchemaTableKeysOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                    }),
-                }),
-                overrides: root_overrides,
-            }),
-            SchemaItem::Sub(SubSchema {
-                root: "tool.tombi".into(),
-                path: tombi_schema_path().to_string_lossy().into_owned(),
-                include: vec!["*.toml".to_string()],
-                lint: None,
-                format: Some(SchemaFormatOptions {
-                    rules: Some(SchemaFormatRules {
-                        array_values_order: Some(SchemaArrayValuesOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                        table_keys_order: Some(SchemaTableKeysOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                    }),
-                }),
-                overrides: subschema_overrides,
-            }),
-        ]);
-        config
-    }
-
-    fn pyproject_with_tombi_subschema_array_config(
-        root_override_order: Option<ArrayValuesOrder>,
-        subschema_override_order: Option<ArrayValuesOrder>,
-    ) -> Config {
-        let root_overrides = root_override_order.map(|order| {
-            vec![SchemaOverrideItem {
-                targets: vec!["tool.tombi.schemas[*].include".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: Some(SchemaOverrideArrayValuesOrderRule::Order(order)),
-                        table_keys_order: None,
-                    }),
-                }),
-                lint: None,
-            }]
-        });
-        let subschema_overrides = subschema_override_order.map(|order| {
-            vec![SchemaOverrideItem {
-                targets: vec!["tool.tombi.schemas[*].include".into()],
-                format: Some(SchemaOverrideFormatOptions {
-                    rules: Some(SchemaOverrideFormatRules {
-                        array_values_order: Some(SchemaOverrideArrayValuesOrderRule::Order(order)),
-                        table_keys_order: None,
-                    }),
-                }),
-                lint: None,
-            }]
-        });
-
-        let mut config = Config::default();
-        config.schemas = Some(vec![
-            SchemaItem::Root(RootSchema {
-                toml_version: None,
-                path: pyproject_schema_path().to_string_lossy().into_owned(),
-                include: vec!["*.toml".to_string()],
-                lint: None,
-                format: Some(SchemaFormatOptions {
-                    rules: Some(SchemaFormatRules {
-                        array_values_order: Some(SchemaArrayValuesOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                        table_keys_order: Some(SchemaTableKeysOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                    }),
-                }),
-                overrides: root_overrides,
-            }),
-            SchemaItem::Sub(SubSchema {
-                root: "tool.tombi".into(),
-                path: tombi_schema_path().to_string_lossy().into_owned(),
-                include: vec!["*.toml".to_string()],
-                lint: None,
-                format: Some(SchemaFormatOptions {
-                    rules: Some(SchemaFormatRules {
-                        array_values_order: Some(SchemaArrayValuesOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                        table_keys_order: Some(SchemaTableKeysOrderRule {
-                            enabled: Some(false.into()),
-                        }),
-                    }),
-                }),
-                overrides: subschema_overrides,
-            }),
-        ]);
-        config
     }
 
     test_format! {
@@ -2285,7 +2079,21 @@ mod schema_overrides {
             description = "A test project"
             requires-python = ">=3.10"
             "#,
-            Config(pyproject_schema_override_reenable_without_order_config()),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["project"]
+                format.rules.table-keys-order.enabled = true
+                "#,
+            ),
         ) -> Ok(
             r#"
             [project]
@@ -2307,10 +2115,30 @@ mod schema_overrides {
             inline-table-brace-space-width = 0
             indent-table-key-value-pairs = true
             "#,
-            Config(pyproject_with_tombi_subschema_table_config(
-                Some(TableKeysOrder::Ascending),
-                None,
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.format.rules"]
+                format.rules.table-keys-order = "ascending"
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+                "#
+            )
         ) -> Ok(
             r#"
             [tool.tombi.format.rules]
@@ -2332,10 +2160,30 @@ mod schema_overrides {
             key-value-equals-sign-alignment = true
             trailing-comment-alignment = true
             "#,
-            Config(pyproject_with_tombi_subschema_table_config(
-                None,
-                Some(TableKeysOrder::Descending),
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.format.rules"]
+                format.rules.table-keys-order = "descending"
+                "#
+            )
         ) -> Ok(
             r#"
             [tool.tombi.format.rules]
@@ -2357,10 +2205,36 @@ mod schema_overrides {
             inline-table-brace-space-width = 0
             indent-table-key-value-pairs = true
             "#,
-            Config(pyproject_with_tombi_subschema_table_config(
-                Some(TableKeysOrder::Ascending),
-                Some(TableKeysOrder::Descending),
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.format.rules"]
+                format.rules.table-keys-order = "ascending"
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.format.rules"]
+
+                [schemas.overrides.format.rules]
+                table-keys-order = "descending"
+                "#,
+            )
         ) -> Ok(
             r#"
             [tool.tombi.format.rules]
@@ -2380,10 +2254,31 @@ mod schema_overrides {
             include = ["z.toml", "a.toml"]
             path = "tombi://www.schemastore.org/tombi.json"
             "#,
-            Config(pyproject_with_tombi_subschema_array_config(
-                Some(ArrayValuesOrder::Ascending),
-                None,
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                [schemas.format.rules]
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.schemas[*].include"]
+                format.rules.array-values-order = "ascending"
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+                "#,
+            ),
         ) -> Ok(
             r#"
             [[tool.tombi.schemas]]
@@ -2401,10 +2296,30 @@ mod schema_overrides {
             include = ["a.toml", "z.toml"]
             path = "tombi://www.schemastore.org/tombi.json"
             "#,
-            Config(pyproject_with_tombi_subschema_array_config(
-                None,
-                Some(ArrayValuesOrder::Descending),
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.schemas[*].include"]
+                format.rules.array-values-order = "descending"
+                "#,
+            ),
         ) -> Ok(
             r#"
             [[tool.tombi.schemas]]
@@ -2422,10 +2337,32 @@ mod schema_overrides {
             include = ["z.toml", "a.toml"]
             path = "tombi://www.schemastore.org/tombi.json"
             "#,
-            Config(pyproject_with_tombi_subschema_array_config(
-                Some(ArrayValuesOrder::Ascending),
-                Some(ArrayValuesOrder::Descending),
-            )),
+            ConfigText(
+                r#"
+                [[schemas]]
+                path = "tombi://www.schemastore.org/tombi.json"
+                include = ["*.toml"]
+
+                [schemas.format.rules]
+                array-values-order.enabled = false
+                table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.schemas[*].include"]
+                format.rules.array-values-order = "ascending"
+
+                [[schemas]]
+                root = "tool.tombi"
+                path = "tombi://www.schemastore.org/pyproject.json"
+                include = ["*.toml"]
+                format.rules.array-values-order.enabled = false
+                format.rules.table-keys-order.enabled = false
+
+                [[schemas.overrides]]
+                targets = ["tool.tombi.schemas[*].include"]
+                format.rules.array-values-order = "descending"
+                "#,
+            ),
         ) -> Ok(
             r#"
             [[tool.tombi.schemas]]

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -2118,7 +2118,7 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2131,7 +2131,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2163,7 +2163,7 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2172,7 +2172,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2208,7 +2208,7 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2221,7 +2221,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2257,12 +2257,11 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
                 array-values-order.enabled = false
-                [schemas.format.rules]
                 table-keys-order.enabled = false
 
                 [[schemas.overrides]]
@@ -2271,7 +2270,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2299,7 +2298,7 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2308,7 +2307,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2340,7 +2339,7 @@ mod schema_overrides {
             ConfigText(
                 r#"
                 [[schemas]]
-                path = "tombi://www.schemastore.org/tombi.json"
+                path = "tombi://www.schemastore.org/pyproject.json"
                 include = ["*.toml"]
 
                 [schemas.format.rules]
@@ -2353,7 +2352,7 @@ mod schema_overrides {
 
                 [[schemas]]
                 root = "tool.tombi"
-                path = "tombi://www.schemastore.org/pyproject.json"
+                path = "tombi://www.schemastore.org/tombi.json"
                 include = ["*.toml"]
                 format.rules.array-values-order.enabled = false
                 format.rules.table-keys-order.enabled = false

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
@@ -3,9 +3,9 @@
   lsp = {
     document-link = {
       cargo-toml.enabled = false,
+      git.enabled = true,
       path.enabled = true,
       workspace.enabled = true,
-      git.enabled = true,
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
@@ -3,8 +3,8 @@
   lsp = {
     document-link = {
       cargo-toml.enabled = true,
-      workspace.enabled = false,
       path.enabled = false,
+      workspace.enabled = false,
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
@@ -3,8 +3,8 @@
   lsp = {
     document-link = {
       cargo-toml.enabled = false,
-      workspace.enabled = true,
       path.enabled = false,
+      workspace.enabled = true,
     },
   },
 }


### PR DESCRIPTION
Formatter test macro now accepts TOML config text and parses it during test setup, so formatter tests can describe schema settings with inline config strings. The formatter schema-order tests were updated to use `ConfigText(...)` instead of constructing `tombi_config::Config` values manually, which removes a large amount of config-builder boilerplate. This also adds the `serde_tombi` dev-dependency needed for async config parsing in tests. Validation: `cargo test -p tombi-formatter --test test_x_tombi_order` currently fails in three `schema_overrides` cases (`test_root_array_override_applies_inside_subschema`, `test_subschema_array_override_applies_without_root_override`, `test_subschema_override_applies_without_root_override`).