### PR TITLE
feat(vscode): add TOML configuration defaults

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -246,6 +246,12 @@
           "additionalProperties": false
         }
       }
+    },
+    "configurationDefaults": {
+      "[toml]": {
+        "editor.suggest.showKeywords": false,
+        "editor.wordBasedSuggestions": "off"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add VS Code configuration defaults for TOML files
- disable keyword suggestions in TOML editors
- turn off word-based suggestions for TOML editors

## Testing
- jq empty editors/vscode/package.json