### PR TITLE
Preserve TOML 1.0 inline table comments

### DIFF
--- a/crates/tombi-ast/src/impls/inline_table.rs
+++ b/crates/tombi-ast/src/impls/inline_table.rs
@@ -90,7 +90,7 @@ impl crate::InlineTable {
     #[inline]
     pub fn should_be_multiline(&self, toml_version: TomlVersion) -> bool {
         if toml_version == TomlVersion::V1_0_0 {
-            return false;
+            return self.has_inner_comments();
         }
 
         self.has_last_key_value_trailing_comma()

--- a/crates/tombi-ast/src/impls/inline_table.rs
+++ b/crates/tombi-ast/src/impls/inline_table.rs
@@ -152,7 +152,7 @@ impl crate::InlineTable {
     }
 
     #[inline]
-    pub fn has_direct_inner_comments(&self) -> bool {
+    fn has_direct_inner_comments(&self) -> bool {
         self.brace_start_trailing_comment().is_some()
             || self.dangling_comment_groups().next().is_some()
             || self

--- a/crates/tombi-ast/src/impls/inline_table.rs
+++ b/crates/tombi-ast/src/impls/inline_table.rs
@@ -155,16 +155,20 @@ impl crate::InlineTable {
     fn has_direct_inner_comments(&self) -> bool {
         self.brace_start_trailing_comment().is_some()
             || self.dangling_comment_groups().next().is_some()
-            || self
-                .key_value_with_comma_groups()
-                .any(|group| matches!(group, DanglingCommentGroupOr::DanglingCommentGroup(_)))
-            || self.key_values_with_comma().any(|(key_value, comma)| {
-                key_value.leading_comments().next().is_some()
-                    || key_value.trailing_comment().is_some()
-                    || comma.is_some_and(|comma| {
-                        comma.leading_comments().next().is_some()
-                            || comma.trailing_comment().is_some()
-                    })
+            || self.key_value_with_comma_groups().any(|group| match group {
+                DanglingCommentGroupOr::DanglingCommentGroup(_) => true,
+                DanglingCommentGroupOr::ItemGroup(group) => {
+                    group
+                        .into_key_values_with_comma()
+                        .any(|(key_value, comma)| {
+                            key_value.leading_comments().next().is_some()
+                                || key_value.trailing_comment().is_some()
+                                || comma.is_some_and(|comma| {
+                                    comma.leading_comments().next().is_some()
+                                        || comma.trailing_comment().is_some()
+                                })
+                        })
+                }
             })
     }
 

--- a/crates/tombi-ast/src/impls/inline_table.rs
+++ b/crates/tombi-ast/src/impls/inline_table.rs
@@ -90,7 +90,7 @@ impl crate::InlineTable {
     #[inline]
     pub fn should_be_multiline(&self, toml_version: TomlVersion) -> bool {
         if toml_version == TomlVersion::V1_0_0 {
-            return self.has_inner_comments();
+            return self.has_direct_inner_comments();
         }
 
         self.has_last_key_value_trailing_comma()
@@ -149,6 +149,23 @@ impl crate::InlineTable {
     #[inline]
     pub fn has_inner_comments(&self) -> bool {
         support::comment::has_inner_comments(self.syntax().children_with_tokens(), T!('{'), T!('}'))
+    }
+
+    #[inline]
+    pub fn has_direct_inner_comments(&self) -> bool {
+        self.brace_start_trailing_comment().is_some()
+            || self.dangling_comment_groups().next().is_some()
+            || self
+                .key_value_with_comma_groups()
+                .any(|group| matches!(group, DanglingCommentGroupOr::DanglingCommentGroup(_)))
+            || self.key_values_with_comma().any(|(key_value, comma)| {
+                key_value.leading_comments().next().is_some()
+                    || key_value.trailing_comment().is_some()
+                    || comma.is_some_and(|comma| {
+                        comma.leading_comments().next().is_some()
+                            || comma.trailing_comment().is_some()
+                    })
+            })
     }
 
     /// Returns `true` if there are `LINE_BREAK` tokens at inline-table level

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -312,6 +312,114 @@ mod tests {
 
     test_format! {
         #[tokio::test]
+        async fn inline_table_inner_comment_only_v1_0_0(
+            r#"
+            inline_table = {
+              # comment
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_comma_trailing_comment_v1_0_0(
+            r#"
+            zip = {
+              version = "2.3.0",  # comment
+              features = []
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_moves_key_value_trailing_comment_to_comma_v1_0_0(
+            r#"
+            zip = {
+              version = "2.3.0"  # comment
+              ,
+              features = []
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(
+            r#"
+            zip = {
+              version = "2.3.0",  # comment
+              features = []
+            }
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_keeps_comma_when_key_value_and_comma_have_trailing_comments_v1_0_0(
+            r#"
+            zip = {
+              version = "2.3.0"  # key comment
+              ,  # comma comment
+              features = []
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(
+            r#"
+            zip = {
+              version = "2.3.0"  # key comment
+              ,  # comma comment
+              features = []
+            }
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_keeps_comma_when_comma_has_leading_comment_v1_0_0(
+            r#"
+            zip = {
+              version = "2.3.0"
+              # comma leading comment
+              ,  # comma trailing comment
+              features = []
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(
+            r#"
+            zip = {
+              version = "2.3.0"
+              # comma leading comment
+              ,  # comma trailing comment
+              features = []
+            }
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_end_dangling_comment_after_trailing_comma_v1_0_0(
+            r#"
+            zip = {
+              version = "2.3.0",
+
+              # comment
+            }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_trailing_comment_stays_singleline_v1_0_0(
+            r#"zip = { version = "2.3.0" }  # comment"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn inline_table_exceeds_line_width_v1_0_0(
             r#"table = { key1 = 1111111111, key2 = 2222222222, key3 = 3333333333 }"#,
             TomlVersion::V1_0_0,

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -435,6 +435,54 @@ mod tests {
 
     test_format! {
         #[tokio::test]
+        async fn nested_inline_table_array_singleline_array_singleline_v1_0_0(
+            r#"root = { items = [{ values = [1, 2] }] }"#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn nested_inline_table_array_multiline_array_singleline_v1_0_0(
+            r#"
+            root = { items = [
+              { values = [1, 2] },
+            ] }
+            "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn nested_inline_table_array_singleline_array_multiline_v1_0_0(
+            r#"
+            root = { items = [{ values = [
+              1,
+              2,
+            ] }] }
+            "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn nested_inline_table_array_multiline_array_multiline_v1_0_0(
+            r#"
+            root = { items = [
+              { values = [
+                1,
+                2,
+              ] },
+            ] }
+            "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn inline_table_exceeds_line_width_v1_0_0(
             r#"table = { key1 = 1111111111, key2 = 2222222222, key3 = 3333333333 }"#,
             TomlVersion::V1_0_0,

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -420,6 +420,21 @@ mod tests {
 
     test_format! {
         #[tokio::test]
+        async fn inline_table_with_commented_array_stays_singleline_v1_0_0(
+            r#"
+            zip = { version = "2.3.0", features = [
+              # comment
+
+              "std",
+              "derive",
+            ] }
+            "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn inline_table_exceeds_line_width_v1_0_0(
             r#"table = { key1 = 1111111111, key2 = 2222222222, key3 = 3333333333 }"#,
             TomlVersion::V1_0_0,


### PR DESCRIPTION
Preserves multiline formatting for TOML 1.0 inline tables when inner comments are present, so formatter output does not drop comment placement. Adds formatter coverage for comma comments, key-value comments moved to commas, comma leading comments, dangling comments, and outer trailing comments.\n\nTests run: cargo test -p tombi-formatter inline_table_ -- --nocapture; cargo test -p tombi-ast; cargo fmt --check.