### PR TITLE
ci: fix release workflow app token input

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -273,7 +273,7 @@ jobs:
         if: steps.stable-version.outputs.stable_version != ''
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.VERSION_UPDATE_APP_CLIENT_ID }}
+          client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
## Summary
- fix the release workflow to read `VERSION_UPDATE_APP_CLIENT_ID` from repository secrets
- keep `actions/create-github-app-token@v3` aligned with how the repository is configured
- unblock the `update-install-script-version` job for stable release tags

## Verification
- inspected failed Actions job 73224466255 in run 25003672484
- confirmed `VERSION_UPDATE_APP_CLIENT_ID` exists in `gh secret list -R tombi-toml/tombi`
- ran YAML parse check with Ruby