### PR TITLE
fix(vscode): set formatter in workspace file

### DIFF
--- a/tombi.code-workspace
+++ b/tombi.code-workspace
@@ -66,6 +66,14 @@
     }
   ],
   "settings": {
+    "editor.formatOnSave": true,
+    "[toml]": {
+      "editor.tabSize": 2,
+      "editor.defaultFormatter": "tombi-toml.tombi",
+      "files.trimTrailingWhitespace": false,
+      "files.trimFinalNewlines": false,
+      "files.insertFinalNewline": false
+    }
     // "tombi.args": ["lsp", "-vv"]
   }
 }

--- a/tombi.code-workspace
+++ b/tombi.code-workspace
@@ -66,9 +66,9 @@
     }
   ],
   "settings": {
-    "editor.formatOnSave": true,
     "[toml]": {
       "editor.tabSize": 2,
+      "editor.formatOnSave": true,
       "editor.defaultFormatter": "tombi-toml.tombi",
       "files.trimTrailingWhitespace": false,
       "files.trimFinalNewlines": false,


### PR DESCRIPTION
## Summary
- move TOML formatter settings into `tombi.code-workspace`
- apply the Tombi formatter across all folders in the multi-root workspace
- keep the existing root `.vscode/settings.json` behavior unchanged

## Testing
- not run (VS Code workspace settings change only)