### PR TITLE
feat(vscode): highlight TOML front matter in Markdown

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -86,6 +86,13 @@
         "language": "toml",
         "scopeName": "source.toml",
         "path": "./syntaxes/toml.tmLanguage.json"
+      },
+      {
+        "scopeName": "text.toml.frontmatter.markdown",
+        "path": "./syntaxes/toml.frontmatter.injection.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ]
       }
     ],
     "semanticTokenTypes": [
@@ -98,6 +105,11 @@
         "id": "key",
         "superType": "variable",
         "description": "Key"
+      },
+      {
+        "id": "boolean",
+        "superType": "keyword",
+        "description": "Boolean"
       },
       {
         "id": "offsetDateTime",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -93,6 +93,19 @@
         "injectTo": [
           "text.html.markdown"
         ]
+      },
+      {
+        "scopeName": "text.toml.markdown-fence",
+        "path": "./syntaxes/toml.markdown-fence.injection.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.toml": "toml"
+        },
+        "tokenTypes": {
+          "meta.embedded.block.toml": "other"
+        }
       }
     ],
     "semanticTokenTypes": [

--- a/editors/vscode/syntaxes/frontmatter-example.md
+++ b/editors/vscode/syntaxes/frontmatter-example.md
@@ -1,0 +1,15 @@
++++
+title = "Front Matter Highlight Sample"
+draft = false
+date = 2026-04-26T10:30:00+09:00
+
+[extra]
+theme = "docs"
+tags = ["tombi", "frontmatter"]
++++
+
+# Front Matter Sample
+
+Open this file in VS Code with the Tombi extension enabled.
+
+The `+++` block above should highlight as TOML inside Markdown front matter.

--- a/editors/vscode/syntaxes/toml.frontmatter.injection.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.frontmatter.injection.tmLanguage.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.0",
+  "scopeName": "text.toml.frontmatter.markdown",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "begin": "\\A(\\+\\+\\+)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.front-matter.begin.toml"
+        }
+      },
+      "end": "^(\\+\\+\\+)\\s*$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.front-matter.end.toml"
+        }
+      },
+      "contentName": "source.toml",
+      "patterns": [
+        {
+          "include": "source.toml"
+        }
+      ]
+    }
+  ]
+}

--- a/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
@@ -1,0 +1,53 @@
+{
+  "version": "1.0.0",
+  "scopeName": "text.toml.markdown-fence",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "begin": "^\\s*(`{3,})\\s*(toml|TOML)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.fenced.markdown"
+        },
+        "2": {
+          "name": "fenced_code.block.language.markdown"
+        }
+      },
+      "end": "^\\s*(`{3,})\\s*$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.fenced.markdown"
+        }
+      },
+      "contentName": "meta.embedded.block.toml",
+      "patterns": [
+        {
+          "include": "source.toml"
+        }
+      ]
+    },
+    {
+      "begin": "^\\s*(~{3,})\\s*(toml|TOML)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.fenced.markdown"
+        },
+        "2": {
+          "name": "fenced_code.block.language.markdown"
+        }
+      },
+      "end": "^\\s*(~{3,})\\s*$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.fenced.markdown"
+        }
+      },
+      "contentName": "meta.embedded.block.toml",
+      "patterns": [
+        {
+          "include": "source.toml"
+        }
+      ]
+    }
+  ]
+}

--- a/editors/vscode/syntaxes/toml.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.tmLanguage.json
@@ -94,21 +94,7 @@
         },
         {
           "name": "punctuation.separator.key.toml",
-          "match": "\\."
-        }
-      ]
-    },
-    "dottedKey": {
-      "patterns": [
-        {
-          "include": "#quotedKey"
-        },
-        {
-          "include": "#bareKey"
-        },
-        {
-          "name": "punctuation.separator.key.toml",
-          "match": "\\."
+          "match": "\\s*\\.\\s*"
         }
       ]
     },
@@ -180,10 +166,6 @@
         }
       ]
     },
-    "bareKey": {
-      "name": "variable.other.key.toml",
-      "match": "[A-Za-z0-9_-]+"
-    },
     "quotedTableKey": {
       "patterns": [
         {
@@ -203,30 +185,6 @@
         },
         {
           "name": "entity.name.type.table.toml string.quoted.single.toml",
-          "begin": "'",
-          "end": "'"
-        }
-      ]
-    },
-    "quotedKey": {
-      "patterns": [
-        {
-          "name": "variable.other.key.toml string.quoted.double.toml",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [
-            {
-              "match": "\\\\([btnfr\"\\\\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
-              "name": "constant.character.escape.toml"
-            },
-            {
-              "match": "\\\\[^btnfr/\"\\\\\\n]",
-              "name": "invalid.illegal.escape.toml"
-            }
-          ]
-        },
-        {
-          "name": "variable.other.key.toml string.quoted.single.toml",
           "begin": "'",
           "end": "'"
         }
@@ -308,7 +266,7 @@
         },
         {
           "name": "string.regexp constant.other.datetime.offset.toml",
-          "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T| ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
+          "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
         },
         {
           "name": "string.regexp constant.other.datetime.local.toml",

--- a/editors/vscode/syntaxes/toml.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.tmLanguage.json
@@ -9,10 +9,42 @@
       "include": "#comment"
     },
     {
-      "include": "#value"
+      "include": "#arrayTable"
+    },
+    {
+      "include": "#table"
+    },
+    {
+      "include": "#keyValue"
     }
   ],
   "repository": {
+    "arrayTable": {
+      "name": "meta.table.array.toml",
+      "match": "^(\\s*)(\\[\\[)([^\\]]+)(\\]\\])(\\s*(?:#.*)?)$",
+      "captures": {
+        "2": {
+          "name": "punctuation.definition.table.array.begin.toml"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#dottedTableKey"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.definition.table.array.end.toml"
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#comment"
+            }
+          ]
+        }
+      }
+    },
     "comment": {
       "captures": {
         "1": {
@@ -25,8 +57,215 @@
       "comment": "Comments",
       "match": "\\s*((#).*)$"
     },
+    "array": {
+      "name": "meta.sequence.toml",
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.begin.toml"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.toml"
+        }
+      },
+      "patterns": [
+        {
+          "name": "punctuation.separator.sequence.toml",
+          "match": ","
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    "dottedTableKey": {
+      "patterns": [
+        {
+          "include": "#quotedTableKey"
+        },
+        {
+          "include": "#bareTableKey"
+        },
+        {
+          "name": "punctuation.separator.key.toml",
+          "match": "\\."
+        }
+      ]
+    },
+    "dottedKey": {
+      "patterns": [
+        {
+          "include": "#quotedKey"
+        },
+        {
+          "include": "#bareKey"
+        },
+        {
+          "name": "punctuation.separator.key.toml",
+          "match": "\\."
+        }
+      ]
+    },
+    "bareTableKey": {
+      "name": "entity.name.type.table.toml",
+      "match": "[A-Za-z0-9_-]+"
+    },
+    "keyValue": {
+      "name": "meta.mapping.key-value.toml",
+      "begin": "^(\\s*)(?=[A-Za-z0-9_\\-\"'])",
+      "end": "$",
+      "patterns": [
+        {
+          "name": "variable.other.key.toml",
+          "match": "(?:\"(?:\\\\.|[^\"])*\"|'[^']*'|[A-Za-z0-9_-]+)(?:\\s*\\.\\s*(?:\"(?:\\\\.|[^\"])*\"|'[^']*'|[A-Za-z0-9_-]+))*(?=\\s*=)"
+        },
+        {
+          "name": "keyword.operator.assignment.toml",
+          "match": "="
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    "inlineKeyValue": {
+      "name": "meta.mapping.key-value.inline.toml",
+      "patterns": [
+        {
+          "name": "variable.other.key.toml",
+          "match": "(?:\"(?:\\\\.|[^\"])*\"|'[^']*'|[A-Za-z0-9_-]+)(?:\\s*\\.\\s*(?:\"(?:\\\\.|[^\"])*\"|'[^']*'|[A-Za-z0-9_-]+))*(?=\\s*=)"
+        },
+        {
+          "name": "keyword.operator.assignment.toml",
+          "match": "="
+        },
+        {
+          "name": "punctuation.separator.sequence.toml",
+          "match": ","
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    "inlineTable": {
+      "name": "meta.inline.table.toml",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.inline-table.begin.toml"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.inline-table.end.toml"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#inlineKeyValue"
+        }
+      ]
+    },
+    "bareKey": {
+      "name": "variable.other.key.toml",
+      "match": "[A-Za-z0-9_-]+"
+    },
+    "quotedTableKey": {
+      "patterns": [
+        {
+          "name": "entity.name.type.table.toml string.quoted.double.toml",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "match": "\\\\([btnfr\"\\\\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr/\"\\\\\\n]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "name": "entity.name.type.table.toml string.quoted.single.toml",
+          "begin": "'",
+          "end": "'"
+        }
+      ]
+    },
+    "quotedKey": {
+      "patterns": [
+        {
+          "name": "variable.other.key.toml string.quoted.double.toml",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "match": "\\\\([btnfr\"\\\\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr/\"\\\\\\n]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "name": "variable.other.key.toml string.quoted.single.toml",
+          "begin": "'",
+          "end": "'"
+        }
+      ]
+    },
+    "table": {
+      "name": "meta.table.toml",
+      "match": "^(\\s*)(\\[)([^\\]]+)(\\])(\\s*(?:#.*)?)$",
+      "captures": {
+        "2": {
+          "name": "punctuation.definition.table.begin.toml"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#dottedTableKey"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.definition.table.end.toml"
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#comment"
+            }
+          ]
+        }
+      }
+    },
     "value": {
       "patterns": [
+        {
+          "include": "#inlineTable"
+        },
+        {
+          "include": "#array"
+        },
         {
           "name": "string.quoted.triple.basic.block.toml",
           "begin": "\"\"\"",
@@ -68,92 +307,52 @@
           "end": "'"
         },
         {
-          "captures": {
-            "1": {
-              "name": "constant.other.datetime.offset.toml"
-            }
-          },
+          "name": "string.regexp constant.other.datetime.offset.toml",
           "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T| ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
         },
         {
-          "captures": {
-            "1": {
-              "name": "constant.other.datetime.local.toml"
-            }
-          },
+          "name": "string.regexp constant.other.datetime.local.toml",
           "match": "(\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)"
         },
         {
-          "name": "constant.other.date.local.toml",
+          "name": "string.regexp constant.other.date.local.toml",
           "match": "\\d{4}\\-\\d{2}\\-\\d{2}"
         },
         {
-          "name": "constant.other.time.local.toml",
+          "name": "string.regexp constant.other.time.local.toml",
           "match": "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
         },
         {
-          "match": "(?<!\\w)(true|false)(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.language.boolean.toml"
-            }
-          }
+          "name": "constant.language.boolean.toml",
+          "match": "(?<!\\w)(true|false)(?!\\w)"
         },
         {
-          "match": "(?<!\\w)([\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))(?:(?:\\.([0-9]+))?[eE][\\+\\-]?[1-9]_?[0-9]*|(?:\\.[0-9_]*)))(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.float.toml"
-            }
-          }
+          "name": "constant.numeric.float.toml",
+          "match": "(?<!\\w)([\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))(?:(?:\\.([0-9]+))?[eE][\\+\\-]?[1-9]_?[0-9]*|(?:\\.[0-9_]*)))(?!\\w)"
         },
         {
-          "match": "(?<!\\w)((?:[\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))))(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.integer.dec.toml"
-            }
-          }
+          "name": "constant.numeric.integer.dec.toml",
+          "match": "(?<!\\w)((?:[\\+\\-]?(0|([1-9](([0-9]|_[0-9])+)?))))(?!\\w)"
         },
         {
-          "match": "(?<!\\w)([\\+\\-]?inf)(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.float.inf.toml"
-            }
-          }
+          "name": "constant.numeric.float.inf.toml",
+          "match": "(?<!\\w)([\\+\\-]?inf)(?!\\w)"
         },
         {
-          "match": "(?<!\\w)([\\+\\-]?nan)(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.float.nan.toml"
-            }
-          }
+          "name": "constant.numeric.float.nan.toml",
+          "match": "(?<!\\w)([\\+\\-]?nan)(?!\\w)"
         },
         {
-          "match": "(?<!\\w)((?:0x(([0-9a-fA-F](([0-9a-fA-F]|_[0-9a-fA-F])+)?))))(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.integer.hex.toml"
-            }
-          }
+          "name": "constant.numeric.integer.hex.toml",
+          "match": "(?<!\\w)((?:0x(([0-9a-fA-F](([0-9a-fA-F]|_[0-9a-fA-F])+)?))))(?!\\w)"
         },
         {
-          "match": "(?<!\\w)(0o[0-7](_?[0-7])*)(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.integer.oct.toml"
-            }
-          }
+          "name": "constant.numeric.integer.oct.toml",
+          "match": "(?<!\\w)(0o[0-7](_?[0-7])*)(?!\\w)"
         },
         {
-          "match": "(?<!\\w)(0b[01](_?[01])*)(?!\\w)",
-          "captures": {
-            "1": {
-              "name": "constant.numeric.integer.bin.toml"
-            }
-          }
+          "name": "constant.numeric.integer.bin.toml",
+          "match": "(?<!\\w)(0b[01](_?[01])*)(?!\\w)"
         }
       ]
     }

--- a/sample.md
+++ b/sample.md
@@ -13,3 +13,10 @@ tags = ["tombi", "frontmatter"]
 Open this file in VS Code with the Tombi extension enabled.
 
 The `+++` block above should highlight as TOML inside Markdown front matter.
+
+```toml
+answer = 42
+published = 2026-04-26T10:30:00+09:00
+enabled = true
+inline = { nested = 1, label = "ok" } # trailing comment
+```

--- a/sample.md
+++ b/sample.md
@@ -15,8 +15,50 @@ Open this file in VS Code with the Tombi extension enabled.
 The `+++` block above should highlight as TOML inside Markdown front matter.
 
 ```toml
-answer = 42
-published = 2026-04-26T10:30:00+09:00
+title = "Complex TOML Sample"
 enabled = true
-inline = { nested = 1, label = "ok" } # trailing comment
+count = 42
+hex = 0x2A
+oct = 0o52
+bin = 0b101010
+ratio = 3.14
+infinite = inf
+not_a_number = nan
+published = 2026-04-26T10:30:00+09:00
+local_datetime = 2026-04-26T10:30:00
+local_date = 2026-04-26
+local_time = 10:30:00
+tags = ["tombi", "markdown", "toml"]
+numbers = [1, 2, 3, 4]
+matrix = [[1, 2], [3, 4], [5, 6]]
+schedule = [
+  2026-04-26T10:30:00+09:00,
+  2026-04-27T11:45:00+09:00,
+]
+inline = { nested = 1, label = "ok", enabled = true } # trailing comment
+inline_nested = {
+  level1 = { level2 = { answer = 42, active = false } },
+  values = [1, 2, { nested = [3, 4, { deep = "value" }] }],
+}
+
+[server]
+host = "127.0.0.1"
+ports = [8080, 8081]
+maintenance = { start = 2026-04-26, end = 2026-04-27 }
+
+[server.metadata]
+owner = "tombi"
+labels = ["syntax", "highlight"]
+
+[[users]]
+name = "alice"
+joined = 2026-04-26
+roles = ["admin", "editor"]
+profile = { active = true, score = 10, prefs = { theme = "light", alerts = [true, false] } }
+
+[[users]]
+name = "bob"
+joined = 2026-04-27
+roles = ["viewer"]
+profile = { active = false, score = 7, prefs = { theme = "dark", alerts = [false] } }
 ```


### PR DESCRIPTION
## Summary

- add a Markdown injection grammar so `+++` front matter is tokenized as TOML
- register the injected grammar in the VS Code extension manifest
- expand the TOML TextMate grammar coverage for tables, arrays, inline tables, keys, booleans, and date/time tokens

## Testing

- `pnpm --dir editors/vscode format:check`
- `pnpm --dir editors/vscode lint:check`
- `pnpm --dir editors/vscode typecheck`
- `pnpm --dir editors/vscode test`

## Notes

- `pnpm --dir editors/vscode package` currently fails on an existing README SVG restriction in `vsce`, unrelated to this change
