### PR TITLE
fix(lsp): resolve type definitions for scalar bindings

### DIFF
--- a/crates/tombi-document-tree/src/value.rs
+++ b/crates/tombi-document-tree/src/value.rs
@@ -109,6 +109,21 @@ impl Value {
         }
     }
 
+    pub fn is_scalar(&self) -> bool {
+        matches!(
+            self,
+            Value::Boolean(_)
+                | Value::Integer(_)
+                | Value::Float(_)
+                | Value::String(_)
+                | Value::OffsetDateTime(_)
+                | Value::LocalDateTime(_)
+                | Value::LocalDate(_)
+                | Value::LocalTime(_)
+                | Value::Incomplete { .. }
+        )
+    }
+
     pub(crate) fn set_comment_directives(
         &mut self,
         comment_directives: Vec<TombiValueCommentDirective>,

--- a/crates/tombi-lsp/src/goto_type_definition/type_definition_source.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/type_definition_source.rs
@@ -53,6 +53,29 @@ impl<'a> TypeDefinitionSource<'a> {
             }
         }
 
+        if remaining_keys(keys, &accessors).is_empty()
+            && matches!(accessors.last(), Some(Accessor::Key(_)))
+            && tombi_document_tree::dig_accessors(document_tree, &accessors)
+                .is_some_and(|(_, value)| value.is_scalar())
+        {
+            let parent_accessors = accessors[..accessors.len().saturating_sub(1)].to_vec();
+            let (resolved_parent_accessors, resolved_parent_schema) =
+                resolve_accessors_for_document_or_schema(
+                    document_tree,
+                    parent_accessors,
+                    schema_context,
+                )
+                .await;
+            if resolved_parent_accessors.is_empty()
+                || tombi_document_tree::dig_accessors(document_tree, &resolved_parent_accessors)
+                    .is_some()
+                || resolved_parent_schema.is_some()
+            {
+                accessors = resolved_parent_accessors;
+                current_schema = resolved_parent_schema;
+            }
+        }
+
         let remaining_keys = remaining_keys(keys, &accessors);
 
         if accessors.is_empty() {

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -213,6 +213,17 @@ mod goto_type_definition_tests {
 
         test_goto_type_definition!(
             #[tokio::test]
+            async fn typed_extra_table_known_scalar_value(
+                r#"
+                [typed_extra_table]
+                known = "█value"
+                "#,
+                SchemaPath(lsp_consistency_test_schema_path()),
+            ) -> Ok(lsp_consistency_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
             async fn typed_extra_table_unevaluated_properties_id_value(
                 r#"
                 [typed_extra_table]

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -16,9 +16,15 @@ use tombi_uri::SchemaUri;
 
 type DocumentSchemas = Arc<RwLock<tombi_hashmap::HashMap<SchemaUri, CachedDocumentSchema>>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SchemaCacheVersion {
+    modified_at_nanos: u64,
+    len: u64,
+}
+
 #[derive(Debug, Clone)]
 struct CachedDocumentSchema {
-    version: Option<u64>,
+    version: Option<SchemaCacheVersion>,
     document_schema: Result<Arc<DocumentSchema>, crate::Error>,
 }
 
@@ -562,19 +568,30 @@ impl SchemaStore {
                 (uri, fragment)
             };
 
-            let cache_version = schema_cache_version(&schema_uri).await;
-            let cached_document_schema = {
-                self.document_schemas
-                    .read()
-                    .await
-                    .get(&schema_uri)
-                    .cloned()
-                    .filter(|cached| cached.version == cache_version)
-            };
+            let cached_document_schema =
+                self.document_schemas.read().await.get(&schema_uri).cloned();
             let document_schema = if let Some(cached_document_schema) = cached_document_schema {
-                match cached_document_schema.document_schema {
-                    Ok(document_schema) => Some(document_schema),
-                    Err(err) => return Err(err),
+                let cache_version = schema_cache_version(&schema_uri).await;
+                if cached_document_schema.version == cache_version {
+                    match cached_document_schema.document_schema {
+                        Ok(document_schema) => Some(document_schema),
+                        Err(err) => return Err(err),
+                    }
+                } else {
+                    match self.fetch_document_schema(&schema_uri).await.transpose() {
+                        Some(document_schema) => {
+                            let cache_version = schema_cache_version(&schema_uri).await;
+                            self.document_schemas.write().await.insert(
+                                schema_uri.clone(),
+                                CachedDocumentSchema {
+                                    version: cache_version,
+                                    document_schema: document_schema.clone(),
+                                },
+                            );
+                            Some(document_schema?)
+                        }
+                        None => None,
+                    }
                 }
             } else {
                 match self.fetch_document_schema(&schema_uri).await.transpose() {
@@ -1049,7 +1066,7 @@ impl SchemaStore {
     }
 }
 
-async fn schema_cache_version(schema_uri: &SchemaUri) -> Option<u64> {
+async fn schema_cache_version(schema_uri: &SchemaUri) -> Option<SchemaCacheVersion> {
     let path = match schema_uri.scheme() {
         "file" => tombi_uri::Uri::to_file_path(schema_uri).ok(),
         "http" | "https" => get_cache_file_path(schema_uri).await,
@@ -1060,12 +1077,13 @@ async fn schema_cache_version(schema_uri: &SchemaUri) -> Option<u64> {
     let modified = metadata.modified().ok()?;
     let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
 
-    Some(
-        duration
+    Some(SchemaCacheVersion {
+        modified_at_nanos: duration
             .as_secs()
             .saturating_mul(1_000_000_000)
             .saturating_add(u64::from(duration.subsec_nanos())),
-    )
+        len: metadata.len(),
+    })
 }
 
 fn matches_schema_patterns(

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -14,8 +14,13 @@ use tombi_config::{SchemaItem, SchemaOverviewOptions, TomlVersion, config_base_d
 use tombi_future::{BoxFuture, Boxable};
 use tombi_uri::SchemaUri;
 
-type DocumentSchemas =
-    Arc<RwLock<tombi_hashmap::HashMap<SchemaUri, Result<Arc<DocumentSchema>, crate::Error>>>>;
+type DocumentSchemas = Arc<RwLock<tombi_hashmap::HashMap<SchemaUri, CachedDocumentSchema>>>;
+
+#[derive(Debug, Clone)]
+struct CachedDocumentSchema {
+    version: Option<u64>,
+    document_schema: Result<Arc<DocumentSchema>, crate::Error>,
+}
 
 /// Options for associating a schema with file patterns
 #[derive(Debug, Clone, Default)]
@@ -374,10 +379,14 @@ impl SchemaStore {
         if has_key
             && let Some(document_schema) = self.fetch_document_schema(&schema_uri).await.transpose()
         {
-            self.document_schemas
-                .write()
-                .await
-                .insert(schema_uri.clone(), document_schema);
+            let version = schema_cache_version(&schema_uri).await;
+            self.document_schemas.write().await.insert(
+                schema_uri.clone(),
+                CachedDocumentSchema {
+                    version,
+                    document_schema,
+                },
+            );
             log::debug!("update schema: {}", schema_uri);
             return Ok(true);
         }
@@ -553,23 +562,34 @@ impl SchemaStore {
                 (uri, fragment)
             };
 
-            let document_schema = {
-                if let Some(document_schema) = self.document_schemas.read().await.get(&schema_uri) {
-                    match document_schema {
-                        Ok(document_schema) => Some(document_schema.clone()),
-                        Err(err) => return Err(err.to_owned()),
+            let cache_version = schema_cache_version(&schema_uri).await;
+            let cached_document_schema = {
+                self.document_schemas
+                    .read()
+                    .await
+                    .get(&schema_uri)
+                    .cloned()
+                    .filter(|cached| cached.version == cache_version)
+            };
+            let document_schema = if let Some(cached_document_schema) = cached_document_schema {
+                match cached_document_schema.document_schema {
+                    Ok(document_schema) => Some(document_schema),
+                    Err(err) => return Err(err),
+                }
+            } else {
+                match self.fetch_document_schema(&schema_uri).await.transpose() {
+                    Some(document_schema) => {
+                        let cache_version = schema_cache_version(&schema_uri).await;
+                        self.document_schemas.write().await.insert(
+                            schema_uri.clone(),
+                            CachedDocumentSchema {
+                                version: cache_version,
+                                document_schema: document_schema.clone(),
+                            },
+                        );
+                        Some(document_schema?)
                     }
-                } else {
-                    match self.fetch_document_schema(&schema_uri).await.transpose() {
-                        Some(document_schema) => {
-                            self.document_schemas
-                                .write()
-                                .await
-                                .insert(schema_uri.clone(), document_schema.clone());
-                            Some(document_schema?)
-                        }
-                        None => None,
-                    }
+                    None => None,
                 }
             };
 
@@ -1029,6 +1049,25 @@ impl SchemaStore {
     }
 }
 
+async fn schema_cache_version(schema_uri: &SchemaUri) -> Option<u64> {
+    let path = match schema_uri.scheme() {
+        "file" => tombi_uri::Uri::to_file_path(schema_uri).ok(),
+        "http" | "https" => get_cache_file_path(schema_uri).await,
+        _ => None,
+    }?;
+
+    let metadata = tokio::fs::metadata(path).await.ok()?;
+    let modified = metadata.modified().ok()?;
+    let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+
+    Some(
+        duration
+            .as_secs()
+            .saturating_mul(1_000_000_000)
+            .saturating_add(u64::from(duration.subsec_nanos())),
+    )
+}
+
 fn matches_schema_patterns(
     include: &[String],
     exclude: Option<&[String]>,
@@ -1245,6 +1284,7 @@ fn parse_override_target(target: &str) -> Option<Vec<PatternAccessor>> {
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
         path::{Path, PathBuf},
         str::FromStr,
         time::Duration,
@@ -1263,6 +1303,12 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("tombi-schema-store-{test_name}-{unique}.json"))
+    }
+
+    fn bump_modified(path: &Path) {
+        let file = fs::File::options().write(true).open(path).unwrap();
+        let modified = file.metadata().unwrap().modified().unwrap() + Duration::from_secs(1);
+        file.set_modified(modified).unwrap();
     }
 
     #[test]
@@ -1376,6 +1422,49 @@ mod tests {
         assert!(matches!(
             document_schema.value_schema.as_deref(),
             Some(ValueSchema::String(_))
+        ));
+
+        let _ = std::fs::remove_file(schema_path);
+    }
+
+    #[tokio::test]
+    async fn reloads_cached_file_schema_when_file_changes() {
+        let schema_path = std::env::temp_dir().join(format!(
+            "tombi_reload_schema_{}_{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let schema_uri = SchemaUri::from_file_path(&schema_path).unwrap();
+        let schema_store = SchemaStore::new();
+
+        std::fs::write(&schema_path, r#"{"type":"string"}"#).unwrap();
+
+        let document_schema = schema_store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            document_schema.value_schema.as_deref(),
+            Some(ValueSchema::String(_))
+        ));
+
+        std::fs::write(&schema_path, r#"{"type":"integer"}"#).unwrap();
+        bump_modified(&schema_path);
+
+        let document_schema = schema_store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            document_schema.value_schema.as_deref(),
+            Some(ValueSchema::Integer(_))
         ));
 
         let _ = std::fs::remove_file(schema_path);


### PR DESCRIPTION
## Summary
- treat scalar value bindings as type-definition lookups on their parent schema node
- invalidate cached document schemas when the underlying schema file changes
- add regression coverage for scalar type-definition lookup and schema cache reloading

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo nextest run -p tombi-extension remote_cache::tests::warms_missing_cache --locked
- cargo test --workspace --doc --locked