### PR TITLE
Prefer subschema schema ordering overrides

### DIFF
--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -2197,7 +2197,7 @@ mod schema_overrides {
 
     test_format! {
         #[tokio::test]
-        async fn test_root_schema_override_precedes_subschema_override(
+        async fn test_subschema_override_precedes_root_schema_override(
             r#"
             [tool.tombi.format.rules]
             trailing-comment-alignment = true
@@ -2238,10 +2238,10 @@ mod schema_overrides {
         ) -> Ok(
             r#"
             [tool.tombi.format.rules]
-            indent-table-key-value-pairs = true
-            inline-table-brace-space-width = 0
-            key-value-equals-sign-alignment = true
             trailing-comment-alignment = true
+            key-value-equals-sign-alignment = true
+            inline-table-brace-space-width = 0
+            indent-table-key-value-pairs = true
             "#
         )
     }
@@ -2330,7 +2330,7 @@ mod schema_overrides {
 
     test_format! {
         #[tokio::test]
-        async fn test_root_array_override_precedes_subschema_override(
+        async fn test_subschema_array_override_precedes_root_array_override(
             r#"
             [[tool.tombi.schemas]]
             include = ["z.toml", "a.toml"]
@@ -2365,7 +2365,7 @@ mod schema_overrides {
         ) -> Ok(
             r#"
             [[tool.tombi.schemas]]
-            include = ["a.toml", "z.toml"]
+            include = ["z.toml", "a.toml"]
             path = "tombi://www.schemastore.org/tombi.json"
             "#
         )

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -95,16 +95,12 @@ impl SchemaContext<'_> {
         current_schema: Option<&crate::CurrentSchema<'_>>,
         accessors: &[crate::Accessor],
     ) -> Option<&crate::ArrayOrderOverride> {
-        if let Some(root_override) = self
-            .root_schema_overrides()
+        self.schema_overrides(current_schema)
             .and_then(|overrides| overrides.array_values_order.find(accessors))
-        {
-            return Some(root_override);
-        }
-
-        self.schema_overrides(current_schema)?
-            .array_values_order
-            .find(accessors)
+            .or_else(|| {
+                self.root_schema_overrides()
+                    .and_then(|overrides| overrides.array_values_order.find(accessors))
+            })
     }
 
     pub fn table_order_override(
@@ -112,16 +108,12 @@ impl SchemaContext<'_> {
         current_schema: Option<&crate::CurrentSchema<'_>>,
         accessors: &[crate::Accessor],
     ) -> Option<&crate::TableOrderOverride> {
-        if let Some(root_override) = self
-            .root_schema_overrides()
+        self.schema_overrides(current_schema)
             .and_then(|overrides| overrides.table_keys_order.find(accessors))
-        {
-            return Some(root_override);
-        }
-
-        self.schema_overrides(current_schema)?
-            .table_keys_order
-            .find(accessors)
+            .or_else(|| {
+                self.root_schema_overrides()
+                    .and_then(|overrides| overrides.table_keys_order.find(accessors))
+            })
     }
 
     pub fn root_table_order_overrides(&self) -> Option<&crate::TableOrderOverrides> {

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -965,6 +965,11 @@ targets = ["items[*]", "tool.tasks[*]"]
 array-values-order.enabled = false
 ```
 
+<Note>
+If both a root schema override and a sub schema override match the same target, the sub schema override takes precedence.
+This precedence is shared by both `format.rules.table-keys-order` and `format.rules.array-values-order`.
+</Note>
+
 ### schemas[*].overrides[*].targets
 
 Accessor patterns to which the override applies.


### PR DESCRIPTION
Adjust schema override precedence so subschema ordering overrides win over root schema overrides for both table-keys-order and array-values-order. Update formatter expectations to match the shared precedence rule. Add a documentation note describing the override precedence for schema overrides.