### PR TITLE
ci: cache TOMBI_CACHE_HOME in CI

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -58,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Create Tombi cache directory
+        run: mkdir -p "$TOMBI_CACHE_HOME"
       - uses: actions/cache@v4
         with:
           path: ${{ env.TOMBI_CACHE_HOME }}

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TOMBI_CACHE_HOME: ${{ github.workspace }}/.cache/tombi
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -55,6 +58,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.TOMBI_CACHE_HOME }}
+          key: ${{ runner.os }}-tombi-cache-${{ hashFiles('Cargo.lock', 'uv.lock', 'schemas/**', 'www.schemastore.org/**', 'www.schemastore.tombi/**', 'tombi.toml', 'type-test.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-tombi-cache-
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -25,16 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' &&
-            github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
       - id: filter
         uses: ./.github/actions/relevant-changes
         with:
-          base-sha: ${{ github.event_name == 'pull_request' &&
-            github.event.pull_request.base.sha || github.event.before }}
-          head-sha: ${{ github.event_name == 'pull_request' &&
-            github.event.pull_request.head.sha || github.sha }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           paths: |
             .cargo/**
             .config/nextest.toml
@@ -66,6 +63,8 @@ jobs:
       TOMBI_HTTP_TIMEOUT: 60
     steps:
       - uses: actions/checkout@v4
+      - name: Create Tombi cache directory
+        run: mkdir -p "$TOMBI_CACHE_HOME"
       - uses: actions/cache@v4
         with:
           path: ${{ env.TOMBI_CACHE_HOME }}

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -25,13 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
       - id: filter
         uses: ./.github/actions/relevant-changes
         with:
-          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          base-sha: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.sha || github.sha }}
           paths: |
             .cargo/**
             .config/nextest.toml
@@ -68,9 +71,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.TOMBI_CACHE_HOME }}
-          key: ${{ runner.os }}-tombi-cache-${{ hashFiles('Cargo.lock', 'uv.lock', 'schemas/**', 'www.schemastore.org/**', 'www.schemastore.tombi/**', 'tombi.toml', 'type-test.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-tombi-cache-
+          key: ${{ runner.os }}-tombi-cache
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Build

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -15,6 +15,7 @@ env:
   CI: 1
   RUSTUP_MAX_RETRIES: 10
   CARGO_PROFILE_TEST_DEBUG: 0
+  TOMBI_CACHE_HOME: ${{ github.workspace }}/.cache/tombi
 
 jobs:
   detect-changes:
@@ -24,13 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
       - id: filter
         uses: ./.github/actions/relevant-changes
         with:
-          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          base-sha: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.sha || github.sha }}
           paths: |
             .cargo/**
             .config/nextest.toml
@@ -58,8 +62,16 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    env:
+      TOMBI_HTTP_TIMEOUT: 60
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.TOMBI_CACHE_HOME }}
+          key: ${{ runner.os }}-tombi-cache-${{ hashFiles('Cargo.lock', 'uv.lock', 'schemas/**', 'www.schemastore.org/**', 'www.schemastore.tombi/**', 'tombi.toml', 'type-test.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-tombi-cache-
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Build


### PR DESCRIPTION
## Summary
- restore and save `TOMBI_CACHE_HOME` in Rust and Python CI jobs
- pin the cache directory to `${{ github.workspace }}/.cache/tombi` so GitHub Actions can reuse it
- keep the cache key tied to lockfiles and schema inputs that affect remote cache contents

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci_rust.yml"); YAML.load_file(".github/workflows/ci_python.yml"); puts "yaml ok"'
