### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/tombi-ast/src/impls/comment.rs
+++ b/crates/tombi-ast/src/impls/comment.rs
@@ -179,7 +179,7 @@ fn resolve_relative_file_schema_uri(
             .map(tombi_uri::SchemaUri::from)
             .map_err(|_| uri_text.to_string())
     } else {
-        return Err(uri_text.to_string());
+        Err(uri_text.to_string())
     }
 }
 

--- a/crates/tombi-config/src/types/bool_default_false.rs
+++ b/crates/tombi-config/src/types/bool_default_false.rs
@@ -2,18 +2,13 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(extend("default" = false)))]
+#[derive(Default)]
 pub struct BoolDefaultFalse(pub bool);
 
 impl BoolDefaultFalse {
     #[inline]
     pub fn value(&self) -> bool {
         self.0
-    }
-}
-
-impl Default for BoolDefaultFalse {
-    fn default() -> Self {
-        Self(false)
     }
 }
 

--- a/crates/tombi-extension/src/completion.rs
+++ b/crates/tombi-extension/src/completion.rs
@@ -682,9 +682,7 @@ pub fn completion_file_path(
     let Ok(source_path) = text_document_uri.to_file_path() else {
         return None;
     };
-    let Some(base_dir) = source_path.parent() else {
-        return None;
-    };
+    let base_dir = source_path.parent()?;
 
     let Some((_, tombi_document_tree::Value::String(string))) =
         dig_accessors(document_tree, accessors)

--- a/crates/tombi-lsp/src/comment_directive.rs
+++ b/crates/tombi-lsp/src/comment_directive.rs
@@ -165,9 +165,7 @@ where
     TombiValueDirectiveContent<WithKeyFormatRules<FormatRules>, WithKeyLintRules<LintRules>>:
         TombiCommentDirectiveImpl,
 {
-    let Some(comment_directives) = comment_directives else {
-        return None;
-    };
+    let comment_directives = comment_directives?;
 
     for comment_directive in comment_directives {
         if let Some(comment_directive_context) = comment_directive.get_context(position) {
@@ -198,9 +196,7 @@ where
     TombiValueDirectiveContent<WithKeyFormatRules<FormatRules>, WithKeyTableLintRules<LintRules>>:
         TombiCommentDirectiveImpl,
 {
-    let Some(comment_directives) = comment_directives else {
-        return None;
-    };
+    let comment_directives = comment_directives?;
 
     for comment_directive in comment_directives {
         if let Some(comment_directive_context) = comment_directive.get_context(position) {

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -251,7 +251,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                                 let Some(mut contents) =
                                                     collect_table_key_completion_contents(
                                                         self,
-                                                        &key_name,
+                                                        key_name,
                                                         position,
                                                         current_editing_key_range(keys, position),
                                                         accessors,
@@ -601,7 +601,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                 if let Some((title, description, deprecated)) = online_ref_metadata
                                 {
                                     completion_contents.push(CompletionContent::new_key(
-                                        &key_name,
+                                        key_name,
                                         position,
                                         current_editing_key_range(keys, position),
                                         title,
@@ -626,7 +626,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                 {
                                     let Some(contents) = collect_table_key_completion_contents(
                                         self,
-                                        &key_name,
+                                        key_name,
                                         position,
                                         current_editing_key_range(keys, position),
                                         accessors,

--- a/crates/tombi-lsp/src/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/goto_type_definition.rs
@@ -136,9 +136,7 @@ pub(super) async fn adjacent_type_definition<
     any_of_schema: Option<&AnyOfSchema>,
     all_of_schema: Option<&AllOfSchema>,
 ) -> Option<TypeDefinition> {
-    let Some(current_schema) = current_schema else {
-        return None;
-    };
+    let current_schema = current_schema?;
 
     if let Some(one_of_schema) = one_of_schema
         && let Some(type_definition) = one_of::get_one_of_type_definition(

--- a/crates/tombi-lsp/src/goto_type_definition/all_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/all_of.rs
@@ -33,7 +33,7 @@ where
     async move {
         let mut all_of_type_definition = None;
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &all_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -41,10 +41,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(type_definition) = value

--- a/crates/tombi-lsp/src/goto_type_definition/any_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/any_of.rs
@@ -31,7 +31,7 @@ where
     log::trace!("schema_uri: {:?}", schema_uri);
 
     async move {
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &any_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -39,10 +39,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(type_definition) = value

--- a/crates/tombi-lsp/src/goto_type_definition/one_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/one_of.rs
@@ -31,7 +31,7 @@ where
     log::trace!("schema_uri: {:?}", schema_uri);
 
     async move {
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &one_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -39,10 +39,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(type_definition) = value

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -205,8 +205,8 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         });
                                 }
 
-                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                                    if let Some(type_definition) = get_one_of_type_definition(
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref()
+                                    && let Some(type_definition) = get_one_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -217,12 +217,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(type_definition);
-                                    }
+                                {
+                                    return Some(type_definition);
                                 }
-                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                                    if let Some(type_definition) = get_any_of_type_definition(
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref()
+                                    && let Some(type_definition) = get_any_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -233,12 +232,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(type_definition);
-                                    }
+                                {
+                                    return Some(type_definition);
                                 }
-                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                    if let Some(type_definition) = get_all_of_type_definition(
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref()
+                                    && let Some(type_definition) = get_all_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -249,9 +247,8 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(type_definition);
-                                    }
+                                {
+                                    return Some(type_definition);
                                 }
 
                                 if let Some(current_schema) =
@@ -313,8 +310,8 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                 return type_definition;
                             }
 
-                            if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                                if let Some(type_definition) = get_one_of_type_definition(
+                            if let Some(one_of_schema) = table_schema.one_of.as_deref()
+                                && let Some(type_definition) = get_one_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -325,12 +322,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
-                                {
-                                    return Some(type_definition);
-                                }
+                            {
+                                return Some(type_definition);
                             }
-                            if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                                if let Some(type_definition) = get_any_of_type_definition(
+                            if let Some(any_of_schema) = table_schema.any_of.as_deref()
+                                && let Some(type_definition) = get_any_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -341,12 +337,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
-                                {
-                                    return Some(type_definition);
-                                }
+                            {
+                                return Some(type_definition);
                             }
-                            if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                if let Some(type_definition) = get_all_of_type_definition(
+                            if let Some(all_of_schema) = table_schema.all_of.as_deref()
+                                && let Some(type_definition) = get_all_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -357,9 +352,8 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
-                                {
-                                    return Some(type_definition);
-                                }
+                            {
+                                return Some(type_definition);
                             }
 
                             None

--- a/crates/tombi-lsp/src/handler/inlay_hint.rs
+++ b/crates/tombi-lsp/src/handler/inlay_hint.rs
@@ -40,8 +40,8 @@ pub async fn handle_inlay_hint(
         )
     };
 
-    if config.cargo_inlay_hint_enabled() {
-        if let Some(hints) = tombi_extension_cargo::inlay_hint(
+    if config.cargo_inlay_hint_enabled()
+        && let Some(hints) = tombi_extension_cargo::inlay_hint(
             &text_document_uri,
             &document_tree,
             visible_range,
@@ -51,13 +51,12 @@ pub async fn handle_inlay_hint(
             config.cargo_extension_features(),
         )
         .await?
-        {
-            return Ok(Some(hints));
-        }
+    {
+        return Ok(Some(hints));
     }
 
-    if config.pyproject_inlay_hint_enabled() {
-        if let Some(hints) = tombi_extension_pyproject::inlay_hint(
+    if config.pyproject_inlay_hint_enabled()
+        && let Some(hints) = tombi_extension_pyproject::inlay_hint(
             &text_document_uri,
             &document_tree,
             visible_range,
@@ -65,9 +64,8 @@ pub async fn handle_inlay_hint(
             config.pyproject_extension_features(),
         )
         .await?
-        {
-            return Ok(Some(hints));
-        }
+    {
+        return Ok(Some(hints));
     }
 
     Ok(None)

--- a/crates/tombi-lsp/src/hover/all_of.rs
+++ b/crates/tombi-lsp/src/hover/all_of.rs
@@ -36,7 +36,7 @@ where
         let mut enum_values = Vec::new();
         let mut result_accessors = tombi_schema_store::Accessors::from(accessors.to_vec());
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &all_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -44,10 +44,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(values) = resolved_schema
@@ -208,7 +205,7 @@ impl GetHoverContent for tombi_schema_store::AllOfSchema {
             let mut value_type_set = tombi_hashmap::IndexSet::new();
             let mut enum_values = Vec::new();
 
-            let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+            let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
                 &self.schemas,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
@@ -216,10 +213,7 @@ impl GetHoverContent for tombi_schema_store::AllOfSchema {
                 &schema_context.schema_visits,
                 accessors,
             )
-            .await
-            else {
-                return None;
-            };
+            .await?;
 
             for resolved_schema in &resolved_schemas {
                 if resolved_schema.value_schema.title().is_some()

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -44,7 +44,7 @@ where
             .as_ref()
             .and_then(|default| DisplayValue::try_from(default).ok());
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &any_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -52,10 +52,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(values) = resolved_schema
@@ -198,7 +195,7 @@ impl GetHoverContent for tombi_schema_store::AnyOfSchema {
                 .as_ref()
                 .and_then(|default| DisplayValue::try_from(default).ok());
 
-            let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+            let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
                 &self.schemas,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
@@ -206,10 +203,7 @@ impl GetHoverContent for tombi_schema_store::AnyOfSchema {
                 &schema_context.schema_visits,
                 accessors,
             )
-            .await
-            else {
-                return None;
-            };
+            .await?;
 
             for resolved_schema in &resolved_schemas {
                 if resolved_schema.value_schema.title().is_some()

--- a/crates/tombi-lsp/src/hover/display_value.rs
+++ b/crates/tombi-lsp/src/hover/display_value.rs
@@ -359,7 +359,7 @@ fn get_enum_from_schemas<'a: 'b, 'b>(
 ) -> tombi_future::BoxFuture<'b, Option<Vec<DisplayValue>>> {
     async move {
         let mut enum_values = Vec::new();
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             schemas,
             std::borrow::Cow::Borrowed(schema_uri),
             std::borrow::Cow::Borrowed(definitions),
@@ -367,10 +367,7 @@ fn get_enum_from_schemas<'a: 'b, 'b>(
             &schema_context.schema_visits,
             &[],
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved in &resolved_schemas {
             if let Some(values) = resolved

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -46,7 +46,7 @@ where
             .as_ref()
             .and_then(|default| DisplayValue::try_from(default).ok());
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &one_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -54,10 +54,7 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await
-        else {
-            return None;
-        };
+        .await?;
 
         for resolved_schema in &resolved_schemas {
             if let Some(values) = resolved_schema
@@ -238,7 +235,7 @@ impl GetHoverContent for tombi_schema_store::OneOfSchema {
                 .as_ref()
                 .and_then(|default| DisplayValue::try_from(default).ok());
 
-            let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
+            let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
                 &self.schemas,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
@@ -246,10 +243,7 @@ impl GetHoverContent for tombi_schema_store::OneOfSchema {
                 &schema_context.schema_visits,
                 accessors,
             )
-            .await
-            else {
-                return None;
-            };
+            .await?;
 
             for resolved_schema in &resolved_schemas {
                 if resolved_schema.value_schema.title().is_some()

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -136,8 +136,8 @@ impl GetHoverContent for tombi_document_tree::Array {
                                     };
                                 }
 
-                                if let Some(one_of_schema) = array_schema.one_of.as_deref() {
-                                    if let Some(hover_content) = get_one_of_hover_content(
+                                if let Some(one_of_schema) = array_schema.one_of.as_deref()
+                                    && let Some(hover_content) = get_one_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -148,13 +148,12 @@ impl GetHoverContent for tombi_document_tree::Array {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
 
-                                if let Some(any_of_schema) = array_schema.any_of.as_deref() {
-                                    if let Some(hover_content) = get_any_of_hover_content(
+                                if let Some(any_of_schema) = array_schema.any_of.as_deref()
+                                    && let Some(hover_content) = get_any_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -165,13 +164,12 @@ impl GetHoverContent for tombi_document_tree::Array {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
 
-                                if let Some(all_of_schema) = array_schema.all_of.as_deref() {
-                                    if let Some(hover_content) = get_all_of_hover_content(
+                                if let Some(all_of_schema) = array_schema.all_of.as_deref()
+                                    && let Some(hover_content) = get_all_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -182,9 +180,8 @@ impl GetHoverContent for tombi_document_tree::Array {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
 
                                 return value

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -378,8 +378,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     return hover_content;
                                 }
 
-                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                                    if let Some(hover_content) = get_one_of_hover_content(
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref()
+                                    && let Some(hover_content) = get_one_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -390,12 +390,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                                    if let Some(hover_content) = get_any_of_hover_content(
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref()
+                                    && let Some(hover_content) = get_any_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -406,12 +405,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                    if let Some(hover_content) = get_all_of_hover_content(
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref()
+                                    && let Some(hover_content) = get_all_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -422,9 +420,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
 
                                 if let Some(current_schema) =
@@ -492,8 +489,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     )
                                     .await
                             } else {
-                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                                    if let Some(hover_content) = get_one_of_hover_content(
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref()
+                                    && let Some(hover_content) = get_one_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -504,12 +501,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                                    if let Some(hover_content) = get_any_of_hover_content(
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref()
+                                    && let Some(hover_content) = get_any_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -520,12 +516,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                    if let Some(hover_content) = get_all_of_hover_content(
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref()
+                                    && let Some(hover_content) = get_all_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -536,9 +531,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
 
                                 None
@@ -567,8 +561,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                     );
                                 }
                             } else {
-                                if let Some(one_of_schema) = table_schema.one_of.as_deref() {
-                                    if let Some(hover_content) = get_one_of_hover_content(
+                                if let Some(one_of_schema) = table_schema.one_of.as_deref()
+                                    && let Some(hover_content) = get_one_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -579,12 +573,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(any_of_schema) = table_schema.any_of.as_deref() {
-                                    if let Some(hover_content) = get_any_of_hover_content(
+                                if let Some(any_of_schema) = table_schema.any_of.as_deref()
+                                    && let Some(hover_content) = get_any_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -595,12 +588,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
-                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                    if let Some(hover_content) = get_all_of_hover_content(
+                                if let Some(all_of_schema) = table_schema.all_of.as_deref()
+                                    && let Some(hover_content) = get_all_of_hover_content(
                                         self,
                                         position,
                                         keys,
@@ -611,9 +603,8 @@ impl GetHoverContent for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
-                                    {
-                                        return Some(hover_content);
-                                    }
+                                {
+                                    return Some(hover_content);
                                 }
                             }
 

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -245,18 +245,20 @@ pub(crate) fn bool_value_schema(allow: bool, range: tombi_text::Range) -> ValueS
     }
 }
 
+type AdjacentApplicators = (
+    Option<Box<OneOfSchema>>,
+    Option<Box<AnyOfSchema>>,
+    Option<Box<AllOfSchema>>,
+    Option<Box<NotSchema>>,
+);
+
 pub(crate) fn adjacent_applicators(
     object: &tombi_json::ObjectNode,
     string_formats: Option<&[tombi_x_keyword::StringFormat]>,
     dialect: Option<crate::JsonSchemaDialect>,
     mut anchor_collector: Option<&mut AnchorCollector>,
     mut dynamic_anchor_collector: Option<&mut DynamicAnchorCollector>,
-) -> (
-    Option<Box<OneOfSchema>>,
-    Option<Box<AnyOfSchema>>,
-    Option<Box<AllOfSchema>>,
-    Option<Box<NotSchema>>,
-) {
+) -> AdjacentApplicators {
     let one_of = object
         .get("oneOf")
         .is_some()

--- a/crates/tombi-schema-store/src/schema/not_schema.rs
+++ b/crates/tombi-schema-store/src/schema/not_schema.rs
@@ -16,8 +16,6 @@ impl NotSchema {
         anchor_collector: Option<&mut AnchorCollector>,
         dynamic_anchor_collector: Option<&mut DynamicAnchorCollector>,
     ) -> Option<Self> {
-        let anchor_collector = anchor_collector;
-        let dynamic_anchor_collector = dynamic_anchor_collector;
         object
             .get("not")
             .and_then(|value| {

--- a/crates/tombi-schema-store/src/schema/value_schema.rs
+++ b/crates/tombi-schema-store/src/schema/value_schema.rs
@@ -15,6 +15,7 @@ use crate::{
     schema::if_then_else_schema::IfThenElseSchema,
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ValueSchema {
     Boolean(BooleanSchema),
@@ -183,8 +184,8 @@ impl ValueSchema {
                 object,
                 string_formats,
                 dialect,
-                anchor_collector.as_deref_mut(),
-                dynamic_anchor_collector.as_deref_mut(),
+                anchor_collector,
+                dynamic_anchor_collector,
             )));
         }
 
@@ -196,11 +197,11 @@ impl ValueSchema {
     /// When "type" is not explicitly specified, we can infer the type from keywords
     /// that are only valid for specific types:
     /// - String: minLength, maxLength, pattern, format, contentEncoding,
-    ///           contentMediaType, contentSchema (content annotations)
+    ///   contentMediaType, contentSchema (content annotations)
     /// - Number: minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf
     /// - Array: items, prefixItems, minItems, maxItems, uniqueItems
     /// - Object: properties, patternProperties, additionalProperties, required,
-    ///           minProperties, maxProperties, propertyNames
+    ///   minProperties, maxProperties, propertyNames
     fn infer_type_from_keywords(
         object: &tombi_json::ObjectNode,
         dialect: Option<crate::JsonSchemaDialect>,

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -14,6 +14,9 @@ use tombi_config::{SchemaItem, SchemaOverviewOptions, TomlVersion};
 use tombi_future::{BoxFuture, Boxable};
 use tombi_uri::SchemaUri;
 
+type DocumentSchemas =
+    Arc<RwLock<tombi_hashmap::HashMap<SchemaUri, Result<Arc<DocumentSchema>, crate::Error>>>>;
+
 /// Options for associating a schema with file patterns
 #[derive(Debug, Clone, Default)]
 pub struct AssociateSchemaOptions {
@@ -27,11 +30,7 @@ pub struct AssociateSchemaOptions {
 #[derive(Debug, Clone)]
 pub struct SchemaStore {
     http_client: HttpClient,
-    document_schemas: Arc<
-        tokio::sync::RwLock<
-            tombi_hashmap::HashMap<SchemaUri, Result<Arc<DocumentSchema>, crate::Error>>,
-        >,
-    >,
+    document_schemas: DocumentSchemas,
     schemas: Arc<RwLock<Vec<crate::Schema>>>,
     options: crate::Options,
     base_dir_path: Arc<RwLock<Option<std::path::PathBuf>>>,

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 mod all_of;
 mod any_of;
 mod array;
@@ -505,12 +507,9 @@ where
     T: Validate + tombi_document_tree::ValueImpl + Sync + Send + std::fmt::Debug,
 {
     async move {
-        let Some(_cycle_guard) = schema_context
+        let _cycle_guard = schema_context
             .schema_visits
-            .get_value_schema_cycle_guard(&resolved_schema.value_schema)
-        else {
-            return None;
-        };
+            .get_value_schema_cycle_guard(&resolved_schema.value_schema)?;
 
         match (value.value_type(), resolved_schema.value_schema.as_ref()) {
             (tombi_document_tree::ValueType::Boolean, tombi_schema_store::ValueSchema::Boolean(_))

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 mod all_of;
 mod any_of;
 mod array;
@@ -176,6 +174,7 @@ pub fn handle_deprecated_value<'a, T>(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn handle_type_mismatch(
     expected: tombi_schema_store::ValueType,
     actual: tombi_document_tree::ValueType,
@@ -210,6 +209,7 @@ fn handle_type_mismatch(
     }
 }
 
+#[allow(clippy::result_large_err)]
 #[inline]
 pub(crate) fn handle_anything_schema<T>(
     _value: &T,
@@ -220,6 +220,7 @@ where
     Ok(crate::EvaluatedLocations::new())
 }
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn handle_nothing_schema<T>(value: &T) -> Result<crate::EvaluatedLocations, crate::Error>
 where
     T: tombi_document_tree::ValueImpl,
@@ -286,6 +287,7 @@ fn handle_unused_noqa<'a>(
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn with_lint_diagnostics(
     result: Result<crate::EvaluatedLocations, crate::Error>,
     lint_rules_diagnostics: Vec<tombi_diagnostic::Diagnostic>,
@@ -339,6 +341,7 @@ fn is_multiple_of_with_tolerance(value: f64, multiple_of: f64) -> bool {
     (quotient - nearest).abs() <= tolerance
 }
 
+#[allow(clippy::result_large_err)]
 fn validate_deprecated<'a, T>(
     deprecated: Option<bool>,
     accessors: &[tombi_schema_store::Accessor],
@@ -372,6 +375,7 @@ where
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn merge_validation_results(
     primary: Result<crate::EvaluatedLocations, crate::Error>,
     secondary: Result<crate::EvaluatedLocations, crate::Error>,
@@ -395,6 +399,7 @@ pub(crate) fn merge_validation_results(
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn filter_table_strict_additional_diagnostics(
     mut error: crate::Error,
 ) -> Result<crate::EvaluatedLocations, crate::Error> {

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use itertools::Itertools;
 use tombi_ast::TombiValueCommentDirective;
 use tombi_comment_directive::value::KeyLinkRules;
@@ -267,6 +265,7 @@ fn should_validate_key_empty(
     )
 }
 
+#[allow(clippy::result_large_err)]
 fn validate_key_empty_rule<T>(
     string_value: &T,
     key_rules: Option<&KeyLinkRules>,
@@ -364,6 +363,7 @@ where
 ///
 /// When `lint_rules` is `None`, all checks use default error severity
 /// and noqa handling is skipped.
+#[allow(clippy::result_large_err)]
 pub(crate) fn validate_raw_string<'a>(
     value: &str,
     display_value: &str,
@@ -606,6 +606,7 @@ pub(crate) fn validate_raw_string<'a>(
 /// When a string value encounters a TOML date/time schema,
 /// check if x-tombi-string-formats includes the corresponding format.
 /// If so, validate the string against the format; otherwise, report type mismatch.
+#[allow(clippy::result_large_err)]
 fn validate_string_as_date_format(
     string_value: &(impl LikeString + ValueImpl + ToString),
     string_format: StringFormat,

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use itertools::Itertools;
 use tombi_ast::TombiValueCommentDirective;
 use tombi_comment_directive::value::KeyLinkRules;
@@ -229,12 +231,10 @@ where
                     lint_rules.as_ref().map(|rules| &rules.common),
                 ),
             }
+        } else if enable_key_empty_validation && should_validate_key_empty(None) {
+            validate_key_empty_rule(string_value, key_rules.as_ref())
         } else {
-            if enable_key_empty_validation && should_validate_key_empty(None) {
-                validate_key_empty_rule(string_value, key_rules.as_ref())
-            } else {
-                Ok(crate::EvaluatedLocations::new())
-            }
+            Ok(crate::EvaluatedLocations::new())
         };
 
         match result {

--- a/extensions/tombi-extension-cargo/src/code_action.rs
+++ b/extensions/tombi-extension-cargo/src/code_action.rs
@@ -450,14 +450,10 @@ fn inherit_dependency_from_workspace_code_action(
     let AccessorContext::Key(crate_key_context) = &contexts[1 + offset] else {
         return None;
     };
-    if dig_keys(
+    dig_keys(
         workspace_document_tree,
         &["workspace", "dependencies", crate_name],
-    )
-    .is_none()
-    {
-        return None;
-    }
+    )?;
 
     match value {
         tombi_document_tree::Value::String(version) => {

--- a/extensions/tombi-extension-cargo/src/completion.rs
+++ b/extensions/tombi-extension-cargo/src/completion.rs
@@ -445,11 +445,7 @@ fn complete_workspace_dependency_inheritance(
         return None;
     }
 
-    let Some((dependency_table_accessors, dependency_name)) =
-        member_dependency_accessors(accessors)
-    else {
-        return None;
-    };
+    let (dependency_table_accessors, dependency_name) = member_dependency_accessors(accessors)?;
 
     let Some((_, tombi_document_tree::Value::Table(current_dependency_table))) =
         dig_accessors(document_tree, dependency_table_accessors)
@@ -464,24 +460,19 @@ fn complete_workspace_dependency_inheritance(
             return None;
         };
 
-        let Some((current_dependency_key, _)) =
-            current_dependency_table.get_key_value(dependency_name.as_str())
-        else {
-            return None;
-        };
+        let (current_dependency_key, _) =
+            current_dependency_table.get_key_value(dependency_name.as_str())?;
 
         current_dependency_key.range()
     } else {
         tombi_text::Range::at(position)
     };
 
-    let Some((_, _, workspace_document_tree)) = find_workspace_cargo_toml(
+    let (_, _, workspace_document_tree) = find_workspace_cargo_toml(
         cargo_toml_path,
         get_workspace_cargo_toml_path(document_tree),
         toml_version,
-    ) else {
-        return None;
-    };
+    )?;
 
     let Some((_, tombi_document_tree::Value::Table(workspace_dependencies))) =
         dig_keys(&workspace_document_tree, &["workspace", "dependencies"])
@@ -537,9 +528,7 @@ fn complete_workspace_dependency_inheritance(
     }
 }
 
-fn member_dependency_accessors<'a>(
-    accessors: &'a [Accessor],
-) -> Option<(&'a [Accessor], Option<&'a Accessor>)> {
+fn member_dependency_accessors(accessors: &[Accessor]) -> Option<(&[Accessor], Option<&Accessor>)> {
     if matches_accessors!(accessors, ["dependencies"])
         || matches_accessors!(accessors, ["dev-dependencies"])
         || matches_accessors!(accessors, ["build-dependencies"])
@@ -625,7 +614,7 @@ async fn complete_crate_version(
                                     CompletionHint::DotTrigger { range, .. }
                                     | CompletionHint::EqualTrigger { range, .. },
                                 ) => Some(vec![TextEdit {
-                                    range: range,
+                                    range,
                                     new_text: "".to_string(),
                                 }]),
                                 _ => None,

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -226,13 +226,14 @@ async fn collect_prefetch_urls(
                         .or_else(|| exact_crates_io_version(version_requirement))
                 });
 
-        if prioritize_inlay_hint && dependency.default_features_hint {
-            if let Some(resolved_version) = resolved_version.as_deref() {
-                urls.awaited.insert(format!(
-                    "https://crates.io/api/v1/crates/{}/{}",
-                    dependency.crate_name, resolved_version
-                ));
-            }
+        if prioritize_inlay_hint
+            && dependency.default_features_hint
+            && let Some(resolved_version) = resolved_version.as_deref()
+        {
+            urls.awaited.insert(format!(
+                "https://crates.io/api/v1/crates/{}/{}",
+                dependency.crate_name, resolved_version
+            ));
         }
 
         if warm_feature_details {

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -721,22 +721,19 @@ fn workspace_dependency_target(
 }
 
 fn dependency_key_tooltip(
-    tooltip: &std::borrow::Cow<'static, str>,
+    tooltip: &str,
     features: Option<&tombi_config::CargoExtensionFeatures>,
 ) -> Option<std::borrow::Cow<'static, str>> {
     if tooltip_matches(tooltip, DocumentLinkToolTip::PathFile) {
         cargo_toml_document_link_enabled(features)
             .then(|| std::borrow::Cow::Borrowed(DocumentLinkToolTip::CargoToml.into()))
     } else {
-        Some(tooltip.clone())
+        Some(std::borrow::Cow::Owned(tooltip.to_owned()))
     }
 }
 
-fn tooltip_matches(
-    tooltip: &std::borrow::Cow<'static, str>,
-    expected: DocumentLinkToolTip,
-) -> bool {
-    tooltip.as_ref() == Into::<&'static str>::into(expected)
+fn tooltip_matches(tooltip: &str, expected: DocumentLinkToolTip) -> bool {
+    tooltip == Into::<&'static str>::into(expected)
 }
 
 fn document_link_for_workspace_dependency(

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -721,14 +721,14 @@ fn workspace_dependency_target(
 }
 
 fn dependency_key_tooltip(
-    tooltip: &str,
+    tooltip: std::borrow::Cow<'static, str>,
     features: Option<&tombi_config::CargoExtensionFeatures>,
 ) -> Option<std::borrow::Cow<'static, str>> {
-    if tooltip_matches(tooltip, DocumentLinkToolTip::PathFile) {
+    if tooltip_matches(&tooltip, DocumentLinkToolTip::PathFile) {
         cargo_toml_document_link_enabled(features)
             .then(|| std::borrow::Cow::Borrowed(DocumentLinkToolTip::CargoToml.into()))
     } else {
-        Some(std::borrow::Cow::Owned(tooltip.to_owned()))
+        Some(tooltip)
     }
 }
 
@@ -767,7 +767,9 @@ fn document_link_for_workspace_dependency(
             .into_iter()
             .flat_map(|document_link| {
                 let mut links = Vec::with_capacity(2);
-                if let Some(tooltip) = dependency_key_tooltip(&document_link.tooltip, features) {
+                if let Some(tooltip) =
+                    dependency_key_tooltip(document_link.tooltip.clone(), features)
+                {
                     links.push(tombi_extension::DocumentLink {
                         target: document_link.target.clone(),
                         range: crate_key.unquoted_range(),
@@ -805,7 +807,9 @@ fn document_link_for_crate_dependency_has_workspace(
             .into_iter()
             .flat_map(|document_link| {
                 let mut links = Vec::with_capacity(2);
-                if let Some(tooltip) = dependency_key_tooltip(&document_link.tooltip, features) {
+                if let Some(tooltip) =
+                    dependency_key_tooltip(document_link.tooltip.clone(), features)
+                {
                     links.push(tombi_extension::DocumentLink {
                         target: document_link.target.clone(),
                         range: crate_key.unquoted_range(),
@@ -1371,7 +1375,7 @@ version = "0.1.0"
         let features = disabled_cargo_toml_link_features();
 
         let tooltip = dependency_key_tooltip(
-            &std::borrow::Cow::Borrowed("Open Path File"),
+            std::borrow::Cow::Borrowed("Open Path File"),
             Some(&features),
         );
 

--- a/extensions/tombi-extension-cargo/src/feature_navigation.rs
+++ b/extensions/tombi-extension-cargo/src/feature_navigation.rs
@@ -671,9 +671,9 @@ fn resolve_dependency_feature_string_target(
     })
 }
 
-fn dependency_entries<'a>(
-    document_tree: &'a tombi_document_tree::DocumentTree,
-) -> Vec<(Vec<Accessor>, &'a tombi_document_tree::Value)> {
+fn dependency_entries(
+    document_tree: &tombi_document_tree::DocumentTree,
+) -> Vec<(Vec<Accessor>, &tombi_document_tree::Value)> {
     let mut entries = Vec::new();
 
     if let Some((_, Value::Table(workspace_dependencies))) =

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -188,14 +188,11 @@ fn format_feature_usage_label(project_root: &Path, cargo_toml_path: &Path, line:
 }
 
 fn get_dependency_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
-    if matches_accessors!(accessors, ["workspace", "dependencies", _]) {
-        Some(accessors)
-    } else if matches_accessors!(accessors, ["dependencies", _])
+    if matches_accessors!(accessors, ["workspace", "dependencies", _])
+        || matches_accessors!(accessors, ["dependencies", _])
         || matches_accessors!(accessors, ["dev-dependencies", _])
         || matches_accessors!(accessors, ["build-dependencies", _])
-    {
-        Some(accessors)
-    } else if matches_accessors!(accessors, ["target", _, "dependencies", _])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _])
         || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
         || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
     {

--- a/extensions/tombi-extension-cargo/src/inlay_hint.rs
+++ b/extensions/tombi-extension-cargo/src/inlay_hint.rs
@@ -1141,7 +1141,7 @@ async fn load_workspace_cargo_toml_entries(
         .into_iter()
         .filter_map(|dependency_key| {
             let (_, workspace_dependency_value) = dig_keys(
-                &workspace_document_tree,
+                workspace_document_tree,
                 &["workspace", "dependencies", dependency_key.as_str()],
             )?;
             let Value::Table(workspace_dependency_table) = workspace_dependency_value else {

--- a/extensions/tombi-extension-cargo/src/workspace.rs
+++ b/extensions/tombi-extension-cargo/src/workspace.rs
@@ -141,10 +141,9 @@ pub(crate) async fn load_workspace_cargo_toml(
                 if let Some((workspace_cargo_toml_path, document_tree)) =
                     load_cargo_toml_document_tree(workspace_cargo_toml_path.clone(), toml_version)
                         .await
+                    && document_tree.contains_key("workspace")
                 {
-                    if document_tree.contains_key("workspace") {
-                        return Some((workspace_cargo_toml_path, document_tree));
-                    }
+                    return Some((workspace_cargo_toml_path, document_tree));
                 }
             } else {
                 return None;
@@ -337,15 +336,13 @@ pub(crate) fn goto_dependency_crates(
                 toml_version,
             ) && let Some((_, tombi_document_tree::Value::String(package_name))) =
                 tombi_document_tree::dig_keys(&subcrate_document_tree, &["package", "name"])
-            {
-                if let Ok(subcrate_cargo_toml_uri) =
+                && let Ok(subcrate_cargo_toml_uri) =
                     tombi_uri::Uri::from_file_path(&subcrate_cargo_toml_path)
-                {
-                    locations.push(tombi_extension::DefinitionLocation {
-                        uri: subcrate_cargo_toml_uri,
-                        range: package_name.unquoted_range(),
-                    });
-                }
+            {
+                locations.push(tombi_extension::DefinitionLocation {
+                    uri: subcrate_cargo_toml_uri,
+                    range: package_name.unquoted_range(),
+                });
             }
         } else if let Some(tombi_document_tree::Value::Boolean(has_workspace)) =
             table.get("workspace")

--- a/extensions/tombi-extension-pyproject/src/did_open.rs
+++ b/extensions/tombi-extension-pyproject/src/did_open.rs
@@ -122,8 +122,8 @@ fn pyproject_sources(document_tree: &DocumentTree) -> Option<&Table> {
     }
 }
 
-fn workspace_pyproject_sources<'a>(
-    document_tree: &'a DocumentTree,
+fn workspace_pyproject_sources(
+    document_tree: &DocumentTree,
     pyproject_toml_path: &Path,
     toml_version: TomlVersion,
 ) -> Option<Table> {

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -44,10 +44,10 @@ pub async fn hover(
     if matches_accessors!(accessors, ["tool", "uv", "sources", _])
         || matches_accessors!(accessors, ["tool", "uv", "sources", _, _])
     {
-        if let Some((_, value)) = dig_accessors(document_tree, &accessors[..4]) {
-            if value.contains(position) {
-                return Ok(None);
-            }
+        if let Some((_, value)) = dig_accessors(document_tree, &accessors[..4])
+            && value.contains(position)
+        {
+            return Ok(None);
         };
 
         return Ok(resolve_pyproject_source_metadata(

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -48,7 +48,7 @@ pub async fn hover(
             && value.contains(position)
         {
             return Ok(None);
-        };
+        }
 
         return Ok(resolve_pyproject_source_metadata(
             document_tree,


### PR DESCRIPTION
Resolves the current cargo clippy warnings across the workspace. Applies clippy-suggested simplifications, derives default where possible, and tightens option handling with ? where appropriate. Adds focused lint allowances for large schema and validator error types where changing the public shape would be more invasive.\n\nValidation: cargo fmt; cargo clippy