### PR TITLE
Remove simplify step from github-pr-flow

### DIFF
--- a/.claude/skills/codex/github-pr-flow/SKILL.md
+++ b/.claude/skills/codex/github-pr-flow/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # GitHub PR Flow
 
-現在のローカル差分をもとに、必要なら別 Skill で PR を作成し、その後の Copilot レビュー依頼を `gh pr edit --add-reviewer @copilot` で行い、待機とレビュー対応を統一 Skill [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) に委譲する Codex 専用 Skill。
+現在のローカル差分をもとに、必要なら別 Skill で PR を作成し、その後の Copilot レビュー依頼を `gh pr edit --add-reviewer @copilot` で行い、待機とレビュー対応を統一 Skill [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) に委譲する Codex 専用 Skill。途中で simplify 系の別 Skill は実行しない。
 
 ## Use This Skill When
 
@@ -48,6 +48,8 @@ PR 作成そのものは別 skill に従う。優先順位:
    - `gh pr create --base main --head <branch> --title ... --body ... --label ...`
 
 PR URL がまだ無い場合は、この Skill の中で PR 作成まで進めてから戻る。
+
+この Step では PR 作成に必要な処理だけを行い、simplify 系の別 Skill を前処理として挟まない。
 
 ### 2. `gh` で Copilot にレビュー依頼する
 

--- a/.claude/skills/codex/github-pr-flow/agents/openai.yaml
+++ b/.claude/skills/codex/github-pr-flow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "github-pr-flow"
   short_description: "Create a PR, request Copilot review, then hand off to the unified review workflow"
-  default_prompt: "Use $github-pr-flow to create a PR from current changes, request Copilot review with `gh pr edit --add-reviewer @copilot`, then use $github-pr-resolve for waiting, CI fixes, and review-thread resolution before stopping short of merge."
+  default_prompt: "Use $github-pr-flow to create a PR from current changes, request Copilot review with `gh pr edit --add-reviewer @copilot`, and then use $github-pr-resolve for waiting, CI fixes, and review-thread resolution before stopping short of merge. Do not run any simplify skill as part of this flow."


### PR DESCRIPTION
## Summary
- remove the simplify-skill step from the github-pr-flow skill description
- update the Codex agent prompt so the flow explicitly skips simplify skills

## Testing
- not run (skill documentation and prompt changes only)