### PR TITLE
fix: resolve schema paths from config base dir

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/dot-config-project-root/.config/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/dot-config-project-root/.config/tombi.toml
@@ -1,5 +1,11 @@
 toml-version = "v1.1.0"
 
+[extensions]
+"tombi-toml/tombi" = {
+  lsp.document-link.path.enabled = true,
+  lsp.goto-definition.path.enabled = true,
+}
+
 [files]
 include = ["**/*.toml"]
 

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1,18 +1,11 @@
 use tombi_config::{JSON_SCHEMASTORE_CATALOG_URL, TOMBI_SCHEMASTORE_CATALOG_URL};
 use tombi_test_lib::{
     adjacent_applicators_test_schema_path, adjacent_one_of_additional_properties_test_schema_path,
-    adjacent_one_of_hover_test_schema_path, lsp_consistency_test_schema_path, project_root_path,
+    adjacent_one_of_hover_test_schema_path, dot_config_project_root_fixture_path,
+    exact_index_string_test_schema_path, lsp_consistency_test_schema_path, project_root_path,
     string_format_test_schema_path, today_local_date, today_local_date_time, today_local_time,
     today_offset_date_time,
 };
-
-fn exact_index_string_test_schema_path() -> std::path::PathBuf {
-    project_root_path().join("schemas/exact-index-string-test.schema.json")
-}
-
-fn dot_config_project_root_fixture_path() -> std::path::PathBuf {
-    project_root_path().join("crates/tombi-lsp/tests/fixtures/dot-config-project-root")
-}
 
 mod completion_labels {
     use super::*;
@@ -772,6 +765,34 @@ mod completion_labels {
                 r#"
                 [[schemas]]
                 path = "sch█"
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schema_catalog_paths_file_completion(
+                r#"
+                [schema.catalog]
+                paths = ["sch█"]
+                "#,
+                SourcePath(project_root_path().join("tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_schema_catalog_paths_file_completion_from_dot_config_project_root(
+                r#"
+                [schema.catalog]
+                paths = ["sch█"]
                 "#,
                 SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
                 SchemaPath(tombi_schema_path()),

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -1,4 +1,6 @@
-use tombi_test_lib::{cargo_feature_navigation_fixture_path, project_root_path};
+use tombi_test_lib::{
+    cargo_feature_navigation_fixture_path, dot_config_project_root_fixture_path, project_root_path,
+};
 
 fn cargo_document_link_all_enabled_config_path() -> std::path::PathBuf {
     project_root_path().join(
@@ -789,6 +791,23 @@ mod document_link_tests {
 
         test_document_link!(
             #[tokio::test]
+            async fn tombi_schemas_path_from_dot_config_tombi_toml(
+                r#"
+                [[schemas]]
+                path = "schemas/name.schema.json"
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+            ) -> Ok(Some(vec![
+                {
+                    path: dot_config_project_root_fixture_path().join("schemas/name.schema.json"),
+                    range: 1:8..1:32,
+                    tooltip: tombi_extension_tombi::DocumentLinkToolTip::Schema,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
             async fn tombi_schema_catalog_paths(
                 r#"
                 [schema]
@@ -816,6 +835,40 @@ mod document_link_tests {
                 {
                     url: "https://www.schemastore.org/api/json/catalog.json",
                     range: 1:22..1:71,
+                    tooltip: tombi_extension_tombi::DocumentLinkToolTip::Catalog,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn tombi_schema_catalog_paths_local_path(
+                r#"
+                [schema]
+                catalog = { paths = ["schemas/type-test.schema.json"] }
+                "#,
+                SourcePath(project_root_path().join("tombi.toml")),
+            ) -> Ok(Some(vec![
+                {
+                    path: project_root_path().join("schemas/type-test.schema.json"),
+                    range: 1:22..1:51,
+                    tooltip: tombi_extension_tombi::DocumentLinkToolTip::Catalog,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
+            async fn tombi_schema_catalog_paths_local_path_from_dot_config_tombi_toml(
+                r#"
+                [schema]
+                catalog = { paths = ["schemas/name.schema.json"] }
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+            ) -> Ok(Some(vec![
+                {
+                    path: dot_config_project_root_fixture_path().join("schemas/name.schema.json"),
+                    range: 1:22..1:46,
                     tooltip: tombi_extension_tombi::DocumentLinkToolTip::Catalog,
                 }
             ]));

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -1,4 +1,6 @@
-use tombi_test_lib::{cargo_feature_navigation_fixture_path, project_root_path};
+use tombi_test_lib::{
+    cargo_feature_navigation_fixture_path, dot_config_project_root_fixture_path, project_root_path,
+};
 
 mod goto_definition_tests {
     use super::*;
@@ -779,6 +781,39 @@ mod goto_definition_tests {
 
     mod tombi_schema {
         use super::*;
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn schema_path_from_dot_config_tombi_toml(
+                r#"
+                [[schemas]]
+                path = "█schemas/name.schema.json"
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+            ) -> Ok([dot_config_project_root_fixture_path().join("schemas/name.schema.json")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn schema_catalog_paths_local_path(
+                r#"
+                [schema]
+                catalog = { paths = ["█schemas/type-test.schema.json"] }
+                "#,
+                SourcePath(project_root_path().join("tombi.toml")),
+            ) -> Ok([project_root_path().join("schemas/type-test.schema.json")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn schema_catalog_paths_local_path_from_dot_config_tombi_toml(
+                r#"
+                [schema]
+                catalog = { paths = ["█schemas/name.schema.json"] }
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+            ) -> Ok([dot_config_project_root_fixture_path().join("schemas/name.schema.json")]);
+        );
 
         test_goto_definition!(
             #[tokio::test]

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -1,14 +1,9 @@
 mod goto_type_definition_tests {
     use super::*;
-    use std::path::PathBuf;
     use tombi_test_lib::{
         adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
-        lsp_consistency_test_schema_path,
+        exact_index_string_test_schema_path, lsp_consistency_test_schema_path,
     };
-
-    fn exact_index_string_test_schema_path() -> PathBuf {
-        tombi_test_lib::project_root_path().join("schemas/exact-index-string-test.schema.json")
-    }
 
     mod tombi_schema {
         use super::*;

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use tombi_test_lib::{
     adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
-    cargo_feature_navigation_fixture_path, cargo_schema_path, lsp_consistency_test_schema_path,
-    one_of_hover_discriminator_test_schema_path, pyproject_schema_path,
-    ref_sibling_annotations_test_schema_path, string_format_test_schema_path, tombi_schema_path,
+    cargo_feature_navigation_fixture_path, cargo_schema_path, exact_index_string_test_schema_path,
+    lsp_consistency_test_schema_path, one_of_hover_discriminator_test_schema_path,
+    pyproject_schema_path, ref_sibling_annotations_test_schema_path,
+    string_format_test_schema_path, tombi_schema_path,
 };
 
 fn nested_table_keys_order_schema_path() -> PathBuf {
@@ -24,10 +25,6 @@ fn array_values_order_one_of_schema_path() -> PathBuf {
 
 fn exact_index_hover_test_schema_path() -> PathBuf {
     tombi_test_lib::project_root_path().join("schemas/exact-index-hover-test.schema.json")
-}
-
-fn exact_index_string_test_schema_path() -> PathBuf {
-    tombi_test_lib::project_root_path().join("schemas/exact-index-string-test.schema.json")
 }
 
 fn exact_index_array_values_order_schema_path() -> PathBuf {

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -22,6 +22,10 @@ pub fn cargo_feature_navigation_fixture_path() -> PathBuf {
     project_root_path().join("crates/tombi-lsp/tests/fixtures/cargo/feature-navigation")
 }
 
+pub fn dot_config_project_root_fixture_path() -> PathBuf {
+    project_root_path().join("crates/tombi-lsp/tests/fixtures/dot-config-project-root")
+}
+
 pub fn cargo_schema_path() -> PathBuf {
     project_root_path()
         .join(tombi_uri::schemastore_hostname!())
@@ -38,6 +42,12 @@ pub fn type_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")
         .join("type-test.schema.json")
+}
+
+pub fn exact_index_string_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("exact-index-string-test.schema.json")
 }
 
 pub fn untagged_union_schema_path() -> PathBuf {

--- a/extensions/tombi-extension-tombi/src/completion.rs
+++ b/extensions/tombi-extension-tombi/src/completion.rs
@@ -53,7 +53,7 @@ pub async fn completion(
         .unwrap_or_default()
         .value()
     {
-        if matches_accessors!(accessors, ["schema", "catalog", "path"])
+        if matches_accessors!(accessors, ["schema", "catalog", "paths", _])
             && let Some(completions) = completion_file_path_from_base_dir(
                 &base_dir,
                 document_tree,

--- a/extensions/tombi-extension-tombi/src/document_link.rs
+++ b/extensions/tombi-extension-tombi/src/document_link.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, str::FromStr};
 
-use tombi_config::{DOT_TOMBI_TOML_FILENAME, TOMBI_TOML_FILENAME, TomlVersion};
+use tombi_config::{DOT_TOMBI_TOML_FILENAME, TOMBI_TOML_FILENAME, TomlVersion, config_base_dir};
 use tombi_document_tree::dig_keys;
 use tombi_extension::get_tombi_github_uri;
 
@@ -150,10 +150,10 @@ pub async fn document_link(
 fn get_document_link(uri: &str, tombi_toml_path: &std::path::Path) -> Option<tombi_uri::Uri> {
     if let Ok(target) = tombi_uri::Uri::from_str(uri) {
         get_tombi_github_uri(&target)
-    } else if let Some(tombi_config_dir) = tombi_toml_path.parent() {
+    } else if let Some(base_dir) = config_base_dir(tombi_toml_path) {
         let mut file_path = std::path::PathBuf::from(uri);
         if file_path.is_relative() {
-            file_path = tombi_config_dir.join(file_path);
+            file_path = base_dir.join(file_path);
         }
         if file_path.exists() {
             tombi_uri::Uri::from_file_path(file_path).ok()

--- a/extensions/tombi-extension-tombi/src/goto_definition.rs
+++ b/extensions/tombi-extension-tombi/src/goto_definition.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use tombi_config::{DOT_TOMBI_TOML_FILENAME, TOMBI_TOML_FILENAME, TomlVersion};
+use tombi_config::{DOT_TOMBI_TOML_FILENAME, TOMBI_TOML_FILENAME, TomlVersion, config_base_dir};
 use tombi_document_tree::dig_accessors;
 use tombi_schema_store::matches_accessors;
 
@@ -88,10 +88,10 @@ pub async fn goto_definition(
 fn get_definition_link(url_str: &str, tombi_toml_path: &std::path::Path) -> Option<tombi_uri::Uri> {
     if let Ok(uri) = tombi_uri::Uri::from_str(url_str) {
         Some(uri)
-    } else if let Some(tombi_config_dir) = tombi_toml_path.parent() {
+    } else if let Some(base_dir) = config_base_dir(tombi_toml_path) {
         let mut file_path = std::path::PathBuf::from(url_str);
         if file_path.is_relative() {
-            file_path = tombi_config_dir.join(file_path);
+            file_path = base_dir.join(file_path);
         }
         if file_path.exists() {
             tombi_uri::Uri::from_file_path(file_path).ok()


### PR DESCRIPTION
## Summary
- resolve `schema.catalog.paths` and related local schema links from the config base directory
- reuse shared fixture/schema path helpers in LSP tests
- add regression tests for `.config/tombi.toml` project-root resolution across completion, document link, and goto definition

## Testing
- cargo fmt --all --check
- cargo check -p tombi-extension-tombi -p tombi-lsp -p tombi-test-lib --locked
- cargo test -p tombi-lsp --locked --test test_completion_labels --test test_document_link --test test_goto_definition --test test_goto_type_definition --test test_hover