### PR TITLE
Deprecate path declaration navigation in pyproject and cargo

### DIFF
--- a/crates/tombi-config/src/extensions/cargo/lsp/goto_declaration.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/goto_declaration.rs
@@ -35,9 +35,10 @@ toggle_features! {
         #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub member: Option<ToggleFeatureDefaultTrue>,
 
-        /// # Path declaration navigation feature
+        /// # Deprecated path declaration navigation feature
         ///
-        /// Whether declaration navigation resolves local filesystem path declarations.
+        /// Deprecated. This setting is accepted for backward compatibility but ignored.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub path: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-config/src/extensions/pyproject/lsp/goto_declaration.rs
+++ b/crates/tombi-config/src/extensions/pyproject/lsp/goto_declaration.rs
@@ -34,9 +34,10 @@ toggle_features! {
         /// Whether declaration navigation resolves workspace member declarations.
         pub member: Option<ToggleFeatureDefaultTrue>,
 
-        /// # Path declaration navigation feature
+        /// # Deprecated path declaration navigation feature
         ///
-        /// Whether declaration navigation resolves local filesystem path declarations.
+        /// Deprecated. This setting is accepted for backward compatibility but ignored.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub path: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -961,6 +961,27 @@ mod document_link_tests {
                     ),
                     range: 4:12..4:18,
                     tooltip: "Open pyproject.toml",
+                },
+                {
+                    path: project_root_path().join(
+                        "crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/member/pyproject.toml"
+                    ),
+                    range: 7:0..7:6,
+                    tooltip: "Open pyproject.toml",
+                },
+                {
+                    path: project_root_path().join(
+                        "crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/pyproject.toml"
+                    ),
+                    range: 7:11..7:27,
+                    tooltip: "Open Workspace pyproject.toml",
+                },
+                {
+                    path: project_root_path().join(
+                        "crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/member/pyproject.toml"
+                    ),
+                    range: 1:17..1:23,
+                    tooltip: "Open pyproject.toml",
                 }
             ]));
         );

--- a/crates/tombi-lsp/tests/test_goto_declaration.rs
+++ b/crates/tombi-lsp/tests/test_goto_declaration.rs
@@ -148,17 +148,6 @@ mod goto_declaration_tests {
 
         test_goto_declaration!(
             #[tokio::test]
-            async fn tool_pyproject_sources_tombi_beta(
-                r#"
-                [tool.uv.sources]
-                tombi-beta█ = { workspace = true }
-                "#,
-                SourcePath(project_root_path().join("python/tombi-beta/pyproject.toml")),
-            ) -> Ok([project_root_path().join("pyproject.toml")]);
-        );
-
-        test_goto_declaration!(
-            #[tokio::test]
             async fn tool_pyproject_sources_tombi_beta_workspace(
                 r#"
                 [tool.uv.sources]
@@ -166,17 +155,6 @@ mod goto_declaration_tests {
                 "#,
                 SourcePath(project_root_path().join("python/tombi-beta/pyproject.toml")),
             ) -> Ok([project_root_path().join("pyproject.toml")]);
-        );
-
-        test_goto_declaration!(
-            #[tokio::test]
-            async fn tool_pyproject_sources_path_dependency(
-                r#"
-                [tool.uv.sources]
-                tombi-beta = { path = "members/app█" }
-                "#,
-                SourcePath(project_root_path().join("python/tombi-beta/pyproject.toml")),
-            ) -> Ok([project_root_path().join("python/tombi-beta/pyproject.toml")]);
         );
 
         test_goto_declaration!(

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -775,6 +775,17 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
+            async fn tool_pyproject_sources_path_dependency(
+                r#"
+                [tool.uv.sources]
+                app = { path = "members/app█" }
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-lsp/tests/fixtures/pyproject_workspace/pyproject.toml")),
+            ) -> Ok([project_root_path().join("crates/tombi-lsp/tests/fixtures/pyproject_workspace/members/app/pyproject.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
             async fn tool_pyproject_workspace_members(
                 r#"
                 [tool.uv.workspace]
@@ -793,6 +804,61 @@ mod goto_definition_tests {
                 "#,
                 SourcePath(project_root_path().join("pyproject.toml")),
             ) -> Ok([project_root_path().join("python/tombi-beta/pyproject.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn project_readme_relative_file(
+                r#"
+                [project]
+                readme = "python/tombi/README.md█"
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok([project_root_path().join("python/tombi/README.md")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn project_readme_file_object_relative_file(
+                r#"
+                [project]
+                readme = { file = "python/tombi/README.md█" }
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok([project_root_path().join("python/tombi/README.md")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn project_license_file_relative_file(
+                r#"
+                [project]
+                license = { file = "python/tombi/README.md█" }
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok([project_root_path().join("python/tombi/README.md")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn project_license_files_relative_file(
+                r#"
+                [project]
+                license-files = ["python/tombi/README.md█"]
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok([project_root_path().join("python/tombi/README.md")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn build_system_backend_path_relative_directory(
+                r#"
+                [build-system]
+                backend-path = ["python█"]
+                "#,
+                SourcePath(project_root_path().join("pyproject.toml")),
+            ) -> Ok([project_root_path().join("python")]);
         );
     }
 

--- a/extensions/tombi-extension-cargo/src/goto_declaration.rs
+++ b/extensions/tombi-extension-cargo/src/goto_declaration.rs
@@ -1,6 +1,6 @@
 use crate::{
-    feature_key_at_accessors, goto_declaration_for_crate_cargo_toml,
-    optional_dependency_value_at_accessors,
+    CargoNavigationFeature, classify_cargo_navigation_feature, feature_key_at_accessors,
+    goto_declaration_for_crate_cargo_toml, optional_dependency_value_at_accessors,
 };
 use tombi_config::TomlVersion;
 use tombi_document_tree::dig_keys;
@@ -21,7 +21,7 @@ pub async fn goto_declaration(
         return Ok(Default::default());
     };
 
-    if !cargo_navigation_enabled(features, accessors) {
+    if !cargo_goto_declaration_enabled(features, accessors) {
         return Ok(None);
     }
 
@@ -40,23 +40,20 @@ pub async fn goto_declaration(
     Ok(Some(locations))
 }
 
-fn cargo_navigation_enabled(
+fn cargo_goto_declaration_enabled(
     features: Option<&tombi_config::CargoExtensionFeatures>,
     accessors: &[tombi_schema_store::Accessor],
 ) -> bool {
     features
         .and_then(|features| features.lsp())
         .and_then(|lsp| lsp.goto_declaration())
-        .and_then(|goto_declaration| {
-            if matches!(
-                accessors.last(),
-                Some(tombi_schema_store::Accessor::Key(key)) if key == "path"
-            ) {
-                goto_declaration.path()
-            } else {
-                goto_declaration.dependency()
-            }
-        })
+        .and_then(
+            |goto_declaration| match classify_cargo_navigation_feature(accessors) {
+                CargoNavigationFeature::Dependency => goto_declaration.dependency(),
+                CargoNavigationFeature::Member => goto_declaration.member(),
+                CargoNavigationFeature::Path => None,
+            },
+        )
         .map(|feature| feature.enabled())
         .unwrap_or_default()
         .value()

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -25,7 +25,7 @@ pub async fn goto_definition(
         return Ok(Default::default());
     };
 
-    if !cargo_navigation_enabled(features, accessors) {
+    if !cargo_goto_definition_enabled(features, accessors) {
         return Ok(None);
     }
 
@@ -122,7 +122,7 @@ pub async fn goto_definition(
     Ok(Some(locations))
 }
 
-fn cargo_navigation_enabled(
+fn cargo_goto_definition_enabled(
     features: Option<&tombi_config::CargoExtensionFeatures>,
     accessors: &[tombi_schema_store::Accessor],
 ) -> bool {

--- a/extensions/tombi-extension-pyproject/src/goto_declaration.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_declaration.rs
@@ -1,12 +1,10 @@
 use tombi_config::TomlVersion;
-use tombi_document_tree::{Value, dig_accessors, dig_keys};
+use tombi_document_tree::dig_keys;
 use tombi_schema_store::matches_accessors;
 
 use crate::{
-    PyprojectNavigationFeature, classify_pyproject_navigation_feature, find_member_project_toml,
-    find_workspace_pyproject_toml, goto_definition::get_path_dependency_definition,
+    PyprojectNavigationFeature, classify_pyproject_navigation_feature,
     goto_definition_for_member_pyproject_toml, goto_definition_for_workspace_pyproject_toml,
-    parse_requirement,
 };
 
 pub async fn goto_declaration(
@@ -24,40 +22,23 @@ pub async fn goto_declaration(
         return Ok(Default::default());
     };
 
-    if !pyproject_navigation_enabled(features, accessors) {
+    if !pyproject_goto_declaration_enabled(features, accessors) {
         return Ok(None);
     }
 
-    let locations = if matches_accessors!(
-        accessors[..accessors.len().min(3)],
-        ["tool", "uv", "sources"]
-    ) {
-        if matches_accessors!(accessors, ["tool", "uv", "sources", _, "path"]) {
-            goto_declaration_for_sources_path(document_tree, accessors, &pyproject_toml_path)?
-        } else {
-            goto_definition_for_member_pyproject_toml(
-                document_tree,
-                accessors,
-                &pyproject_toml_path,
-                toml_version,
-                false,
-            )?
-        }
+    let locations = if matches_accessors!(accessors, ["tool", "uv", "sources", _, "workspace"]) {
+        goto_definition_for_member_pyproject_toml(
+            document_tree,
+            accessors,
+            &pyproject_toml_path,
+            toml_version,
+            false,
+        )?
     } else if matches_accessors!(
         accessors[..accessors.len().min(3)],
         ["tool", "uv", "workspace"]
     ) {
         goto_definition_for_workspace_pyproject_toml(
-            document_tree,
-            accessors,
-            &pyproject_toml_path,
-            toml_version,
-        )?
-    } else if matches_accessors!(accessors, ["project", "dependencies", _])
-        || matches_accessors!(accessors, ["project", "optional-dependencies", _, _])
-        || matches_accessors!(accessors, ["dependency-groups", _, _])
-    {
-        goto_declaration_for_dependency_package(
             document_tree,
             accessors,
             &pyproject_toml_path,
@@ -74,7 +55,7 @@ pub async fn goto_declaration(
     Ok(Some(locations))
 }
 
-fn pyproject_navigation_enabled(
+fn pyproject_goto_declaration_enabled(
     features: Option<&tombi_config::PyprojectExtensionFeatures>,
     accessors: &[tombi_schema_store::Accessor],
 ) -> bool {
@@ -85,119 +66,12 @@ fn pyproject_navigation_enabled(
             |goto_declaration| match classify_pyproject_navigation_feature(accessors) {
                 PyprojectNavigationFeature::Dependency => goto_declaration.dependency(),
                 PyprojectNavigationFeature::Member => goto_declaration.member(),
-                PyprojectNavigationFeature::Path => goto_declaration.path(),
+                PyprojectNavigationFeature::Path => None,
             },
         )
         .map(|feature| feature.enabled())
         .unwrap_or_default()
         .value()
-}
-
-fn goto_declaration_for_dependency_package(
-    document_tree: &tombi_document_tree::DocumentTree,
-    accessors: &[tombi_schema_store::Accessor],
-    pyproject_toml_path: &std::path::Path,
-    toml_version: TomlVersion,
-) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    if dig_keys(document_tree, &["tool", "uv", "workspace"]).is_some() {
-        return Ok(Vec::with_capacity(0));
-    }
-
-    // Get the dependency string from the current position
-    let Some((_, Value::String(dependency))) = dig_accessors(document_tree, accessors) else {
-        return Ok(Vec::with_capacity(0));
-    };
-
-    // Parse the PEP 508 requirement to extract package name
-    let Some(requirement) = parse_requirement(dependency.value()) else {
-        return Ok(Vec::with_capacity(0));
-    };
-    let package_name = requirement.name.as_ref();
-
-    let mut locations = Vec::new();
-
-    if let Some((_, Value::Table(sources))) = dig_keys(document_tree, &["tool", "uv", "sources"])
-        && let Some((_, Value::Table(source_table))) = sources.get_key_value(package_name)
-    {
-        if let Some((_, Value::Boolean(is_workspace))) = source_table.get_key_value("workspace")
-            && is_workspace.value()
-            && let Some(location) = get_workspace_dependency_declaration(
-                package_name,
-                pyproject_toml_path,
-                toml_version,
-            )
-        {
-            locations.push(location);
-        }
-
-        if let Some((_, Value::String(path))) = source_table.get_key_value("path") {
-            if let Some(location) = get_path_dependency_declaration(pyproject_toml_path, path) {
-                locations.push(location);
-            } else if let Some(location) =
-                get_path_dependency_definition(pyproject_toml_path, path.value(), toml_version)
-            {
-                locations.push(location);
-            }
-        }
-    }
-
-    Ok(locations)
-}
-
-fn get_workspace_dependency_declaration(
-    package_name: &str,
-    pyproject_toml_path: &std::path::Path,
-    toml_version: TomlVersion,
-) -> Option<tombi_extension::Location> {
-    // Find the workspace pyproject.toml
-    let (workspace_pyproject_toml_path, _, workspace_document_tree) =
-        find_workspace_pyproject_toml(pyproject_toml_path, toml_version)?;
-
-    // Find the member project
-    let (_, member_range) = find_member_project_toml(
-        package_name,
-        &workspace_document_tree,
-        &workspace_pyproject_toml_path,
-        toml_version,
-    )?;
-
-    let Ok(workspace_pyproject_toml_uri) =
-        tombi_uri::Uri::from_file_path(&workspace_pyproject_toml_path)
-    else {
-        return None;
-    };
-
-    Some(tombi_extension::Location {
-        uri: workspace_pyproject_toml_uri,
-        range: member_range,
-    })
-}
-
-fn goto_declaration_for_sources_path(
-    document_tree: &tombi_document_tree::DocumentTree,
-    accessors: &[tombi_schema_store::Accessor],
-    pyproject_toml_path: &std::path::Path,
-) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    let Some((_, Value::String(path_value))) = dig_accessors(document_tree, accessors) else {
-        return Ok(Vec::with_capacity(0));
-    };
-
-    if let Some(location) = get_path_dependency_declaration(pyproject_toml_path, path_value) {
-        return Ok(vec![location]);
-    }
-
-    Ok(Vec::with_capacity(0))
-}
-
-fn get_path_dependency_declaration(
-    pyproject_toml_path: &std::path::Path,
-    path_value: &tombi_document_tree::String,
-) -> Option<tombi_extension::Location> {
-    let uri = tombi_uri::Uri::from_file_path(pyproject_toml_path).ok()?;
-    Some(tombi_extension::Location {
-        uri,
-        range: path_value.unquoted_range(),
-    })
 }
 
 pub fn get_current_declaration(

--- a/extensions/tombi-extension-pyproject/src/goto_definition.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_definition.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use std::path::Path;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
 use tombi_hashmap::IndexSet;
@@ -7,10 +8,10 @@ use tombi_schema_store::{Accessor, matches_accessors};
 use crate::{
     DependencyRequirement, PyprojectNavigationFeature, classify_pyproject_navigation_feature,
     collect_dependency_requirements_from_document_tree, find_dependency_group_key,
-    find_member_project_toml, find_workspace_pyproject_toml, get_project_name,
-    goto_definition_for_member_pyproject_toml, goto_definition_for_workspace_pyproject_toml,
+    find_workspace_pyproject_toml, get_project_name, goto_definition_for_member_pyproject_toml,
+    goto_definition_for_workspace_pyproject_toml, is_pyproject_path_accessors,
     load_pyproject_toml_document_tree, parse_requirement, project_name_reference_locations,
-    resolve_member_pyproject_toml_path,
+    resolve_member_pyproject_toml_path, resolve_relative_path_uri,
 };
 
 pub async fn goto_definition(
@@ -28,7 +29,7 @@ pub async fn goto_definition(
         return Ok(Default::default());
     };
 
-    if !pyproject_navigation_enabled(features, accessors) {
+    if !pyproject_goto_definition_enabled(features, accessors) {
         return Ok(None);
     }
 
@@ -39,6 +40,13 @@ pub async fn goto_definition(
             &pyproject_toml_path,
             toml_version,
         )?
+    } else if matches_accessors!(accessors, ["tool", "uv", "sources", _, "path"]) {
+        goto_definition_for_relative_package(
+            document_tree,
+            accessors,
+            &pyproject_toml_path,
+            toml_version,
+        )
     } else if matches_accessors!(
         accessors[..accessors.len().min(3)],
         ["tool", "uv", "sources"]
@@ -50,6 +58,8 @@ pub async fn goto_definition(
             toml_version,
             accessors.last() != Some(&tombi_schema_store::Accessor::Key("workspace".to_string())),
         )?
+    } else if is_pyproject_path_accessors(accessors) {
+        goto_definition_for_relative_file(document_tree, accessors, &pyproject_toml_path)
     } else if matches_accessors!(
         accessors[..accessors.len().min(3)],
         ["tool", "uv", "workspace"]
@@ -86,8 +96,43 @@ pub async fn goto_definition(
     Ok(Some(locations))
 }
 
+fn goto_definition_for_relative_package(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    pyproject_toml_path: &Path,
+    toml_version: TomlVersion,
+) -> Vec<tombi_extension::Location> {
+    let Some((_, Value::String(path_value))) = dig_accessors(document_tree, accessors) else {
+        return Vec::with_capacity(0);
+    };
+
+    get_path_dependency_definition(pyproject_toml_path, path_value.value(), toml_version)
+        .into_iter()
+        .collect()
+}
+
+fn goto_definition_for_relative_file(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    pyproject_toml_path: &Path,
+) -> Vec<tombi_extension::Location> {
+    let Some((_, Value::String(path_value))) = dig_accessors(document_tree, accessors) else {
+        return Vec::with_capacity(0);
+    };
+
+    let Some(uri) = resolve_relative_path_uri(pyproject_toml_path, Path::new(path_value.value()))
+    else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri,
+        range: tombi_text::Range::default(),
+    }]
+}
+
 #[inline]
-fn pyproject_navigation_enabled(
+fn pyproject_goto_definition_enabled(
     features: Option<&tombi_config::PyprojectExtensionFeatures>,
     accessors: &[tombi_schema_store::Accessor],
 ) -> bool {
@@ -131,15 +176,23 @@ fn goto_definition_for_dependency_package(
             if !is_workspace.value() {
                 return Ok(Vec::with_capacity(0));
             }
-            if let Some(location) = get_current_workspace_dependency_definition(
+            let definition_accessors = [
+                Accessor::Key("tool".to_string()),
+                Accessor::Key("uv".to_string()),
+                Accessor::Key("sources".to_string()),
+                Accessor::Key(package_name.to_string()),
+                Accessor::Key("workspace".to_string()),
+            ];
+            if let Some(location) = goto_definition_for_member_pyproject_toml(
                 document_tree,
-                package_name,
+                &definition_accessors,
                 pyproject_toml_path,
                 toml_version,
-            )
-            .or_else(|| {
-                get_workspace_dependency_definition(package_name, pyproject_toml_path, toml_version)
-            }) {
+                true,
+            )?
+            .into_iter()
+            .next()
+            {
                 return Ok(vec![location]);
             } else {
                 return Ok(Vec::with_capacity(0));
@@ -210,62 +263,6 @@ fn goto_definition_for_dependency_group(
     crate::include_group_locations(document_tree, accessors, pyproject_toml_path)
 }
 
-fn get_workspace_dependency_definition(
-    package_name: &str,
-    pyproject_toml_path: &std::path::Path,
-    toml_version: TomlVersion,
-) -> Option<tombi_extension::Location> {
-    // Find the workspace pyproject.toml
-    let (workspace_path, _, workspace_document_tree) =
-        find_workspace_pyproject_toml(pyproject_toml_path, toml_version)?;
-
-    // Find the member project
-    let (member_pyproject_toml_path, _) = find_member_project_toml(
-        package_name,
-        &workspace_document_tree,
-        &workspace_path,
-        toml_version,
-    )?;
-
-    let member_document_tree =
-        load_pyproject_toml_document_tree(&member_pyproject_toml_path, toml_version)?;
-    let package_name = get_project_name(&member_document_tree)?;
-    let member_pyproject_toml_uri =
-        tombi_uri::Uri::from_file_path(&member_pyproject_toml_path).ok()?;
-
-    Some(tombi_extension::Location {
-        uri: member_pyproject_toml_uri,
-        range: package_name.unquoted_range(),
-    })
-}
-
-fn get_current_workspace_dependency_definition(
-    workspace_document_tree: &tombi_document_tree::DocumentTree,
-    package_name: &str,
-    workspace_pyproject_toml_path: &std::path::Path,
-    toml_version: TomlVersion,
-) -> Option<tombi_extension::Location> {
-    dig_keys(workspace_document_tree, &["tool", "uv", "workspace"])?;
-
-    let (member_pyproject_toml_path, _) = find_member_project_toml(
-        package_name,
-        workspace_document_tree,
-        workspace_pyproject_toml_path,
-        toml_version,
-    )?;
-
-    let member_document_tree =
-        load_pyproject_toml_document_tree(&member_pyproject_toml_path, toml_version)?;
-    let package_name = get_project_name(&member_document_tree)?;
-    let member_pyproject_toml_uri =
-        tombi_uri::Uri::from_file_path(&member_pyproject_toml_path).ok()?;
-
-    Some(tombi_extension::Location {
-        uri: member_pyproject_toml_uri,
-        range: package_name.unquoted_range(),
-    })
-}
-
 pub(crate) fn collect_workspace_project_dependency_definitions(
     package_name: &str,
     pyproject_toml_path: &std::path::Path,
@@ -276,6 +273,10 @@ pub(crate) fn collect_workspace_project_dependency_definitions(
     else {
         return Vec::with_capacity(0);
     };
+
+    if workspace_pyproject_toml_path == pyproject_toml_path {
+        return Vec::with_capacity(0);
+    }
 
     let Ok(workspace_uri) = tombi_uri::Uri::from_file_path(&workspace_pyproject_toml_path) else {
         return Vec::with_capacity(0);

--- a/extensions/tombi-extension-pyproject/src/lib.rs
+++ b/extensions/tombi-extension-pyproject/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) use goto_definition::{
 pub(crate) use manifest::{
     PackageLocation, find_workspace_pyproject_toml, get_project_name,
     load_pyproject_toml_document_tree, resolve_member_pyproject_toml_path,
+    resolve_relative_path_uri,
 };
 pub(crate) use references::project_name_reference_locations;
 use tombi_schema_store::matches_accessors;
@@ -53,10 +54,7 @@ pub(crate) enum PyprojectNavigationFeature {
 pub(crate) fn classify_pyproject_navigation_feature(
     accessors: &[tombi_schema_store::Accessor],
 ) -> PyprojectNavigationFeature {
-    if matches!(
-        accessors.last(),
-        Some(tombi_schema_store::Accessor::Key(key)) if key == "path"
-    ) {
+    if is_pyproject_path_accessors(accessors) {
         PyprojectNavigationFeature::Path
     } else if matches_accessors!(
         accessors[..accessors.len().min(3)],
@@ -69,4 +67,15 @@ pub(crate) fn classify_pyproject_navigation_feature(
     } else {
         PyprojectNavigationFeature::Dependency
     }
+}
+
+pub(crate) fn is_pyproject_path_accessors(accessors: &[tombi_schema_store::Accessor]) -> bool {
+    matches!(
+        accessors.last(),
+        Some(tombi_schema_store::Accessor::Key(key)) if key == "path"
+    ) || matches_accessors!(accessors, ["project", "readme"])
+        || matches_accessors!(accessors, ["project", "readme", "file"])
+        || matches_accessors!(accessors, ["project", "license", "file"])
+        || matches_accessors!(accessors, ["project", "license-files", _])
+        || matches_accessors!(accessors, ["build-system", "backend-path", _])
 }

--- a/extensions/tombi-extension-pyproject/src/manifest.rs
+++ b/extensions/tombi-extension-pyproject/src/manifest.rs
@@ -39,6 +39,12 @@ pub(crate) fn find_workspace_pyproject_toml(
     tombi_ast::Root,
     tombi_document_tree::DocumentTree,
 )> {
+    if let Some((root, document_tree)) = load_pyproject_toml(pyproject_toml_path, toml_version)
+        && tombi_document_tree::dig_keys(&document_tree, &["tool", "uv", "workspace"]).is_some()
+    {
+        return Some((pyproject_toml_path.to_path_buf(), root, document_tree));
+    }
+
     let (workspace_pyproject_toml_path, (root, document_tree)) =
         tombi_extension_manifest::find_ancestor_manifest(
             pyproject_toml_path,
@@ -68,6 +74,21 @@ pub(crate) fn resolve_member_pyproject_toml_path(
         Path::new(dependency_path),
         "pyproject.toml",
     )
+}
+
+pub(crate) fn resolve_relative_path_uri(
+    base_pyproject_toml_path: &Path,
+    relative_path: &Path,
+) -> Option<tombi_uri::Uri> {
+    let resolved_path = if relative_path.is_absolute() {
+        relative_path.to_path_buf()
+    } else {
+        base_pyproject_toml_path.parent()?.join(relative_path)
+    };
+
+    resolved_path.exists().then_some(())?;
+
+    tombi_uri::Uri::from_file_path(&resolved_path).ok()
 }
 
 fn load_pyproject_toml(


### PR DESCRIPTION
## Summary
- deprecate path-based goto declaration handling in cargo and pyproject extensions
- shift navigation coverage to goto definition tests and update affected fixtures
- align pyproject document link expectations with the current workspace link behavior

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked
