### PR TITLE
Refine hover schema order handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,6 +3998,7 @@ dependencies = [
  "tombi-ast",
  "tombi-cache",
  "tombi-comment-directive",
+ "tombi-comment-directive-serde",
  "tombi-comment-directive-store",
  "tombi-config",
  "tombi-date-time",

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["fs", "io-std", "rt-multi-thread"] }
 tombi-ast.workspace = true
 tombi-cache.workspace = true
 tombi-comment-directive.workspace = true
+tombi-comment-directive-serde.workspace = true
 tombi-comment-directive-store.workspace = true
 tombi-config.workspace = true
 tombi-date-time.workspace = true

--- a/crates/tombi-lsp/src/completion/comment.rs
+++ b/crates/tombi-lsp/src/completion/comment.rs
@@ -158,18 +158,12 @@ pub async fn get_tombi_comment_directive_content_completion_contents(
         Default::default(),
         Default::default(),
     );
-    let schema_context = tombi_schema_store::SchemaContext {
+    let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
         toml_version,
-        root_schema: source_schema.root_schema.as_deref(),
-        sub_schema_uri_map: None,
-        deprecated_lint_level: None,
-        schema_format_rules: None,
-        schema_lint_rules: None,
-        schema_overrides: None,
-        schema_visits: Default::default(),
-        store: schema_store,
-        strict: None,
-    };
+        Some(&source_schema),
+        schema_store,
+        None,
+    );
 
     Some(
         find_completion_contents_with_tree(

--- a/crates/tombi-lsp/src/goto_type_definition/comment.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/comment.rs
@@ -70,18 +70,12 @@ pub async fn get_tombi_value_comment_directive_type_definition(
         Default::default(),
     );
 
-    let schema_context = tombi_schema_store::SchemaContext {
-        toml_version: TOMBI_COMMENT_DIRECTIVE_TOML_VERSION,
-        root_schema: source_schema.root_schema.as_deref(),
-        sub_schema_uri_map: None,
-        deprecated_lint_level: None,
-        schema_format_rules: None,
-        schema_lint_rules: None,
-        schema_overrides: None,
-        schema_visits: Default::default(),
-        store: schema_store,
-        strict: None,
-    };
+    let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
+        TOMBI_COMMENT_DIRECTIVE_TOML_VERSION,
+        Some(&source_schema),
+        schema_store,
+        None,
+    );
 
     get_type_definition(&document_tree, position_in_content, &keys, &schema_context).await
 }

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -92,20 +92,7 @@ pub async fn handle_goto_type_definition(
             &document_source.document_tree(),
             position,
             &keys,
-            &SchemaContext {
-                toml_version,
-                root_schema: source_schema
-                    .as_ref()
-                    .and_then(|s| s.root_schema.as_deref()),
-                sub_schema_uri_map: source_schema.as_ref().map(|s| &s.sub_schema_uri_map),
-                deprecated_lint_level: source_schema.as_ref().and_then(|s| s.deprecated_lint_level),
-                schema_format_rules: source_schema.as_ref().map(|s| &s.schema_format_rules),
-                schema_lint_rules: source_schema.as_ref().map(|s| &s.schema_lint_rules),
-                schema_overrides: source_schema.as_ref().map(|s| &s.schema_overrides),
-                schema_visits: Default::default(),
-                store: &schema_store,
-                strict: None,
-            },
+            &SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None),
         )
         .await
         {

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -87,14 +87,12 @@ pub async fn handle_goto_type_definition(
         return Ok(Default::default());
     }
 
+    let schema_context =
+        SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None);
+
     Ok(
-        match get_type_definition(
-            &document_source.document_tree(),
-            position,
-            &keys,
-            &SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None),
-        )
-        .await
+        match get_type_definition(&document_source.document_tree(), position, &keys, &schema_context)
+            .await
         {
             Some(TypeDefinition {
                 schema_uri, range, ..

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -90,20 +90,7 @@ pub async fn handle_hover(
         &document_tree,
         position,
         &keys,
-        &SchemaContext {
-            toml_version,
-            root_schema: source_schema
-                .as_ref()
-                .and_then(|s| s.root_schema.as_deref()),
-            sub_schema_uri_map: source_schema.as_ref().map(|s| &s.sub_schema_uri_map),
-            deprecated_lint_level: source_schema.as_ref().and_then(|s| s.deprecated_lint_level),
-            schema_format_rules: source_schema.as_ref().map(|s| &s.schema_format_rules),
-            schema_lint_rules: source_schema.as_ref().map(|s| &s.schema_lint_rules),
-            schema_overrides: source_schema.as_ref().map(|s| &s.schema_overrides),
-            schema_visits: Default::default(),
-            store: &schema_store,
-            strict: None,
-        },
+        &SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None),
     )
     .await;
 

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -86,13 +86,10 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let mut hover_content = get_hover_content(
-        &document_tree,
-        position,
-        &keys,
-        &SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None),
-    )
-    .await;
+    let schema_context =
+        SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None);
+
+    let mut hover_content = get_hover_content(&document_tree, position, &keys, &schema_context).await;
 
     if let Some(HoverContent::Value(hover_value_content)) = &mut hover_content {
         hover_value_content.range = range;

--- a/crates/tombi-lsp/src/hover/comment.rs
+++ b/crates/tombi-lsp/src/hover/comment.rs
@@ -142,18 +142,12 @@ async fn get_comment_directive_toml_content_hover_content(
             Default::default(),
         );
 
-        let schema_context = tombi_schema_store::SchemaContext {
+        let schema_context = tombi_schema_store::SchemaContext::from_source_schema(
             toml_version,
-            root_schema: source_schema.root_schema.as_deref(),
-            sub_schema_uri_map: None,
-            deprecated_lint_level: None,
-            schema_format_rules: None,
-            schema_lint_rules: None,
-            schema_overrides: None,
-            schema_visits: Default::default(),
-            store: schema_store,
-            strict: None,
-        };
+            Some(&source_schema),
+            schema_store,
+            None,
+        );
 
         if let Some(hover_content) = get_hover_content(
             &directive_ast

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
+use tombi_comment_directive::value::{ArrayCommonFormatRules, ArrayCommonLintRules};
+use tombi_comment_directive_serde::get_comment_directive_content;
 
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, Accessors, ArraySchema, CurrentSchema, ValueSchema, ValueType};
@@ -214,6 +216,13 @@ impl GetHoverContent for tombi_document_tree::Array {
                             hover_content.as_mut()
                         {
                             hover_value_content.range = Some(self.range());
+                            if let Some(constraints) = hover_value_content.constraints.as_mut() {
+                                constraints.values_order = schema_context.array_values_order(
+                                    accessors,
+                                    Some(current_schema),
+                                    comment_directive_array_values_order(self).as_ref(),
+                                );
+                            }
                         }
 
                         return hover_content;
@@ -322,6 +331,26 @@ impl GetHoverContent for tombi_document_tree::Array {
         }
         .boxed()
     }
+}
+
+fn comment_directive_array_values_order(
+    array: &tombi_document_tree::Array,
+) -> Option<tombi_schema_store::ArrayOrderOverride> {
+    let comment_directive = get_comment_directive_content::<
+        ArrayCommonFormatRules,
+        ArrayCommonLintRules,
+    >(array.comment_directives()?.cloned())?;
+
+    let disabled = comment_directive
+        .array_values_order_disabled()
+        .unwrap_or_default();
+    let order = comment_directive.array_values_order().map(Into::into);
+
+    (disabled || order.is_some()).then_some(tombi_schema_store::ArrayOrderOverride {
+        target: Vec::new(),
+        disabled,
+        order,
+    })
 }
 
 impl GetHoverContent for ArraySchema {

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
+use tombi_comment_directive::value::{TableCommonFormatRules, TableCommonLintRules};
+use tombi_comment_directive_serde::get_comment_directive_content;
 
 use tombi_future::Boxable;
 use tombi_schema_store::{
@@ -556,6 +558,14 @@ impl GetHoverContent for tombi_document_tree::Table {
                                 hover_content.as_mut()
                             {
                                 hover_value_content.range = Some(self.range());
+                                if let Some(constraints) = hover_value_content.constraints.as_mut()
+                                {
+                                    constraints.keys_order = schema_context.table_keys_order(
+                                        accessors,
+                                        Some(current_schema),
+                                        comment_directive_table_keys_order(self).as_ref(),
+                                    );
+                                }
                             } else {
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {
                                     if let Some(hover_content) = get_one_of_hover_content(
@@ -684,6 +694,26 @@ impl GetHoverContent for tombi_document_tree::Table {
         }
         .boxed()
     }
+}
+
+fn comment_directive_table_keys_order(
+    table: &tombi_document_tree::Table,
+) -> Option<tombi_schema_store::TableOrderOverride> {
+    let comment_directive = get_comment_directive_content::<
+        TableCommonFormatRules,
+        TableCommonLintRules,
+    >(table.comment_directives()?.cloned())?;
+
+    let disabled = comment_directive
+        .table_keys_order_disabled()
+        .unwrap_or_default();
+    let order = comment_directive.table_keys_order().map(Into::into);
+
+    (disabled || order.is_some()).then_some(tombi_schema_store::TableOrderOverride {
+        target: Vec::new(),
+        disabled,
+        order,
+    })
 }
 
 impl GetHoverContent for TableSchema {

--- a/crates/tombi-lsp/tests/fixtures/array-values-order.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/array-values-order.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "x-tombi-array-values-order": "ascending",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/fixtures/nested-table-keys-order.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/nested-table-keys-order.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "nested": {
+      "type": "object",
+      "x-tombi-table-keys-order": "ascending",
+      "properties": {
+        "a": {
+          "type": "integer"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -7,6 +7,16 @@ use tombi_test_lib::{
     ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
 };
 
+fn nested_table_keys_order_schema_path() -> PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("crates/tombi-lsp/tests/fixtures/nested-table-keys-order.schema.json")
+}
+
+fn array_values_order_schema_path() -> PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("crates/tombi-lsp/tests/fixtures/array-values-order.schema.json")
+}
+
 fn cargo_feature_usage_hover_description(
     project_root: &Path,
     locations: &[(PathBuf, u32)],
@@ -948,6 +958,158 @@ mod hover_keys_value {
         );
     }
 
+    mod table_keys_order_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn hides_keys_order_when_schema_format_rule_is_disabled(
+                r#"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                    toml_version: None,
+                    path: tombi_schema_store::SchemaUri::from_file_path(
+                        nested_table_keys_order_schema_path(),
+                    )
+                    .unwrap()
+                    .to_string(),
+                    include: vec!["*.toml".to_string()],
+                    lint: None,
+                    format: Some(tombi_config::SchemaFormatOptions {
+                        rules: Some(tombi_config::SchemaFormatRules {
+                            array_values_order: None,
+                            table_keys_order: Some(tombi_config::SchemaTableKeysOrderRule {
+                                enabled: Some(false.into()),
+                            }),
+                        }),
+                    }),
+                    overrides: None,
+                })),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": None::<&str>
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn uses_schema_override_for_keys_order_in_hover(
+                r#"
+                [nested█]
+                b = 1
+                a = 2
+                "#,
+                SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                    toml_version: None,
+                    path: tombi_schema_store::SchemaUri::from_file_path(
+                        nested_table_keys_order_schema_path(),
+                    )
+                    .unwrap()
+                    .to_string(),
+                    include: vec!["*.toml".to_string()],
+                    lint: None,
+                    format: None,
+                    overrides: Some(vec![tombi_config::SchemaOverrideItem {
+                        targets: vec!["nested".into()],
+                        lint: None,
+                        format: Some(tombi_config::SchemaOverrideFormatOptions {
+                            rules: Some(tombi_config::SchemaOverrideFormatRules {
+                                array_values_order: None,
+                                table_keys_order: Some(
+                                    tombi_config::SchemaOverrideTableKeysOrderRule::Order(
+                                        tombi_x_keyword::TableKeysOrder::Descending,
+                                    ),
+                                ),
+                            }),
+                        }),
+                    }]),
+                })),
+            ) -> Ok({
+                "Keys": "nested",
+                "Value": "Table?",
+                "Keys Order": Some("descending")
+            });
+        );
+    }
+
+    mod array_values_order_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn hides_values_order_when_schema_format_rule_is_disabled(
+                r#"
+                items = ["b", "a"]█
+                "#,
+                SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                    toml_version: None,
+                    path: tombi_schema_store::SchemaUri::from_file_path(
+                        array_values_order_schema_path(),
+                    )
+                    .unwrap()
+                    .to_string(),
+                    include: vec!["*.toml".to_string()],
+                    lint: None,
+                    format: Some(tombi_config::SchemaFormatOptions {
+                        rules: Some(tombi_config::SchemaFormatRules {
+                            array_values_order: Some(tombi_config::SchemaArrayValuesOrderRule {
+                                enabled: Some(false.into()),
+                            }),
+                            table_keys_order: None,
+                        }),
+                    }),
+                    overrides: None,
+                })),
+            ) -> Ok({
+                "Keys": "items",
+                "Value": "Array?",
+                "Values Order": None::<&str>
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn uses_schema_override_for_values_order_in_hover(
+                r#"
+                items = ["b", "a"]█
+                "#,
+                SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                    toml_version: None,
+                    path: tombi_schema_store::SchemaUri::from_file_path(
+                        array_values_order_schema_path(),
+                    )
+                    .unwrap()
+                    .to_string(),
+                    include: vec!["*.toml".to_string()],
+                    lint: None,
+                    format: None,
+                    overrides: Some(vec![tombi_config::SchemaOverrideItem {
+                        targets: vec!["items".into()],
+                        lint: None,
+                        format: Some(tombi_config::SchemaOverrideFormatOptions {
+                            rules: Some(tombi_config::SchemaOverrideFormatRules {
+                                array_values_order: Some(
+                                    tombi_config::SchemaOverrideArrayValuesOrderRule::Order(
+                                        tombi_x_keyword::ArrayValuesOrder::Descending,
+                                    ),
+                                ),
+                                table_keys_order: None,
+                            }),
+                        }),
+                    }]),
+                })),
+            ) -> Ok({
+                "Keys": "items",
+                "Value": "Array?",
+                "Values Order": Some("descending")
+            });
+        );
+    }
+
     #[macro_export]
     macro_rules! test_hover_keys_value {
         (#[tokio::test] async fn $name:ident(
@@ -955,6 +1117,9 @@ mod hover_keys_value {
         ) -> Ok({
             "Keys": $keys:expr,
             "Value": $value_type:expr
+            $(, "Schema": $has_schema:expr)?
+            $(, "Keys Order": $keys_order:expr)?
+            $(, "Values Order": $values_order:expr)?
             $(, "Title": $title:expr)?
             $(, "Description": $description:expr)?
             $(, "Enum": [$($enum_values:expr),* $(,)?])?
@@ -983,6 +1148,7 @@ mod hover_keys_value {
                 struct TestArgs {
                     source_file_path: Option<std::path::PathBuf>,
                     schema_file_path: Option<std::path::PathBuf>,
+                    schema_items: Vec<tombi_config::SchemaItem>,
                     subschemas: Vec<SubSchemaPath>,
                     backend_options: tombi_lsp::backend::Options,
                 }
@@ -1007,6 +1173,15 @@ mod hover_keys_value {
                 impl ApplyTestArg for SchemaPath {
                     fn apply(self, args: &mut TestArgs) {
                         args.schema_file_path = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct SchemaItemArg(tombi_config::SchemaItem);
+
+                impl ApplyTestArg for SchemaItemArg {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.schema_items.push(self.0);
                     }
                 }
 
@@ -1037,7 +1212,7 @@ mod hover_keys_value {
                 });
 
                 let backend = service.inner();
-                let mut schema_items = Vec::new();
+                let mut schema_items = args.schema_items.clone();
 
                 if let Some(schema_file_path) = args.schema_file_path.as_ref() {
                     let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
@@ -1176,7 +1351,13 @@ mod hover_keys_value {
 
                 log::debug!("hover_content: {:#?}", hover_content);
 
-                if args.schema_file_path.is_some() {
+                if let Some(expected_has_schema) = None::<bool> $(.or(Some($has_schema)))? {
+                    assert_eq!(
+                        hover_content.schema_uri.is_some(),
+                        expected_has_schema,
+                        "Schema presence is not equal",
+                    );
+                } else if args.schema_file_path.is_some() || !args.schema_items.is_empty() {
                     assert!(hover_content.schema_uri.is_some(), "The hover target is not defined in the schema.");
                 } else {
                     assert!(hover_content.schema_uri.is_none(), "The hover target is defined in the schema.");
@@ -1184,6 +1365,67 @@ mod hover_keys_value {
 
                 pretty_assertions::assert_eq!(hover_content.accessors.to_string(), $keys, "Keys are not equal");
                 pretty_assertions::assert_eq!(hover_content.value_type.to_string(), $value_type, "Value type are not equal");
+                $(
+                    let expected_keys_order = $keys_order.map(ToString::to_string);
+                    let actual_keys_order = hover_content
+                        .constraints
+                        .as_ref()
+                        .and_then(|constraints| constraints.keys_order.as_ref())
+                        .map(|keys_order| match keys_order {
+                            tombi_schema_store::XTombiTableKeysOrder::All(keys_order) => {
+                                keys_order.to_string()
+                            }
+                            tombi_schema_store::XTombiTableKeysOrder::Groups(groups) => groups
+                                .iter()
+                                .map(|group| format!("{}={}", group.target, group.order))
+                                .collect::<Vec<_>>()
+                                .join(","),
+                        });
+                    pretty_assertions::assert_eq!(
+                        actual_keys_order,
+                        expected_keys_order,
+                        "Keys order is not equal"
+                    );
+                )?
+                $(
+                    let expected_values_order = $values_order.map(ToString::to_string);
+                    let actual_values_order = hover_content
+                        .constraints
+                        .as_ref()
+                        .and_then(|constraints| constraints.values_order.as_ref())
+                        .map(|values_order| match values_order {
+                            tombi_schema_store::XTombiArrayValuesOrder::All(values_order) => {
+                                values_order.to_string()
+                            }
+                            tombi_schema_store::XTombiArrayValuesOrder::Groups(groups) => match groups {
+                                tombi_x_keyword::ArrayValuesOrderGroup::OneOf(values_order) => {
+                                    format!(
+                                        "oneOf:{}",
+                                        values_order
+                                            .iter()
+                                            .map(ToString::to_string)
+                                            .collect::<Vec<_>>()
+                                            .join(",")
+                                    )
+                                }
+                                tombi_x_keyword::ArrayValuesOrderGroup::AnyOf(values_order) => {
+                                    format!(
+                                        "anyOf:{}",
+                                        values_order
+                                            .iter()
+                                            .map(ToString::to_string)
+                                            .collect::<Vec<_>>()
+                                            .join(",")
+                                    )
+                                }
+                            },
+                        });
+                    pretty_assertions::assert_eq!(
+                        actual_values_order,
+                        expected_values_order,
+                        "Values order is not equal"
+                    );
+                )?
                 $(
                     let expected_title = $title;
                     pretty_assertions::assert_eq!(

--- a/crates/tombi-schema-store/src/schema/schema_context.rs
+++ b/crates/tombi-schema-store/src/schema/schema_context.rs
@@ -18,9 +18,44 @@ pub struct SchemaContext<'a> {
 }
 
 impl SchemaContext<'_> {
+    pub fn from_source_schema<'a>(
+        toml_version: tombi_config::TomlVersion,
+        source_schema: Option<&'a crate::SourceSchema>,
+        store: &'a crate::SchemaStore,
+        strict: Option<bool>,
+    ) -> SchemaContext<'a> {
+        SchemaContext {
+            toml_version,
+            root_schema: source_schema.and_then(|schema| schema.root_schema.as_deref()),
+            sub_schema_uri_map: source_schema.map(|schema| &schema.sub_schema_uri_map),
+            deprecated_lint_level: source_schema.and_then(|schema| schema.deprecated_lint_level),
+            schema_format_rules: source_schema.map(|schema| &schema.schema_format_rules),
+            schema_lint_rules: source_schema.map(|schema| &schema.schema_lint_rules),
+            schema_overrides: source_schema.map(|schema| &schema.schema_overrides),
+            schema_visits: Default::default(),
+            store,
+            strict,
+        }
+    }
+
     #[inline]
     pub fn strict(&self) -> bool {
         self.strict.unwrap_or_else(|| self.store.strict())
+    }
+
+    pub fn with_strict(&self, strict: Option<bool>) -> SchemaContext<'_> {
+        SchemaContext {
+            toml_version: self.toml_version,
+            root_schema: self.root_schema,
+            sub_schema_uri_map: self.sub_schema_uri_map,
+            deprecated_lint_level: self.deprecated_lint_level,
+            schema_format_rules: self.schema_format_rules,
+            schema_lint_rules: self.schema_lint_rules,
+            schema_overrides: self.schema_overrides,
+            schema_visits: self.schema_visits.clone(),
+            store: self.store,
+            strict,
+        }
     }
 
     #[inline]
@@ -118,6 +153,76 @@ impl SchemaContext<'_> {
 
     pub fn root_table_order_overrides(&self) -> Option<&crate::TableOrderOverrides> {
         Some(&self.root_schema_overrides()?.table_keys_order)
+    }
+
+    pub fn table_keys_order(
+        &self,
+        accessors: &[crate::Accessor],
+        current_schema: Option<&crate::CurrentSchema<'_>>,
+        comment_directive_override: Option<&crate::TableOrderOverride>,
+    ) -> Option<crate::XTombiTableKeysOrder> {
+        if let Some(override_item) = comment_directive_override {
+            if override_item.disabled {
+                return None;
+            }
+            if let Some(order) = override_item.order {
+                return Some(crate::XTombiTableKeysOrder::All(order));
+            }
+        }
+
+        if let Some(override_item) = self.table_order_override(current_schema, accessors) {
+            if override_item.disabled {
+                return None;
+            }
+            if let Some(order) = override_item.order {
+                return Some(crate::XTombiTableKeysOrder::All(order));
+            }
+        }
+
+        let current_schema = current_schema?;
+        if !self.schema_table_keys_order_enabled(Some(current_schema)) {
+            return None;
+        }
+
+        match current_schema.value_schema.as_ref() {
+            crate::ValueSchema::Table(table_schema) => table_schema.keys_order.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn array_values_order(
+        &self,
+        accessors: &[crate::Accessor],
+        current_schema: Option<&crate::CurrentSchema<'_>>,
+        comment_directive_override: Option<&crate::ArrayOrderOverride>,
+    ) -> Option<crate::XTombiArrayValuesOrder> {
+        if let Some(override_item) = comment_directive_override {
+            if override_item.disabled {
+                return None;
+            }
+            if let Some(order) = override_item.order {
+                return Some(crate::XTombiArrayValuesOrder::All(order));
+            }
+        }
+
+        if let Some(override_item) = self.array_order_override(current_schema, accessors) {
+            if override_item.disabled {
+                return None;
+            }
+            if let Some(order) = override_item.order {
+                return Some(crate::XTombiArrayValuesOrder::All(order));
+            }
+        }
+
+        let current_schema = current_schema?;
+        if !self.schema_array_values_order_enabled(Some(current_schema)) {
+            return None;
+        }
+
+        match current_schema.value_schema.as_ref() {
+            crate::ValueSchema::Array(array_schema) => array_schema.values_order.clone(),
+            _ => None,
+        }
     }
 
     fn schema_overrides(


### PR DESCRIPTION
## Summary
- add SchemaContext helpers to construct contexts from source schemas and resolve effective table/array order settings
- update hover, goto type definition, and comment directive paths to reuse the shared schema context setup
- show hover order constraints from schema overrides and comment directives, with fixture coverage for array/table ordering cases

## Testing
- cargo test -p tombi-schema-store
- cargo test -p tombi-lsp --test test_hover