### PR TITLE
feat(formatter): add blank line spacing options

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(cargo:*)",
@@ -15,7 +15,5 @@
       "Bash(mkdir:*)"
     ]
   },
-  "enabledMcpjsonServers": [
-    "playwright"
-  ]
+  "enabledMcpjsonServers": ["playwright"]
 }

--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -7,6 +7,7 @@ use tombi_future::{BoxFuture, Boxable};
 use tombi_schema_store::{Accessor, CurrentSchema, PatternAccessor};
 use tombi_syntax::SyntaxElement;
 
+use crate::node::make_break_line;
 use crate::node::make_dangling_comment_group_from_leading_comments;
 use crate::rule::TableOrderOverride;
 use crate::rule::root_table_keys_order;
@@ -51,7 +52,11 @@ impl crate::Edit for tombi_ast::Root {
                         )
                     {
                         changes.push(crate::Change::AppendTop {
-                            new: vec![SyntaxElement::Node(dangling_comment_group)],
+                            new: vec![
+                                SyntaxElement::Node(dangling_comment_group),
+                                SyntaxElement::Token(make_break_line()),
+                                SyntaxElement::Token(make_break_line()),
+                            ],
                         });
                         for comment in self.first_item_leading_comments() {
                             changes.push(crate::Change::Remove {

--- a/crates/tombi-ast-editor/src/node.rs
+++ b/crates/tombi-ast-editor/src/node.rs
@@ -10,7 +10,7 @@ pub fn make_break_line() -> tombi_syntax::SyntaxToken {
     parse_as::<tombi_ast::Root>("\n")
         .into_syntax_node_mut()
         .first_token()
-        .unwrap()
+        .expect("parsing a newline as Root should produce a line-break token")
 }
 
 pub fn make_comma_with_trailing_comment(

--- a/crates/tombi-ast-editor/src/node.rs
+++ b/crates/tombi-ast-editor/src/node.rs
@@ -6,6 +6,13 @@ pub fn make_comma() -> tombi_syntax::SyntaxNode {
     parse_as::<tombi_ast::Comma>(",").into_syntax_node_mut()
 }
 
+pub fn make_break_line() -> tombi_syntax::SyntaxToken {
+    parse_as::<tombi_ast::Root>("\n")
+        .into_syntax_node_mut()
+        .first_token()
+        .unwrap()
+}
+
 pub fn make_comma_with_trailing_comment(
     trailing_comment: &tombi_ast::TrailingComment,
 ) -> tombi_syntax::SyntaxNode {

--- a/crates/tombi-config/src/format.rs
+++ b/crates/tombi-config/src/format.rs
@@ -8,9 +8,10 @@
 //! this structure is currently empty.
 
 use crate::{
-    ArrayBracketSpaceWidth, ArrayCommaSpaceWidth, DateTimeDelimiter, IndentStyle, IndentWidth,
-    InlineTableBraceSpaceWidth, InlineTableCommaSpaceWidth, KeyValueEqualsSignSpaceWidth,
-    LineEnding, LineWidth, StringQuoteStyle, TrailingCommentSpaceWidth,
+    ArrayBracketSpaceWidth, ArrayCommaSpaceWidth, BlankLines, BlankLinesLimit, DateTimeDelimiter,
+    IndentStyle, IndentWidth, InlineTableBraceSpaceWidth, InlineTableCommaSpaceWidth,
+    KeyValueEqualsSignSpaceWidth, LineEnding, LineWidth, StringQuoteStyle,
+    TrailingCommentSpaceWidth,
 };
 
 /// # Formatter options
@@ -68,6 +69,32 @@ pub struct FormatRules {
         schemars(default = "DateTimeDelimiter::default")
     )]
     pub date_time_delimiter: Option<DateTimeDelimiter>,
+
+    /// # The blank lines limit between groups.
+    ///
+    /// Consecutive groups remain separate for sorting purposes,
+    /// and existing blank lines between them are preserved up to this limit.
+    ///
+    /// ```toml
+    /// # BEFORE
+    /// key1 = "value1"
+    /// key2 = "value2"
+    ///
+    /// key3 = "value3"
+    ///
+    ///
+    /// key4 = "value4"
+    ///
+    /// # AFTER (`group-blank-lines-limit = 1`)
+    /// key1 = "value1"
+    /// key2 = "value2"
+    ///
+    /// key3 = "value3"
+    ///
+    /// key4 = "value4"
+    /// ```
+    #[cfg_attr(feature = "jsonschema", schemars(default = "BlankLinesLimit::default"))]
+    pub group_blank_lines_limit: Option<BlankLinesLimit>,
 
     /// # The style of indentation
     ///
@@ -212,6 +239,42 @@ pub struct FormatRules {
     #[cfg_attr(feature = "jsonschema", schemars(default = "LineWidth::default"))]
     pub line_width: Option<LineWidth>,
 
+    /// # The number of blank lines between tables.
+    ///
+    /// This applies when the formatter inserts spacing between table or array-of-table blocks.
+    ///
+    /// ```toml
+    /// # BEFORE
+    /// [aaa]
+    /// key1 = "value1"
+    /// [bbb]
+    /// key2 = "value2"
+    ///
+    /// # AFTER (`table-blank-lines = 2`)
+    /// [aaa]
+    /// key1 = "value1"
+    ///
+    ///
+    /// [bbb]
+    /// key2 = "value2"
+    /// ```
+    ///
+    /// Tight parent/child table adjacency is controlled separately, so this does not apply
+    /// when a child table follows a parent table that has no key-value pairs.
+    ///
+    /// ```toml
+    /// # BEFORE
+    /// [aaa]
+    ///
+    /// [aaa.bbb]
+    ///
+    /// # AFTER
+    /// [aaa]
+    /// [aaa.bbb]
+    /// ```
+    #[cfg_attr(feature = "jsonschema", schemars(default = "BlankLines::default"))]
+    pub table_blank_lines: Option<BlankLines>,
+
     /// # The number of spaces before the trailing comment.
     ///
     /// ```toml
@@ -237,6 +300,9 @@ impl FormatRules {
             date_time_delimiter: self
                 .date_time_delimiter
                 .or(override_rules.date_time_delimiter),
+            group_blank_lines_limit: self
+                .group_blank_lines_limit
+                .or(override_rules.group_blank_lines_limit),
             indent_style: self.indent_style.or(override_rules.indent_style),
             indent_sub_tables: self.indent_sub_tables.or(override_rules.indent_sub_tables),
             indent_table_key_value_pairs: self
@@ -263,6 +329,7 @@ impl FormatRules {
                 .or(override_rules.key_value_equals_sign_space_width),
             line_ending: self.line_ending.or(override_rules.line_ending),
             line_width: self.line_width.or(override_rules.line_width),
+            table_blank_lines: self.table_blank_lines.or(override_rules.table_blank_lines),
             trailing_comment_space_width: self
                 .trailing_comment_space_width
                 .or(override_rules.trailing_comment_space_width),

--- a/crates/tombi-config/src/types.rs
+++ b/crates/tombi-config/src/types.rs
@@ -1,5 +1,6 @@
 mod array_bracket_space_width;
 mod array_comma_space_width;
+mod blank_lines;
 mod bool_default_false;
 mod bool_default_true;
 mod date_time_delimiter;
@@ -17,6 +18,7 @@ mod trailing_comment_space_width;
 
 pub use array_bracket_space_width::ArrayBracketSpaceWidth;
 pub use array_comma_space_width::ArrayCommaSpaceWidth;
+pub use blank_lines::{BlankLines, BlankLinesLimit};
 pub use bool_default_false::BoolDefaultFalse;
 pub use bool_default_true::BoolDefaultTrue;
 pub use date_time_delimiter::DateTimeDelimiter;

--- a/crates/tombi-config/src/types/blank_lines.rs
+++ b/crates/tombi-config/src/types/blank_lines.rs
@@ -1,0 +1,55 @@
+use std::num::NonZeroU8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BlankLines(u8);
+
+impl BlankLines {
+    #[inline]
+    pub fn value(&self) -> u8 {
+        self.0
+    }
+}
+
+impl Default for BlankLines {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+impl TryFrom<u8> for BlankLines {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(Self(value))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BlankLinesLimit(NonZeroU8);
+
+impl BlankLinesLimit {
+    #[inline]
+    pub fn value(&self) -> u8 {
+        self.0.get()
+    }
+}
+
+impl Default for BlankLinesLimit {
+    fn default() -> Self {
+        Self(NonZeroU8::new(1).unwrap())
+    }
+}
+
+impl TryFrom<u8> for BlankLinesLimit {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        NonZeroU8::new(value)
+            .map(Self)
+            .ok_or("BlankLinesLimit must be a non-zero u8")
+    }
+}

--- a/crates/tombi-config/src/types/blank_lines.rs
+++ b/crates/tombi-config/src/types/blank_lines.rs
@@ -18,11 +18,9 @@ impl Default for BlankLines {
     }
 }
 
-impl TryFrom<u8> for BlankLines {
-    type Error = &'static str;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(Self(value))
+impl From<u8> for BlankLines {
+    fn from(value: u8) -> Self {
+        Self(value)
     }
 }
 

--- a/crates/tombi-extension/Cargo.toml
+++ b/crates/tombi-extension/Cargo.toml
@@ -24,3 +24,4 @@ tower-lsp.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+tombi-schema-store = { workspace = true, features = ["native"] }

--- a/crates/tombi-formatter/src/format.rs
+++ b/crates/tombi-formatter/src/format.rs
@@ -40,33 +40,21 @@ fn filter_map_unique_keys<'a>(
         .unique()
 }
 
-pub(crate) fn has_empty_line_before<T: AstNode>(node: &T) -> bool {
-    fn previous_non_whitespace(
-        mut element: tombi_syntax::SyntaxElement,
-    ) -> Option<tombi_syntax::SyntaxElement> {
-        loop {
-            if element.kind() != WHITESPACE {
-                return Some(element);
+pub(crate) fn blank_lines_before<T: AstNode>(node: &T) -> u8 {
+    let mut line_break_count = 0usize;
+    let mut current = node.syntax().prev_sibling_or_token();
+
+    while let Some(element) = current {
+        match element.kind() {
+            WHITESPACE => current = element.prev_sibling_or_token(),
+            LINE_BREAK => {
+                line_break_count += 1;
+                current = element.prev_sibling_or_token();
             }
-            element = element.prev_sibling_or_token()?;
+            _ => break,
         }
     }
 
-    let Some(prev) = node
-        .syntax()
-        .prev_sibling_or_token()
-        .and_then(previous_non_whitespace)
-    else {
-        return false;
-    };
-    if prev.kind() != LINE_BREAK {
-        return false;
-    }
-    let Some(prev_prev) = prev
-        .prev_sibling_or_token()
-        .and_then(previous_non_whitespace)
-    else {
-        return false;
-    };
-    prev_prev.kind() == LINE_BREAK
+    let blank_lines = line_break_count.saturating_sub(1);
+    u8::try_from(blank_lines).unwrap_or(u8::MAX)
 }

--- a/crates/tombi-formatter/src/format/array_of_table.rs
+++ b/crates/tombi-formatter/src/format/array_of_table.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use itertools::Itertools;
+use tombi_ast::DanglingCommentGroupOr;
 
 use crate::{Format, format::filter_map_unique_keys};
 
@@ -31,18 +32,14 @@ impl Format for tombi_ast::ArrayOfTable {
             f.inc_indent();
         }
 
-        let dangling_comment_groups = self.dangling_comment_groups().collect_vec();
-        if !dangling_comment_groups.is_empty() {
-            write!(f, "{}", f.line_ending())?;
-            dangling_comment_groups.format(f)?;
-        }
-
-        let key_value_groups = self.key_value_groups().collect_vec();
+        let key_value_groups = itertools::chain!(
+            self.dangling_comment_groups()
+                .map(DanglingCommentGroupOr::DanglingCommentGroup),
+            self.key_value_groups()
+        )
+        .collect_vec();
         if !key_value_groups.is_empty() {
-            if !dangling_comment_groups.is_empty() {
-                write!(f, "{}", f.line_ending())?;
-            }
-            write!(f, "{}", f.line_ending())?;
+            f.write_line_ending()?;
             key_value_groups.format(f)?;
         }
 
@@ -114,6 +111,61 @@ mod tests {
             [[package]]
             name = "toml-rs"
             version = "0.4.0"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_group_blank_lines_limit_between_dangling_comments_and_first_key_value(
+            r#"
+            [[dependencies]]
+            # aaa
+
+
+
+            tombi-schema-store.workspace = true
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(1.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [[dependencies]]
+            # aaa
+
+            tombi-schema-store.workspace = true
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn array_of_table_group_blank_lines_limit_between_dangling_comments_and_first_key_value_two(
+            r#"
+            [[dependencies]]
+            # aaa
+
+
+
+            tombi-schema-store.workspace = true
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [[dependencies]]
+            # aaa
+
+
+            tombi-schema-store.workspace = true
             "#
         )
     }

--- a/crates/tombi-formatter/src/format/comment.rs
+++ b/crates/tombi-formatter/src/format/comment.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use tombi_ast::{AstNode, DanglingCommentGroupOr, LeadingComment, TrailingComment};
 
-use super::{Format, has_empty_line_before};
+use super::{Format, blank_lines_before};
 
 impl Format for tombi_ast::DanglingCommentGroup {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
@@ -27,10 +27,18 @@ impl Format for Vec<tombi_ast::DanglingCommentGroup> {
             return Ok(());
         }
 
-        for (i, group) in self.iter().enumerate() {
-            if i != 0 {
-                write!(f, "{}", f.line_ending())?;
-                write!(f, "{}", f.line_ending())?;
+        let mut has_written_group = false;
+
+        for group in self {
+            if has_written_group {
+                let blank_lines = blank_lines_before(group).min(f.group_blank_lines_limit());
+                if blank_lines == 0 {
+                    f.write_line_ending()?;
+                } else {
+                    f.write_blank_lines(blank_lines)?;
+                }
+            } else {
+                has_written_group = true;
             }
             group.format(f)?;
         }
@@ -50,10 +58,13 @@ impl<T: Format + AstNode> Format for Vec<DanglingCommentGroupOr<T>> {
                         continue;
                     }
                     if has_written_group {
-                        if has_empty_line_before(comment_group) {
-                            write!(f, "{}", f.line_ending())?;
+                        let blank_lines =
+                            blank_lines_before(group).min(f.group_blank_lines_limit());
+                        if blank_lines == 0 {
+                            f.write_line_ending()?;
+                        } else {
+                            f.write_blank_lines(blank_lines)?;
                         }
-                        write!(f, "{}", f.line_ending())?;
                     } else {
                         has_written_group = true;
                     }
@@ -61,8 +72,13 @@ impl<T: Format + AstNode> Format for Vec<DanglingCommentGroupOr<T>> {
                 }
                 DanglingCommentGroupOr::ItemGroup(item_group) => {
                     if has_written_group {
-                        write!(f, "{}", f.line_ending())?;
-                        write!(f, "{}", f.line_ending())?;
+                        let blank_lines =
+                            blank_lines_before(group).min(f.group_blank_lines_limit());
+                        if blank_lines == 0 {
+                            f.write_line_ending()?;
+                        } else {
+                            f.write_blank_lines(blank_lines)?;
+                        }
                     } else {
                         has_written_group = true;
                     }
@@ -176,6 +192,7 @@ fn format_comment(
 mod tests {
     use itertools::Itertools;
     use tombi_ast::AstNode;
+    use tombi_config::FormatRules;
 
     use crate::{Formatter, test_format};
 
@@ -202,6 +219,62 @@ mod tests {
             "#,
             TomlVersion::V1_0_0
         ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn comment_groups_follow_group_blank_lines_limit(
+            r#"
+            # comment1
+            # comment2
+
+            # comment3
+
+
+            # comment4
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(1.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            # comment1
+            # comment2
+
+            # comment3
+
+            # comment4
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn comment_groups_follow_group_blank_lines_limit_two(
+            r#"
+            # comment1
+
+
+
+            # comment2
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            # comment1
+
+
+            # comment2
+            "#
+        )
     }
 
     test_format! {

--- a/crates/tombi-formatter/src/format/root.rs
+++ b/crates/tombi-formatter/src/format/root.rs
@@ -1,30 +1,31 @@
-use std::fmt::Write;
-
 use itertools::Itertools;
+use tombi_ast::DanglingCommentGroupOr;
 
-use super::Format;
+use super::{Format, blank_lines_before};
 
 impl Format for tombi_ast::Root {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
         f.reset();
 
         let dangling_comment_groups = self.dangling_comment_groups().collect_vec();
-        dangling_comment_groups.format(f)?;
-
         let key_value_groups = self.key_value_groups().collect_vec();
-        if !dangling_comment_groups.is_empty() && !key_value_groups.is_empty() {
-            write!(f, "{}", f.line_ending())?;
-            write!(f, "{}", f.line_ending())?;
-        }
-        key_value_groups.format(f)?;
+        let has_root_content = !dangling_comment_groups.is_empty() || !key_value_groups.is_empty();
+        let groups = itertools::chain!(
+            dangling_comment_groups
+                .into_iter()
+                .map(DanglingCommentGroupOr::DanglingCommentGroup),
+            key_value_groups
+        )
+        .collect_vec();
+
+        groups.format(f)?;
 
         let table_or_array_of_tables = self.table_or_array_of_tables().collect_vec();
 
-        if (!dangling_comment_groups.is_empty() || !key_value_groups.is_empty())
-            && !table_or_array_of_tables.is_empty()
-        {
-            write!(f, "{}", f.line_ending())?;
-            write!(f, "{}", f.line_ending())?;
+        if has_root_content && !table_or_array_of_tables.is_empty() {
+            f.write_blank_lines(
+                blank_lines_before(&table_or_array_of_tables[0]).min(f.group_blank_lines_limit()),
+            )?;
         }
         table_or_array_of_tables.format(f)?;
 
@@ -37,7 +38,7 @@ impl Format for Vec<tombi_ast::TableOrArrayOfTable> {
         let mut header = Header::Root;
         for (i, table_or_array_of_table) in self.iter().enumerate() {
             if i != 0 {
-                write!(f, "{}", f.line_ending())?;
+                f.write_line_ending()?;
             }
             match table_or_array_of_table {
                 tombi_ast::TableOrArrayOfTable::Table(table) => {
@@ -61,7 +62,9 @@ impl Format for Vec<tombi_ast::TableOrArrayOfTable> {
                                 || !header_keys.starts_with(&pre_header_keys)
                                 || has_dangling_comments
                             {
-                                write!(f, "{}", f.line_ending())?;
+                                for _ in 0..f.table_blank_lines() {
+                                    f.write_line_ending()?;
+                                }
                             }
                         }
                     };
@@ -90,7 +93,9 @@ impl Format for Vec<tombi_ast::TableOrArrayOfTable> {
                                 || !header_keys.starts_with(&pre_header_keys)
                                 || has_dangling_comments
                             {
-                                write!(f, "{}", f.line_ending())?;
+                                for _ in 0..f.table_blank_lines() {
+                                    f.write_line_ending()?;
+                                }
                             }
                         }
                         Header::ArrayOfTable {
@@ -103,7 +108,9 @@ impl Format for Vec<tombi_ast::TableOrArrayOfTable> {
                                 || pre_header_keys.same_as(&header_keys)
                                 || has_dangling_comments
                             {
-                                write!(f, "{}", f.line_ending())?;
+                                for _ in 0..f.table_blank_lines() {
+                                    f.write_line_ending()?;
+                                }
                             }
                         }
                     };
@@ -142,6 +149,8 @@ enum Header {
 
 #[cfg(test)]
 mod test {
+    use tombi_config::FormatRules;
+
     use crate::{Formatter, test_format};
 
     test_format! {
@@ -156,6 +165,57 @@ mod test {
 
     test_format! {
         #[tokio::test]
+        async fn root_group_blank_lines_limit_between_dangling_comments_and_first_key_value(
+            r#"
+            # aaa
+
+
+
+            key = "value"
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(1.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            # aaa
+
+            key = "value"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn root_group_blank_lines_limit_between_dangling_comments_and_first_key_value_two(
+            r#"
+            # aaa
+
+
+
+            key = "value"
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            # aaa
+
+
+            key = "value"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn empty_table_space_on_other_table(
             r#"
             [foo]
@@ -163,6 +223,27 @@ mod test {
             [bar.baz]
             "#
         ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_blank_lines_does_not_expand_tight_parent_child_tables(
+            r#"
+            [foo]
+            [foo.bar]
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    table_blank_lines: Some(3.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [foo]
+            [foo.bar]
+            "#
+        )
     }
 
     test_format! {

--- a/crates/tombi-formatter/src/format/root.rs
+++ b/crates/tombi-formatter/src/format/root.rs
@@ -1,7 +1,9 @@
 use itertools::Itertools;
 use tombi_ast::DanglingCommentGroupOr;
 
-use super::{Format, blank_lines_before};
+use crate::format::blank_lines_before;
+
+use super::Format;
 
 impl Format for tombi_ast::Root {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
@@ -9,7 +11,9 @@ impl Format for tombi_ast::Root {
 
         let dangling_comment_groups = self.dangling_comment_groups().collect_vec();
         let key_value_groups = self.key_value_groups().collect_vec();
-        let has_root_content = !dangling_comment_groups.is_empty() || !key_value_groups.is_empty();
+        let dangling_comment_group_is_empty = dangling_comment_groups.is_empty();
+        let key_value_groups_is_empty = key_value_groups.is_empty();
+
         let groups = itertools::chain!(
             dangling_comment_groups
                 .into_iter()
@@ -22,10 +26,17 @@ impl Format for tombi_ast::Root {
 
         let table_or_array_of_tables = self.table_or_array_of_tables().collect_vec();
 
-        if has_root_content && !table_or_array_of_tables.is_empty() {
-            f.write_blank_lines(
-                blank_lines_before(&table_or_array_of_tables[0]).min(f.group_blank_lines_limit()),
-            )?;
+        if (!dangling_comment_group_is_empty || !key_value_groups_is_empty)
+            && !table_or_array_of_tables.is_empty()
+        {
+            if key_value_groups_is_empty {
+                f.write_blank_lines(
+                    blank_lines_before(&table_or_array_of_tables[0])
+                        .min(f.group_blank_lines_limit()),
+                )?;
+            } else {
+                f.write_blank_lines(f.table_blank_lines())?;
+            }
         }
         table_or_array_of_tables.format(f)?;
 

--- a/crates/tombi-formatter/src/format/root.rs
+++ b/crates/tombi-formatter/src/format/root.rs
@@ -234,7 +234,7 @@ mod test {
             "#,
             FormatOptions {
                 rules: Some(FormatRules {
-                    table_blank_lines: Some(3.try_into().unwrap()),
+                    table_blank_lines: Some(3.into()),
                     ..Default::default()
                 }),
             }

--- a/crates/tombi-formatter/src/format/table.rs
+++ b/crates/tombi-formatter/src/format/table.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use itertools::Itertools;
+use tombi_ast::DanglingCommentGroupOr;
 
 use crate::{Format, format::filter_map_unique_keys};
 
@@ -31,18 +32,14 @@ impl Format for tombi_ast::Table {
             f.inc_indent();
         }
 
-        let dangling_comment_groups = self.dangling_comment_groups().collect_vec();
-        if !dangling_comment_groups.is_empty() {
-            write!(f, "{}", f.line_ending())?;
-            dangling_comment_groups.format(f)?;
-        }
-
-        let key_value_groups = self.key_value_groups().collect_vec();
+        let key_value_groups = itertools::chain!(
+            self.dangling_comment_groups()
+                .map(DanglingCommentGroupOr::DanglingCommentGroup),
+            self.key_value_groups()
+        )
+        .collect_vec();
         if !key_value_groups.is_empty() {
-            if !dangling_comment_groups.is_empty() {
-                write!(f, "{}", f.line_ending())?;
-            }
-            write!(f, "{}", f.line_ending())?;
+            f.write_line_ending()?;
             key_value_groups.format(f)?;
         }
 
@@ -65,6 +62,8 @@ impl Format for tombi_ast::Table {
 
 #[cfg(test)]
 mod tests {
+    use tombi_config::FormatRules;
+
     use crate::{Formatter, test_format};
 
     test_format! {
@@ -97,6 +96,101 @@ mod tests {
             version = "0.4.0"
             "#
         ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_group_blank_lines_limit(
+            r#"
+            [table]
+            key1 = "value1"
+            key2 = "value2"
+
+            key3 = "value3"
+
+
+            key4 = "value4"
+
+
+
+            key5 = "value5"
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [table]
+            key1 = "value1"
+            key2 = "value2"
+
+            key3 = "value3"
+
+
+            key4 = "value4"
+
+
+            key5 = "value5"
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_group_blank_lines_limit_between_dangling_comments_and_first_key_value(
+            r#"
+            [dependencies]
+            # aaa
+
+
+
+            tombi-schema-store.workspace = true
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(1.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [dependencies]
+            # aaa
+
+            tombi-schema-store.workspace = true
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn table_group_blank_lines_limit_between_dangling_comments_and_first_key_value_two(
+            r#"
+            [dependencies]
+            # aaa
+
+
+
+            tombi-schema-store.workspace = true
+            "#,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r#"
+            [dependencies]
+            # aaa
+
+
+            tombi-schema-store.workspace = true
+            "#
+        )
     }
 
     test_format! {

--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use itertools::Itertools;
-use tombi_ast::AstNode;
+use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{Format, format::write_trailing_comment_alignment_space, types::WithAlignmentHint};
@@ -98,25 +98,18 @@ fn format_multiline_array(
 
     f.inc_indent();
 
-    let dangling_comment_groups = array.dangling_comment_groups().collect_vec();
-    dangling_comment_groups.format(f)?;
-
     let groups = array
-        .value_with_comma_groups()
-        .map(|group| {
+        .dangling_comment_groups()
+        .map(DanglingCommentGroupOr::DanglingCommentGroup)
+        .chain(array.value_with_comma_groups().map(|group| {
             WithAlignmentHint::new_with_dangling_comment_group_or(
                 group,
                 None,
                 *trailing_comment_alignment_width,
             )
-        })
+        }))
         .collect_vec();
     if !groups.is_empty() {
-        if !dangling_comment_groups.is_empty() {
-            write!(f, "{}", f.line_ending())?;
-            write!(f, "{}", f.line_ending())?;
-        }
-
         groups.format(f)?;
     }
 

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use itertools::Itertools;
-use tombi_ast::AstNode;
+use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use tombi_config::TomlVersion;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -105,28 +105,21 @@ fn format_multiline_inline_table(
 
     f.inc_indent();
 
-    let dangling_comment_groups = table.dangling_comment_groups().collect_vec();
-    dangling_comment_groups.format(f)?;
-
     let key_values = table.key_values().collect_vec();
     let equal_alignment_width = f.key_value_equal_alignment_width(key_values.iter());
 
     let groups = table
-        .key_value_with_comma_groups()
-        .map(|group| {
+        .dangling_comment_groups()
+        .map(DanglingCommentGroupOr::DanglingCommentGroup)
+        .chain(table.key_value_with_comma_groups().map(|group| {
             WithAlignmentHint::new_with_dangling_comment_group_or(
                 group,
                 equal_alignment_width,
                 *trailing_comment_alignment_width,
             )
-        })
+        }))
         .collect_vec();
     if !groups.is_empty() {
-        if !dangling_comment_groups.is_empty() {
-            write!(f, "{}", f.line_ending())?;
-            write!(f, "{}", f.line_ending())?;
-        }
-
         groups.format(f)?;
     }
 

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -238,6 +238,16 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
+    pub(crate) const fn group_blank_lines_limit(&self) -> u8 {
+        self.definitions.group_blank_lines_limit
+    }
+
+    #[inline]
+    pub(crate) const fn table_blank_lines(&self) -> u8 {
+        self.definitions.table_blank_lines
+    }
+
+    #[inline]
     pub(crate) const fn indent_sub_tables(&self) -> bool {
         self.definitions.indent_sub_tables
     }
@@ -352,6 +362,16 @@ impl<'a> Formatter<'a> {
     #[inline]
     pub(crate) fn reset(&mut self) {
         self.reset_indent();
+    }
+
+    #[inline]
+    pub(crate) fn write_line_ending(&mut self) -> Result<(), std::fmt::Error> {
+        write!(self, "{}", self.line_ending())
+    }
+
+    #[inline]
+    pub(crate) fn write_blank_lines(&mut self, count: u8) -> Result<(), std::fmt::Error> {
+        self.write_str(&self.line_ending().repeat(usize::from(count) + 1))
     }
 
     #[inline]

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -11,6 +11,8 @@ use tombi_config::{DateTimeDelimiter, FormatOptions, IndentStyle, StringQuoteSty
 pub struct FormatDefinitions {
     pub line_width: u8,
     pub line_ending: tombi_config::LineEnding,
+    pub group_blank_lines_limit: u8,
+    pub table_blank_lines: u8,
     pub indent_style: IndentStyle,
     pub indent_sub_tables: bool,
     pub indent_table_key_values: bool,
@@ -41,6 +43,18 @@ impl FormatDefinitions {
                 .as_ref()
                 .and_then(|rules| rules.line_ending)
                 .unwrap_or_default(),
+            group_blank_lines_limit: options
+                .rules
+                .as_ref()
+                .and_then(|rules| rules.group_blank_lines_limit)
+                .unwrap_or_default()
+                .value(),
+            table_blank_lines: options
+                .rules
+                .as_ref()
+                .and_then(|rules| rules.table_blank_lines)
+                .unwrap_or_default()
+                .value(),
             indent_style: options
                 .rules
                 .as_ref()

--- a/crates/tombi-formatter/src/lib.rs
+++ b/crates/tombi-formatter/src/lib.rs
@@ -366,6 +366,70 @@ mod test {
 
     test_format! {
         #[tokio::test]
+        async fn test_document_comment_directive_format_with_group_blank_lines_limit_2(r#"
+            #:tombi toml-version = "v1.1.0"
+
+
+            key1 = 1  # key value1 trailing comment
+            "#,
+            FormatOptions{
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(r#"
+            #:tombi toml-version = "v1.1.0"
+
+
+            key1 = 1  # key value1 trailing comment
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn test_document_comment_directive_format_table(r#"
+            #:tombi toml-version = "v1.1.0"
+            [table]
+            key1 = 1
+            "#
+        ) -> Ok(r#"
+            #:tombi toml-version = "v1.1.0"
+
+            [table]
+            key1 = 1
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn test_document_comment_directive_format_table_with_group_blank_lines_limit_2(r#"
+            #:tombi toml-version = "v1.1.0"
+
+
+            [table]
+            key1 = 1  # key value1 trailing comment
+            "#,
+            FormatOptions{
+                rules: Some(FormatRules {
+                    group_blank_lines_limit: Some(2.try_into().unwrap()),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(r#"
+            #:tombi toml-version = "v1.1.0"
+
+
+            [table]
+            key1 = 1  # key value1 trailing comment
+            "#
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
         async fn test_sample_toml(
 r#"
 # key values begin dangling comment1

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -236,6 +236,63 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_group_blank_lines_limit_two_between_comment_and_first_table(
+                r#"
+                # comment
+
+
+                [table]
+                key = "value"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                # comment
+
+
+                [table]
+                key = "value"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_two_before_table_is_clamped_by_table_blank_lines(
+                r#"
+                key = "value"
+
+                # comment
+
+
+                [table]
+                key = "value"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = "value"
+
+                # comment
+
+                [table]
+                key = "value"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_group_blank_lines_limit_in_array(
                 r#"
                 key = [

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -666,6 +666,54 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_table_blank_lines_one_between_root_key_values_and_first_table(
+                r#"
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(1.into()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key1 = "value1"
+
+                [bbb]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_zero_between_root_key_values_and_first_table(
+                r#"
+                key1 = "value1"
+
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(0.into()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_table_blank_lines_one(
                 r#"
                 [aaa]

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -127,6 +127,479 @@ mod format_options {
         }
     }
 
+    mod group_blank_lines_limit {
+        use super::*;
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_one(
+                r#"
+                key1 = "value1"
+                key2 = "value2"
+
+                key3 = "value3"
+
+
+                key4 = "value4"
+
+
+
+                key5 = "value5"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(1.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key1 = "value1"
+                key2 = "value2"
+
+                key3 = "value3"
+
+                key4 = "value4"
+
+                key5 = "value5"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_two(
+                r#"
+                key1 = "value1"
+                key2 = "value2"
+
+                key3 = "value3"
+
+
+                key4 = "value4"
+
+
+
+                key5 = "value5"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key1 = "value1"
+                key2 = "value2"
+
+                key3 = "value3"
+
+
+                key4 = "value4"
+
+
+                key5 = "value5"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_mixed_root_groups_two(
+                r#"
+                key1 = "value1"
+
+                # aaa
+
+
+
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key1 = "value1"
+
+                # aaa
+
+
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_in_array(
+                r#"
+                key = [
+                  1111111111,
+                  2222222222,
+
+                  3333333333,
+
+
+                  4444444444,
+
+
+
+                  5555555555
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(1.try_into().unwrap()),
+                        line_width: Some(10.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = [
+                  1111111111,
+                  2222222222,
+
+                  3333333333,
+
+                  4444444444,
+
+                  5555555555
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_in_array_two(
+                r#"
+                key = [
+                  1111111111,
+                  2222222222,
+
+                  3333333333,
+
+
+                  4444444444,
+
+
+
+                  5555555555
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(10.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = [
+                  1111111111,
+                  2222222222,
+
+                  3333333333,
+
+
+                  4444444444,
+
+
+                  5555555555
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_mixed_groups_in_array_two(
+                r#"
+                key = [
+                  1111111111,
+
+                  # aaa
+
+
+
+                  2222222222
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(10.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = [
+                  1111111111,
+
+                  # aaa
+
+
+                  2222222222
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_between_array_dangling_comments_and_first_item_group(
+                r#"
+                key = [
+                  # aaa
+
+
+
+                  1111111111
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(1.try_into().unwrap()),
+                        line_width: Some(10.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = [
+                  # aaa
+
+                  1111111111
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_between_array_dangling_comments_and_first_item_group_two(
+                r#"
+                key = [
+                  # aaa
+
+
+
+                  1111111111
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(10.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                key = [
+                  # aaa
+
+
+                  1111111111
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_in_inline_table(
+                r#"
+                table = {
+                  key1 = "value1",
+                  key2 = "value2",
+
+                  key3 = "value3",
+
+
+                  key4 = "value4",
+
+
+
+                  key5 = "value5"
+                }
+                "#,
+                tombi_config::TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(1.try_into().unwrap()),
+                        line_width: Some(20.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                table = {
+                  key1 = "value1",
+                  key2 = "value2",
+
+                  key3 = "value3",
+
+                  key4 = "value4",
+
+                  key5 = "value5"
+                }
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_in_inline_table_two(
+                r#"
+                table = {
+                  key1 = "value1",
+                  key2 = "value2",
+
+                  key3 = "value3",
+
+
+                  key4 = "value4",
+
+
+
+                  key5 = "value5"
+                }
+                "#,
+                tombi_config::TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(20.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                table = {
+                  key1 = "value1",
+                  key2 = "value2",
+
+                  key3 = "value3",
+
+
+                  key4 = "value4",
+
+
+                  key5 = "value5"
+                }
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_mixed_groups_in_inline_table_two(
+                r#"
+                table = {
+                  key1 = "value1",
+
+                  # aaa
+
+
+
+                  key2 = "value2"
+                }
+                "#,
+                tombi_config::TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(20.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                table = {
+                  key1 = "value1",
+
+                  # aaa
+
+
+                  key2 = "value2"
+                }
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_between_inline_table_dangling_comments_and_first_item_group(
+                r#"
+                table = {
+                  # aaa
+
+
+
+                  key1 = "value1"
+                }
+                "#,
+                tombi_config::TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(1.try_into().unwrap()),
+                        line_width: Some(20.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                table = {
+                  # aaa
+
+                  key1 = "value1"
+                }
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_group_blank_lines_limit_between_inline_table_dangling_comments_and_first_item_group_two(
+                r#"
+                table = {
+                  # aaa
+
+
+
+                  key1 = "value1"
+                }
+                "#,
+                tombi_config::TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        group_blank_lines_limit: Some(2.try_into().unwrap()),
+                        line_width: Some(20.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                table = {
+                  # aaa
+
+
+                  key1 = "value1"
+                }
+                "#
+            )
+        }
+    }
+
     mod date_time_delimiter {
         use super::*;
 
@@ -183,6 +656,197 @@ mod format_options {
             ) -> Ok(
                 r#"
                 key = 2024-01-01T10:00:00
+                "#
+            )
+        }
+    }
+
+    mod table_blank_lines {
+        use super::*;
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_one(
+                r#"
+                [aaa]
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(1.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [aaa]
+                key1 = "value1"
+
+                [bbb]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_zero(
+                r#"
+                [aaa]
+                key1 = "value1"
+
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(0.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [aaa]
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_two_between_parent_and_child_table_with_key_values(
+                r#"
+                [foo]
+                key1 = "value1"
+                [foo.bar]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [foo]
+                key1 = "value1"
+
+
+                [foo.bar]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_two_between_parent_and_child_array_of_tables_with_key_values(
+                r#"
+                [foo]
+                key1 = "value1"
+                [[foo.bar]]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [foo]
+                key1 = "value1"
+
+
+                [[foo.bar]]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_two(
+                r#"
+                [aaa]
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(2.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [aaa]
+                key1 = "value1"
+
+
+                [bbb]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_zero_between_array_of_tables_with_same_header(
+                r#"
+                [[foo]]
+                key1 = "value1"
+
+                [[foo]]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(0.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [[foo]]
+                key1 = "value1"
+                [[foo]]
+                key2 = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_table_blank_lines_three(
+                r#"
+                [aaa]
+                key1 = "value1"
+                [bbb]
+                key2 = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        table_blank_lines: Some(3.try_into().unwrap()),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [aaa]
+                key1 = "value1"
+
+
+
+                [bbb]
+                key2 = "value2"
                 "#
             )
         }

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -675,7 +675,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(1.try_into().unwrap()),
+                        table_blank_lines: Some(1.into()),
                         ..Default::default()
                     }),
                 }
@@ -702,7 +702,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(0.try_into().unwrap()),
+                        table_blank_lines: Some(0.into()),
                         ..Default::default()
                     }),
                 }
@@ -727,7 +727,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(2.try_into().unwrap()),
+                        table_blank_lines: Some(2.into()),
                         ..Default::default()
                     }),
                 }
@@ -754,7 +754,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(2.try_into().unwrap()),
+                        table_blank_lines: Some(2.into()),
                         ..Default::default()
                     }),
                 }
@@ -781,7 +781,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(2.try_into().unwrap()),
+                        table_blank_lines: Some(2.into()),
                         ..Default::default()
                     }),
                 }
@@ -809,7 +809,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(0.try_into().unwrap()),
+                        table_blank_lines: Some(0.into()),
                         ..Default::default()
                     }),
                 }
@@ -834,7 +834,7 @@ mod format_options {
                 "#,
                 FormatOptions {
                     rules: Some(FormatRules {
-                        table_blank_lines: Some(3.try_into().unwrap()),
+                        table_blank_lines: Some(3.into()),
                         ..Default::default()
                     }),
                 }

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -837,7 +837,7 @@ mod table_keys_order {
                 ConfigText(
                     r#"
                     [[schemas]]
-                    path = "tombi://json.schemastore.org/cargo.json"
+                    path = "tombi://www.schemastore.org/cargo.json"
                     include = ["Cargo.toml"]
                     [schemas.format.rules.array-values-order]
                     enabled = false

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -232,7 +232,7 @@ fn write_table_keys_order(
                     f,
                     "  - {}: {}\n",
                     key.target,
-                    markdown_code(&key.order, strike)
+                    markdown_code(key.order, strike)
                 )?;
             }
             Ok(())

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -142,7 +142,7 @@ mod goto_type_definition_tests {
                 "#,
                 SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
-            ) -> Ok("https://www.schemastore.org/partial-taskipy.json");
+            ) -> Ok("https://json.schemastore.org/partial-taskipy.json");
         );
 
         test_goto_type_definition!(

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -20,7 +20,7 @@ mod goto_type_definition_tests {
                 r#"
                 toml-version = "█v1.0.0"
                 "#,
-                SourcePath(tombi_schema_path()),
+                SourcePath("tombi.toml".into()),
                 SchemaPath(tombi_schema_path()),
             ) -> Ok(tombi_schema_path());
         );
@@ -32,7 +32,7 @@ mod goto_type_definition_tests {
                 [schema.catalog]
                 path = "█https://www.schemastore.org/api/json/catalog.json"
                 "#,
-                SourcePath(tombi_schema_path()),
+                SourcePath("tombi.toml".into()),
                 SchemaPath(tombi_schema_path()),
             ) -> Ok(tombi_schema_path());
         );
@@ -43,7 +43,7 @@ mod goto_type_definition_tests {
                 r#"
                 [[schemas█]]
                 "#,
-                SourcePath(tombi_schema_path()),
+                SourcePath("tombi.toml".into()),
                 SchemaPath(tombi_schema_path()),
             ) -> Ok(tombi_schema_path());
         );
@@ -60,7 +60,7 @@ mod goto_type_definition_tests {
                 [package]
                 name█ = "tombi"
                 "#,
-                SourcePath(cargo_schema_path()),
+                SourcePath("Cargo.toml".into()),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok(cargo_schema_path());
         );
@@ -72,7 +72,7 @@ mod goto_type_definition_tests {
                 [package]
                 readme = "█README.md"
                 "#,
-                SourcePath(cargo_schema_path()),
+                SourcePath("Cargo.toml".into()),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok(cargo_schema_path());
         );
@@ -84,7 +84,7 @@ mod goto_type_definition_tests {
                 [dependencies]
                 serde█ = { workspace = true }
                 "#,
-                SourcePath(cargo_schema_path()),
+                SourcePath("Cargo.toml".into()),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok(cargo_schema_path());
         );
@@ -96,7 +96,7 @@ mod goto_type_definition_tests {
                 [profile.release]
                 strip = "debuginfo█"
                 "#,
-                SourcePath(cargo_schema_path()),
+                SourcePath("Cargo.toml".into()),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok(cargo_schema_path());
         );
@@ -114,7 +114,7 @@ mod goto_type_definition_tests {
                 [project]
                 readme = "█1.0.0"
                 "#,
-                SourcePath(pyproject_schema_path()),
+                SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
             ) -> Ok(pyproject_schema_path());
         );
@@ -128,7 +128,7 @@ mod goto_type_definition_tests {
                     "█pytest>=8.3.3",
                 ]
                 "#,
-                SourcePath(pyproject_schema_path()),
+                SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
             ) -> Ok(pyproject_schema_path());
         );
@@ -140,7 +140,7 @@ mod goto_type_definition_tests {
                 [tool.taskipy.tasks]
                 format█ = "ruff"
                 "#,
-                SourcePath(pyproject_schema_path()),
+                SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
             ) -> Ok("https://json.schemastore.org/partial-taskipy.json");
         );
@@ -153,7 +153,7 @@ mod goto_type_definition_tests {
                 [project]
                 name = "tombi"
                 "#,
-                SourcePath(pyproject_schema_path()),
+                SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-document-directive.json");
         );
@@ -170,7 +170,6 @@ mod goto_type_definition_tests {
                 repo = "builtin"
                 ho█oks = []
                 "#,
-                SourcePath(adjacent_one_of_hover_test_schema_path()),
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
             ) -> Ok(adjacent_one_of_hover_test_schema_path());
         );
@@ -185,7 +184,6 @@ mod goto_type_definition_tests {
                   { id = "█hook" }
                 ]
                 "#,
-                SourcePath(adjacent_one_of_hover_test_schema_path()),
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
             ) -> Ok(adjacent_one_of_hover_test_schema_path());
         );
@@ -200,7 +198,6 @@ mod goto_type_definition_tests {
                 r#"
                 offset_date_time_all = 2024-01-15T█10:30:00Z
                 "#,
-                SourcePath(adjacent_applicators_test_schema_path()),
                 SchemaPath(adjacent_applicators_test_schema_path()),
             ) -> Ok(adjacent_applicators_test_schema_path());
         );
@@ -211,7 +208,6 @@ mod goto_type_definition_tests {
                 r#"
                 boolean_all = tr█ue
                 "#,
-                SourcePath(adjacent_applicators_test_schema_path()),
                 SchemaPath(adjacent_applicators_test_schema_path()),
             ) -> Ok(adjacent_applicators_test_schema_path());
         );
@@ -227,7 +223,6 @@ mod goto_type_definition_tests {
                 [typed_extra_table]
                 extra = { id = "█value" }
                 "#,
-                SourcePath(lsp_consistency_test_schema_path()),
                 SchemaPath(lsp_consistency_test_schema_path()),
             ) -> Ok(lsp_consistency_test_schema_path());
         );
@@ -238,7 +233,6 @@ mod goto_type_definition_tests {
                 r#"
                 typed_unevaluated_tuple = [1, { id = "█value" }]
                 "#,
-                SourcePath(lsp_consistency_test_schema_path()),
                 SchemaPath(lsp_consistency_test_schema_path()),
             ) -> Ok(lsp_consistency_test_schema_path());
         );
@@ -249,7 +243,6 @@ mod goto_type_definition_tests {
                 r#"
                 typed_overflow_tuple = [1, { id = "█value" }]
                 "#,
-                SourcePath(lsp_consistency_test_schema_path()),
                 SchemaPath(lsp_consistency_test_schema_path()),
             ) -> Ok(lsp_consistency_test_schema_path());
         );
@@ -260,7 +253,6 @@ mod goto_type_definition_tests {
                 r#"
                 items = ["zero", "█scoped"]
                 "#,
-                SourcePath(lsp_consistency_test_schema_path()),
                 SubSchemaPath {
                     root: "items[1]".to_string(),
                     path: exact_index_string_test_schema_path(),
@@ -283,7 +275,6 @@ mod goto_type_definition_tests {
                 [table]
                 integer = 42
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-document-directive.json");
         );
@@ -295,7 +286,6 @@ mod goto_type_definition_tests {
                 #:tombi schema.strict█ = true
                 integer = 42
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-document-directive.json");
         );
@@ -309,7 +299,6 @@ mod goto_type_definition_tests {
                 [table]
                 integer = 42
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-document-directive.json");
         );
@@ -322,7 +311,6 @@ mod goto_type_definition_tests {
 
                 key = "value"
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-root-table-directive.json");
         );
@@ -335,7 +323,6 @@ mod goto_type_definition_tests {
 
                 # tombi: lint.rules.const-value.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-group-boundary-directive.json");
         );
@@ -347,7 +334,6 @@ mod goto_type_definition_tests {
                 # tombi: lint.rules.key-empty█ = "off"
                 string = "string"
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-string-directive.json");
         );
@@ -362,7 +348,6 @@ mod goto_type_definition_tests {
                   "string"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-array-directive.json");
         );
@@ -377,7 +362,6 @@ mod goto_type_definition_tests {
                   "string"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-array-directive.json");
         );
@@ -391,7 +375,6 @@ mod goto_type_definition_tests {
                   "string"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-string-directive.json");
         );
@@ -404,7 +387,6 @@ mod goto_type_definition_tests {
                   "string" # tombi: lint.rules.string-min-length█ = "off"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-string-directive.json");
         );
@@ -417,7 +399,6 @@ mod goto_type_definition_tests {
                   "string", # tombi: lint.rules.string-min-length█ = "off"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-string-directive.json");
         );
@@ -431,7 +412,6 @@ mod goto_type_definition_tests {
                   , # tombi: lint.rules.string-min-length█ = "off"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-string-directive.json");
         );
@@ -445,7 +425,6 @@ mod goto_type_definition_tests {
                   # tombi: lint.rules.array-min-items█ = "off"
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-group-boundary-directive.json");
         );
@@ -459,7 +438,6 @@ mod goto_type_definition_tests {
                   ,
                 ] # tombi: lint.rules.array-min-items█ = "off"
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-array-directive.json");
         );
@@ -473,7 +451,6 @@ mod goto_type_definition_tests {
                   []
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-array-directive.json");
         );
@@ -485,7 +462,6 @@ mod goto_type_definition_tests {
                 # tombi: lint.rules.table-min-properties█ = "off"
                 inline-table = { key = "value", }
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-inline-table-directive.json");
         );
@@ -499,7 +475,6 @@ mod goto_type_definition_tests {
                   { key = "value", }
                 ]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-inline-table-directive.json");
         );
@@ -512,7 +487,6 @@ mod goto_type_definition_tests {
                   key = "value",
                 }
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-inline-table-directive.json");
         );
@@ -523,7 +497,6 @@ mod goto_type_definition_tests {
                 r#"
                 inline-table = { key = "value", } # tombi: lint.rules.table-min-properties█ = "off"
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-inline-table-directive.json");
         );
@@ -535,7 +508,6 @@ mod goto_type_definition_tests {
                 # tombi: lint.rules.const-value.disabled█ = true
                 [table]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-table-directive.json");
         );
@@ -547,7 +519,6 @@ mod goto_type_definition_tests {
                 [table]
                 # tombi: lint.rules.const-value.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-table-directive.json");
         );
@@ -559,7 +530,6 @@ mod goto_type_definition_tests {
                 # tombi: lint.rules.const-value.disabled█ = true
                 [[array]]
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-array-of-table-directive.json");
         );
@@ -570,7 +540,6 @@ mod goto_type_definition_tests {
                 r#"
                 [[array]] # tombi: lint.rules.const-value.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-array-of-table-directive.json");
         );
@@ -582,7 +551,6 @@ mod goto_type_definition_tests {
                 [[array]]
                 # tombi: lint.rules.const-value.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-table-directive.json");
         );
@@ -593,7 +561,6 @@ mod goto_type_definition_tests {
                 r#"
                 key = "value"  # tombi: lint.rules.string-pattern.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-string-directive.json");
         );
@@ -604,7 +571,6 @@ mod goto_type_definition_tests {
                 r#"
                 key1.key2 = "value"  # tombi: lint.rules.string-pattern.disabled█ = true
                 "#,
-                SourcePath(type_test_schema_path()),
                 SchemaPath(type_test_schema_path()),
             ) -> Ok("tombi://www.schemastore.tombi/tombi-key-string-directive.json");
         );
@@ -735,8 +701,7 @@ mod goto_type_definition_tests {
 
                 let source_path = args
                     .source_file_path
-                    .as_ref()
-                    .ok_or("SourcePath must be provided for goto_type_definition tests")?;
+                    .unwrap_or("test.toml".into());
 
                 let temp_dir = source_path.parent().ok_or("failed to get parent directory")?;
                 let Ok(temp_file) = tempfile::NamedTempFile::with_suffix_in(

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -142,7 +142,7 @@ mod goto_type_definition_tests {
                 "#,
                 SourcePath("pyproject.toml".into()),
                 SchemaPath(pyproject_schema_path()),
-            ) -> Ok("https://json.schemastore.org/partial-taskipy.json");
+            ) -> Ok("https://www.schemastore.org/partial-taskipy.json");
         );
 
         test_goto_type_definition!(

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -626,18 +626,22 @@ The number of blank lines inserted between table or array-of-table blocks when t
 
 ```toml
 # BEFORE
-[aaa]
 key1 = "value1"
-[bbb]
+[aaa]
 key2 = "value2"
+[bbb]
+key3 = "value3"
 
 # AFTER (`table-blank-lines = 2`)
-[aaa]
 key1 = "value1"
 
 
-[bbb]
+[aaa]
 key2 = "value2"
+
+
+[bbb]
+key3 = "value3"
 ```
 
 Tight parent/child table adjacency is controlled separately, so this does not apply when a child table follows a parent table that has no key-value pairs.

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -444,6 +444,33 @@ These boundaries remain significant for auto-sorting. The formatter only caps th
 - Default: `1`
 - Minimum: `1`
 
+```toml
+# BEFORE
+key1 = "value1"
+key2 = "value2"
+
+key3 = "value3"
+
+
+key4 = "value4"
+
+
+
+key5 = "value5"
+
+# AFTER (`group-blank-lines-limit = 2`)
+key1 = "value1"
+key2 = "value2"
+
+key3 = "value3"
+
+
+key4 = "value4"
+
+
+key5 = "value5"
+```
+
 ### format.rules.indent-style
 
 The style of indentation
@@ -596,6 +623,35 @@ The number of blank lines inserted between table or array-of-table blocks when t
 - Type: `Number`
 - Default: `1`
 - Minimum: `0`
+
+```toml
+# BEFORE
+[aaa]
+key1 = "value1"
+[bbb]
+key2 = "value2"
+
+# AFTER (`table-blank-lines = 2`)
+[aaa]
+key1 = "value1"
+
+
+[bbb]
+key2 = "value2"
+```
+
+Tight parent/child table adjacency is controlled separately, so this does not apply when a child table follows a parent table that has no key-value pairs.
+
+```toml
+# BEFORE
+[aaa]
+
+[aaa.bbb]
+
+# AFTER
+[aaa]
+[aaa.bbb]
+```
 
 ### format.rules.trailing-comment-alignment
 

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -41,6 +41,7 @@ Therefore, it is recommended to place `tombi.toml` only at the root of your proj
     - [format.rules.array-bracket-space-width](#format-rules-array-bracket-space-width)
     - [format.rules.array-comma-space-width](#format-rules-array-comma-space-width)
     - [format.rules.date-time-delimiter](#format-rules-date-time-delimiter)
+    - [format.rules.group-blank-lines-limit](#format-rules-group-blank-lines-limit)
     - [format.rules.indent-style](#format-rules-indent-style)
     - [format.rules.indent-sub-tables](#format-rules-indent-sub-tables)
     - [format.rules.indent-table-key-value-pairs](#format-rules-indent-table-key-value-pairs)
@@ -52,6 +53,7 @@ Therefore, it is recommended to place `tombi.toml` only at the root of your proj
     - [format.rules.line-ending](#format-rules-line-ending)
     - [format.rules.line-width](#format-rules-line-width)
     - [format.rules.string-quote-style](#format-rules-string-quote-style)
+    - [format.rules.table-blank-lines](#format-rules-table-blank-lines)
     - [format.rules.trailing-comment-alignment](#format-rules-trailing-comment-alignment)
     - [format.rules.trailing-comment-space-width](#format-rules-trailing-comment-space-width)
 - [lint](#lint)
@@ -156,6 +158,7 @@ exclude = [".cache/**/*.toml"]
 array-bracket-space-width = 0
 array-comma-space-width = 1
 date-time-delimiter = "T"
+group-blank-lines-limit = 1
 indent-style = "space"
 indent-sub-tables = false
 indent-table-key-value-pairs = false
@@ -167,6 +170,7 @@ key-value-equals-sign-space-width = 1
 line-ending = "lf"
 line-width = 80
 string-quote-style = "double"
+table-blank-lines = 1
 trailing-comment-alignment = false
 trailing-comment-space-width = 2
 
@@ -242,6 +246,7 @@ enabled = true
 array-bracket-space-width = 1
 array-comma-space-width = 1
 date-time-delimiter = "space"
+group-blank-lines-limit = 1
 indent-style = "tab"
 indent-sub-tables = true
 indent-table-key-value-pairs = true
@@ -253,6 +258,7 @@ key-value-equals-sign-space-width = 1
 line-ending = "crlf"
 line-width = 120
 string-quote-style = "single"
+table-blank-lines = 1
 trailing-comment-alignment = true
 trailing-comment-space-width = 1
 
@@ -428,6 +434,16 @@ In accordance with [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), yo
   - `space`: Use space between date and time like `2001-01-01 00:00:00`
   - `preserve`: Preserve the original delimiter.
 
+### format.rules.group-blank-lines-limit
+
+The maximum number of blank lines to preserve between groups.
+
+These boundaries remain significant for auto-sorting. The formatter only caps the amount of spacing that is preserved.
+
+- Type: `Number`
+- Default: `1`
+- Minimum: `1`
+
 ### format.rules.indent-style
 
 The style of indentation
@@ -531,31 +547,6 @@ key3.key4 = "value3"
 This feature does **not** apply to key-value pairs inside single line inline tables.
 </Warning>
 
-### format.rules.trailing-comment-alignment
-
-Whether to align the trailing comments in the key-value pairs.
-
-If `true`, the trailing comments in value/key-value pairs will be aligned.
-
-- Type: `Boolean`
-- Default: `false`
-
-```toml
-# BEFORE
-key = "value1"  # comment 1
-key2 = "value2"  # comment 2
-key3.key4 = "value3"  # comment 3
-
-# AFTER
-key = "value1"        # comment 1
-key2 = "value2"       # comment 2
-key3.key4 = "value3"  # comment 3
-```
-
-<Note>
-The trailing comments of table header are not targeted by alignment.
-</Note>
-
 ### format.rules.key-value-equals-sign-space-width
 
 The number of spaces around the equals sign in a key-value pair.
@@ -597,6 +588,39 @@ The preferred quote character for strings.
   - `double`: Prefer the double quote like `"value"`
   - `single`: Prefer the single quote like `'value'`
   - `preserve`: Preserve the original quote
+
+### format.rules.table-blank-lines
+
+The number of blank lines inserted between table or array-of-table blocks when they are separated.
+
+- Type: `Number`
+- Default: `1`
+- Minimum: `0`
+
+### format.rules.trailing-comment-alignment
+
+Whether to align the trailing comments in the key-value pairs.
+
+If `true`, the trailing comments in value/key-value pairs will be aligned.
+
+- Type: `Boolean`
+- Default: `false`
+
+```toml
+# BEFORE
+key = "value1"  # comment 1
+key2 = "value2"  # comment 2
+key3.key4 = "value3"  # comment 3
+
+# AFTER
+key = "value1"        # comment 1
+key2 = "value2"       # comment 2
+key3.key4 = "value3"  # comment 3
+```
+
+<Note>
+The trailing comments of table header are not targeted by alignment.
+</Note>
 
 ### format.rules.trailing-comment-space-width
 

--- a/docs/src/routes/docs/language-server/command.mdx
+++ b/docs/src/routes/docs/language-server/command.mdx
@@ -177,7 +177,7 @@ Returns `true` if the schema was updated successfully, `false` otherwise.
 ```typescript
 // Update a schema from its remote source
 const updated = await client.sendRequest("tombi/updateSchema", {
-  textDocument: { uri: "https://json.schemastore.org/cargo.json" }
+  textDocument: { uri: "https://www.schemastore.org/cargo.json" }
 });
 
 if (updated) {

--- a/docs/src/routes/docs/reference/difference-taplo.mdx
+++ b/docs/src/routes/docs/reference/difference-taplo.mdx
@@ -155,8 +155,14 @@ The following table shows the correspondence between [Taplo's options](https://t
     </tr>
     <tr>
       <td><code>allowed_blank_lines</code></td>
-      <td>Not supported</td>
-      <td>For [Auto Sorting](/docs/formatter/auto-sorting).</td>
+      <td>
+        [`group-blank-lines-limit`](/docs/configuration#format-rules-group-blank-lines-limit), <br />
+        [`table-blank-lines`](/docs/configuration#format-rules-table-blank-lines)
+      </td>
+      <td>
+        Use <code>group-blank-lines-limit</code> to preserve blank lines between groups, and
+        <code>table-blank-lines</code> to control blank lines between tables.
+      </td>
     </tr>
     <tr>
       <td><code>crlf</code></td>

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -865,6 +865,7 @@ opt = "optional"
             .expect("TOML serialization failed");
         let expected = r#"
 simple_value = 42
+
 [nested]
 value = "nested value"
 "#;

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -865,7 +865,6 @@ opt = "optional"
             .expect("TOML serialization failed");
         let expected = r#"
 simple_value = 42
-
 [nested]
 value = "nested value"
 "#;

--- a/www.schemastore.org/README.md
+++ b/www.schemastore.org/README.md
@@ -10,22 +10,22 @@ To use these embedded schemas, simply replace the `http://` or `https://` scheme
 
 Instead of:
 ```
-https://json.schemastore.org/cargo.json
+https://www.schemastore.org/cargo.json
 ```
 
 Use:
 ```
-tombi://json.schemastore.org/cargo.json
+tombi://www.schemastore.org/cargo.json
 ```
 
 ## Available Schemas
 
 The following schemas are available:
 
-- `tombi://json.schemastore.org/api/json/catalog.json` - Schema catalog
-- `tombi://json.schemastore.org/cargo.json` - Cargo manifest schema
-- `tombi://json.schemastore.org/pyproject.json` - PyProject schema
-- `tombi://json.schemastore.org/tombi.json` - Tombi configuration schema
+- `tombi://www.schemastore.org/api/json/catalog.json` - Schema catalog
+- `tombi://www.schemastore.org/cargo.json` - Cargo manifest schema
+- `tombi://www.schemastore.org/pyproject.json` - PyProject schema
+- `tombi://www.schemastore.org/tombi.json` - Tombi configuration schema
 
 ## Benefits
 
@@ -37,7 +37,7 @@ The following schemas are available:
 ## Compatibility
 
 The `tombi://` scheme is fully compatible with the standard JSON Schema Store URLs. You can use either:
-- `https://json.schemastore.org/...` (fetches from the internet)
-- `tombi://json.schemastore.org/...` (uses embedded schema)
+- `https://www.schemastore.org/...` (fetches from the internet)
+- `tombi://www.schemastore.org/...` (uses embedded schema)
 
 Both URLs point to the same schema content, but the `tombi://` version uses the embedded copy for better performance and offline support.

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -216,6 +216,19 @@
           ],
           "default": "T"
         },
+        "group-blank-lines-limit": {
+          "title": "The blank lines limit between groups.",
+          "description": "Consecutive groups remain separate for sorting purposes,\nand existing blank lines between them are preserved up to this limit.\n\n```toml\n# BEFORE\nkey1 = \"value1\"\nkey2 = \"value2\"\n\nkey3 = \"value3\"\n\n\nkey4 = \"value4\"\n\n# AFTER (`group-blank-lines-limit = 1`)\nkey1 = \"value1\"\nkey2 = \"value2\"\n\nkey3 = \"value3\"\n\nkey4 = \"value4\"\n```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BlankLinesLimit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1
+        },
         "indent-style": {
           "title": "The style of indentation",
           "description": "Whether to use spaces or tabs for indentation.\n\n- `space`: Use spaces for indentation.\n- `tab`: Use tabs for indentation.",
@@ -356,6 +369,19 @@
           ],
           "default": 80
         },
+        "table-blank-lines": {
+          "title": "The number of blank lines between tables.",
+          "description": "This applies when the formatter inserts spacing between table or array-of-table blocks.\n\n```toml\n# BEFORE\n[aaa]\nkey1 = \"value1\"\n[bbb]\nkey2 = \"value2\"\n\n# AFTER (`table-blank-lines = 2`)\n[aaa]\nkey1 = \"value1\"\n\n\n[bbb]\nkey2 = \"value2\"\n```\n\nTight parent/child table adjacency is controlled separately, so this does not apply\nwhen a child table follows a parent table that has no key-value pairs.\n\n```toml\n# BEFORE\n[aaa]\n\n[aaa.bbb]\n\n# AFTER\n[aaa]\n[aaa.bbb]\n```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BlankLines"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1
+        },
         "trailing-comment-space-width": {
           "title": "The number of spaces before the trailing comment.",
           "description": "```toml\nkey = \"value\"  # trailing comment\n#            ^^  <- this\n```",
@@ -404,6 +430,12 @@
           "const": "preserve"
         }
       ]
+    },
+    "BlankLinesLimit": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 1,
+      "maximum": 255
     },
     "IndentStyle": {
       "type": "string",
@@ -476,6 +508,12 @@
       "type": "integer",
       "format": "uint8",
       "minimum": 1,
+      "maximum": 255
+    },
+    "BlankLines": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0,
       "maximum": 255
     },
     "TrailingCommentSpaceWidth": {

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -188,27 +188,6 @@ impl Target {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn unix_targets_always_use_tar_gz() {
-        unsafe {
-            std::env::set_var("TOMBI_TARGET", "aarch64-apple-darwin");
-        }
-        let target = Target::get(Path::new("."));
-        assert_eq!(
-            target.cli_artifact_name,
-            format!("tombi-cli-{DEV_VERSION}-aarch64-apple-darwin.tar.gz")
-        );
-
-        unsafe {
-            std::env::remove_var("TOMBI_TARGET");
-        }
-    }
-}
-
 fn tar_gz(src_path: &Path, root_dir: &str, dest_path: &Path) -> anyhow::Result<()> {
     let encoder = GzEncoder::new(File::create(dest_path)?, Compression::best());
     let mut archive = TarBuilder::new(encoder);
@@ -258,4 +237,25 @@ fn zip(src_path: &Path, symbols_path: Option<&PathBuf>, dest_path: &Path) -> any
     }
     writer.finish()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_targets_always_use_tar_gz() {
+        unsafe {
+            std::env::set_var("TOMBI_TARGET", "aarch64-apple-darwin");
+        }
+        let target = Target::get(Path::new("."));
+        assert_eq!(
+            target.cli_artifact_name,
+            format!("tombi-cli-{DEV_VERSION}-aarch64-apple-darwin.tar.gz")
+        );
+
+        unsafe {
+            std::env::remove_var("TOMBI_TARGET");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add formatter options for preserving group blank lines and controlling blank lines between tables, with schema and docs updates
- update root/table/array/inline-table/comment formatting paths and declarative tests to apply the new spacing rules consistently
- include follow-up fixes needed for this branch, including clippy cleanups and enabling the native HTTP client feature for tombi-extension tests

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p serde_tombi ser::tests::test_serialize_nested_struct -- --exact
- cargo test -p tombi-extension remote_cache::tests::warms_missing_cache -- --exact
