### PR TITLE
Fix install.sh release update workflow

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -251,8 +251,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
+      pull-requests: write
     steps:
       - name: Detect stable release tag
         id: stable-version
@@ -342,6 +342,7 @@ jobs:
           fi
 
       - name: Commit updated install script
+        id: commit-install-script
         if: steps.should-update.outputs.should_update == 'true'
         shell: bash
         env:
@@ -349,47 +350,47 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet -- docs/public/install.sh; then
+            echo "created_commit=false" >> "${GITHUB_OUTPUT}"
             echo "install.sh is already up to date."
             exit 0
           fi
 
+          branch_name="github-actions/install-sh-v${STABLE_VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${branch_name}"
           git add docs/public/install.sh
           git commit -m "docs: update install.sh stable version to ${STABLE_VERSION}"
+          echo "branch_name=${branch_name}" >> "${GITHUB_OUTPUT}"
+          echo "created_commit=true" >> "${GITHUB_OUTPUT}"
 
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push failed on attempt ${attempt}; rebasing on origin/main and retrying."
-            git fetch origin main
-            git rebase origin/main
-          done
+      - name: Push branch and create pull request
+        if: steps.commit-install-script.outputs.created_commit == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_VERSION: ${{ steps.stable-version.outputs.stable_version }}
+          BRANCH_NAME: ${{ steps.commit-install-script.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          git push --force origin HEAD:"${BRANCH_NAME}"
 
-          echo "Failed to push install.sh update after multiple attempts." >&2
-          exit 1
+          existing_pr_number="$(
+            gh pr list \
+              --base main \
+              --head "${BRANCH_NAME}" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
 
-      - name: Trigger docs deploy
-        if: steps.should-update.outputs.should_update == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'deploy_docs.yml',
-              ref: 'main',
-            })
+          if [ -n "${existing_pr_number}" ]; then
+            echo "Pull request #${existing_pr_number} already exists for ${BRANCH_NAME}."
+            exit 0
+          fi
 
-      - name: Trigger install.sh CI
-        if: steps.should-update.outputs.should_update == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ci_install_script.yml',
-              ref: 'main',
-            })
+          gh pr create \
+            --base main \
+            --head "${BRANCH_NAME}" \
+            --title "docs: update install.sh stable version to ${STABLE_VERSION}" \
+            --body "This PR updates \`docs/public/install.sh\` to use the stable release \`${STABLE_VERSION}\`."

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -164,7 +164,7 @@ download_and_install() {
 }
 
 # Version
-LATEST_STABLE_VERSION="0.9.21"
+LATEST_STABLE_VERSION="0.9.22"
 if [ -n "${__SPECIFIED_VERSION}" ]; then
 	VERSION="${__SPECIFIED_VERSION}"
 	print_step "Using specified version: ${VERSION}"


### PR DESCRIPTION
This changes the release workflow so stable install.sh updates are pushed to a dedicated branch and opened as a pull request instead of pushing directly to main. It also removes the manual docs and install-script workflow dispatches because those checks now run through the normal PR and post-merge paths. Finally, it updates docs/public/install.sh so the embedded stable version matches v0.9.22.