### PR TITLE
Fix tombi config path resolution and completions

### DIFF
--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -803,6 +803,64 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
+            async fn tombi_files_include_file_completion(
+                r#"
+                [files]
+                include = ["sch█"]
+                "#,
+                SourcePath(project_root_path().join("tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_files_exclude_file_completion(
+                r#"
+                [files]
+                exclude = ["sch█"]
+                "#,
+                SourcePath(project_root_path().join("tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_files_include_file_completion_from_dot_config_project_root(
+                r#"
+                [files]
+                include = ["█"]
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "product.toml",
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_files_exclude_file_completion_from_dot_config_project_root(
+                r#"
+                [files]
+                exclude = ["█"]
+                "#,
+                SourcePath(dot_config_project_root_fixture_path().join(".config/tombi.toml")),
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                "product.toml",
+                "schemas/",
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
             async fn tombi_toml_version_v1_0_0_comment_directive(
                 r#"
                 toml-version = "v1.0.0" # tombi:█

--- a/extensions/tombi-extension-tombi/src/completion.rs
+++ b/extensions/tombi-extension-tombi/src/completion.rs
@@ -53,6 +53,19 @@ pub async fn completion(
         .unwrap_or_default()
         .value()
     {
+        if (matches_accessors!(accessors, ["files", "include", _])
+            || matches_accessors!(accessors, ["files", "exclude", _]))
+            && let Some(completions) = completion_file_path_from_base_dir(
+                &base_dir,
+                document_tree,
+                position,
+                accessors,
+                Some(&[]),
+            )
+        {
+            return Ok(Some(completions));
+        }
+
         if matches_accessors!(accessors, ["schema", "catalog", "paths", _])
             && let Some(completions) = completion_file_path_from_base_dir(
                 &base_dir,


### PR DESCRIPTION
## Summary
- resolve `.config/tombi.toml` relative paths from the project root for tombi config navigation features
- add path completions for `schema.catalog.paths` and `files.include` / `files.exclude`
- add and deduplicate LSP test helpers and regression coverage for root and `.config` config cases

## Testing
- cargo fmt --all
- cargo test -p tombi-lsp --test test_goto_definition schema_path_from_dot_config_tombi_toml -- --nocapture
- cargo test -p tombi-lsp --test test_document_link tombi_schemas_path_from_dot_config_tombi_toml -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_schema_catalog_paths_file_completion -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_schema_catalog_paths_file_completion_from_dot_config_project_root -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_files_include_file_completion -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_files_exclude_file_completion -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_files_include_file_completion_from_dot_config_project_root -- --nocapture
- cargo test -p tombi-lsp --test test_completion_labels tombi_files_exclude_file_completion_from_dot_config_project_root -- --nocapture
- cargo test -p tombi-config config_base_dir -- --nocapture
- cargo test -p serde_tombi dot_config -- --nocapture