### PR TITLE
style: format rust sources

### DIFF
--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -8,8 +8,8 @@ use tombi_schema_store::{Accessor, CurrentSchema, PatternAccessor};
 use tombi_syntax::SyntaxElement;
 
 use crate::node::make_dangling_comment_group_from_leading_comments;
-use crate::rule::root_table_keys_order;
 use crate::rule::TableOrderOverride;
+use crate::rule::root_table_keys_order;
 use tombi_ast::{DanglingCommentGroupOr, GetHeaderAccessors};
 
 impl crate::Edit for tombi_ast::Root {

--- a/crates/tombi-linter/tests/integration/cargo_schema.rs
+++ b/crates/tombi-linter/tests/integration/cargo_schema.rs
@@ -165,7 +165,9 @@ fn deprecated_override_config(deprecated_level: SeverityLevel) -> tombi_config::
     config
 }
 
-fn deprecated_root_lint_for_subschema_config(deprecated_level: SeverityLevel) -> tombi_config::Config {
+fn deprecated_root_lint_for_subschema_config(
+    deprecated_level: SeverityLevel,
+) -> tombi_config::Config {
     let schema_path = project_root_path()
         .join("schemas")
         .join("deprecated-test.schema.json");

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -817,21 +817,18 @@ impl SchemaStore {
                                     document_schema.schema_uri.clone(),
                                 );
                                 if let Some(format_rules) = &matching_schema.format_rules {
-                                    source_schema.schema_format_rules.insert(
-                                        schema_uri_key.clone(),
-                                        format_rules.clone(),
-                                    );
+                                    source_schema
+                                        .schema_format_rules
+                                        .insert(schema_uri_key.clone(), format_rules.clone());
                                 }
                                 if let Some(lint_rules) = &matching_schema.lint_rules {
-                                    source_schema.schema_lint_rules.insert(
-                                        schema_uri_key.clone(),
-                                        lint_rules.clone(),
-                                    );
+                                    source_schema
+                                        .schema_lint_rules
+                                        .insert(schema_uri_key.clone(), lint_rules.clone());
                                 }
-                                source_schema.schema_overrides.insert(
-                                    schema_uri_key,
-                                    matching_schema.overrides.clone(),
-                                );
+                                source_schema
+                                    .schema_overrides
+                                    .insert(schema_uri_key, matching_schema.overrides.clone());
                             }
                         }
                         None => {
@@ -849,7 +846,8 @@ impl SchemaStore {
                             }
                             let mut schema_lint_rules = crate::SchemaLintRulesMap::default();
                             if let Some(lint_rules) = &matching_schema.lint_rules {
-                                schema_lint_rules.insert(schema_uri_key.clone(), lint_rules.clone());
+                                schema_lint_rules
+                                    .insert(schema_uri_key.clone(), lint_rules.clone());
                             }
                             let mut schema_overrides = crate::SchemaOverridesMap::default();
                             schema_overrides
@@ -912,7 +910,8 @@ impl SchemaStore {
                             }
                             let mut schema_lint_rules = crate::SchemaLintRulesMap::default();
                             if let Some(lint_rules) = &matching_schema.lint_rules {
-                                schema_lint_rules.insert(schema_uri_key.clone(), lint_rules.clone());
+                                schema_lint_rules
+                                    .insert(schema_uri_key.clone(), lint_rules.clone());
                             }
                             let mut schema_overrides = crate::SchemaOverridesMap::default();
                             schema_overrides

--- a/xtask/src/command/set_version.rs
+++ b/xtask/src/command/set_version.rs
@@ -113,7 +113,13 @@ fn set_install_sh_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut patch = Patch::new(sh, project_root_path().join("docs").join("public").join("install.sh"))?;
+    let mut patch = Patch::new(
+        sh,
+        project_root_path()
+            .join("docs")
+            .join("public")
+            .join("install.sh"),
+    )?;
     patch.replace_install_sh_version(version);
     patch.commit(sh)?;
     Ok(())
@@ -166,10 +172,14 @@ impl Patch {
         let value_end = self.contents[value_start..]
             .find('"')
             .map(|offset| value_start + offset)
-            .unwrap_or_else(|| panic!("Expected closing quote after '{prefix}' in '{}'", self.path.display()));
+            .unwrap_or_else(|| {
+                panic!(
+                    "Expected closing quote after '{prefix}' in '{}'",
+                    self.path.display()
+                )
+            });
 
-        self.contents
-            .replace_range(value_start..value_end, version);
+        self.contents.replace_range(value_start..value_end, version);
         self
     }
 


### PR DESCRIPTION
## Summary
Format Rust source files across the AST editor, schema store, linter integration test, and xtask version command.
This change only restructures imports and wraps long lines for consistency.

## Testing
Not run (format-only changes).