### PR TITLE
Fix pyproject uv source child hover

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/members/my-package1/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/members/my-package1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "my-package1"
+version = "0.1.0"
+description = "A test package used by hover fixtures."

--- a/crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "workspace"
+version = "0.1.0"
+
+[tool.uv.workspace]
+members = ["members/my-package1"]
+
+[tool.uv.sources]
+my-package1 = { workspace = true }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -799,6 +799,49 @@ mod hover_keys_value {
 
         test_hover_keys_value!(
             #[tokio::test]
+            async fn pyproject_source_package_key_hover_metadata(
+                r#"
+                [tool.uv.workspace]
+                members = ["members/my-package1"]
+
+                [tool.uv.sources]
+                my-package1█ = { workspace = true }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/pyproject.toml"
+                )),
+                SchemaPath(pyproject_schema_path()),
+            ) -> Ok({
+                "Keys": "tool.uv.sources.my-package1",
+                "Value": "(Table | Array)?",
+                "Title": Some("my-package1"),
+                "Description": Some("A test package used by hover fixtures."),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn pyproject_source_child_field_hover_keeps_schema_metadata(
+                r#"
+                [tool.uv.workspace]
+                members = ["members/my-package1"]
+
+                [tool.uv.sources]
+                my-package1.workspace█ = true
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/pyproject-hover-metadata/pyproject.toml"
+                )),
+                SchemaPath(pyproject_schema_path()),
+            ) -> Ok({
+                "Keys": "tool.uv.sources.my-package1.workspace",
+                "Value": "Boolean",
+                "Description": Some("When set to `false`, the package will be fetched from the remote index, rather than\nincluded as a workspace package."),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
             async fn pyproject_workspace_dependency_hover_metadata_disabled_by_extensions(
                 r#"
                 [project]

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -44,9 +44,13 @@ pub async fn hover(
     if matches_accessors!(accessors, ["tool", "uv", "sources", _])
         || matches_accessors!(accessors, ["tool", "uv", "sources", _, _])
     {
-        if !is_hovering_source_package_key(document_tree, &accessors[..4], position) {
-            return Ok(None);
-        }
+        if let Some((_, tombi_document_tree::Value::Table(table))) =
+            dig_accessors(document_tree, &accessors[..3])
+        {
+            if table.keys().all(|key| !key.range().contains(position)) {
+                return Ok(None);
+            }
+        };
 
         return Ok(resolve_pyproject_source_metadata(
             document_tree,
@@ -89,25 +93,6 @@ pub async fn hover(
     }
 
     fetch_pypi_metadata(package_name, offline, cache_options).await
-}
-
-fn is_hovering_source_package_key(
-    document_tree: &tombi_document_tree::DocumentTree,
-    source_accessors: &[Accessor],
-    position: tombi_text::Position,
-) -> bool {
-    let source_keys = source_accessors
-        .iter()
-        .map(Accessor::as_key)
-        .collect::<Option<Vec<_>>>();
-    let Some(source_keys) = source_keys else {
-        return false;
-    };
-    let Some((source_key, _)) = dig_keys(document_tree, &source_keys) else {
-        return false;
-    };
-
-    source_key.range().contains(position)
 }
 
 fn resolve_pyproject_dependency_metadata_from_sources(

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -28,7 +28,7 @@ pub async fn hover(
     text_document_uri: &tombi_uri::Uri,
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[Accessor],
-    _position: tombi_text::Position,
+    position: tombi_text::Position,
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
@@ -44,6 +44,10 @@ pub async fn hover(
     if matches_accessors!(accessors, ["tool", "uv", "sources", _])
         || matches_accessors!(accessors, ["tool", "uv", "sources", _, _])
     {
+        if !is_hovering_source_package_key(document_tree, &accessors[..4], position) {
+            return Ok(None);
+        }
+
         return Ok(resolve_pyproject_source_metadata(
             document_tree,
             &accessors[..4],
@@ -85,6 +89,25 @@ pub async fn hover(
     }
 
     fetch_pypi_metadata(package_name, offline, cache_options).await
+}
+
+fn is_hovering_source_package_key(
+    document_tree: &tombi_document_tree::DocumentTree,
+    source_accessors: &[Accessor],
+    position: tombi_text::Position,
+) -> bool {
+    let source_keys = source_accessors
+        .iter()
+        .map(Accessor::as_key)
+        .collect::<Option<Vec<_>>>();
+    let Some(source_keys) = source_keys else {
+        return false;
+    };
+    let Some((source_key, _)) = dig_keys(document_tree, &source_keys) else {
+        return false;
+    };
+
+    source_key.range().contains(position)
 }
 
 fn resolve_pyproject_dependency_metadata_from_sources(


### PR DESCRIPTION
## Summary
- Limit pyproject uv source package metadata hover to the package key itself.
- Let child fields such as workspace keep their schema-provided hover metadata.
- Add generic my-package1 hover fixtures and coverage for package-key vs child-field behavior.

## Tests
- cargo fmt
- cargo test -p tombi-lsp pyproject_source_ --test test_hover
- cargo test -p tombi-lsp pyproject_ --test test_hover
- cargo test -p tombi-extension-pyproject