### PR TITLE
Fix workspace lint config for cargo check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,7 @@ ignored = [
   "wasm-bindgen",
   "wasm-bindgen-futures",
 ]
+
+[workspace.lints.rust]
+aarch64_softfloat_neon = "warn"
+deprecated = "warn"


### PR DESCRIPTION
Move the workspace Rust lint configuration under [workspace.lints.rust] in the root Cargo manifest. This fixes cargo check for workspace members like editors/zed on newer Cargo versions, which reject a top-level [lints] section in a virtual manifest.