### PR TITLE
fix(vscode): broaden markdown TOML fence matching

### DIFF
--- a/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
@@ -4,50 +4,42 @@
   "injectionSelector": "L:text.html.markdown",
   "patterns": [
     {
-      "begin": "^\\s*(`{3,})\\s*(toml|TOML)\\s*$",
+      "include": "#toml-code-block"
+    }
+  ],
+  "repository": {
+    "toml-code-block": {
+      "begin": "(?:^|\\G)([\\t ]*)(`{3,}|~{3,})[\\t ]*(?i:(toml)([\\t ]+[^`~\\r\\n]*)?$)",
       "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.fenced.markdown"
-        },
         "2": {
+          "name": "punctuation.definition.markdown"
+        },
+        "3": {
           "name": "fenced_code.block.language.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.attributes.markdown"
         }
       },
-      "end": "^\\s*(`{3,})\\s*$",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(?:^|\\G)(\\1|[\\t ]{0,3})(\\2)[\\t ]*$",
       "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.fenced.markdown"
+        "2": {
+          "name": "punctuation.definition.markdown"
         }
       },
-      "contentName": "meta.embedded.block.toml",
       "patterns": [
         {
-          "include": "source.toml"
-        }
-      ]
-    },
-    {
-      "begin": "^\\s*(~{3,})\\s*(toml|TOML)\\s*$",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.fenced.markdown"
-        },
-        "2": {
-          "name": "fenced_code.block.language.markdown"
-        }
-      },
-      "end": "^\\s*(~{3,})\\s*$",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.fenced.markdown"
-        }
-      },
-      "contentName": "meta.embedded.block.toml",
-      "patterns": [
-        {
-          "include": "source.toml"
+          "begin": "(?:^|\\G)([\\t ]*)(.*)",
+          "while": "(?:^|\\G)(?![\\t ]*([`~]{3,})[\\t ]*$)",
+          "contentName": "meta.embedded.block.toml",
+          "patterns": [
+            {
+              "include": "source.toml"
+            }
+          ]
         }
       ]
     }
-  ]
+  }
 }

--- a/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.markdown-fence.injection.tmLanguage.json
@@ -9,20 +9,20 @@
   ],
   "repository": {
     "toml-code-block": {
-      "begin": "(?:^|\\G)([\\t ]*)(`{3,}|~{3,})[\\t ]*(?i:(toml)([\\t ]+[^`~\\r\\n]*)?$)",
+      "begin": "(?:^|\\G)([\\t ]*)(([`~])\\3\\3(\\3*))[\\t ]*(?i:(toml)([\\t ]+[^`~\\r\\n]*)?$)",
       "beginCaptures": {
         "2": {
           "name": "punctuation.definition.markdown"
         },
-        "3": {
+        "5": {
           "name": "fenced_code.block.language.markdown"
         },
-        "4": {
+        "6": {
           "name": "fenced_code.block.language.attributes.markdown"
         }
       },
       "name": "markup.fenced_code.block.markdown",
-      "end": "(?:^|\\G)(\\1|[\\t ]{0,3})(\\2)[\\t ]*$",
+      "end": "(?:^|\\G)(\\1|[\\t ]{0,3})(\\3\\3\\3\\4\\3*)[\\t ]*$",
       "endCaptures": {
         "2": {
           "name": "punctuation.definition.markdown"


### PR DESCRIPTION
## Summary
- align the TOML markdown fence injection with VS Code's standard fenced code block structure
- accept indented and attribute-bearing `toml` fences instead of only exact ` ```toml ` / ` ~~~toml ` matches
- keep the TOML embedded scope mapping while reducing fallback to Markdown's unknown fence handling

## Verification
- `pnpm --dir editors/vscode typecheck`
- `pnpm --dir editors/vscode test`
