### PR TITLE
Handle key-value trailing commas

### DIFF
--- a/crates/tombi-ast-editor/src/edit/array_of_table.rs
+++ b/crates/tombi-ast-editor/src/edit/array_of_table.rs
@@ -45,8 +45,9 @@ impl crate::Edit for tombi_ast::ArrayOfTable {
                                 continue;
                             };
 
-                            let key_values = key_value_group.key_values().collect_vec();
-                            for key_value in &key_values {
+                            let key_values_with_comma =
+                                key_value_group.key_values_with_comma().collect_vec();
+                            for (key_value, _) in &key_values_with_comma {
                                 changes.extend(
                                     key_value
                                         .edit(
@@ -64,7 +65,7 @@ impl crate::Edit for tombi_ast::ArrayOfTable {
                                 table_keys_order(
                                     node,
                                     &accessors,
-                                    key_values,
+                                    key_values_with_comma,
                                     current_schema.as_ref(),
                                     schema_context,
                                     comment_directive.clone(),

--- a/crates/tombi-ast-editor/src/edit/table.rs
+++ b/crates/tombi-ast-editor/src/edit/table.rs
@@ -45,8 +45,9 @@ impl crate::Edit for tombi_ast::Table {
                                 continue;
                             };
 
-                            let key_values = key_value_group.key_values().collect_vec();
-                            for key_value in &key_values {
+                            let key_values_with_comma =
+                                key_value_group.key_values_with_comma().collect_vec();
+                            for (key_value, _) in &key_values_with_comma {
                                 changes.extend(
                                     key_value
                                         .edit(
@@ -64,7 +65,7 @@ impl crate::Edit for tombi_ast::Table {
                                 table_keys_order(
                                     node,
                                     &accessors,
-                                    key_values,
+                                    key_values_with_comma,
                                     current_schema.as_ref(),
                                     schema_context,
                                     comment_directive.clone(),

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -38,21 +38,23 @@ pub async fn root_table_keys_order<'a>(
 
     let mut changes = Vec::new();
     for key_value_group in key_value_groups {
-        let key_values = key_value_group.key_values().collect_vec();
-        if key_values.is_empty() {
+        let key_values_with_comma = key_value_group.key_values_with_comma().collect_vec();
+        if key_values_with_comma.is_empty() {
             continue;
         }
 
         changes.extend(
             table_keys_order(
                 &tombi_document_tree::Value::Table(
-                    key_values
-                        .clone()
+                    key_values_with_comma
+                        .iter()
+                        .map(|(kv, _)| kv.clone())
+                        .collect_vec()
                         .into_document_tree_and_errors(schema_context.toml_version)
                         .tree,
                 ),
                 &[],
-                key_values,
+                key_values_with_comma,
                 current_schema,
                 schema_context,
                 comment_directive.clone(),

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -19,14 +19,14 @@ use crate::rule::TableOrderOverrides;
 pub async fn table_keys_order<'a>(
     value: &'a tombi_document_tree::Value,
     accessors: &'a [Accessor],
-    key_values: Vec<tombi_ast::KeyValue>,
+    key_values_with_comma: Vec<(tombi_ast::KeyValue, Option<tombi_ast::Comma>)>,
     current_schema: Option<&'a CurrentSchema<'a>>,
     schema_context: &'a SchemaContext<'a>,
     comment_directive: Option<
         TombiValueDirectiveContent<TableCommonFormatRules, TableCommonLintRules>,
     >,
 ) -> Vec<crate::Change> {
-    if key_values.is_empty() {
+    if key_values_with_comma.is_empty() {
         return Vec::with_capacity(0);
     }
 
@@ -47,26 +47,21 @@ pub async fn table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    let original_ranges = key_values
-        .iter()
-        .map(|key_value| key_value.syntax().range())
-        .collect_vec();
-
     let old = std::ops::RangeInclusive::new(
-        SyntaxElement::Node(key_values.first().unwrap().syntax().clone()),
-        SyntaxElement::Node(key_values.last().unwrap().syntax().clone()),
+        SyntaxElement::Node(key_values_with_comma.first().unwrap().0.syntax().clone()),
+        SyntaxElement::Node(key_values_with_comma.last().unwrap().0.syntax().clone()),
     );
 
-    let Some(sorted_key_values) = get_sorted_accessors(
+    let Some(sorted_key_values_with_comma) = get_sorted_accessors(
         value,
         accessors,
-        key_values
+        key_values_with_comma
             .into_iter()
-            .map(|kv| {
+            .map(|(kv, comma)| {
                 (
                     kv.get_accessors(schema_context.toml_version)
                         .unwrap_or_default(),
-                    kv,
+                    (kv, comma),
                 )
             })
             .collect_vec(),
@@ -80,17 +75,18 @@ pub async fn table_keys_order<'a>(
         return Vec::with_capacity(0);
     };
 
-    if sorted_key_values
-        .iter()
-        .map(|key_value| key_value.syntax().range())
-        .eq(original_ranges)
-    {
-        return Vec::with_capacity(0);
-    }
-
-    let new = sorted_key_values
+    let new = sorted_key_values_with_comma
         .into_iter()
-        .map(|kv| SyntaxElement::Node(kv.syntax().clone()))
+        .flat_map(|(value, comma)| {
+            if let Some(comma) = comma {
+                vec![
+                    SyntaxElement::Node(value.syntax().clone()),
+                    SyntaxElement::Node(comma.syntax().clone()),
+                ]
+            } else {
+                vec![SyntaxElement::Node(value.syntax().clone())]
+            }
+        })
         .collect_vec();
 
     vec![crate::Change::ReplaceRange { old, new }]

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -49,7 +49,13 @@ pub async fn table_keys_order<'a>(
 
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(key_values_with_comma.first().unwrap().0.syntax().clone()),
-        SyntaxElement::Node(key_values_with_comma.last().unwrap().0.syntax().clone()),
+        {
+            let (last_key_value, last_comma) = key_values_with_comma.last().unwrap();
+            match last_comma {
+                Some(comma) => SyntaxElement::Node(comma.syntax().clone()),
+                None => SyntaxElement::Node(last_key_value.syntax().clone()),
+            }
+        },
     );
 
     let Some(sorted_key_values_with_comma) = get_sorted_accessors(

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -47,6 +47,11 @@ pub async fn table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
+    let original_ranges = key_values
+        .iter()
+        .map(|key_value| key_value.syntax().range())
+        .collect_vec();
+
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(key_values.first().unwrap().syntax().clone()),
         SyntaxElement::Node(key_values.last().unwrap().syntax().clone()),
@@ -74,6 +79,14 @@ pub async fn table_keys_order<'a>(
     else {
         return Vec::with_capacity(0);
     };
+
+    if sorted_key_values
+        .iter()
+        .map(|key_value| key_value.syntax().range())
+        .eq(original_ranges)
+    {
+        return Vec::with_capacity(0);
+    }
 
     let new = sorted_key_values
         .into_iter()

--- a/crates/tombi-ast/src/node/key_value_group.rs
+++ b/crates/tombi-ast/src/node/key_value_group.rs
@@ -1,6 +1,7 @@
 use tombi_syntax::SyntaxNode;
 
 use crate::AstNode;
+use crate::support::iter::WithCommaIter;
 use tombi_syntax::SyntaxKind::KEY_VALUE_GROUP;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -21,6 +22,20 @@ impl KeyValueGroup {
         self.syntax()
             .children_with_tokens()
             .filter_map(|el| el.into_node().and_then(crate::KeyValue::cast))
+    }
+
+    #[inline]
+    pub fn key_values_with_comma(
+        &self,
+    ) -> impl Iterator<Item = (crate::KeyValue, Option<crate::Comma>)> {
+        WithCommaIter::new(self.syntax().children())
+    }
+
+    #[inline]
+    pub fn into_key_values_with_comma(
+        self,
+    ) -> impl Iterator<Item = (crate::KeyValue, Option<crate::Comma>)> {
+        WithCommaIter::new(self.syntax.children())
     }
 
     #[inline]

--- a/crates/tombi-formatter/src/format/array_of_table.rs
+++ b/crates/tombi-formatter/src/format/array_of_table.rs
@@ -65,6 +65,8 @@ impl Format for tombi_ast::ArrayOfTable {
 
 #[cfg(test)]
 mod tests {
+    use tombi_config::FormatRules;
+
     use crate::{Formatter, test_format};
 
     test_format! {
@@ -169,6 +171,31 @@ mod tests {
             name = "toml-rs"  # key trailing comment
             ,  # comma trailing comment
             version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_keeps_comma_when_both_key_value_and_comma_have_trailing_comments_with_indent(
+            r#"
+            [[package]]
+            name = "toml-rs" # key trailing comment
+            , # comma trailing comment
+            version = "0.4.0"
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    indent_table_key_value_pairs: Some(true),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [[package]]
+              name = "toml-rs"  # key trailing comment
+              ,  # comma trailing comment
+              version = "0.4.0"
             "#
         )
     }

--- a/crates/tombi-formatter/src/format/array_of_table.rs
+++ b/crates/tombi-formatter/src/format/array_of_table.rs
@@ -101,6 +101,80 @@ mod tests {
 
     test_format! {
         #[tokio::test]
+        async fn array_of_table_removes_trailing_commas(
+            r#"
+            [[package]]
+            name = "toml-rs",
+            version = "0.4.0",
+            "#
+        ) -> Ok(
+            r#"
+            [[package]]
+            name = "toml-rs"
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_moves_comma_trailing_comment_to_key_value(
+            r#"
+            [[package]]
+            name = "toml-rs", # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [[package]]
+            name = "toml-rs"  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_keeps_comma_when_comma_has_leading_comment(
+            r#"
+            [[package]]
+            name = "toml-rs"
+            # comma leading comment
+            , # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [[package]]
+            name = "toml-rs"
+            # comma leading comment
+            ,  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_keeps_comma_when_both_key_value_and_comma_have_trailing_comments(
+            r#"
+            [[package]]
+            name = "toml-rs" # key trailing comment
+            , # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [[package]]
+            name = "toml-rs"  # key trailing comment
+            ,  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn array_of_table_with_full_comment1(
             r#"
             # header leading comment1

--- a/crates/tombi-formatter/src/format/key_value.rs
+++ b/crates/tombi-formatter/src/format/key_value.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use itertools::Itertools;
 use tombi_ast::AstNode;
 
-use crate::{Format, types::WithAlignmentHint};
+use crate::{Format, format::write_trailing_comment_alignment_space, types::WithAlignmentHint};
 
 impl Format for tombi_ast::KeyValue {
     #[inline]
@@ -48,12 +48,16 @@ impl Format for WithAlignmentHint<&tombi_ast::KeyValue> {
 
 impl Format for tombi_ast::KeyValueGroup {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
-        let key_values = self.key_values().collect_vec();
-        let equal_alignment_width = f.key_value_equal_alignment_width(key_values.iter());
-        let trailing_comment_alignment_width =
-            f.trailing_comment_alignment_width(key_values.iter(), equal_alignment_width)?;
+        let key_values_with_comma = self.key_values_with_comma().collect_vec();
+        let equal_alignment_width = f.key_value_equal_alignment_width(
+            key_values_with_comma.iter().map(|(key_value, _)| key_value),
+        );
+        let trailing_comment_alignment_width = f.trailing_comment_alignment_width(
+            key_values_with_comma.iter().map(|(key_value, _)| key_value),
+            equal_alignment_width,
+        )?;
 
-        for (i, key_value) in key_values.iter().enumerate() {
+        for (i, (key_value, comma)) in key_values_with_comma.iter().enumerate() {
             if i != 0 {
                 write!(f, "{}", f.line_ending())?;
             }
@@ -64,6 +68,45 @@ impl Format for tombi_ast::KeyValueGroup {
                 trailing_comment_alignment_width,
             }
             .format(f)?;
+
+            if let Some(comma) = comma {
+                let leading_comments = comma.leading_comments().collect_vec();
+                let key_value_has_trailing_comment = key_value.trailing_comment().is_some();
+                if let Some(trailing_comment) = comma.trailing_comment() {
+                    if leading_comments.is_empty() && !key_value_has_trailing_comment {
+                        if let Some(trailing_comment_alignment_width) =
+                            trailing_comment_alignment_width
+                        {
+                            write_trailing_comment_alignment_space(
+                                f,
+                                trailing_comment_alignment_width,
+                            )?;
+                        }
+                        trailing_comment.format(f)?;
+                    } else {
+                        write!(f, "{}", f.line_ending())?;
+                        if !leading_comments.is_empty() {
+                            leading_comments.format(f)?;
+                        }
+                        f.write_indent()?;
+                        write!(f, ",")?;
+                        if let Some(trailing_comment_alignment_width) =
+                            trailing_comment_alignment_width
+                        {
+                            write_trailing_comment_alignment_space(
+                                f,
+                                trailing_comment_alignment_width,
+                            )?;
+                        }
+                        trailing_comment.format(f)?;
+                    }
+                } else if !leading_comments.is_empty() {
+                    write!(f, "{}", f.line_ending())?;
+                    leading_comments.format(f)?;
+                    f.write_indent()?;
+                    write!(f, ",")?;
+                }
+            }
         }
 
         Ok(())

--- a/crates/tombi-formatter/src/format/table.rs
+++ b/crates/tombi-formatter/src/format/table.rs
@@ -101,6 +101,80 @@ mod tests {
 
     test_format! {
         #[tokio::test]
+        async fn table_removes_trailing_commas(
+            r#"
+            [package]
+            name = "toml-rs",
+            version = "0.4.0",
+            "#
+        ) -> Ok(
+            r#"
+            [package]
+            name = "toml-rs"
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_moves_comma_trailing_comment_to_key_value(
+            r#"
+            [package]
+            name = "toml-rs", # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [package]
+            name = "toml-rs"  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_keeps_comma_when_comma_has_leading_comment(
+            r#"
+            [package]
+            name = "toml-rs"
+            # comma leading comment
+            , # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [package]
+            name = "toml-rs"
+            # comma leading comment
+            ,  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_keeps_comma_when_both_key_value_and_comma_have_trailing_comments(
+            r#"
+            [package]
+            name = "toml-rs" # key trailing comment
+            , # comma trailing comment
+            version = "0.4.0"
+            "#
+        ) -> Ok(
+            r#"
+            [package]
+            name = "toml-rs"  # key trailing comment
+            ,  # comma trailing comment
+            version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn table_with_full_comment(
             r#"
             # header leading comment1

--- a/crates/tombi-linter/src/diagnostic.rs
+++ b/crates/tombi-linter/src/diagnostic.rs
@@ -4,6 +4,8 @@ pub enum DiagnosticKind {
     DottedKeysOutOfOrder,
     #[error("Defining tables out-of-order is discouraged")]
     TablesOutOfOrder,
+    #[error("trailing comma after key-value not allowed")]
+    ForbiddenKeyValueTrailingComma,
     #[error("inline table must be single line in TOML v1.0.0 or earlier")]
     InlineTableMustSingleLine,
     #[error("trailing comma in inline table not allowed in TOML v1.0.0 or earlier")]
@@ -26,6 +28,7 @@ impl Diagnostic {
         match self.kind {
             DiagnosticKind::DottedKeysOutOfOrder => "dotted-keys-out-of-order",
             DiagnosticKind::TablesOutOfOrder => "tables-out-of-order",
+            DiagnosticKind::ForbiddenKeyValueTrailingComma => "forbidden-key-value-trailing-comma",
             DiagnosticKind::InlineTableMustSingleLine => "inline-table-must-single-line",
             DiagnosticKind::ForbiddenInlineTableLastComma => "forbidden-inline-table-last-comma",
             DiagnosticKind::MissingArrayComma => "missing-array-comma",

--- a/crates/tombi-linter/src/diagnostic.rs
+++ b/crates/tombi-linter/src/diagnostic.rs
@@ -4,7 +4,7 @@ pub enum DiagnosticKind {
     DottedKeysOutOfOrder,
     #[error("Defining tables out-of-order is discouraged")]
     TablesOutOfOrder,
-    #[error("trailing comma after key-value not allowed")]
+    #[error("Trailing comma after key-value is not allowed")]
     ForbiddenKeyValueTrailingComma,
     #[error("inline table must be single line in TOML v1.0.0 or earlier")]
     InlineTableMustSingleLine,

--- a/crates/tombi-linter/src/lint/array_of_table.rs
+++ b/crates/tombi-linter/src/lint/array_of_table.rs
@@ -6,6 +6,7 @@ impl Lint for tombi_ast::ArrayOfTable {
     fn lint<'a: 'b, 'b>(&'a self, l: &'a mut crate::Linter<'_>) -> tombi_future::BoxFuture<'b, ()> {
         async move {
             crate::rule::DottedKeysOutOfOrderRule::check(self, l).await;
+            crate::rule::TrailingCommaRule::check(self, l).await;
 
             for key_value in self.key_values() {
                 key_value.lint(l).await;

--- a/crates/tombi-linter/src/lint/root.rs
+++ b/crates/tombi-linter/src/lint/root.rs
@@ -7,6 +7,7 @@ impl Lint for tombi_ast::Root {
         async move {
             crate::rule::DottedKeysOutOfOrderRule::check(self, l).await;
             crate::rule::TablesOutOfOrderRule::check(self, l).await;
+            crate::rule::TrailingCommaRule::check(self, l).await;
 
             for key_value in self.key_values() {
                 key_value.lint(l).await;

--- a/crates/tombi-linter/src/lint/table.rs
+++ b/crates/tombi-linter/src/lint/table.rs
@@ -6,6 +6,7 @@ impl Lint for tombi_ast::Table {
     fn lint<'a: 'b, 'b>(&'a self, l: &'a mut crate::Linter<'_>) -> tombi_future::BoxFuture<'b, ()> {
         async move {
             crate::rule::DottedKeysOutOfOrderRule::check(self, l).await;
+            crate::rule::TrailingCommaRule::check(self, l).await;
 
             for key_value in self.key_values() {
                 key_value.lint(l).await;

--- a/crates/tombi-linter/src/rule.rs
+++ b/crates/tombi-linter/src/rule.rs
@@ -2,10 +2,12 @@ mod dotted_keys_out_of_order;
 mod inline_table_toml_version;
 mod missing_comma;
 mod tables_out_of_order;
+mod trailing_comma;
 pub use dotted_keys_out_of_order::DottedKeysOutOfOrderRule;
 pub use inline_table_toml_version::InlineTableTomlVersionRule;
 pub use missing_comma::MissingCommaRule;
 pub use tables_out_of_order::TablesOutOfOrderRule;
+pub use trailing_comma::TrailingCommaRule;
 
 pub trait Rule<N> {
     async fn check(node: &N, l: &mut crate::Linter<'_>);

--- a/crates/tombi-linter/src/rule/trailing_comma.rs
+++ b/crates/tombi-linter/src/rule/trailing_comma.rs
@@ -1,0 +1,95 @@
+use tombi_ast::DanglingCommentGroupOr;
+use tombi_config::SeverityLevel;
+
+use crate::{Diagnostic, DiagnosticKind, Rule};
+
+pub struct TrailingCommaRule;
+
+fn check_key_value_groups(
+    groups: impl Iterator<Item = DanglingCommentGroupOr<tombi_ast::KeyValueGroup>>,
+    l: &mut crate::Linter<'_>,
+) {
+    for group in groups {
+        let DanglingCommentGroupOr::ItemGroup(key_value_group) = group else {
+            continue;
+        };
+
+        for (_, comma) in key_value_group.key_values_with_comma() {
+            let Some(comma) = comma else {
+                continue;
+            };
+
+            l.extend_diagnostics(Diagnostic {
+                kind: DiagnosticKind::ForbiddenKeyValueTrailingComma,
+                level: SeverityLevel::Error,
+                range: comma.range(),
+            });
+        }
+    }
+}
+
+impl Rule<tombi_ast::Root> for TrailingCommaRule {
+    async fn check(node: &tombi_ast::Root, l: &mut crate::Linter<'_>) {
+        check_key_value_groups(node.key_value_groups(), l);
+    }
+}
+
+impl Rule<tombi_ast::Table> for TrailingCommaRule {
+    async fn check(node: &tombi_ast::Table, l: &mut crate::Linter<'_>) {
+        check_key_value_groups(node.key_value_groups(), l);
+    }
+}
+
+impl Rule<tombi_ast::ArrayOfTable> for TrailingCommaRule {
+    async fn check(node: &tombi_ast::ArrayOfTable, l: &mut crate::Linter<'_>) {
+        check_key_value_groups(node.key_value_groups(), l);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_lint;
+
+    test_lint! {
+        #[test]
+        fn root_key_value_trailing_comma(
+            r#"
+            key1 = 1,
+            key2 = 2
+            "#
+        ) -> Err([crate::DiagnosticKind::ForbiddenKeyValueTrailingComma])
+    }
+
+    test_lint! {
+        #[test]
+        fn table_key_value_trailing_comma(
+            r#"
+            [package]
+            name = "toml-rs",
+            version = "0.4.0"
+            "#
+        ) -> Err([crate::DiagnosticKind::ForbiddenKeyValueTrailingComma])
+    }
+
+    test_lint! {
+        #[test]
+        fn array_of_table_key_value_trailing_comma(
+            r#"
+            [[package]]
+            name = "toml-rs",
+            version = "0.4.0"
+            "#
+        ) -> Err([crate::DiagnosticKind::ForbiddenKeyValueTrailingComma])
+    }
+
+    test_lint! {
+        #[test]
+        fn key_value_without_trailing_comma_ok(
+            r#"
+            [package]
+            name = "toml-rs"
+            version = "0.4.0"
+            "#
+        ) -> Ok(_)
+    }
+}

--- a/crates/tombi-linter/src/rule/trailing_comma.rs
+++ b/crates/tombi-linter/src/rule/trailing_comma.rs
@@ -19,11 +19,13 @@ fn check_key_value_groups(
                 continue;
             };
 
-            l.extend_diagnostics(Diagnostic {
-                kind: DiagnosticKind::ForbiddenKeyValueTrailingComma,
-                level: SeverityLevel::Error,
-                range: comma.range(),
-            });
+            if let Some(comma_token) = comma.comma() {
+                l.extend_diagnostics(Diagnostic {
+                    kind: DiagnosticKind::ForbiddenKeyValueTrailingComma,
+                    level: SeverityLevel::Error,
+                    range: comma_token.range(),
+                });
+            }
         }
     }
 }

--- a/crates/tombi-parser/src/parse/array_of_table.rs
+++ b/crates/tombi-parser/src/parse/array_of_table.rs
@@ -113,6 +113,65 @@ mod test {
 
     test_parser! {
         #[test]
+        fn array_of_table_multi_keys_with_trailing_commas(
+            r#"
+            [[package]]
+            name = "toml-rs",
+            version = "0.4.0",
+            "#
+        ) -> Ok(
+            {
+                ARRAY_OF_TABLE: {
+                    DOUBLE_BRACKET_START: "[[",
+                    KEYS: {
+                        BARE_KEY: {
+                            BARE_KEY: "package"
+                        }
+                    },
+                    DOUBLE_BRACKET_END: "]]",
+                    LINE_BREAK: "\n",
+                    KEY_VALUE_GROUP: {
+                        KEY_VALUE: {
+                            KEYS: {
+                                BARE_KEY: {
+                                    BARE_KEY: "name"
+                                }
+                            },
+                            WHITESPACE: " ",
+                            EQUAL: "=",
+                            WHITESPACE: " ",
+                            BASIC_STRING: {
+                                BASIC_STRING: "\"toml-rs\""
+                            }
+                        },
+                        COMMA: {
+                            COMMA: ","
+                        },
+                        KEY_VALUE: {
+                            LINE_BREAK: "\n",
+                            KEYS: {
+                                BARE_KEY: {
+                                    BARE_KEY: "version"
+                                }
+                            },
+                            WHITESPACE: " ",
+                            EQUAL: "=",
+                            WHITESPACE: " ",
+                            BASIC_STRING: {
+                                BASIC_STRING: "\"0.4.0\""
+                            }
+                        },
+                        COMMA: {
+                            COMMA: ","
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    test_parser! {
+        #[test]
         fn hex_like_array_of_table_key(
             r#"
             [[0x96f]]

--- a/crates/tombi-parser/src/parse/key_value_group.rs
+++ b/crates/tombi-parser/src/parse/key_value_group.rs
@@ -1,4 +1,4 @@
-use tombi_syntax::SyntaxKind::*;
+use tombi_syntax::{SyntaxKind::*, T};
 
 use crate::{
     parse::{Parse, is_group_separator},
@@ -17,6 +17,11 @@ impl Parse for tombi_ast::KeyValueGroup {
             }
 
             tombi_ast::KeyValue::parse(p);
+
+            let n = peek_leading_comments(p);
+            if p.nth_at(n, T![,]) {
+                tombi_ast::Comma::parse(p);
+            }
 
             if !p.at(LINE_BREAK) {
                 break;

--- a/crates/tombi-parser/src/parse/table.rs
+++ b/crates/tombi-parser/src/parse/table.rs
@@ -131,6 +131,65 @@ mod test {
 
     test_parser! {
         #[test]
+        fn table_multi_keys_with_trailing_commas(
+            r#"
+            [package]
+            name = "toml-rs",
+            version = "0.4.0",
+            "#
+        ) -> Ok(
+            {
+                TABLE: {
+                    BRACKET_START: "[",
+                    KEYS: {
+                        BARE_KEY: {
+                            BARE_KEY: "package"
+                        }
+                    },
+                    BRACKET_END: "]",
+                    LINE_BREAK: "\n",
+                    KEY_VALUE_GROUP: {
+                        KEY_VALUE: {
+                            KEYS: {
+                                BARE_KEY: {
+                                    BARE_KEY: "name"
+                                }
+                            },
+                            WHITESPACE: " ",
+                            EQUAL: "=",
+                            WHITESPACE: " ",
+                            BASIC_STRING: {
+                                BASIC_STRING: "\"toml-rs\""
+                            }
+                        },
+                        COMMA: {
+                            COMMA: ","
+                        },
+                        KEY_VALUE: {
+                            LINE_BREAK: "\n",
+                            KEYS: {
+                                BARE_KEY: {
+                                    BARE_KEY: "version"
+                                }
+                            },
+                            WHITESPACE: " ",
+                            EQUAL: "=",
+                            WHITESPACE: " ",
+                            BASIC_STRING: {
+                                BASIC_STRING: "\"0.4.0\""
+                            }
+                        },
+                        COMMA: {
+                            COMMA: ","
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    test_parser! {
+        #[test]
         fn hex_like_table_key(
             r#"
             [0x96f]


### PR DESCRIPTION
Parses commas after table, array-of-table, and root key-value entries so they can be formatted or diagnosed consistently. Adds formatter behavior to remove key-value trailing commas while preserving comma comments when needed. Adds a linter rule for forbidden key-value trailing commas and avoids no-op table key order edits when sorted order is unchanged.\n\nTests: cargo test -p tombi-parser table_multi_keys_with_trailing_commas; cargo test -p tombi-parser array_of_table_multi_keys_with_trailing_commas; cargo test -p tombi-formatter removes_trailing_commas; cargo test -p tombi-linter trailing_comma