### PR TITLE
fix(pyproject): link build-system requires

### DIFF
--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -1027,6 +1027,25 @@ mod document_link_tests {
 
         test_document_link!(
             #[tokio::test]
+            async fn pyproject_build_system_requires(
+                r#"
+                [build-system]
+                requires = [
+                  "maturin>=1.5,<2.0",
+                ]
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://pypi.org/project/maturin/",
+                    range: 2:3..2:20,
+                    tooltip: "Open PyPI Package",
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
             async fn pyproject_default_features_disable_pyproject_toml_links(
                 r#"
                 [project]

--- a/extensions/tombi-extension-pyproject/src/document_link.rs
+++ b/extensions/tombi-extension-pyproject/src/document_link.rs
@@ -167,6 +167,20 @@ pub async fn document_link(
         )?);
     }
 
+    // Handle [build-system] section
+    if let Some((_, tombi_document_tree::Value::Array(requires))) =
+        dig_keys(document_tree, &["build-system", "requires"])
+    {
+        document_links.extend(document_link_for_project_dependencies(
+            requires,
+            pyproject_sources,
+            &pyproject_toml_path,
+            toml_version,
+            pyproject_toml_document_link_enabled.value(),
+            pypi_org_document_link_enabled.value(),
+        )?);
+    }
+
     document_links.extend(document_link_for_tool_uv_dependencies(
         document_tree,
         pyproject_sources,


### PR DESCRIPTION
## Summary
- add document links for `build-system.requires` entries in `pyproject.toml`
- reuse the existing PyPI/link resolution path for dependency arrays
- add LSP regression coverage for the new document link case

## Testing
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked