### PR TITLE
docs: refine formatter intro wording

### DIFF
--- a/docs/src/routes/docs/formatter/index.mdx
+++ b/docs/src/routes/docs/formatter/index.mdx
@@ -1,11 +1,11 @@
 
 # Formatter
 
-The most significant feature of Tombi's formatter is its Auto Sorting,
+The most impressive feature of Tombi's formatter is its Auto Sorting,
 which sorts entries by default based on [JSON Schema](https://json-schema.org/) metadata retrieved from [Schema Store](https://www.schemastore.org/).
 
 Tombi was originally designed as a uniform formatter inspired by [Black](https://black.readthedocs.io/en/stable/index.html).
-To better accommodate Taplo users, this policy was gradually relaxed, and Tombi has evolved into a formatter with many [config options](/docs/configuration#available-options).
+To welcome users coming from Taplo, this policy was gradually relaxed, and Tombi has evolved into a formatter with many [options](/docs/configuration#available-options).
 
 Tombi's default formatting options reflect its core philosophy.
 You can also influence formatting while typing by using [Magic Trailing Comma](/docs/formatter/magic-trailing-comma) or [Magic Trigger](/docs/language-server/completion#magic-trigger) instead of configuration.


### PR DESCRIPTION
## Summary
- refine the opening wording in the formatter docs
- simplify the Taplo migration sentence and link text

## Testing
- pnpm lint *(fails in this workspace because `biome.json` targets schema 2.2.4 while the installed CLI is 2.3.12, and Biome also scans generated `target/` JSON files)*
- pnpm format