### PR TITLE
ci: manage install.sh stable version in release workflow

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -247,25 +247,93 @@ jobs:
           gh release create ${{ github.ref_name }} --generate-notes ${{ env.ASSETS }}
 
   update-install-script-version:
-    needs: [release-cli-and-vscode]
+    needs: [release-notes]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "stable_version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Skipping install.sh update for non-stable tag: ${REF_NAME}"
+            echo "stable_version=" >> "${GITHUB_OUTPUT}"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.stable-version.outputs.stable_version != ''
         with:
           ref: main
 
-      - name: Update embedded stable version
+      - name: Decide whether install.sh should be updated
+        id: should-update
+        if: steps.stable-version.outputs.stable_version != ''
         shell: bash
+        env:
+          STABLE_VERSION: ${{ steps.stable-version.outputs.stable_version }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          perl -0pi -e 's/LATEST_STABLE_VERSION="[^"]+"/LATEST_STABLE_VERSION="'"${version}"'"/' docs/public/install.sh
+          current_version="$(
+            sed -n 's/^LATEST_STABLE_VERSION="\([0-9][0-9.]*\)"$/\1/p' docs/public/install.sh
+          )"
+
+          if [ -z "${current_version}" ]; then
+            echo "LATEST_STABLE_VERSION entry not found in docs/public/install.sh" >&2
+            exit 1
+          fi
+
+          IFS=. read -r current_major current_minor current_patch <<EOF
+          ${current_version}
+          EOF
+          IFS=. read -r stable_major stable_minor stable_patch <<EOF
+          ${STABLE_VERSION}
+          EOF
+
+          should_update=false
+          if [ "${stable_major}" -gt "${current_major}" ]; then
+            should_update=true
+          elif [ "${stable_major}" -eq "${current_major}" ] && [ "${stable_minor}" -gt "${current_minor}" ]; then
+            should_update=true
+          elif [ "${stable_major}" -eq "${current_major}" ] \
+            && [ "${stable_minor}" -eq "${current_minor}" ] \
+            && [ "${stable_patch}" -gt "${current_patch}" ]; then
+            should_update=true
+          fi
+
+          echo "current_version=${current_version}" >> "${GITHUB_OUTPUT}"
+          echo "should_update=${should_update}" >> "${GITHUB_OUTPUT}"
+
+          if [ "${should_update}" != "true" ]; then
+            echo "Skipping install.sh update because ${STABLE_VERSION} is not newer than ${current_version}."
+          fi
+
+      - name: Update embedded stable version
+        if: steps.should-update.outputs.should_update == 'true'
+        shell: bash
+        env:
+          STABLE_VERSION: ${{ steps.stable-version.outputs.stable_version }}
+        run: |
+          set -euo pipefail
+          sed -i 's/^LATEST_STABLE_VERSION=.*/LATEST_STABLE_VERSION="'"${STABLE_VERSION}"'"/' docs/public/install.sh
+
+          if ! grep -Fxq "LATEST_STABLE_VERSION=\"${STABLE_VERSION}\"" docs/public/install.sh; then
+            echo "Failed to update embedded stable version to ${STABLE_VERSION}" >&2
+            exit 1
+          fi
 
       - name: Commit updated install script
+        if: steps.should-update.outputs.should_update == 'true'
         shell: bash
+        env:
+          STABLE_VERSION: ${{ steps.stable-version.outputs.stable_version }}
         run: |
           set -euo pipefail
           if git diff --quiet -- docs/public/install.sh; then
@@ -276,5 +344,40 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/public/install.sh
-          git commit -m "docs: update install.sh stable version to ${GITHUB_REF_NAME#v}"
-          git push origin HEAD:main
+          git commit -m "docs: update install.sh stable version to ${STABLE_VERSION}"
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push failed on attempt ${attempt}; rebasing on origin/main and retrying."
+            git fetch origin main
+            git rebase origin/main
+          done
+
+          echo "Failed to push install.sh update after multiple attempts." >&2
+          exit 1
+
+      - name: Trigger docs deploy
+        if: steps.should-update.outputs.should_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy_docs.yml',
+              ref: 'main',
+            })
+
+      - name: Trigger install.sh CI
+        if: steps.should-update.outputs.should_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci_install_script.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -272,6 +272,7 @@ jobs:
         if: steps.stable-version.outputs.stable_version != ''
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Decide whether install.sh should be updated
         id: should-update
@@ -281,12 +282,23 @@ jobs:
           STABLE_VERSION: ${{ steps.stable-version.outputs.stable_version }}
         run: |
           set -euo pipefail
+          semver_re='^[0-9]+\.[0-9]+\.[0-9]+$'
           current_version="$(
-            sed -n 's/^LATEST_STABLE_VERSION="\([0-9][0-9.]*\)"$/\1/p' docs/public/install.sh
+            sed -n 's/^LATEST_STABLE_VERSION="\([0-9]\+\.[0-9]\+\.[0-9]\+\)"$/\1/p' docs/public/install.sh
           )"
 
           if [ -z "${current_version}" ]; then
             echo "LATEST_STABLE_VERSION entry not found in docs/public/install.sh" >&2
+            exit 1
+          fi
+
+          if ! [[ "${current_version}" =~ ${semver_re} ]]; then
+            echo "LATEST_STABLE_VERSION must be a stable semver, got: ${current_version}" >&2
+            exit 1
+          fi
+
+          if ! [[ "${STABLE_VERSION}" =~ ${semver_re} ]]; then
+            echo "Stable tag version must be a stable semver, got: ${STABLE_VERSION}" >&2
             exit 1
           fi
 

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -245,3 +245,36 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && needs.check-release-notes.outputs.exists == 'false'
         run: |
           gh release create ${{ github.ref_name }} --generate-notes ${{ env.ASSETS }}
+
+  update-install-script-version:
+    needs: [release-cli-and-vscode]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Update embedded stable version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          perl -0pi -e 's/LATEST_STABLE_VERSION="[^"]+"/LATEST_STABLE_VERSION="'"${version}"'"/' docs/public/install.sh
+
+      - name: Commit updated install script
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/public/install.sh; then
+            echo "install.sh is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/public/install.sh
+          git commit -m "docs: update install.sh stable version to ${GITHUB_REF_NAME#v}"
+          git push origin HEAD:main

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -164,7 +164,7 @@ download_and_install() {
 }
 
 # Version
-LATEST_STABLE_VERSION="0.9.20"
+LATEST_STABLE_VERSION="0.9.21"
 if [ -n "${__SPECIFIED_VERSION}" ]; then
 	VERSION="${__SPECIFIED_VERSION}"
 	print_step "Using specified version: ${VERSION}"

--- a/xtask/src/command/set_version.rs
+++ b/xtask/src/command/set_version.rs
@@ -28,7 +28,6 @@ pub fn run(sh: &Shell) -> anyhow::Result<()> {
     set_pyproject_toml_version(sh, &version)?;
     set_package_json_versions(sh, &version)?;
     set_snapcraft_yaml_version(sh, &version)?;
-    set_install_sh_version(sh, &version)?;
 
     println!("TOMBI_VERSION={version}");
 
@@ -108,37 +107,6 @@ fn set_snapcraft_yaml_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn set_install_sh_version(sh: &Shell, version: &str) -> anyhow::Result<()> {
-    if !is_stable_semver(version) {
-        return Ok(());
-    }
-
-    let mut patch = Patch::new(
-        sh,
-        project_root_path()
-            .join("docs")
-            .join("public")
-            .join("install.sh"),
-    )?;
-    patch.replace_install_sh_version(version);
-    patch.commit(sh)?;
-    Ok(())
-}
-
-fn is_stable_semver(version: &str) -> bool {
-    let mut parts = version.split('.');
-    matches!(
-        (parts.next(), parts.next(), parts.next(), parts.next()),
-        (Some(major), Some(minor), Some(patch), None)
-            if !major.is_empty()
-                && !minor.is_empty()
-                && !patch.is_empty()
-                && major.chars().all(|c| c.is_ascii_digit())
-                && minor.chars().all(|c| c.is_ascii_digit())
-                && patch.chars().all(|c| c.is_ascii_digit())
-    )
-}
-
 struct Patch {
     path: PathBuf,
     contents: String,
@@ -159,27 +127,6 @@ impl Patch {
             format!("Expected '{}' to be in '{}'", from, self.path.display())
         );
         self.contents = self.contents.replace(from, to);
-        self
-    }
-
-    fn replace_install_sh_version(&mut self, version: &str) -> &mut Patch {
-        let prefix = r#"LATEST_STABLE_VERSION=""#;
-        let start = self
-            .contents
-            .find(prefix)
-            .unwrap_or_else(|| panic!("Expected '{prefix}' to be in '{}'", self.path.display()));
-        let value_start = start + prefix.len();
-        let value_end = self.contents[value_start..]
-            .find('"')
-            .map(|offset| value_start + offset)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Expected closing quote after '{prefix}' in '{}'",
-                    self.path.display()
-                )
-            });
-
-        self.contents.replace_range(value_start..value_end, version);
         self
     }
 


### PR DESCRIPTION
Move install.sh stable-version updates out of xtask and into the release workflow.
The workflow now persists the stable version on main after a tagged release and keeps docs/public/install.sh aligned at 0.9.21 for this branch diff.
It also skips non-stable or non-newer tags, retries push-after-rebase when main has moved, and dispatches docs deploy plus install.sh CI after an update.