### PR TITLE
Move workspace lint settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ xshell.version = "0.2.7"
 zed_extension_api = "0.7.0"
 zip = { version = "2.3.0" }
 
+[workspace.lints.rust]
+aarch64_softfloat_neon = "warn"
+deprecated = "warn"
+
 [workspace.metadata.cargo-shear]
 ignored = [
   "semver",
@@ -138,7 +142,3 @@ ignored = [
   "wasm-bindgen",
   "wasm-bindgen-futures",
 ]
-
-[workspace.lints.rust]
-aarch64_softfloat_neon = "warn"
-deprecated = "warn"


### PR DESCRIPTION
## Summary
- Move the workspace Rust lint settings above the cargo-shear metadata block in Cargo.toml.
- Keep the existing lint values unchanged.

## Tests
- Not run; configuration ordering only.