### PR TITLE
test: remove obsolete maturin pyproject cases

### DIFF
--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -391,29 +391,6 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
-            async fn test_tool_maturin_include(
-                r#"
-                [tool.maturin]
-                include = [
-                  { path = "www.schemastore.org/**/*.json", format = "sdist" },
-                  { path = "www.schemastore.tombi/**/*.json", format = "sdist" },
-                ]
-                "#,
-                SchemaPath(pyproject_schema_path()),
-                SourcePath(project_root_path().join("pyproject.toml")),
-            ) -> Ok(
-                r#"
-                [tool.maturin]
-                include = [
-                  { format = "sdist", path = "www.schemastore.org/**/*.json" },
-                  { format = "sdist", path = "www.schemastore.tombi/**/*.json" },
-                ]
-                "#
-            )
-        }
-
-        test_format! {
-            #[tokio::test]
             async fn test_tool_table_keys_order_disabled_is_true(
                 r#"
                 [project]

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1468,28 +1468,6 @@ mod completion_labels {
 
         test_completion_labels! {
             #[tokio::test]
-            async fn pyproject_tool_maturin_include_array(
-                r#"
-                [tool.maturin]
-                bindings = "bin"
-                include = [
-                    █
-                    { path = "www.schemastore.org/**/*.json", format = "sdist" },
-                ]
-                "#,
-                SourcePath(project_root_path().join("pyproject.toml")),
-                SchemaPath(pyproject_schema_path()),
-            ) -> Ok([
-                "format",
-                "path",
-                "\"\"",
-                "''",
-                "{}",
-            ]);
-        }
-
-        test_completion_labels! {
-            #[tokio::test]
             async fn pyproject_project_leading_comments_directive_newline_name_eq_tombi(
                 r#"
                 # tombi: lint.rules█


### PR DESCRIPTION
## Summary
- remove obsolete `tool.maturin.include` formatter test coverage
- remove matching LSP completion test coverage for the same obsolete pyproject case
- keep the focused formatter and LSP test targets green

## Testing
- cargo fmt --all --check
- cargo test -p tombi-formatter --test test_x_tombi_order
- cargo test -p tombi-lsp --test test_completion_labels