### PR TITLE
fix(lsp): resolve trailing-space completion for dot/equal triggers (#1751)

### DIFF
--- a/crates/tombi-extension/src/completion.rs
+++ b/crates/tombi-extension/src/completion.rs
@@ -334,7 +334,8 @@ impl CompletionContent {
 
         let key_range = match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range } | CompletionHint::EqualTrigger { range, .. },
+                CompletionHint::DotTrigger { range, .. }
+                | CompletionHint::EqualTrigger { range, .. },
             ) => tombi_text::Range::new(range.end, position),
             _ => replace_range.unwrap_or_else(|| tombi_text::Range::at(position)),
         };

--- a/crates/tombi-extension/src/completion/completion_edit.rs
+++ b/crates/tombi-extension/src/completion/completion_edit.rs
@@ -35,8 +35,8 @@ impl CompletionEdit {
     ) -> Option<Self> {
         match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. }
-                | CompletionHint::EqualTrigger { range, .. },
+                CompletionHint::DotTrigger { cleanup_range, .. }
+                | CompletionHint::EqualTrigger { cleanup_range, .. },
             ) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = {label}"),
@@ -44,7 +44,7 @@ impl CompletionEdit {
                 }),
                 insert_text_format: None,
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -79,8 +79,8 @@ impl CompletionEdit {
     ) -> Option<Self> {
         match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. }
-                | CompletionHint::EqualTrigger { range, .. },
+                CompletionHint::DotTrigger { cleanup_range, .. }
+                | CompletionHint::EqualTrigger { cleanup_range, .. },
             ) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = ${{0:{label}}}"),
@@ -88,7 +88,7 @@ impl CompletionEdit {
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -103,8 +103,8 @@ impl CompletionEdit {
     ) -> Option<Self> {
         match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. }
-                | CompletionHint::EqualTrigger { range, .. },
+                CompletionHint::DotTrigger { cleanup_range, .. }
+                | CompletionHint::EqualTrigger { cleanup_range, .. },
             ) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = {quote}$1{quote}$0"),
@@ -112,7 +112,7 @@ impl CompletionEdit {
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -169,8 +169,8 @@ impl CompletionEdit {
     ) -> Option<Self> {
         match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. }
-                | CompletionHint::EqualTrigger { range, .. },
+                CompletionHint::DotTrigger { cleanup_range, .. }
+                | CompletionHint::EqualTrigger { cleanup_range, .. },
             ) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: " = [$1]$0".to_string(),
@@ -178,7 +178,7 @@ impl CompletionEdit {
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -221,7 +221,8 @@ impl CompletionEdit {
     ) -> Option<Self> {
         match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. } | CompletionHint::EqualTrigger { range },
+                CompletionHint::DotTrigger { cleanup_range, .. }
+                | CompletionHint::EqualTrigger { cleanup_range, .. },
             ) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: " = { $1 }$0".to_string(),
@@ -229,7 +230,7 @@ impl CompletionEdit {
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -291,25 +292,25 @@ impl CompletionEdit {
                     additional_text_edits,
                 })
             }
-            Some(CompletionHint::EqualTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::EqualTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = {{ {key_name}$1 }}$0"),
-                    range: key_range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
-            Some(CompletionHint::DotTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::DotTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(".{key_name}"),
-                    range: key_range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: None,
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -353,25 +354,25 @@ impl CompletionEdit {
                     additional_text_edits,
                 })
             }
-            Some(CompletionHint::EqualTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::EqualTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = {{ {key_name} = {value_label} }}"),
-                    range: key_range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: None,
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
-            Some(CompletionHint::DotTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::DotTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(".{key_name} = {value_label}"),
-                    range: key_range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: None,
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
@@ -413,25 +414,25 @@ impl CompletionEdit {
                     additional_text_edits,
                 })
             }
-            Some(CompletionHint::EqualTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::EqualTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(" = {{ ${{1:{key_name}}} }}$0"),
-                    range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),
-            Some(CompletionHint::DotTrigger { range, .. }) => Some(Self {
+            Some(CompletionHint::DotTrigger { cleanup_range, .. }) => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!(".${{0:{key_name}}}"),
-                    range,
+                    range: tombi_text::Range::at(cleanup_range.end),
                 }),
                 insert_text_format: None,
                 additional_text_edits: Some(vec![TextEdit {
-                    range,
+                    range: cleanup_range,
                     new_text: "".to_string(),
                 }]),
             }),

--- a/crates/tombi-extension/src/completion/completion_hint.rs
+++ b/crates/tombi-extension/src/completion/completion_hint.rs
@@ -7,9 +7,11 @@ pub enum CompletionHint {
     },
     DotTrigger {
         range: tombi_text::Range,
+        cleanup_range: tombi_text::Range,
     },
     EqualTrigger {
         range: tombi_text::Range,
+        cleanup_range: tombi_text::Range,
     },
     Comma {
         leading_comma: Option<CommaHint>,

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -103,6 +103,10 @@ pub fn extract_keys_and_hint(
             {
                 completion_hint = Some(CompletionHint::DotTrigger {
                     range: last_token.range(),
+                    cleanup_range: tombi_text::Range {
+                        start: last_token.range().start,
+                        end: position,
+                    },
                 });
             }
             continue;
@@ -114,7 +118,13 @@ pub fn extract_keys_and_hint(
             match (kv.eq(), kv.value()) {
                 (Some(_), Some(_)) => {}
                 (Some(eq), None) => {
-                    completion_hint = Some(CompletionHint::EqualTrigger { range: eq.range() });
+                    completion_hint = Some(CompletionHint::EqualTrigger {
+                        range: eq.range(),
+                        cleanup_range: tombi_text::Range {
+                            start: kv_keys.range().end,
+                            end: position,
+                        },
+                    });
                 }
                 (None, None) => {
                     if let Some(last_dot) = kv_keys
@@ -128,6 +138,10 @@ pub fn extract_keys_and_hint(
                     {
                         completion_hint = Some(CompletionHint::DotTrigger {
                             range: last_dot.range(),
+                            cleanup_range: tombi_text::Range {
+                                start: last_dot.range().start,
+                                end: position,
+                            },
                         });
                     }
                 }

--- a/crates/tombi-lsp/src/completion/value.rs
+++ b/crates/tombi-lsp/src/completion/value.rs
@@ -192,7 +192,7 @@ impl FindCompletionContents for tombi_document_tree::Value {
                         let last_key = keys.last();
 
                         match (&last_key, completion_hint) {
-                            (Some(last_key), Some(CompletionHint::EqualTrigger { range }))
+                            (Some(last_key), Some(CompletionHint::EqualTrigger { range, .. }))
                                 if range.end < position =>
                             {
                                 vec![CompletionContent::new_type_hint_key(
@@ -238,7 +238,8 @@ pub fn type_hint_value(
     if let Some(key) = key {
         let need_key_hint = match completion_hint {
             Some(
-                CompletionHint::DotTrigger { range, .. } | CompletionHint::EqualTrigger { range },
+                CompletionHint::DotTrigger { range, .. }
+                | CompletionHint::EqualTrigger { range, .. },
             ) => range.end == position || range.end <= key.range().start,
             Some(
                 CompletionHint::InTableHeader

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -1049,7 +1049,8 @@ fn get_property_value_completion_contents<'a: 'b, 'b>(
         if keys.len() == 1 {
             match completion_hint {
                 Some(
-                    CompletionHint::DotTrigger { range } | CompletionHint::EqualTrigger { range },
+                    CompletionHint::DotTrigger { range, .. }
+                    | CompletionHint::EqualTrigger { range, .. },
                 ) => {
                     let key = keys.first().unwrap();
                     if current_schema.is_none() {

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -87,12 +87,21 @@ pub async fn handle_goto_type_definition(
         return Ok(Default::default());
     }
 
-    let schema_context =
-        SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None);
+    let schema_context = SchemaContext::from_source_schema(
+        toml_version,
+        source_schema.as_ref(),
+        &schema_store,
+        None,
+    );
 
     Ok(
-        match get_type_definition(&document_source.document_tree(), position, &keys, &schema_context)
-            .await
+        match get_type_definition(
+            &document_source.document_tree(),
+            position,
+            &keys,
+            &schema_context,
+        )
+        .await
         {
             Some(TypeDefinition {
                 schema_uri, range, ..

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -86,10 +86,15 @@ pub async fn handle_hover(
         return Ok(None);
     }
 
-    let schema_context =
-        SchemaContext::from_source_schema(toml_version, source_schema.as_ref(), &schema_store, None);
+    let schema_context = SchemaContext::from_source_schema(
+        toml_version,
+        source_schema.as_ref(),
+        &schema_store,
+        None,
+    );
 
-    let mut hover_content = get_hover_content(&document_tree, position, &keys, &schema_context).await;
+    let mut hover_content =
+        get_hover_content(&document_tree, position, &keys, &schema_context).await;
 
     if let Some(HoverContent::Value(hover_value_content)) = &mut hover_content {
         hover_value_content.range = range;

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -31,10 +31,44 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn tombi_lsp_completion_dot_with_trailing_space(
+                r#"
+                [lsp]
+                completion. █
+                "#,
+                Select("enabled"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [lsp]
+                completion.enabled
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn tombi_lsp_completion_equal(
                 r#"
                 [lsp]
                 completion=█
+                "#,
+                Select("enabled"),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok(
+                r#"
+                [lsp]
+                completion = { enabled$1 }$0
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn tombi_lsp_completion_equal_with_trailing_space(
+                r#"
+                [lsp]
+                completion = █
                 "#,
                 Select("enabled"),
                 SchemaPath(tombi_schema_path()),
@@ -130,10 +164,44 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn cargo_dependencies_serde_dot_work_with_trailing_space(
+                r#"
+                [dependencies]
+                serde. work█
+                "#,
+                Select("workspace = true"),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok(
+                r#"
+                [dependencies]
+                serde.workspace = true
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn cargo_dependencies_serde_eq_work(
                 r#"
                 [dependencies]
                 serde=work█
+                "#,
+                Select("workspace = true"),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok(
+                r#"
+                [dependencies]
+                serde = { workspace = true }
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn cargo_dependencies_serde_eq_work_with_trailing_space(
+                r#"
+                [dependencies]
+                serde = work█
                 "#,
                 Select("workspace = true"),
                 SchemaPath(cargo_schema_path()),
@@ -175,6 +243,23 @@ mod completion_edit {
                 r#"
                 [dependencies]
                 serde = { workspace = true }
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn cargo_lib_proc_macro_equal_with_trailing_space(
+                r#"
+                [lib]
+                proc-macro = █
+                "#,
+                Select("true"),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok(
+                r#"
+                [lib]
+                proc-macro = true
                 "#
             );
         }
@@ -811,6 +896,16 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn key_dot_select_true_with_trailing_space(
+                "key. █",
+                Select("true"),
+            ) -> Ok(
+                "key = true"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn key_dot_select_false(
                 "key.█",
                 Select("false"),
@@ -843,6 +938,16 @@ mod completion_edit {
             #[tokio::test]
             async fn key_dot_select_basic_string(
                 "key.█",
+                Select("\"\""),
+            ) -> Ok(
+                "key = \"$1\"$0"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn key_dot_select_basic_string_with_trailing_space(
+                "key. █",
                 Select("\"\""),
             ) -> Ok(
                 "key = \"$1\"$0"
@@ -901,6 +1006,16 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn key_dot_select_array_with_trailing_space(
+                "key. █",
+                Select("[]"),
+            ) -> Ok(
+                "key = [$1]$0"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn key_equal_select_true(
                 "key=█",
                 Select("true"),
@@ -913,6 +1028,16 @@ mod completion_edit {
             #[tokio::test]
             async fn key_equal_select_false(
                 "key=█",
+                Select("false"),
+            ) -> Ok(
+                "key = false"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn key_equal_select_false_with_trailing_space(
+                "key = █",
                 Select("false"),
             ) -> Ok(
                 "key = false"
@@ -1230,6 +1355,9 @@ mod completion_edit {
                 )
                 .await;
 
+                let cursor_position = tombi_text::Position::default()
+                    + tombi_text::RelativePosition::of(&toml_text[..index]);
+
                 let Ok(Some(completion_contents)) = tombi_lsp::handler::handle_completion(
                     &backend,
                     CompletionParams {
@@ -1237,9 +1365,7 @@ mod completion_edit {
                             text_document: TextDocumentIdentifier {
                                 uri: toml_file_url,
                             },
-                            position: (tombi_text::Position::default()
-                                + tombi_text::RelativePosition::of(&toml_text[..index]))
-                            .into_lsp(&line_index),
+                            position: cursor_position.into_lsp(&line_index),
                         },
                         work_done_progress_params: WorkDoneProgressParams::default(),
                         partial_result_params: PartialResultParams {
@@ -1287,6 +1413,62 @@ mod completion_edit {
                 let mut new_text = "".to_string();
                 match completion_edit.text_edit {
                     CompletionTextEdit::Edit(text_edit) => {
+                        let pre_cursor_text = {
+                            let start_line = text_edit.range.start.line as usize;
+                            let start_col = text_edit.range.start.column as usize;
+                            let cursor_line = cursor_position.line as usize;
+                            let cursor_col = cursor_position.column as usize;
+                            let before_cursor = &toml_text[..index];
+                            let line_starts: Vec<usize> = std::iter::once(0)
+                                .chain(before_cursor.match_indices('\n').map(|(i, _)| i + 1))
+                                .collect();
+                            if start_line > cursor_line
+                                || (start_line == cursor_line && start_col >= cursor_col)
+                            {
+                                None
+                            } else if start_line < line_starts.len() {
+                                let line_start_byte = line_starts[start_line];
+                                let byte_start = line_start_byte + start_col;
+                                if byte_start <= index && byte_start <= before_cursor.len() {
+                                    Some(&before_cursor[byte_start..index])
+                                } else {
+                                    Some("")
+                                }
+                            } else {
+                                Some("")
+                            }
+                        };
+                        if let Some(pre_cursor_text) = pre_cursor_text {
+                            let filter_text = completion_content
+                                .filter_text
+                                .as_deref()
+                                .unwrap_or(completion_content.label.as_str());
+                            assert!(
+                                filter_text.starts_with(pre_cursor_text),
+                                "text_edit.range covers text {:?} before the cursor that is not a \
+                                 prefix of the completion's filter_text/label ({:?}).\n\
+                                 \n\
+                                 VSCode hides completion candidates whose `text_edit` range spans \
+                                 pre-cursor text that is not a prefix of the completion's \
+                                 `filterText` (or `label`, when `filterText` is unset). Such items \
+                                 never reach the suggestion list, so the completion silently stops \
+                                 working in the editor — even though tests that apply edits directly \
+                                 (like this one) still produce the expected output.\n\
+                                 \n\
+                                 Keep `text_edit.range` scoped to either the cursor position \
+                                 (`Range::at(position)`) or the exact range of the word prefix being \
+                                 completed (so the pre-cursor slice is a prefix of the filter_text). \
+                                 Any pre-cursor cleanup — deleting trigger characters like `.` / `=`, \
+                                 trailing whitespace, partial keys that are NOT the filter prefix, \
+                                 etc. — MUST be expressed via `additional_text_edits`.\n\
+                                 \n\
+                                 See `CompletionEdit` in \
+                                 `crates/tombi-extension/src/completion/completion_edit.rs` for examples.",
+                                pre_cursor_text,
+                                filter_text,
+                            );
+                        }
+
                         let mut cursor = toml_text.split('\n').enumerate();
                         let start_line = text_edit.range.start.line as usize;
                         let end_line = text_edit.range.end.line as usize;

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -1205,6 +1205,7 @@ mod completion_edit {
                     LspService,
                 };
                 use tombi_text::IntoLsp;
+                use unicode_segmentation::UnicodeSegmentation;
 
                 tombi_test_lib::init_log();
 
@@ -1418,24 +1419,30 @@ mod completion_edit {
                             let start_col = text_edit.range.start.column as usize;
                             let cursor_line = cursor_position.line as usize;
                             let cursor_col = cursor_position.column as usize;
-                            let before_cursor = &toml_text[..index];
-                            let line_starts: Vec<usize> = std::iter::once(0)
-                                .chain(before_cursor.match_indices('\n').map(|(i, _)| i + 1))
-                                .collect();
-                            if start_line > cursor_line
-                                || (start_line == cursor_line && start_col >= cursor_col)
-                            {
+                            if (start_line, start_col) >= (cursor_line, cursor_col) {
                                 None
-                            } else if start_line < line_starts.len() {
-                                let line_start_byte = line_starts[start_line];
-                                let byte_start = line_start_byte + start_col;
-                                if byte_start <= index && byte_start <= before_cursor.len() {
-                                    Some(&before_cursor[byte_start..index])
-                                } else {
-                                    Some("")
-                                }
                             } else {
-                                Some("")
+                                // `column` is a grapheme count (see
+                                // `tombi_text::RelativePosition::of`), so convert it to a
+                                // byte offset via the same grapheme iteration instead of
+                                // treating it as a byte index.
+                                let before_cursor = &toml_text[..index];
+                                let line_start = std::iter::once(0)
+                                    .chain(
+                                        before_cursor
+                                            .char_indices()
+                                            .filter_map(|(i, c)| (c == '\n').then_some(i + 1)),
+                                    )
+                                    .nth(start_line)
+                                    .unwrap_or(before_cursor.len());
+                                let byte_offset_in_line: usize = before_cursor[line_start..]
+                                    .graphemes(true)
+                                    .take(start_col)
+                                    .map(str::len)
+                                    .sum();
+                                let byte_start =
+                                    (line_start + byte_offset_in_line).min(before_cursor.len());
+                                Some(&before_cursor[byte_start..])
                             }
                         };
                         if let Some(pre_cursor_text) = pre_cursor_text {


### PR DESCRIPTION
## Summary
- Fixes #1751: completions triggered after `.` / `=` with trailing whitespace (`key. █`, `key = █`) or a partial key (`serde = work█`) produced duplicated whitespace or got silently dropped in VSCode because `text_edit` ranges touched non-identifier text before the cursor.
- Introduces a `cleanup_range` field on `DotTrigger` / `EqualTrigger` that spans from the trigger to the cursor, and reshapes `CompletionEdit::{new_literal, ..., new_key, new_key_with_literal, new_additional_key}` so `text_edit.range` stays anchored at the cursor while all pre-cursor deletion moves to `additional_text_edits` (the VSCode-compatible pattern).
- Adds trailing-space test cases and an assertion inside `test_completion_edit\!` that rejects any `text_edit` whose pre-cursor slice is not a prefix of `filter_text`/`label`, with a detailed message explaining the VSCode filter rule to prevent future regressions.

## Test plan
- [x] `cargo nextest run --package tombi-lsp` (559 passed / 0 failed)
- [x] `cargo fmt -- --check`
- [ ] Manually verify in VSCode that `key. █`, `key = █`, and `serde = work█` style completions apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)