### PR TITLE
docs: add built-in schema usage guide

### DIFF
--- a/docs/src/routes/docs/json-schema.mdx
+++ b/docs/src/routes/docs/json-schema.mdx
@@ -14,6 +14,23 @@ This section explains how Tombi prioritizes the application of `x-tombi-*` keys 
 2. JSON Schema specified in [the Tombi configuration file](/docs/configuration#search-priority)
 3. JSON Schema from the [JSON Schema Store](https://www.schemastore.org)
 
+## Built-in schemas
+
+Tombi embeds a subset of SchemaStore schemas into the binary. To use an embedded schema, replace the `https://` scheme with `tombi://`.
+
+For example, use `tombi://www.schemastore.org/cargo.json` instead of `https://www.schemastore.org/cargo.json`.
+
+Currently, the following built-in schemas are available:
+
+- `tombi://www.schemastore.org/api/json/catalog.json`
+- `tombi://www.schemastore.org/cargo.json`
+- `tombi://www.schemastore.org/pyproject.json`
+- `tombi://www.schemastore.org/tombi.json`
+
+<Note>
+Built-in schemas are useful when you want schema validation and completion to work offline, or when you want to avoid fetching schemas over the network.
+</Note>
+
 ## Tombi metadata
 
 Tombi supports the following metadata keys in your JSON Schema.

--- a/docs/src/routes/docs/json-schema.mdx
+++ b/docs/src/routes/docs/json-schema.mdx
@@ -16,19 +16,23 @@ This section explains how Tombi prioritizes the application of `x-tombi-*` keys 
 
 ## Built-in schemas
 
-Tombi embeds a subset of SchemaStore schemas into the binary. To use an embedded schema, replace the `https://` scheme with `tombi://`.
+Tombi embeds a subset of JSON Schema Store schemas into the binary. To use an embedded schema, replace the `https://` scheme with `tombi://`.
 
 For example, use `tombi://www.schemastore.org/cargo.json` instead of `https://www.schemastore.org/cargo.json`.
 
-Currently, the following built-in schemas are available:
+The authoritative list of embedded schemas is available from the embedded catalog:
 
 - `tombi://www.schemastore.org/api/json/catalog.json`
+
+Some common embedded schema URIs include:
+
 - `tombi://www.schemastore.org/cargo.json`
 - `tombi://www.schemastore.org/pyproject.json`
 - `tombi://www.schemastore.org/tombi.json`
 
 <Note>
 Built-in schemas are useful when you want schema validation and completion to work offline, or when you want to avoid fetching schemas over the network.
+The embedded catalog above is the source of truth for which schemas are built into the current binary.
 </Note>
 
 ## Tombi metadata


### PR DESCRIPTION
## Summary
Add a Built-in schemas section to the JSON Schema docs.
Document the tombi:// URL form used to reference embedded schemas.
List the currently available built-in schemas and note the offline/network-avoidance use case.