### PR TITLE
Add schema catalog path examples

### DIFF
--- a/crates/tombi-config/src/types/schema_catalog_path.rs
+++ b/crates/tombi-config/src/types/schema_catalog_path.rs
@@ -1,5 +1,3 @@
-use super::OneOrMany;
-
 pub const TOMBI_SCHEMASTORE_CATALOG_URL: &str = concat!(
     "tombi://",
     tombi_uri::schemastore_hostname!(),
@@ -15,6 +13,8 @@ pub const JSON_SCHEMASTORE_CATALOG_URL: &str = concat!(
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "jsonschema", schemars(example = TOMBI_SCHEMASTORE_CATALOG_URL))]
+#[cfg_attr(feature = "jsonschema", schemars(example = JSON_SCHEMASTORE_CATALOG_URL))]
 pub struct SchemaCatalogPath(String);
 
 impl SchemaCatalogPath {
@@ -41,12 +41,6 @@ impl SchemaCatalogPath {
 impl std::fmt::Display for SchemaCatalogPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Default for OneOrMany<SchemaCatalogPath> {
-    fn default() -> Self {
-        Self::One(JSON_SCHEMASTORE_CATALOG_URL.into())
     }
 }
 

--- a/crates/tombi-config/src/types/schema_catalog_path.rs
+++ b/crates/tombi-config/src/types/schema_catalog_path.rs
@@ -9,7 +9,7 @@ pub const JSON_SCHEMASTORE_CATALOG_URL: &str = concat!(
     "/api/json/catalog.json"
 );
 
-/// Generic value that can be either single or multiple
+/// Schema catalog path or URL
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -464,6 +464,8 @@ mod completion_labels {
                 "#,
                 SchemaPath(tombi_schema_path()),
             ) -> Ok([
+                "\"https://www.schemastore.org/api/json/catalog.json\"",
+                "\"tombi://www.schemastore.org/api/json/catalog.json\"",
                 "\"\"",
                 "''",
             ]);
@@ -478,6 +480,8 @@ mod completion_labels {
                 "#,
                 SchemaPath(tombi_schema_path()),
             ) -> Ok([
+                "\"https://www.schemastore.org/api/json/catalog.json\"",
+                "\"tombi://www.schemastore.org/api/json/catalog.json\"",
                 "\"\"",
                 "''",
             ]);

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -931,7 +931,11 @@
     },
     "SchemaCatalogPath": {
       "description": "Generic value that can be either single or multiple",
-      "type": "string"
+      "type": "string",
+      "examples": [
+        "tombi://www.schemastore.org/api/json/catalog.json",
+        "https://www.schemastore.org/api/json/catalog.json"
+      ]
     },
     "SchemaItem": {
       "title": "Schema item",

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -930,7 +930,7 @@
       "additionalProperties": false
     },
     "SchemaCatalogPath": {
-      "description": "Generic value that can be either single or multiple",
+      "description": "Schema catalog path or URL",
       "type": "string",
       "examples": [
         "tombi://www.schemastore.org/api/json/catalog.json",


### PR DESCRIPTION
## Summary
- add JSON Schema examples for `SchemaCatalogPath`
- remove the unused `Default` impl on `OneOrMany<SchemaCatalogPath>`
- regenerate `www.schemastore.org/tombi.json`

## Testing
- cargo fmt --all --check
- cargo test -p tombi-config schema_catalog_paths --locked
- cargo run -p xtask -- codegen jsonschema