### PR TITLE
Improve docs tables and workspace goto navigation

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/pyproject_workspace/members/app1/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/pyproject_workspace/members/app1/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "app"
+name = "app1"
 version = "0.1.0"
 dependencies = ["pydantic"]
 

--- a/crates/tombi-lsp/tests/fixtures/pyproject_workspace/pyproject.toml
+++ b/crates/tombi-lsp/tests/fixtures/pyproject_workspace/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
 
 [tool.uv.workspace]
 members = [
-  "members/app",
+  "members/app1",
   "members/app2",
   "members/app3",
 ]

--- a/crates/tombi-lsp/tests/test_goto_declaration.rs
+++ b/crates/tombi-lsp/tests/test_goto_declaration.rs
@@ -162,14 +162,14 @@ mod goto_declaration_tests {
             async fn project_dependencies_workspace_jump(
                 r#"
                 [project]
-                name = "app"
+                name = "app1"
                 version = "0.1.0"
                 dependencies = [
                     "pydantic█"
                 ]
                 "#,
-                SourcePath(pyproject_workspace_fixtures_path().join("members/app/pyproject.toml")),
-            ) -> Ok([]);
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
+            ) -> Ok([pyproject_workspace_fixtures_path().join("pyproject.toml")]);
         );
 
         test_goto_declaration!(
@@ -183,7 +183,7 @@ mod goto_declaration_tests {
 
                 [tool.uv.workspace]
                 members = [
-                    "members/app",
+                    "members/app1",
                     "members/app2",
                     "members/app3",
                 ]
@@ -200,11 +200,11 @@ mod goto_declaration_tests {
             async fn tool_pyproject_workspace_members_jump_to_member_project(
                 r#"
                 [tool.uv.workspace]
-                members = ["members/app█"]
+                members = ["members/app1█"]
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("pyproject.toml")),
             ) -> Ok([
-                pyproject_workspace_fixtures_path().join("members/app/pyproject.toml"),
+                pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml"),
             ]);
         );
 
@@ -217,7 +217,7 @@ mod goto_declaration_tests {
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("pyproject.toml")),
             ) -> Ok([
-                pyproject_workspace_fixtures_path().join("members/app/pyproject.toml"),
+                pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml"),
                 pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml"),
                 pyproject_workspace_fixtures_path().join("members/app3/pyproject.toml"),
             ]);

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -961,6 +961,23 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
+            async fn member_workspace_dependency_with_version_jumps_to_member_definition(
+                r#"
+                [project]
+                name = "app2"
+                version = "0.1.0"
+                dependencies = [
+                  "app3>=0.1.0█",
+                ]
+                "#,
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml")),
+            ) -> Ok([
+                pyproject_workspace_fixtures_path().join("members/app3/pyproject.toml")
+            ]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
             async fn workspace_dependencies_list_member_usages(
                 r#"
                 [project]

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -205,13 +205,68 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
+            async fn package_version_workspace(
+                r#"
+                [package]
+                version.workspace█ = true
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-future/Cargo.toml")),
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn package_authors_workspace(
+                r#"
+                [package]
+                authors.workspace█ = true
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-future/Cargo.toml")),
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn package_edition_workspace(
+                r#"
+                [package]
+                edition.workspace█ = true
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-future/Cargo.toml")),
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn package_repository_workspace(
+                r#"
+                [package]
+                repository.workspace█ = true
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-future/Cargo.toml")),
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn package_license_workspace(
+                r#"
+                [package]
+                license.workspace█ = true
+                "#,
+                SourcePath(project_root_path().join("crates/tombi-future/Cargo.toml")),
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
             async fn workspace_dependencies_serde(
                 r#"
                 [workspace.dependencies]
                 serde█ = { version = "1.0.0" }
                 "#,
                 SourcePath(project_root_path().join("Cargo.toml")),
-            ) -> Ok([]);
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
         );
 
         test_goto_definition!(
@@ -237,10 +292,7 @@ mod goto_definition_tests {
                 tombi-ast-editor█ = { path = "crates/tombi-ast-editor" }
                 "#,
                 SourcePath(project_root_path().join("Cargo.toml")),
-            ) -> Ok([
-                project_root_path().join("crates/tombi-ast-editor/Cargo.toml"),
-                project_root_path().join("crates/tombi-formatter/Cargo.toml"),
-            ]);
+            ) -> Ok([project_root_path().join("crates/tombi-ast-editor/Cargo.toml")]);
         );
 
         test_goto_definition!(
@@ -255,7 +307,7 @@ mod goto_definition_tests {
                 semver█ = { version = "1.0.23" }
                 "#,
                 SourcePath(project_root_path().join("Cargo.toml")),
-            ) -> Ok([project_root_path().join("crates/tombi-lsp/Cargo.toml")]);
+            ) -> Ok([project_root_path().join("Cargo.toml")]);
         );
 
         test_goto_definition!(
@@ -457,12 +509,7 @@ mod goto_definition_tests {
                     cargo_feature_navigation_fixture_path().join("workspace/provider/Cargo.toml")
                 ),
             ) -> Ok([
-                cargo_feature_navigation_fixture_path().join("workspace/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/renamed-consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/renamed-consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/weak-consumer/Cargo.toml"),
+                cargo_feature_navigation_fixture_path().join("workspace/provider/Cargo.toml")
             ]);
         );
 
@@ -482,10 +529,7 @@ mod goto_definition_tests {
                     cargo_feature_navigation_fixture_path().join("workspace/provider/Cargo.toml")
                 ),
             ) -> Ok([
-                cargo_feature_navigation_fixture_path().join("workspace/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/renamed-consumer/Cargo.toml"),
-                cargo_feature_navigation_fixture_path().join("workspace/weak-consumer/Cargo.toml"),
+                cargo_feature_navigation_fixture_path().join("workspace/provider/Cargo.toml")
             ]);
         );
 
@@ -733,10 +777,7 @@ mod goto_definition_tests {
                 ci█ = ["ruff"]
                 "#,
                 SourcePath(project_root_path().join("pyproject.toml")),
-            ) -> Ok([
-                project_root_path().join("pyproject.toml"),
-                project_root_path().join("pyproject.toml"),
-            ]);
+            ) -> Ok([project_root_path().join("pyproject.toml")]);
         );
 
         test_goto_definition!(
@@ -778,10 +819,10 @@ mod goto_definition_tests {
             async fn tool_pyproject_sources_path_dependency(
                 r#"
                 [tool.uv.sources]
-                app = { path = "members/app█" }
+                app1 = { path = "members/app1█" }
                 "#,
                 SourcePath(project_root_path().join("crates/tombi-lsp/tests/fixtures/pyproject_workspace/pyproject.toml")),
-            ) -> Ok([project_root_path().join("crates/tombi-lsp/tests/fixtures/pyproject_workspace/members/app/pyproject.toml")]);
+            ) -> Ok([project_root_path().join("crates/tombi-lsp/tests/fixtures/pyproject_workspace/members/app1/pyproject.toml")]);
         );
 
         test_goto_definition!(
@@ -874,16 +915,14 @@ mod goto_definition_tests {
             async fn project_dependencies_inherit_workspace_version(
                 r#"
                 [project]
-                name = "app"
+                name = "app1"
                 version = "0.1.0"
                 dependencies = [
                     "pydantic█"
                 ]
                 "#,
-                SourcePath(pyproject_workspace_fixtures_path().join("members/app/pyproject.toml")),
-            ) -> Ok([
-                pyproject_workspace_fixtures_path().join("pyproject.toml")
-            ]);
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
+            ) -> Ok([pyproject_workspace_fixtures_path().join("pyproject.toml")]);
         );
 
         test_goto_definition!(
@@ -899,8 +938,24 @@ mod goto_definition_tests {
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml")),
             ) -> Ok([
-                pyproject_workspace_fixtures_path().join("members/app3/pyproject.toml"),
-                pyproject_workspace_fixtures_path().join("members/app3/pyproject.toml"),
+                pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml")
+            ]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
+            async fn member_pypi_dependency_not_managed_by_workspace_stays_on_itself(
+                r#"
+                [project]
+                name = "app2"
+                version = "0.1.0"
+                dependencies = [
+                  "httpx█",
+                ]
+                "#,
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml")),
+            ) -> Ok([
+                pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml")
             ]);
         );
 
@@ -909,22 +964,19 @@ mod goto_definition_tests {
             async fn workspace_dependencies_list_member_usages(
                 r#"
                 [project]
-                name = "app"
+                name = "workspace"
                 version = "0.1.0"
                 dependencies = ["pydantic█"]
 
                 [tool.uv.workspace]
                 members = [
-                    "members/app",
+                    "members/app1",
                     "members/app2",
                     "members/app3",
                 ]
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("pyproject.toml")),
-            ) -> Ok([
-                pyproject_workspace_fixtures_path().join("members/app/pyproject.toml"),
-                pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml"),
-            ]);
+            ) -> Ok([pyproject_workspace_fixtures_path().join("pyproject.toml")]);
         );
 
         test_goto_definition!(
@@ -941,7 +993,7 @@ mod goto_definition_tests {
 
                 [tool.uv.workspace]
                 members = [
-                    "members/app",
+                    "members/app1",
                     "members/app2",
                     "members/app3",
                 ]

--- a/crates/tombi-lsp/tests/test_inlay_hint.rs
+++ b/crates/tombi-lsp/tests/test_inlay_hint.rs
@@ -1543,10 +1543,10 @@ test_inlay_hint!(
     #[tokio::test]
     async fn pyproject_inlay_hint_finds_uv_lock_from_ancestor_directory(
         SourceFile {
-            path = "members/app/pyproject.toml",
+            path = "members/app1/pyproject.toml",
             content = r#"
             [project]
-            name = "app"
+            name = "app1"
             version = "0.1.0"
             dependencies = ["pytest>=8.0"]
             "#,
@@ -1557,7 +1557,7 @@ test_inlay_hint!(
             version = 1
 
             [[package]]
-            name = "app"
+            name = "app1"
             version = "0.1.0"
             dependencies = [{ name = "pytest" }]
 

--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -316,6 +316,28 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
+            async fn target_optional_dependency_include_declaration_adds_dependency_key(
+                r#"
+                [package]
+                name = "example"
+                version = "0.1.0"
+
+                [target.'cfg(unix)'.dependencies]
+                schemars = { version = "1.0", optional█ = true }
+
+                [features]
+                bundle = ["dep:schemars"]
+                "#,
+                SourcePath(project_root_path().join("crates/example/Cargo.toml")),
+                IncludeDeclaration(true),
+            ) -> Ok([
+                project_root_path().join("crates/example/Cargo.toml"),
+                project_root_path().join("crates/example/Cargo.toml"),
+            ]);
+        );
+
+        test_references!(
+            #[tokio::test]
             async fn workspace_dependency_key_lists_member_usages(
                 r#"
                 [workspace]
@@ -407,13 +429,13 @@ mod references_tests {
             async fn project_dependencies_workspace_usage_locations(
                 r#"
                 [project]
-                name = "app"
+                name = "app1"
                 version = "0.1.0"
                 dependencies = [
                     "pydantic█"
                 ]
                 "#,
-                SourcePath(pyproject_workspace_fixtures_path().join("members/app/pyproject.toml")),
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
             ) -> Ok([
                 pyproject_workspace_fixtures_path().join("pyproject.toml"),
             ]);
@@ -442,13 +464,13 @@ mod references_tests {
             async fn pyproject_references_use_references_setting_not_goto_definition(
                 r#"
                 [project]
-                name = "app"
+                name = "app1"
                 version = "0.1.0"
                 dependencies = [
                     "pydantic█"
                 ]
                 "#,
-                SourcePath(pyproject_workspace_fixtures_path().join("members/app/pyproject.toml")),
+                SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
                 ConfigPath(fixture_config_path("pyproject-references-only-enabled")),
             ) -> Ok([
                 pyproject_workspace_fixtures_path().join("pyproject.toml"),

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -3,13 +3,15 @@
 
 :root {
   --docs-fixed-header-height: 80px;
-  --docs-sticky-table-offset: 12px;
+  --docs-sticky-table-offset: 20px;
 }
 
 html {
   overflow-x: hidden;
   max-width: 100vw;
-  scroll-padding-top: 100px; /* header height (80px) + offset (20px) */
+  scroll-padding-top: calc(
+    var(--docs-fixed-header-height) + var(--docs-sticky-table-offset)
+  );
 }
 
 body {
@@ -84,7 +86,9 @@ main {
 .mdx-content h5,
 .mdx-content h6,
 .mdx-content [id] {
-  scroll-margin-top: 100px; /* header height (80px) + offset (20px) */
+  scroll-margin-top: calc(
+    var(--docs-fixed-header-height) + var(--docs-sticky-table-offset)
+  );
 }
 
 .no-content h1,

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -202,6 +202,7 @@ main {
 }
 
 .mdx-content .mdx-table-cloned-head th {
+  box-sizing: border-box;
   padding: 0.5rem 1rem;
   text-align: left;
   font-weight: 600;

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -186,12 +186,19 @@ main {
   padding: 0.5rem 1rem;
   text-align: left;
   min-width: 100px;
-  background-color: rgba(119, 170, 221, 0.1);
 }
 
 .mdx-content th {
   font-weight: 600;
-  background-color: rgba(119, 170, 221, 0.2);
+  background-color: rgba(119, 170, 221, 0.32);
+}
+
+.mdx-content tbody tr:nth-child(odd) td {
+  background-color: rgba(119, 170, 221, 0.1);
+}
+
+.mdx-content tbody tr:nth-child(even) td {
+  background-color: rgba(119, 170, 221, 0.16);
 }
 
 /* First row corners */
@@ -214,11 +221,19 @@ main {
 
 :root.dark .mdx-content th,
 :root.dark .mdx-content td {
-  background-color: rgba(119, 170, 221, 0.05);
+  background-color: transparent;
 }
 
 :root.dark .mdx-content th {
-  background-color: rgba(119, 170, 221, 0.1);
+  background-color: rgba(119, 170, 221, 0.2);
+}
+
+:root.dark .mdx-content tbody tr:nth-child(odd) td {
+  background-color: rgba(119, 170, 221, 0.05);
+}
+
+:root.dark .mdx-content tbody tr:nth-child(even) td {
+  background-color: rgba(119, 170, 221, 0.09);
 }
 
 /* Table scrollbar styles for better UX */

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -1,6 +1,11 @@
 @import "https://cdnjs.cloudflare.com/ajax/libs/prism-themes/1.5.0/prism-vsc-dark-plus.min.css";
 @import "./styles/code-block.css";
 
+:root {
+  --docs-fixed-header-height: 80px;
+  --docs-sticky-table-offset: 12px;
+}
+
 html {
   overflow-x: hidden;
   max-width: 100vw;
@@ -173,12 +178,64 @@ main {
 }
 
 /* Table Styles */
-.mdx-content table {
-  border-collapse: collapse;
-  margin: 1rem 0rem;
+.mdx-content .mdx-table-shell {
+  position: relative;
+}
+
+.mdx-content .mdx-table-sticky-head {
+  display: none;
+}
+
+.mdx-content .mdx-table-shell[data-sticky-active="true"] .mdx-table-sticky-head {
   display: block;
+  position: fixed;
+  z-index: 50;
+  overflow: hidden;
+  pointer-events: none;
+  background-color: rgb(201, 217, 240);
+}
+
+.mdx-content .mdx-table-cloned-head {
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+.mdx-content .mdx-table-cloned-head th {
+  padding: 0.5rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  background-color: rgb(201, 217, 240);
+}
+
+.mdx-content .mdx-table-cloned-head thead tr:first-child th:first-child {
+  border-top-left-radius: 8px;
+}
+
+.mdx-content .mdx-table-cloned-head thead tr:first-child th:last-child {
+  border-top-right-radius: 8px;
+}
+
+.mdx-content .mdx-table-shell[data-sticky-active="true"] .mdx-table-cloned-head thead tr:first-child th:first-child {
+  border-top-left-radius: 0;
+}
+
+.mdx-content .mdx-table-shell[data-sticky-active="true"] .mdx-table-cloned-head thead tr:first-child th:last-child {
+  border-top-right-radius: 0;
+}
+
+.mdx-content .mdx-table-scroll {
+  margin: 1rem 0rem;
   overflow-x: auto;
+  overflow-y: hidden;
   max-width: 100%;
+}
+
+.mdx-content .mdx-table-scroll table {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: max-content;
+  min-width: 100%;
 }
 
 .mdx-content th,
@@ -224,6 +281,14 @@ main {
   background-color: transparent;
 }
 
+:root.dark .mdx-content .mdx-table-shell[data-sticky-active="true"] .mdx-table-sticky-head {
+  background-color: rgb(46, 60, 78);
+}
+
+:root.dark .mdx-content .mdx-table-cloned-head th {
+  background-color: rgb(46, 60, 78);
+}
+
 :root.dark .mdx-content th {
   background-color: rgba(119, 170, 221, 0.2);
 }
@@ -237,26 +302,26 @@ main {
 }
 
 /* Table scrollbar styles for better UX */
-.mdx-content table::-webkit-scrollbar {
+.mdx-content .mdx-table-scroll::-webkit-scrollbar {
   height: 6px;
 }
 
-.mdx-content table::-webkit-scrollbar-track {
+.mdx-content .mdx-table-scroll::-webkit-scrollbar-track {
   background: rgba(119, 170, 221, 0.1);
   border-radius: 3px;
 }
 
-.mdx-content table::-webkit-scrollbar-thumb {
+.mdx-content .mdx-table-scroll::-webkit-scrollbar-thumb {
   background: rgba(119, 170, 221, 0.3);
   border-radius: 3px;
 }
 
-.mdx-content table::-webkit-scrollbar-thumb:hover {
+.mdx-content .mdx-table-scroll::-webkit-scrollbar-thumb:hover {
   background: rgba(119, 170, 221, 0.5);
 }
 
 /* Firefox */
-.mdx-content table {
+.mdx-content .mdx-table-scroll {
   scrollbar-width: thin;
   scrollbar-color: rgba(119, 170, 221, 0.3) rgba(119, 170, 221, 0.1);
 }

--- a/docs/src/components/Sidebar.tsx
+++ b/docs/src/components/Sidebar.tsx
@@ -69,7 +69,7 @@ const TreeItem = (props: { item: DocIndex; level: number }) => {
 
 export function Sidebar() {
   return (
-    <nav class="w-[250px] h-screen sticky top-0 overflow-y-auto p-4 bg-[--color-bg-secondary] border-r border-[--color-border] md:block hidden">
+    <nav class="w-[250px] shrink-0 h-screen sticky top-0 overflow-y-auto p-4 bg-[--color-bg-secondary] border-r border-[--color-border] md:block hidden">
       <For each={docIndexs}>{(item) => <TreeItem item={item} level={0} />}</For>
     </nav>
   );

--- a/docs/src/components/Table.tsx
+++ b/docs/src/components/Table.tsx
@@ -13,7 +13,6 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
       return;
     }
 
-    const stickyTop = 80;
     let rafId = 0;
     let resizeObserver: ResizeObserver | undefined;
 
@@ -21,6 +20,12 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
       if (!shellRef || !scrollRef || !tableRef || !stickyRef) {
         return;
       }
+
+      const stickyTop = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--docs-fixed-header-height",
+        ),
+      );
 
       const thead = tableRef.querySelector("thead");
       if (!thead) {

--- a/docs/src/components/Table.tsx
+++ b/docs/src/components/Table.tsx
@@ -14,42 +14,65 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
     }
 
     let rafId = 0;
+    let needsLayoutSync = true;
     let resizeObserver: ResizeObserver | undefined;
+    let clonedTable: HTMLTableElement | undefined;
+    let clonedHead: HTMLTableSectionElement | undefined;
 
-    const renderStickyHeader = () => {
+    const readCssLength = (name: string) =>
+      Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(name),
+      ) || 0;
+
+    const clearStickyHeader = () => {
+      shellRef?.setAttribute("data-sticky-active", "false");
+      stickyRef?.replaceChildren();
+      clonedTable = undefined;
+      clonedHead = undefined;
+    };
+
+    const ensureStickyHeader = () => {
       if (!shellRef || !scrollRef || !tableRef || !stickyRef) {
-        return;
+        return null;
       }
-
-      const stickyTop = Number.parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue(
-          "--docs-fixed-header-height",
-        ),
-      );
 
       const thead = tableRef.querySelector("thead");
       if (!thead) {
-        shellRef.dataset.stickyActive = "false";
-        stickyRef.replaceChildren();
-        return;
+        clearStickyHeader();
+        return null;
       }
 
-      const shellRect = shellRef.getBoundingClientRect();
-      const tableRect = tableRef.getBoundingClientRect();
       const originalCells = Array.from(thead.querySelectorAll("th"));
       if (originalCells.length === 0) {
-        shellRef.dataset.stickyActive = "false";
+        clearStickyHeader();
+        return null;
+      }
+
+      if (!clonedTable || !clonedHead || !stickyRef.contains(clonedTable)) {
         stickyRef.replaceChildren();
+
+        clonedTable = document.createElement("table");
+        clonedTable.className = "mdx-table-cloned-head";
+        clonedHead = thead.cloneNode(true) as HTMLTableSectionElement;
+        clonedTable.appendChild(clonedHead);
+        stickyRef.appendChild(clonedTable);
+      }
+
+      return { originalCells, clonedHead, clonedTable };
+    };
+
+    const updateStickyHeaderLayout = () => {
+      if (!shellRef || !tableRef) {
         return;
       }
 
-      stickyRef.replaceChildren();
+      const stickyHeader = ensureStickyHeader();
+      if (!stickyHeader) {
+        return;
+      }
 
-      const clonedTable = document.createElement("table");
-      clonedTable.className = "mdx-table-cloned-head";
-      const clonedHead = thead.cloneNode(true) as HTMLTableSectionElement;
-      clonedTable.appendChild(clonedHead);
-      stickyRef.appendChild(clonedTable);
+      const { originalCells, clonedHead, clonedTable } = stickyHeader;
+      const tableRect = tableRef.getBoundingClientRect();
 
       const clonedCells = Array.from(clonedHead.querySelectorAll("th"));
       originalCells.forEach((cell, index) => {
@@ -64,7 +87,24 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
       });
 
       clonedTable.style.width = `${tableRect.width}px`;
+    };
 
+    const updateStickyHeaderPosition = () => {
+      if (!shellRef || !scrollRef) {
+        return;
+      }
+
+      const stickyHeader = ensureStickyHeader();
+      if (!stickyHeader) {
+        return;
+      }
+
+      const { clonedHead, clonedTable } = stickyHeader;
+      const stickyTop =
+        readCssLength("--docs-fixed-header-height") +
+        readCssLength("--docs-sticky-table-offset");
+
+      const shellRect = shellRef.getBoundingClientRect();
       const stickyHeight = clonedHead.getBoundingClientRect().height;
       const shouldStick =
         shellRect.top <= stickyTop && shellRect.bottom > stickyTop + stickyHeight;
@@ -80,26 +120,41 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
       clonedTable.style.transform = `translateX(${-scrollRef.scrollLeft}px)`;
     };
 
-    const requestRender = () => {
+    const renderStickyHeader = () => {
+      if (needsLayoutSync) {
+        updateStickyHeaderLayout();
+        needsLayoutSync = false;
+      }
+
+      updateStickyHeaderPosition();
+    };
+
+    const requestRender = (syncLayout = false) => {
+      needsLayoutSync = needsLayoutSync || syncLayout;
       cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(renderStickyHeader);
     };
 
-    resizeObserver = new ResizeObserver(requestRender);
+    resizeObserver = new ResizeObserver(() => requestRender(true));
     resizeObserver.observe(shellRef);
     resizeObserver.observe(tableRef);
 
-    window.addEventListener("scroll", requestRender, { passive: true });
-    window.addEventListener("resize", requestRender);
-    scrollRef.addEventListener("scroll", requestRender, { passive: true });
-    requestRender();
+    const handleWindowScroll = () => requestRender();
+    const handleWindowResize = () => requestRender(true);
+    const handleTableScroll = () => requestRender();
+
+    window.addEventListener("scroll", handleWindowScroll, { passive: true });
+    window.addEventListener("resize", handleWindowResize);
+    scrollRef.addEventListener("scroll", handleTableScroll, { passive: true });
+    requestRender(true);
 
     onCleanup(() => {
       cancelAnimationFrame(rafId);
       resizeObserver?.disconnect();
-      window.removeEventListener("scroll", requestRender);
-      window.removeEventListener("resize", requestRender);
-      scrollRef?.removeEventListener("scroll", requestRender);
+      window.removeEventListener("scroll", handleWindowScroll);
+      window.removeEventListener("resize", handleWindowResize);
+      scrollRef?.removeEventListener("scroll", handleTableScroll);
+      clearStickyHeader();
     });
   });
 

--- a/docs/src/components/Table.tsx
+++ b/docs/src/components/Table.tsx
@@ -1,0 +1,111 @@
+import { onCleanup, onMount } from "solid-js";
+import type { JSX } from "solid-js";
+
+export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
+  const { children, ...tableProps } = props;
+  let shellRef: HTMLDivElement | undefined;
+  let scrollRef: HTMLDivElement | undefined;
+  let tableRef: HTMLTableElement | undefined;
+  let stickyRef: HTMLDivElement | undefined;
+
+  onMount(() => {
+    if (!shellRef || !scrollRef || !tableRef || !stickyRef) {
+      return;
+    }
+
+    const stickyTop = 80;
+    let rafId = 0;
+    let resizeObserver: ResizeObserver | undefined;
+
+    const renderStickyHeader = () => {
+      if (!shellRef || !scrollRef || !tableRef || !stickyRef) {
+        return;
+      }
+
+      const thead = tableRef.querySelector("thead");
+      if (!thead) {
+        shellRef.dataset.stickyActive = "false";
+        stickyRef.replaceChildren();
+        return;
+      }
+
+      const shellRect = shellRef.getBoundingClientRect();
+      const tableRect = tableRef.getBoundingClientRect();
+      const originalCells = Array.from(thead.querySelectorAll("th"));
+      if (originalCells.length === 0) {
+        shellRef.dataset.stickyActive = "false";
+        stickyRef.replaceChildren();
+        return;
+      }
+
+      stickyRef.replaceChildren();
+
+      const clonedTable = document.createElement("table");
+      clonedTable.className = "mdx-table-cloned-head";
+      const clonedHead = thead.cloneNode(true) as HTMLTableSectionElement;
+      clonedTable.appendChild(clonedHead);
+      stickyRef.appendChild(clonedTable);
+
+      const clonedCells = Array.from(clonedHead.querySelectorAll("th"));
+      originalCells.forEach((cell, index) => {
+        const clonedCell = clonedCells[index];
+        if (!clonedCell) {
+          return;
+        }
+        const width = cell.getBoundingClientRect().width;
+        clonedCell.style.width = `${width}px`;
+        clonedCell.style.minWidth = `${width}px`;
+        clonedCell.style.maxWidth = `${width}px`;
+      });
+
+      clonedTable.style.width = `${tableRect.width}px`;
+
+      const stickyHeight = clonedHead.getBoundingClientRect().height;
+      const shouldStick =
+        shellRect.top <= stickyTop && shellRect.bottom > stickyTop + stickyHeight;
+
+      shellRef.dataset.stickyActive = shouldStick ? "true" : "false";
+      if (!shouldStick) {
+        return;
+      }
+
+      stickyRef.style.top = `${stickyTop}px`;
+      stickyRef.style.left = `${shellRect.left}px`;
+      stickyRef.style.width = `${shellRect.width}px`;
+      clonedTable.style.transform = `translateX(${-scrollRef.scrollLeft}px)`;
+    };
+
+    const requestRender = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(renderStickyHeader);
+    };
+
+    resizeObserver = new ResizeObserver(requestRender);
+    resizeObserver.observe(shellRef);
+    resizeObserver.observe(tableRef);
+
+    window.addEventListener("scroll", requestRender, { passive: true });
+    window.addEventListener("resize", requestRender);
+    scrollRef.addEventListener("scroll", requestRender, { passive: true });
+    requestRender();
+
+    onCleanup(() => {
+      cancelAnimationFrame(rafId);
+      resizeObserver?.disconnect();
+      window.removeEventListener("scroll", requestRender);
+      window.removeEventListener("resize", requestRender);
+      scrollRef?.removeEventListener("scroll", requestRender);
+    });
+  });
+
+  return (
+    <div class="mdx-table-shell" data-sticky-active="false" ref={shellRef}>
+      <div class="mdx-table-sticky-head" aria-hidden="true" ref={stickyRef} />
+      <div class="mdx-table-scroll" ref={scrollRef}>
+        <table {...tableProps} ref={tableRef}>
+          {children}
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/index.tsx
+++ b/docs/src/components/index.tsx
@@ -6,3 +6,4 @@ export { Note, Tip } from "./Highlight";
 export { InstallationMethodGrid } from "./InstallationMethodGrid";
 export { LinkCard } from "./LinkCard";
 export { PageHeading } from "./PageHeading";
+export { Table as table } from "./Table";

--- a/docs/src/routes/docs.tsx
+++ b/docs/src/routes/docs.tsx
@@ -23,12 +23,12 @@ export default function DocumentationLayout(props: RouteSectionProps) {
   });
 
   return (
-    <div class="flex w-full max-w-[100vw] overflow-x-hidden">
+    <div class="flex w-full max-w-[100vw]">
       <Sidebar />
       <main
         ref={mainRef}
         tabindex="-1"
-        class="flex-1 p-4 mdx-content min-h-screen max-w-full overflow-x-hidden outline-none"
+        class="flex-1 min-w-0 p-4 mdx-content min-h-screen max-w-full outline-none"
       >
         <div class="max-w-full">
           {props.children}

--- a/docs/src/routes/docs/extensions/tombi-extension-cargo.mdx
+++ b/docs/src/routes/docs/extensions/tombi-extension-cargo.mdx
@@ -93,7 +93,7 @@ Behavior:
 
 The extension can show inline hints for workspace-aware dependency values in `Cargo.toml`.
 
-Current hints cover resolved dependency versions, `default-features`, and workspace-inherited values so you can inspect the effective dependency state without leaving the manifest.
+Current hints cover resolved dependency versions, `default-features`, and workspace-inherited values so you can inspect the effective dependency state without leaving the current `Cargo.toml`.
 
 ### Go to Definition
 For example, suppose you have a `Cargo.toml` like the one below:
@@ -105,12 +105,15 @@ serde = { workspace = true }
 tombi-ast = { workspace = true }
 ```
 
-In this case, when your cursor is on `workspace`, executing "Go to Definition" will navigate you to the **workspace** definition or to the **crate** definition managed by the workspace.
+In this case, when your cursor is on `workspace`, executing "Go to Definition" will navigate you to the corresponding entry in the workspace's `Cargo.toml`.
 
-In the example above, for `serde` (an external crate), you'll be navigated to the **workspace** definition, while for `tombi-ast` (a crate managed by the workspace), you'll be navigated to the **crate** definition.
+When your cursor is on the dependency key itself, Tombi first checks whether the workspace-managed dependency resolves to a local crate:
+
+- `serde` has no local `Cargo.toml`, so "Go to Definition" jumps to `workspace.dependencies.serde` in the workspace `Cargo.toml`.
+- `tombi-ast` resolves to a local workspace crate, so "Go to Definition" jumps to that crate's `Cargo.toml` and lands on the `package.name` value.
 
 <Note>
-If you consistently want to navigate to the **workspace**'s `Cargo.toml`, use "Go to Declaration".
+"Go to Declaration" always uses the matching entry in the workspace `Cargo.toml` for `workspace = true`.
 </Note>
 
 #### Go to crate definition from `workspace.dependencies`
@@ -119,7 +122,8 @@ If you consistently want to navigate to the **workspace**'s `Cargo.toml`, use "G
 tombi-ast = { path = "crates/tombi-ast" }
 ```
 
-In this case, when your cursor is on `path`, executing "Go to Definition" will navigate you to the crate definition.
+In this case, when your cursor is on the dependency key, executing "Go to Definition" navigates to the target crate's `Cargo.toml` and lands on its `package.name` value when the workspace dependency resolves to a member or local path.
+When your cursor is on `path`, executing "Go to Definition" will navigate you to the crate definition.
 
 ### Go to Declaration
 ```toml
@@ -128,7 +132,29 @@ serde = { workspace = true }
 tombi-ast = { workspace = true }
 ```
 
-In this case, when your cursor is on `workspace`, executing "Go to Declaration" will navigate you to the crate definition.
+In this case, when your cursor is on `workspace`, executing "Go to Declaration" will navigate you to the corresponding entry in the workspace's `Cargo.toml`.
+
+### Navigation List
+
+The table below describes the intended accessor-by-accessor split between `Go to Definition`, `Go to Declaration`, and `Find References`.
+
+| type | Accessors | Go to Definition | Go to Declaration | Find References |
+| --- | --- | --- | --- | --- |
+| `dependency` | `package.name` | Current `Cargo.toml` at `package.name` | - | Usages of this package from member `Cargo.toml` files and workspace dependency entries |
+| `dependency` | `features.*` | Current `Cargo.toml` at `features.*` | - | Usages of that feature from local features and dependency feature strings |
+| `dependency` | `features.*.*` | Referenced feature definition in the same crate, or in the dependency crate's `Cargo.toml` | - | - |
+| `dependency` | `dependencies.*`<br />`dev-dependencies.*`<br />`build-dependencies.*`<br />`target.*.dependencies.*`<br />`target.*.dev-dependencies.*`<br />`target.*.build-dependencies.*` | Dependency crate's `Cargo.toml` at `package.name`,<br />or the workspace `Cargo.toml` at `workspace.dependencies.*` when `workspace = true`,<br />or the current dependency entry when no more specific target exists | Workspace `Cargo.toml` at `workspace.dependencies.*` when `workspace = true` | - |
+| `dependency` | `workspace.dependencies.*` | Target crate's `Cargo.toml` at `package.name` when the workspace dependency resolves to a local crate,<br />or the current `workspace.dependencies.*` entry when it does not | - | Dependency entries in member `Cargo.toml` files that use this workspace dependency |
+| `dependency` | `dependencies.*.workspace`<br />`dev-dependencies.*.workspace`<br />`build-dependencies.*.workspace`<br />`target.*.dependencies.*.workspace`<br />`target.*.dev-dependencies.*.workspace`<br />`target.*.build-dependencies.*.workspace` | Workspace `Cargo.toml` at the matching `workspace.dependencies.*` entry | Workspace `Cargo.toml` at the matching `workspace.dependencies.*` entry | - |
+| `dependency` | `dependencies.*.features.*`<br />`dev-dependencies.*.features.*`<br />`build-dependencies.*.features.*`<br />`target.*.dependencies.*.features.*`<br />`target.*.dev-dependencies.*.features.*`<br />`target.*.build-dependencies.*.features.*` | Referenced dependency crate's `Cargo.toml` at `features.*` | - | - |
+| `dependency` | `dependencies.*.optional`<br />`dev-dependencies.*.optional`<br />`build-dependencies.*.optional`<br />`target.*.dependencies.*.optional`<br />`target.*.dev-dependencies.*.optional`<br />`target.*.build-dependencies.*.optional` | Current dependency entry's `optional` field | - | Implicit feature usages generated from this optional dependency |
+| `member` | `workspace.members`<br />`workspace.members.*` | Member crate's `Cargo.toml` at `package.name` | - | - |
+| `member` | `workspace.default-members`<br />`workspace.default-members.*` | Default member crate's `Cargo.toml` at `package.name` | - | - |
+| `path` | `workspace.dependencies.*.path`<br />`dependencies.*.path`<br />`dev-dependencies.*.path`<br />`build-dependencies.*.path`<br />`target.*.dependencies.*.path`<br />`target.*.dev-dependencies.*.path`<br />`target.*.build-dependencies.*.path` | Referenced local crate's `Cargo.toml` at `package.name` | - | - |
+| `path` | `bin.*.path` | Referenced source file | - | - |
+
+When `Go to Definition` returns the current location for a definition-site accessor, Tombi is intentionally signaling that there is no more specific definition target.
+In editors such as VS Code, this allows `editor.gotoLocation.alternativeDefinitionCommand` to take over and open the configured fallback, typically `References`.
 
 ### Code Actions
 
@@ -228,6 +254,6 @@ The workspace entry keeps the original requirement, and the member now follows t
 
 The extension enriches `Cargo.toml` with contextual document links so you can jump directly to related resources:
 - Entries in `[workspace.members]` and `[workspace.default-members]` open the corresponding member crate's `Cargo.toml`.
-- Dependencies in member manifests surface links to the workspace definition (when `workspace = true`), local path manifests, git repositories, custom registries, or crates.io when applicable.
+- Dependencies in member `Cargo.toml` files surface links to the workspace definition (when `workspace = true`), local path `Cargo.toml` files, git repositories, custom registries, or crates.io when applicable.
 - `[workspace.dependencies]` entries provide quick access both to the workspace declaration and the external source (registry/git/crates.io).
 - Fields such as `package.workspace`, `lints.workspace`, and `[bin]` targets link back to their workspace counterparts or the referenced source file for faster navigation.

--- a/docs/src/routes/docs/extensions/tombi-extension-pyproject.mdx
+++ b/docs/src/routes/docs/extensions/tombi-extension-pyproject.mdx
@@ -84,10 +84,12 @@ dependencies = ["bird-feeder", "tqdm>=4,<5"]
 bird-feeder = { workspace = true }
 ```
 
-In this case, when your cursor is on `workspace`, executing "Go to Definition" will navigate you to the **package** definition managed by the workspace.
+In this case, when your cursor is on `workspace`, executing "Go to Definition" will navigate you to the corresponding workspace-member entry in the workspace's `pyproject.toml`.
+
+When your cursor is on the source key itself, such as `bird-feeder`, "Go to Definition" navigates to the member package's `pyproject.toml` and lands on its `project.name` value.
 
 <Note>
-If you consistently want to navigate to the workspace manifest that defines the source, use "Go to Declaration".
+The same entry in the workspace `pyproject.toml` is used for "Go to Declaration".
 </Note>
 
 ### Go to Declaration
@@ -106,6 +108,33 @@ In this case, when your cursor is on `workspace`, executing "Go to Declaration" 
 
 `Go to Declaration` also works when the cursor is placed on the dependency string itself (for example `"bird-feeder"`).
 If the package comes from `tool.uv.sources` with `workspace = true`, the command jumps to the member entry in the workspace `pyproject.toml`, letting you inspect which pattern pulled the project into the workspace.
+
+### Navigation List
+
+The table below describes the intended accessor-by-accessor split between `Go to Definition`, `Go to Declaration`, and `Find References`.
+
+For dependency strings, `Go to Definition` follows a compact rule:
+- stay on the current string when this file itself is the source of truth for the PyPI dependency
+- jump to the workspace dependency entry when the version is inherited from the workspace
+- jump to the target package's `project.name` when the dependency resolves to a workspace member or local source
+
+| type | Accessors | Go to Definition | Go to Declaration | Find References |
+| --- | --- | --- | --- | --- |
+| `dependency` | `project.name` | Current `pyproject.toml` at `project.name` | - | Usages of this package from dependency strings and `tool.uv.sources.*` entries |
+| `dependency` | `project.dependencies.*`<br />`project.optional-dependencies.*.*`<br />`dependency-groups.*.*` | Current dependency string,<br />or the workspace `pyproject.toml` dependency entry that provides its version,<br /> or the target package's `pyproject.toml` at `project.name` when it resolves to a workspace member<br />or local source | The entry that defines the dependency, such as `tool.uv.sources.*` in the current `pyproject.toml`<br />or a workspace dependency entry in the workspace `pyproject.toml` | Other dependency-string usages of the same package |
+| `dependency` | `dependency-groups.*` | Current `dependency-groups.*` key | - | `include-group` entries that reference this dependency group |
+| `dependency` | `dependency-groups.*.*.include-group` | Referenced `dependency-groups.*` key in the same `pyproject.toml` | - | - |
+| `member` | `tool.uv.workspace.members`<br />`tool.uv.workspace.members.*` | Member package's `pyproject.toml` at `project.name` | Member package's `pyproject.toml` at `project.name` | - |
+| `member` | `tool.uv.sources.*` | Member package's `pyproject.toml` at `project.name`,<br />or the referenced local project's `pyproject.toml` at `project.name` | Workspace `pyproject.toml` at the matching `tool.uv.workspace.members.*` entry when the source is workspace-managed | Dependency strings and source entries that use this package |
+| `member` | `tool.uv.sources.*.workspace` | Workspace `pyproject.toml` at the matching `tool.uv.workspace.members.*` entry | Workspace `pyproject.toml` at the matching `tool.uv.workspace.members.*` entry | Dependency strings and source entries that use this package |
+| `path` | `tool.uv.sources.*.path` | Referenced local project's `pyproject.toml` at `project.name` | - | Dependency strings and source entries that use this package |
+| `path` | `project.readme`<br />`project.readme.file` | Referenced file | - | - |
+| `path` | `project.license.file` | Referenced file | - | - |
+| `path` | `project.license-files.*` | Referenced file, or each file matched by the glob | - | - |
+| `path` | `build-system.backend-path.*` | Referenced backend file or directory | - | - |
+
+When `Go to Definition` returns the current location for a definition-site accessor, Tombi is intentionally signaling that there is no more specific definition target.
+In editors such as VS Code, this allows `editor.gotoLocation.alternativeDefinitionCommand` to take over and open the configured fallback, typically `References`.
 
 ### Code Actions
 
@@ -161,5 +190,5 @@ When the workspace has not registered the dependency yet, this action adds the c
 
 The extension annotates key project metadata with document links so you can jump to the right file or website in one click:
 - entries in `[tool.uv.workspace.members]` and matches found via globs open the associated member project's `pyproject.toml`
-- sources declared under `[tool.uv.sources]` with `workspace = true` expose links to both the member manifest and the workspace root configuration
+- sources declared under `[tool.uv.sources]` with `workspace = true` expose links to both the member `pyproject.toml` and the workspace root `pyproject.toml`
 - dependency arrays in `[project.dependencies]`, `[project.optional-dependencies.*]`, and `[dependency-groups.*]` link to local workspace packages when available, or fall back to the package page on PyPI

--- a/docs/src/routes/layout.tsx
+++ b/docs/src/routes/layout.tsx
@@ -4,7 +4,7 @@ import { Header } from "~/components/header/index";
 
 export default function Layout(props: { children: JSX.Element }) {
   return (
-    <div class="min-h-screen bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 overflow-y-auto">
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
       <Header />
       <AnchorHandler />
       {props.children}

--- a/extensions/tombi-extension-cargo/src/accessors.rs
+++ b/extensions/tombi-extension-cargo/src/accessors.rs
@@ -1,0 +1,110 @@
+use tombi_document_tree::{Value, dig_accessors};
+use tombi_schema_store::{Accessor, matches_accessors};
+
+#[inline]
+pub(crate) fn is_package_name_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["package", "name"])
+}
+
+#[inline]
+pub(crate) fn is_feature_key_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["features", _])
+}
+
+#[inline]
+pub(crate) fn is_dependency_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependencies", _])
+        || matches_accessors!(accessors, ["dev-dependencies", _])
+        || matches_accessors!(accessors, ["build-dependencies", _])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _])
+        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
+        || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
+}
+
+#[inline]
+pub(crate) fn is_workspace_dependency_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["workspace", "dependencies", _])
+}
+
+#[inline]
+pub(crate) fn is_any_dependency_accessor(accessors: &[Accessor]) -> bool {
+    is_workspace_dependency_accessor(accessors) || is_dependency_accessor(accessors)
+}
+
+#[inline]
+pub(crate) fn is_dependency_path_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependencies", _, "path"])
+        || matches_accessors!(accessors, ["dev-dependencies", _, "path"])
+        || matches_accessors!(accessors, ["build-dependencies", _, "path"])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _, "path"])
+        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "path"])
+        || matches_accessors!(accessors, ["target", _, "build-dependencies", _, "path"])
+}
+
+#[inline]
+pub(crate) fn is_any_dependency_path_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["workspace", "dependencies", _, "path"])
+        || is_dependency_path_accessor(accessors)
+}
+
+#[inline]
+pub(crate) fn is_workspace_key_accessor(accessors: &[Accessor]) -> bool {
+    matches!(accessors.last(), Some(Accessor::Key(key)) if key == "workspace")
+}
+
+#[inline]
+pub(crate) fn is_optional_dependency_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependencies", _, "optional"])
+        || matches_accessors!(accessors, ["dev-dependencies", _, "optional"])
+        || matches_accessors!(accessors, ["build-dependencies", _, "optional"])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _, "optional"])
+        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "optional"])
+        || matches_accessors!(
+            accessors,
+            ["target", _, "build-dependencies", _, "optional"]
+        )
+}
+
+#[inline]
+pub(crate) fn is_workspace_definition_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["workspace", "dependencies", _])
+        || matches_accessors!(accessors, ["workspace", "dependencies", _, "path"])
+        || matches_accessors!(accessors, ["workspace", "members"])
+        || matches_accessors!(accessors, ["workspace", "members", _])
+        || matches_accessors!(accessors, ["workspace", "default-members"])
+        || matches_accessors!(accessors, ["workspace", "default-members", _])
+}
+
+#[inline]
+pub(crate) fn is_workspace_flag_accessor(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependencies", _, "workspace"])
+        || matches_accessors!(accessors, ["dev-dependencies", _, "workspace"])
+        || matches_accessors!(accessors, ["build-dependencies", _, "workspace"])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _, "workspace"])
+        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "workspace"])
+        || matches_accessors!(
+            accessors,
+            ["target", _, "build-dependencies", _, "workspace"]
+        )
+}
+
+#[inline]
+pub(crate) fn is_workspace_managed_dependency_accessor(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+) -> bool {
+    is_dependency_accessor(accessors)
+        && matches!(
+            dig_accessors(document_tree, accessors),
+            Some((_, Value::Table(table)))
+                if matches!(
+                    table.get("workspace"),
+                    Some(Value::Boolean(has_workspace)) if has_workspace.value()
+                )
+        )
+}
+
+#[inline]
+pub(crate) fn dependency_parent_accessors(accessors: &[Accessor]) -> &[Accessor] {
+    &accessors[..accessors.len().saturating_sub(1)]
+}

--- a/extensions/tombi-extension-cargo/src/code_action.rs
+++ b/extensions/tombi-extension-cargo/src/code_action.rs
@@ -569,13 +569,7 @@ fn convert_dependency_to_table_format_code_action(
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[Accessor],
 ) -> Option<CodeAction> {
-    if (matches_accessors!(accessors, ["dependencies", _])
-        || matches_accessors!(accessors, ["dev-dependencies", _])
-        || matches_accessors!(accessors, ["build-dependencies", _])
-        || matches_accessors!(accessors, ["workspace", "dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _]))
+    if (crate::is_any_dependency_accessor(accessors))
         && let Some((_, tombi_document_tree::Value::String(version))) =
             dig_accessors(document_tree, accessors)
     {

--- a/extensions/tombi-extension-cargo/src/completion.rs
+++ b/extensions/tombi-extension-cargo/src/completion.rs
@@ -19,7 +19,10 @@ use tombi_version_sort::version_sort;
 use tower_lsp::lsp_types::InsertTextFormat;
 
 use crate::cargo_lock::{exact_crates_io_version, load_cached_cargo_lock};
-use crate::{find_cargo_toml, find_workspace_cargo_toml, get_workspace_cargo_toml_path};
+use crate::{
+    find_cargo_toml, find_workspace_cargo_toml, get_workspace_cargo_toml_path,
+    is_any_dependency_path_accessor, is_dependency_accessor,
+};
 
 enum CargoCompletionFeature {
     DependencyVersion,
@@ -153,13 +156,7 @@ fn completion_cargo_file_path(
         return Some(completions);
     }
 
-    if (matches_accessors!(accessors, ["dependencies", _, "path"])
-        || matches_accessors!(accessors, ["dev-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["build-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["workspace", "dependencies", _, "path"])
+    if (is_any_dependency_path_accessor(accessors)
         || matches_accessors!(accessors, ["patch", _, _, "path"])
         || matches_accessors!(accessors, ["replace", _, "path"])
         || matches_accessors!(accessors, ["package", "readme"])
@@ -334,13 +331,7 @@ async fn completion_member(
             )
             .await;
         }
-    } else if matches_accessors!(accessors, ["dependencies", _])
-        || matches_accessors!(accessors, ["dev-dependencies", _])
-        || matches_accessors!(accessors, ["build-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
-    {
+    } else if is_dependency_accessor(accessors) {
         if !cargo_completion_enabled(features, CargoCompletionFeature::DependencyVersion) {
             return Ok(None);
         }

--- a/extensions/tombi-extension-cargo/src/feature_navigation.rs
+++ b/extensions/tombi-extension-cargo/src/feature_navigation.rs
@@ -335,18 +335,20 @@ pub(crate) fn feature_key_at_accessors<'a>(
     dig_keys(document_tree, &["features", feature_name.as_str()]).map(|(key, _)| key)
 }
 
-pub(crate) fn optional_dependency_value_at_accessors<'a>(
+pub(crate) fn is_optional_dependency<'a>(
     document_tree: &'a tombi_document_tree::DocumentTree,
     accessors: &'a [Accessor],
-) -> Option<bool> {
-    let dependency_accessors = dependency_optional_accessors(accessors)?;
+) -> bool {
+    let Some(dependency_accessors) = dependency_optional_accessors(accessors) else {
+        return false;
+    };
     let Some((_, Value::Table(table))) = dig_accessors(document_tree, dependency_accessors) else {
-        return None;
+        return false;
     };
-    let Value::Boolean(optional) = table.get("optional")? else {
-        return None;
+    let Some(Value::Boolean(optional)) = table.get("optional") else {
+        return false;
     };
-    Some(optional.value())
+    optional.value()
 }
 
 pub(crate) fn feature_usage_target_for_optional_dependency(

--- a/extensions/tombi-extension-cargo/src/goto_declaration.rs
+++ b/extensions/tombi-extension-cargo/src/goto_declaration.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CargoNavigationFeature, classify_cargo_navigation_feature, feature_key_at_accessors,
-    goto_declaration_for_crate_cargo_toml, optional_dependency_value_at_accessors,
+    CargoNavigationFeature, classify_cargo_navigation_feature, dependency_parent_accessors,
+    feature_key_at_accessors, goto_workspace_managed_dependency_locations, is_optional_dependency,
 };
 use tombi_config::TomlVersion;
 use tombi_document_tree::dig_keys;
@@ -25,7 +25,7 @@ pub async fn goto_declaration(
         return Ok(None);
     }
 
-    let locations = goto_declaration_for_crate_cargo_toml(
+    let locations = goto_workspace_managed_dependency_locations(
         document_tree,
         accessors,
         &cargo_toml_path,
@@ -76,39 +76,16 @@ pub fn get_current_declaration(
         });
     }
 
-    let (dependency_key, _) = if matches_accessors!(accessors, ["dependencies", _, "optional"])
-        || matches_accessors!(accessors, ["dev-dependencies", _, "optional"])
-        || matches_accessors!(accessors, ["build-dependencies", _, "optional"])
-    {
-        if !optional_dependency_value_at_accessors(document_tree, accessors).unwrap_or_default() {
-            return None;
-        }
-        dig_keys(
-            document_tree,
-            &[accessors.first()?.as_key()?, accessors.get(1)?.as_key()?],
-        )?
-    } else if matches_accessors!(accessors, ["target", _, "dependencies", _, "optional"])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "optional"])
-        || matches_accessors!(
-            accessors,
-            ["target", _, "build-dependencies", _, "optional"]
-        )
-    {
-        if !optional_dependency_value_at_accessors(document_tree, accessors).unwrap_or_default() {
-            return None;
-        }
-        dig_keys(
-            document_tree,
-            &[
-                "target",
-                accessors.get(1)?.as_key()?,
-                accessors.get(2)?.as_key()?,
-                accessors.get(3)?.as_key()?,
-            ],
-        )?
-    } else {
+    if !is_optional_dependency(document_tree, accessors) {
         return None;
-    };
+    }
+
+    let parent_keys = dependency_parent_accessors(accessors)
+        .iter()
+        .map(Accessor::as_key)
+        .collect::<Option<Vec<_>>>()?;
+
+    let (dependency_key, _) = dig_keys(document_tree, &parent_keys)?;
 
     Some(tombi_extension::Location {
         uri: cargo_toml_uri.clone(),

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -32,11 +32,11 @@ pub async fn goto_definition(
     }
 
     let locations = if is_package_name_accessor(accessors) {
-        goto_definition_for_package_name(document_tree, accessors, &text_document_uri)
+        goto_definition_for_package_name(document_tree, accessors, text_document_uri)
     } else if is_feature_key_accessor(accessors) {
-        goto_definition_for_feature_key(document_tree, accessors, &text_document_uri)
+        goto_definition_for_feature_key(document_tree, accessors, text_document_uri)
     } else if is_optional_dependency_accessor(accessors) {
-        goto_definition_for_optional_dependency(document_tree, accessors, &text_document_uri)
+        goto_definition_for_optional_dependency(document_tree, accessors, text_document_uri)
     } else if let Some(feature_string) = feature_table_string_at_accessors(document_tree, accessors)
         && let Some(location) = resolve_feature_table_string(
             document_tree,
@@ -51,7 +51,7 @@ pub async fn goto_definition(
         goto_workspace_definition_locations(
             document_tree,
             accessors,
-            &text_document_uri,
+            text_document_uri,
             &cargo_toml_path,
             toml_version,
         )?

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -1,10 +1,10 @@
 use crate::{
     CargoNavigationFeature, classify_cargo_navigation_feature, dependency_feature_string_context,
     dependency_parent_accessors, feature_table_string_at_accessors, find_workspace_cargo_toml,
-    get_workspace_cargo_toml_path, goto_workspace_managed_dependency_locations,
-    goto_definition_for_workspace_cargo_toml, is_feature_key_accessor,
-    is_dependency_accessor, is_optional_dependency_accessor, is_package_name_accessor,
-    is_workspace_definition_accessor, is_workspace_dependency_accessor, is_workspace_flag_accessor,
+    get_workspace_cargo_toml_path, goto_definition_for_workspace_cargo_toml,
+    goto_workspace_managed_dependency_locations, is_dependency_accessor, is_feature_key_accessor,
+    is_optional_dependency_accessor, is_package_name_accessor, is_workspace_definition_accessor,
+    is_workspace_dependency_accessor, is_workspace_flag_accessor,
     is_workspace_managed_dependency_accessor, resolve_dependency_feature_string,
     resolve_feature_table_string,
 };

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -1,14 +1,16 @@
 use crate::{
-    CargoNavigationFeature, classify_cargo_navigation_feature, collect_feature_usage_locations,
-    collect_feature_usage_locations_in_manifest, dependency_feature_string_context,
-    feature_table_string_at_accessors, feature_usage_target_for_feature_key,
-    feature_usage_target_for_optional_dependency, goto_declaration_for_crate_cargo_toml,
-    goto_definition_for_workspace_cargo_toml, optional_dependency_value_at_accessors,
-    package_name_reference_locations, resolve_dependency_feature_string,
-    resolve_feature_table_string, workspace_dependency_usage_locations,
+    CargoNavigationFeature, classify_cargo_navigation_feature, dependency_feature_string_context,
+    dependency_parent_accessors, feature_table_string_at_accessors, find_workspace_cargo_toml,
+    get_workspace_cargo_toml_path, goto_workspace_managed_dependency_locations,
+    goto_definition_for_workspace_cargo_toml, is_feature_key_accessor,
+    is_dependency_accessor, is_optional_dependency_accessor, is_package_name_accessor,
+    is_workspace_definition_accessor, is_workspace_dependency_accessor, is_workspace_flag_accessor,
+    is_workspace_managed_dependency_accessor, resolve_dependency_feature_string,
+    resolve_feature_table_string,
 };
 use tombi_config::TomlVersion;
-use tombi_schema_store::matches_accessors;
+use tombi_document_tree::{Value, dig_keys};
+use tombi_schema_store::{Accessor, matches_accessors};
 
 pub async fn goto_definition(
     text_document_uri: &tombi_uri::Uri,
@@ -29,15 +31,12 @@ pub async fn goto_definition(
         return Ok(None);
     }
 
-    let locations = if matches_accessors!(accessors, ["package", "name"]) {
-        package_name_reference_locations(document_tree, accessors, &cargo_toml_path, toml_version)
-            .await?
-    } else if let Some(target) = feature_usage_target_for_feature_key(&cargo_toml_path, accessors) {
-        collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
-            .await
-            .into_iter()
-            .filter_map(|location| location.get_location())
-            .collect()
+    let locations = if is_package_name_accessor(accessors) {
+        goto_definition_for_package_name(document_tree, accessors, &text_document_uri)
+    } else if is_feature_key_accessor(accessors) {
+        goto_definition_for_feature_key(document_tree, accessors, &text_document_uri)
+    } else if is_optional_dependency_accessor(accessors) {
+        goto_definition_for_optional_dependency(document_tree, accessors, &text_document_uri)
     } else if let Some(feature_string) = feature_table_string_at_accessors(document_tree, accessors)
         && let Some(location) = resolve_feature_table_string(
             document_tree,
@@ -48,6 +47,14 @@ pub async fn goto_definition(
         && let Some(location) = location.get_location()
     {
         vec![location]
+    } else if is_workspace_definition_accessor(accessors) {
+        goto_workspace_definition_locations(
+            document_tree,
+            accessors,
+            &text_document_uri,
+            &cargo_toml_path,
+            toml_version,
+        )?
     } else if let Some((feature_string, dependency_accessors)) =
         dependency_feature_string_context(document_tree, accessors)
         && let Some(location) = resolve_dependency_feature_string(
@@ -60,58 +67,27 @@ pub async fn goto_definition(
         && let Some(location) = location.get_location()
     {
         vec![location]
-    } else if optional_dependency_value_at_accessors(document_tree, accessors).unwrap_or_default()
-        && let Some(target) =
-            feature_usage_target_for_optional_dependency(&cargo_toml_path, accessors)
-    {
-        // `optional = true` defines an implicit feature in the same manifest.
-        // Keep goto-definition local; workspace-wide usage collection belongs to goto-declaration.
-        collect_feature_usage_locations_in_manifest(
-            document_tree,
-            &cargo_toml_path,
-            &target,
-            toml_version,
-        )
-        .into_iter()
-        .filter_map(|location| location.get_location())
-        .collect()
-    } else if accessors.first() == Some(&tombi_schema_store::Accessor::Key("workspace".to_string()))
-    {
-        let mut locations = goto_definition_for_workspace_cargo_toml(
+    } else if is_workspace_flag_accessor(accessors) {
+        goto_workspace_managed_dependency_locations(
             document_tree,
             accessors,
             &cargo_toml_path,
             toml_version,
-            true,
-        )?;
-
-        if matches_accessors!(accessors, ["workspace", "dependencies", _]) {
-            locations.extend(workspace_dependency_usage_locations(
-                document_tree,
-                accessors,
-                &cargo_toml_path,
-                toml_version,
-            )?);
-        } else {
-            // For Root Package
-            // See: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
-            locations.extend(goto_declaration_for_crate_cargo_toml(
-                document_tree,
-                accessors,
-                &cargo_toml_path,
-                toml_version,
-                true,
-            )?);
-        }
-
-        locations
+            false,
+        )?
+    } else if is_workspace_managed_dependency_accessor(document_tree, accessors) {
+        goto_workspace_dependency_locations(
+            document_tree,
+            accessors,
+            &cargo_toml_path,
+            toml_version,
+        )?
     } else {
-        goto_declaration_for_crate_cargo_toml(
+        goto_dependency_definition_locations(
             document_tree,
             accessors,
             &cargo_toml_path,
             toml_version,
-            accessors.last() != Some(&tombi_schema_store::Accessor::Key("workspace".to_string())),
         )?
     };
 
@@ -120,6 +96,169 @@ pub async fn goto_definition(
     }
 
     Ok(Some(locations))
+}
+
+fn goto_definition_for_package_name(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+) -> Vec<tombi_extension::Location> {
+    debug_assert!(matches_accessors!(accessors, ["package", "name"]));
+
+    let Some((_, Value::String(package_name))) = dig_keys(document_tree, &["package", "name"])
+    else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: package_name.unquoted_range(),
+    }]
+}
+
+fn goto_definition_for_feature_key(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+) -> Vec<tombi_extension::Location> {
+    debug_assert!(matches_accessors!(accessors, ["features", _]));
+
+    let Some(feature_name) = accessors.get(1).and_then(Accessor::as_key) else {
+        return Vec::with_capacity(0);
+    };
+
+    let Some((key, _)) = dig_keys(document_tree, &["features", feature_name]) else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: key.unquoted_range(),
+    }]
+}
+
+fn goto_definition_for_optional_dependency(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+) -> Vec<tombi_extension::Location> {
+    let dependency_accessors = dependency_parent_accessors(accessors);
+    let Some(dependency_names) = dependency_accessors
+        .iter()
+        .map(Accessor::as_key)
+        .collect::<Option<Vec<_>>>()
+    else {
+        return Vec::with_capacity(0);
+    };
+
+    let Some((dependency_key, _)) = dig_keys(document_tree, &dependency_names) else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: dependency_key.unquoted_range(),
+    }]
+}
+
+fn goto_workspace_definition_locations(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+    cargo_toml_path: &std::path::Path,
+    toml_version: TomlVersion,
+) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
+    let locations = goto_definition_for_workspace_cargo_toml(
+        document_tree,
+        accessors,
+        cargo_toml_path,
+        toml_version,
+        true,
+    )?;
+
+    if !locations.is_empty() || !is_workspace_dependency_accessor(accessors) {
+        return Ok(locations);
+    }
+
+    let Some(dependency_name) = accessors.get(2).and_then(Accessor::as_key) else {
+        return Ok(Vec::new());
+    };
+    let Some((key, _)) = dig_keys(
+        document_tree,
+        &["workspace", "dependencies", dependency_name],
+    ) else {
+        return Ok(Vec::new());
+    };
+
+    Ok(vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: key.unquoted_range(),
+    }])
+}
+
+fn goto_workspace_dependency_locations(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    cargo_toml_path: &std::path::Path,
+    toml_version: TomlVersion,
+) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
+    let resolved_target_locations = goto_dependency_definition_locations(
+        document_tree,
+        accessors,
+        cargo_toml_path,
+        toml_version,
+    )?;
+
+    if resolved_target_locations.is_empty() {
+        return goto_workspace_managed_dependency_locations(
+            document_tree,
+            accessors,
+            cargo_toml_path,
+            toml_version,
+            false,
+        );
+    }
+
+    Ok(resolved_target_locations)
+}
+
+fn goto_dependency_definition_locations(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    cargo_toml_path: &std::path::Path,
+    toml_version: TomlVersion,
+) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
+    let mut locations = goto_workspace_managed_dependency_locations(
+        document_tree,
+        accessors,
+        cargo_toml_path,
+        toml_version,
+        true,
+    )?;
+
+    if !is_dependency_accessor(accessors)
+        && !is_workspace_managed_dependency_accessor(document_tree, accessors)
+    {
+        return Ok(locations);
+    }
+
+    let workspace_cargo_toml_path = find_workspace_cargo_toml(
+        cargo_toml_path,
+        get_workspace_cargo_toml_path(document_tree),
+        toml_version,
+    )
+    .map(|(workspace_path, _, _)| workspace_path);
+
+    locations.retain(|location| {
+        let Ok(location_path) = location.uri.to_file_path() else {
+            return true;
+        };
+        workspace_cargo_toml_path
+            .as_ref()
+            .is_none_or(|workspace_path| location_path != *workspace_path)
+    });
+
+    Ok(locations)
 }
 
 fn cargo_goto_definition_enabled(

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -9,7 +9,8 @@ use tombi_schema_store::{Accessor, matches_accessors};
 use crate::{
     collect_feature_usage_locations, dependency_package_name, feature_key_at_accessors,
     feature_usage_target_for_feature_key, find_cargo_toml, find_workspace_cargo_toml,
-    get_workspace_cargo_toml_path, load_cargo_toml, sanitize_dependency_key,
+    get_workspace_cargo_toml_path, is_any_dependency_accessor, load_cargo_toml,
+    sanitize_dependency_key,
 };
 
 #[derive(Debug, Deserialize)]
@@ -188,14 +189,7 @@ fn format_feature_usage_label(project_root: &Path, cargo_toml_path: &Path, line:
 }
 
 fn get_dependency_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
-    if matches_accessors!(accessors, ["workspace", "dependencies", _])
-        || matches_accessors!(accessors, ["dependencies", _])
-        || matches_accessors!(accessors, ["dev-dependencies", _])
-        || matches_accessors!(accessors, ["build-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
-    {
+    if is_any_dependency_accessor(accessors) {
         Some(accessors)
     } else {
         None

--- a/extensions/tombi-extension-cargo/src/lib.rs
+++ b/extensions/tombi-extension-cargo/src/lib.rs
@@ -1,3 +1,4 @@
+mod accessors;
 mod cargo_lock;
 mod cargo_toml;
 mod code_action;
@@ -21,25 +22,29 @@ pub use goto_declaration::goto_declaration;
 pub use goto_definition::goto_definition;
 pub use hover::hover;
 pub use inlay_hint::inlay_hint;
-pub(crate) use references::package_name_reference_locations;
 pub use references::references;
 
+pub(crate) use accessors::{
+    dependency_parent_accessors, is_any_dependency_accessor, is_any_dependency_path_accessor,
+    is_dependency_accessor, is_dependency_path_accessor, is_feature_key_accessor,
+    is_optional_dependency_accessor, is_package_name_accessor, is_workspace_definition_accessor,
+    is_workspace_dependency_accessor, is_workspace_flag_accessor, is_workspace_key_accessor,
+    is_workspace_managed_dependency_accessor,
+};
 pub(crate) use cargo_toml::{
     CrateLocation, dependency_package_name, find_cargo_toml, get_uri_relative_to_cargo_toml,
     load_cargo_toml,
 };
 pub(crate) use feature_navigation::{
-    CargoTargetLocation, collect_feature_usage_locations,
-    collect_feature_usage_locations_in_manifest, dependency_feature_string_context,
+    CargoTargetLocation, collect_feature_usage_locations, dependency_feature_string_context,
     feature_key_at_accessors, feature_table_string_at_accessors,
     feature_usage_target_for_feature_key, feature_usage_target_for_optional_dependency,
-    optional_dependency_value_at_accessors, resolve_dependency_feature_string,
-    resolve_feature_table_string,
+    is_optional_dependency, resolve_dependency_feature_string, resolve_feature_table_string,
 };
 pub(crate) use workspace::{
     canonicalize_or_original, find_package_cargo_toml_paths, find_workspace_cargo_toml,
-    get_workspace_cargo_toml_path, goto_declaration_for_crate_cargo_toml,
-    goto_definition_for_workspace_cargo_toml, goto_workspace_member_crates,
+    get_workspace_cargo_toml_path, goto_definition_for_workspace_cargo_toml,
+    goto_workspace_managed_dependency_locations, goto_workspace_member_crates,
     load_cargo_toml_document_tree, load_workspace_cargo_toml, sanitize_dependency_key,
     workspace_dependency_usage_locations,
 };

--- a/extensions/tombi-extension-cargo/src/references.rs
+++ b/extensions/tombi-extension-cargo/src/references.rs
@@ -1,9 +1,10 @@
 use crate::{
     collect_feature_usage_locations, dependency_package_name, feature_usage_target_for_feature_key,
     feature_usage_target_for_optional_dependency, get_workspace_cargo_toml_path,
-    goto_workspace_member_crates, load_cargo_toml, load_workspace_cargo_toml,
-    optional_dependency_value_at_accessors, workspace_dependency_usage_locations,
+    goto_workspace_member_crates, is_optional_dependency, is_workspace_dependency_accessor,
+    load_cargo_toml, load_workspace_cargo_toml, workspace_dependency_usage_locations,
 };
+use itertools::Itertools;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{LikeString, Value, dig_accessors, dig_keys};
 use tombi_schema_store::{Accessor, matches_accessors};
@@ -26,53 +27,36 @@ pub async fn references(
         return Ok(None);
     }
 
-    if matches_accessors!(accessors, ["package", "name"]) {
-        let locations = package_name_reference_locations(
-            document_tree,
-            accessors,
-            &cargo_toml_path,
-            toml_version,
-        )
-        .await?;
-        return Ok((!locations.is_empty()).then_some(locations));
-    }
-
-    if let Some(target) = feature_usage_target_for_feature_key(&cargo_toml_path, accessors) {
-        let locations =
-            collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
-                .await
-                .into_iter()
-                .filter_map(|location| location.get_location())
-                .collect::<Vec<_>>();
-
-        return Ok((!locations.is_empty()).then_some(locations));
-    }
-
-    if optional_dependency_value_at_accessors(document_tree, accessors).unwrap_or_default()
+    let locations = if matches_accessors!(accessors, ["package", "name"]) {
+        package_name_reference_locations(document_tree, accessors, &cargo_toml_path, toml_version)
+            .await?
+    } else if let Some(target) = feature_usage_target_for_feature_key(&cargo_toml_path, accessors) {
+        collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
+            .await
+            .into_iter()
+            .filter_map(|location| location.get_location())
+            .collect_vec()
+    } else if is_optional_dependency(document_tree, accessors)
         && let Some(target) =
             feature_usage_target_for_optional_dependency(&cargo_toml_path, accessors)
     {
-        let locations =
-            collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
-                .await
-                .into_iter()
-                .filter_map(|location| location.get_location())
-                .collect::<Vec<_>>();
-
-        return Ok((!locations.is_empty()).then_some(locations));
-    }
-
-    if matches_accessors!(accessors, ["workspace", "dependencies", _]) {
-        let locations = workspace_dependency_usage_locations(
+        collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
+            .await
+            .into_iter()
+            .filter_map(|location| location.get_location())
+            .collect_vec()
+    } else if is_workspace_dependency_accessor(accessors) {
+        workspace_dependency_usage_locations(
             document_tree,
             accessors,
             &cargo_toml_path,
             toml_version,
-        )?;
-        return Ok((!locations.is_empty()).then_some(locations));
-    }
+        )?
+    } else {
+        Vec::with_capacity(0)
+    };
 
-    Ok(None)
+    Ok((!locations.is_empty()).then_some(locations))
 }
 
 pub(crate) async fn package_name_reference_locations(
@@ -84,7 +68,7 @@ pub(crate) async fn package_name_reference_locations(
     debug_assert!(matches_accessors!(accessors, ["package", "name"]));
 
     let Some((_, Value::String(package_name))) = dig_accessors(document_tree, accessors) else {
-        return Ok(Vec::new());
+        return Ok(Vec::with_capacity(0));
     };
 
     let Some((workspace_cargo_toml_path, workspace_document_tree)) = load_workspace_cargo_toml(
@@ -94,7 +78,7 @@ pub(crate) async fn package_name_reference_locations(
     )
     .await
     else {
-        return Ok(Vec::new());
+        return Ok(Vec::with_capacity(0));
     };
 
     let mut locations = Vec::new();

--- a/extensions/tombi-extension-cargo/src/workspace.rs
+++ b/extensions/tombi-extension-cargo/src/workspace.rs
@@ -11,7 +11,11 @@ use tombi_extension::file_cache_version;
 use tombi_hashmap::HashMap;
 use tombi_schema_store::matches_accessors;
 
-use crate::{CrateLocation, find_cargo_toml, get_uri_relative_to_cargo_toml, load_cargo_toml};
+use crate::{
+    CrateLocation, find_cargo_toml, get_uri_relative_to_cargo_toml, is_dependency_accessor,
+    is_dependency_path_accessor, is_workspace_dependency_accessor, is_workspace_key_accessor,
+    load_cargo_toml,
+};
 
 const MAX_DID_OPEN_CARGO_TOML_CACHE_ENTRIES: usize = 128;
 
@@ -309,15 +313,7 @@ pub(crate) fn goto_dependency_crates(
     toml_version: TomlVersion,
     jump_to_subcrate: bool,
 ) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    debug_assert!(
-        matches_accessors!(accessors, ["workspace", "dependencies", _])
-            || matches_accessors!(accessors, ["dependencies", _])
-            || matches_accessors!(accessors, ["dev-dependencies", _])
-            || matches_accessors!(accessors, ["build-dependencies", _])
-            || matches_accessors!(accessors, ["target", _, "dependencies", _])
-            || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
-            || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
-    );
+    debug_assert!(is_workspace_dependency_accessor(accessors) || is_dependency_accessor(accessors));
 
     let Some((tombi_schema_store::Accessor::Key(_crate_name), crate_value)) =
         dig_accessors(workspace_document_tree, accessors)
@@ -359,7 +355,7 @@ pub(crate) fn goto_dependency_crates(
                     jump_to_subcrate,
                 )?);
             } else {
-                locations.extend(goto_declaration_for_crate_cargo_toml(
+                locations.extend(goto_workspace_managed_dependency_locations(
                     workspace_document_tree,
                     &accessors,
                     workspace_cargo_toml_path,
@@ -455,12 +451,7 @@ pub(crate) fn goto_crate_package(
 ) -> Result<Option<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
     debug_assert!(
         matches_accessors!(accessors, ["workspace", "dependencies", _, "path"])
-            || matches_accessors!(accessors, ["dependencies", _, "path"])
-            || matches_accessors!(accessors, ["dev-dependencies", _, "path"])
-            || matches_accessors!(accessors, ["build-dependencies", _, "path"])
-            || matches_accessors!(accessors, ["target", _, "dependencies", _, "path"])
-            || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "path"])
-            || matches_accessors!(accessors, ["target", _, "build-dependencies", _, "path"])
+            || is_dependency_path_accessor(accessors)
     );
 
     let Some((_, value)) = dig_accessors(workspace_document_tree, accessors) else {
@@ -671,20 +662,14 @@ pub(crate) fn goto_definition_for_workspace_cargo_toml(
     }
 }
 
-pub(crate) fn goto_declaration_for_crate_cargo_toml(
+pub(crate) fn goto_workspace_managed_dependency_locations(
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[tombi_schema_store::Accessor],
     cargo_toml_path: &std::path::Path,
     toml_version: TomlVersion,
     jump_to_subcrate: bool,
 ) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    let location = if matches_accessors!(accessors, ["dependencies", _])
-        || matches_accessors!(accessors, ["dev-dependencies", _])
-        || matches_accessors!(accessors, ["build-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _])
-    {
+    let location = if is_dependency_accessor(accessors) {
         return goto_dependency_crates(
             document_tree,
             accessors,
@@ -692,8 +677,7 @@ pub(crate) fn goto_declaration_for_crate_cargo_toml(
             toml_version,
             jump_to_subcrate,
         );
-    } else if accessors.last() == Some(&tombi_schema_store::Accessor::Key("workspace".to_string()))
-    {
+    } else if is_workspace_key_accessor(accessors) {
         goto_workspace(
             accessors,
             cargo_toml_path,
@@ -701,13 +685,7 @@ pub(crate) fn goto_declaration_for_crate_cargo_toml(
             toml_version,
             jump_to_subcrate,
         )
-    } else if matches_accessors!(accessors, ["dependencies", _, "path"])
-        || matches_accessors!(accessors, ["dev-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["build-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "path"])
-        || matches_accessors!(accessors, ["target", _, "build-dependencies", _, "path"])
-    {
+    } else if is_dependency_path_accessor(accessors) {
         goto_crate_package(document_tree, accessors, cargo_toml_path, toml_version)
     } else if matches_accessors!(accessors, ["bin", _, "path"]) {
         goto_bin_path_target(document_tree, accessors, cargo_toml_path)

--- a/extensions/tombi-extension-pyproject/src/accessors.rs
+++ b/extensions/tombi-extension-pyproject/src/accessors.rs
@@ -1,0 +1,54 @@
+use tombi_schema_store::{Accessor, matches_accessors};
+
+#[inline]
+pub(crate) fn is_project_name_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["project", "name"])
+}
+
+#[inline]
+pub(crate) fn is_dependency_name_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["project", "dependencies", _])
+        || matches_accessors!(accessors, ["project", "optional-dependencies", _, _])
+        || matches_accessors!(accessors, ["dependency-groups", _, _])
+}
+
+#[inline]
+pub(crate) fn is_dependency_group_name_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependency-groups", _])
+}
+
+#[inline]
+pub(crate) fn is_dependency_groups_include_group_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["dependency-groups", _, _, "include-group"])
+}
+
+#[inline]
+pub(crate) fn has_uv_sources_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(
+        accessors[..accessors.len().min(3)],
+        ["tool", "uv", "sources"]
+    )
+}
+
+#[inline]
+pub(crate) fn is_uv_sources_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["tool", "uv", "sources", _])
+}
+
+#[inline]
+pub(crate) fn is_uv_source_workspace_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["tool", "uv", "sources", _, "workspace"])
+}
+
+#[inline]
+pub(crate) fn is_uv_source_path_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(accessors, ["tool", "uv", "sources", _, "path"])
+}
+
+#[inline]
+pub(crate) fn is_uv_workspace_accessors(accessors: &[Accessor]) -> bool {
+    matches_accessors!(
+        accessors[..accessors.len().min(3)],
+        ["tool", "uv", "workspace"]
+    )
+}

--- a/extensions/tombi-extension-pyproject/src/document_link.rs
+++ b/extensions/tombi-extension-pyproject/src/document_link.rs
@@ -289,7 +289,7 @@ fn document_link_for_member_pyproject_toml(
     if let Some((workspace_key, tombi_document_tree::Value::Boolean(is_workspace))) =
         source.get_key_value("workspace")
         && is_workspace.value()
-        && let Some((member_project_toml_path, _)) = find_member_project_toml(
+        && let Some((package_location, _)) = find_member_project_toml(
             &package_name_key.value,
             &workspace_pyproject_toml_document_tree,
             &workspace_pyproject_toml_path,
@@ -297,7 +297,7 @@ fn document_link_for_member_pyproject_toml(
         )
     {
         if let Ok(member_project_toml_uri) =
-            tombi_uri::Uri::from_file_path(&member_project_toml_path)
+            tombi_uri::Uri::from_file_path(&package_location.pyproject_toml_path)
         {
             document_links.push(tombi_extension::DocumentLink {
                 target: member_project_toml_uri,

--- a/extensions/tombi-extension-pyproject/src/goto_declaration.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_declaration.rs
@@ -1,10 +1,12 @@
 use tombi_config::TomlVersion;
-use tombi_document_tree::dig_keys;
+use tombi_document_tree::{Value, dig_accessors, dig_keys};
 use tombi_schema_store::matches_accessors;
 
 use crate::{
     PyprojectNavigationFeature, classify_pyproject_navigation_feature,
-    goto_definition_for_member_pyproject_toml, goto_definition_for_workspace_pyproject_toml,
+    collect_workspace_project_dependency_definitions, goto_definition_for_member_pyproject_toml,
+    goto_definition_for_workspace_pyproject_toml, is_dependency_name_accessors,
+    is_uv_source_workspace_accessors, is_uv_workspace_accessors, parse_requirement,
 };
 
 pub async fn goto_declaration(
@@ -26,7 +28,7 @@ pub async fn goto_declaration(
         return Ok(None);
     }
 
-    let locations = if matches_accessors!(accessors, ["tool", "uv", "sources", _, "workspace"]) {
+    let locations = if is_uv_source_workspace_accessors(accessors) {
         goto_definition_for_member_pyproject_toml(
             document_tree,
             accessors,
@@ -34,11 +36,15 @@ pub async fn goto_declaration(
             toml_version,
             false,
         )?
-    } else if matches_accessors!(
-        accessors[..accessors.len().min(3)],
-        ["tool", "uv", "workspace"]
-    ) {
+    } else if is_uv_workspace_accessors(accessors) {
         goto_definition_for_workspace_pyproject_toml(
+            document_tree,
+            accessors,
+            &pyproject_toml_path,
+            toml_version,
+        )?
+    } else if is_dependency_name_accessors(accessors) {
+        goto_declaration_for_dependency_package(
             document_tree,
             accessors,
             &pyproject_toml_path,
@@ -53,6 +59,81 @@ pub async fn goto_declaration(
     }
 
     Ok(Some(locations))
+}
+
+fn goto_declaration_for_dependency_package(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[tombi_schema_store::Accessor],
+    pyproject_toml_path: &std::path::Path,
+    toml_version: TomlVersion,
+) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
+    let Some((_, Value::String(dep_str))) = dig_accessors(document_tree, accessors) else {
+        return Ok(Vec::with_capacity(0));
+    };
+    let Some(requirement) = parse_requirement(dep_str.value()) else {
+        return Ok(Vec::with_capacity(0));
+    };
+    let package_name = requirement.name.as_ref();
+
+    let mut locations = dependency_source_declaration_locations(
+        document_tree,
+        pyproject_toml_path,
+        package_name,
+        toml_version,
+    )?;
+
+    if locations.is_empty() && requirement.version_or_url.is_none() {
+        locations.extend(collect_workspace_project_dependency_definitions(
+            package_name,
+            pyproject_toml_path,
+            toml_version,
+        ));
+    }
+
+    Ok(locations)
+}
+
+fn dependency_source_declaration_locations(
+    document_tree: &tombi_document_tree::DocumentTree,
+    pyproject_toml_path: &std::path::Path,
+    package_name: &str,
+    toml_version: TomlVersion,
+) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
+    let Some((_, Value::Table(sources))) = dig_keys(document_tree, &["tool", "uv", "sources"])
+    else {
+        return Ok(Vec::with_capacity(0));
+    };
+    let Some((source_key, Value::Table(source_table))) = sources.get_key_value(package_name) else {
+        return Ok(Vec::with_capacity(0));
+    };
+
+    if let Some((_, Value::Boolean(is_workspace))) = source_table.get_key_value("workspace")
+        && is_workspace.value()
+    {
+        let accessors = [
+            tombi_schema_store::Accessor::Key("tool".to_string()),
+            tombi_schema_store::Accessor::Key("uv".to_string()),
+            tombi_schema_store::Accessor::Key("sources".to_string()),
+            tombi_schema_store::Accessor::Key(package_name.to_string()),
+            tombi_schema_store::Accessor::Key("workspace".to_string()),
+        ];
+        return goto_definition_for_member_pyproject_toml(
+            document_tree,
+            &accessors,
+            pyproject_toml_path,
+            toml_version,
+            false,
+        );
+    }
+
+    let Ok(uri) = tombi_uri::Uri::from_file_path(pyproject_toml_path) else {
+        return Ok(Vec::with_capacity(0));
+    };
+
+    Ok(vec![tombi_extension::Location {
+        uri,
+        range: source_key.unquoted_range(),
+    }])
 }
 
 fn pyproject_goto_declaration_enabled(

--- a/extensions/tombi-extension-pyproject/src/goto_definition.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_definition.rs
@@ -318,12 +318,12 @@ fn goto_definition_for_dependency_package(
         if !workspace_dependency_definitions.is_empty() {
             return Ok(workspace_dependency_definitions);
         }
+    }
 
-        if let Some(location) =
-            get_workspace_member_package_definition(package_name, pyproject_toml_path, toml_version)
-        {
-            return Ok(vec![location]);
-        }
+    if let Some(location) =
+        get_workspace_member_package_definition(package_name, pyproject_toml_path, toml_version)
+    {
+        return Ok(vec![location]);
     }
 
     Ok(goto_definition_for_dependency_string(

--- a/extensions/tombi-extension-pyproject/src/goto_definition.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_definition.rs
@@ -2,16 +2,22 @@ use itertools::Itertools;
 use std::path::Path;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_hashmap::IndexSet;
-use tombi_schema_store::{Accessor, matches_accessors};
+use tombi_schema_store::Accessor;
 
 use crate::{
-    DependencyRequirement, PyprojectNavigationFeature, classify_pyproject_navigation_feature,
-    collect_dependency_requirements_from_document_tree, find_dependency_group_key,
-    find_workspace_pyproject_toml, get_project_name, goto_definition_for_member_pyproject_toml,
-    goto_definition_for_workspace_pyproject_toml, is_pyproject_path_accessors,
-    load_pyproject_toml_document_tree, parse_requirement, project_name_reference_locations,
-    resolve_member_pyproject_toml_path, resolve_relative_path_uri,
+    DependencyRequirement, PyprojectNavigationFeature,
+    accessors::{
+        is_dependency_group_name_accessors, is_dependency_groups_include_group_accessors,
+        is_uv_sources_accessors,
+    },
+    classify_pyproject_navigation_feature, collect_dependency_requirements_from_document_tree,
+    find_dependency_group_key, find_member_project_toml, find_workspace_pyproject_toml,
+    get_project_name, goto_definition_for_member_pyproject_toml,
+    goto_definition_for_workspace_pyproject_toml, has_uv_sources_accessors,
+    is_dependency_name_accessors, is_project_name_accessors, is_pyproject_path_accessors,
+    is_uv_source_path_accessors, is_uv_source_workspace_accessors, is_uv_workspace_accessors,
+    load_pyproject_toml_document_tree, parse_requirement, resolve_member_pyproject_toml_path,
+    resolve_relative_path_uri,
 };
 
 pub async fn goto_definition(
@@ -33,55 +39,43 @@ pub async fn goto_definition(
         return Ok(None);
     }
 
-    let locations = if matches_accessors!(accessors, ["project", "name"]) {
-        project_name_reference_locations(
-            document_tree,
-            accessors,
-            &pyproject_toml_path,
-            toml_version,
-        )?
-    } else if matches_accessors!(accessors, ["tool", "uv", "sources", _, "path"]) {
+    let locations = if is_project_name_accessors(accessors) {
+        goto_definition_for_project_name(document_tree, &text_document_uri)
+    } else if is_dependency_group_name_accessors(accessors) {
+        goto_definition_for_dependency_group_name(document_tree, accessors, &text_document_uri)
+    } else if is_uv_source_path_accessors(accessors) {
         goto_definition_for_relative_package(
             document_tree,
             accessors,
             &pyproject_toml_path,
             toml_version,
         )
-    } else if matches_accessors!(
-        accessors[..accessors.len().min(3)],
-        ["tool", "uv", "sources"]
-    ) {
+    } else if has_uv_sources_accessors(accessors) {
+        let jump_to_package = is_uv_sources_accessors(accessors)
+            || !source_is_workspace_managed(document_tree, accessors);
         goto_definition_for_member_pyproject_toml(
             document_tree,
             accessors,
             &pyproject_toml_path,
             toml_version,
-            accessors.last() != Some(&tombi_schema_store::Accessor::Key("workspace".to_string())),
+            jump_to_package,
         )?
     } else if is_pyproject_path_accessors(accessors) {
         goto_definition_for_relative_file(document_tree, accessors, &pyproject_toml_path)
-    } else if matches_accessors!(
-        accessors[..accessors.len().min(3)],
-        ["tool", "uv", "workspace"]
-    ) {
+    } else if is_uv_workspace_accessors(accessors) {
         goto_definition_for_workspace_pyproject_toml(
             document_tree,
             accessors,
             &pyproject_toml_path,
             toml_version,
         )?
-    } else if matches_accessors!(accessors, ["dependency-groups", _, _, "include-group"]) {
+    } else if is_dependency_groups_include_group_accessors(accessors) {
         goto_definition_for_include_group(document_tree, accessors, &pyproject_toml_path)?
-    } else if matches_accessors!(accessors, ["dependency-groups", _]) {
-        goto_definition_for_dependency_group(document_tree, accessors, &pyproject_toml_path)?
-    } else if matches_accessors!(accessors, ["project", "dependencies", _])
-        || matches_accessors!(accessors, ["project", "optional-dependencies", _, _])
-        || matches_accessors!(accessors, ["dependency-groups", _, _])
-    {
-        // Handle dependencies in project.dependencies, project.optional-dependencies, or dependency-groups
+    } else if is_dependency_name_accessors(accessors) {
         goto_definition_for_dependency_package(
             document_tree,
             accessors,
+            &text_document_uri,
             &pyproject_toml_path,
             toml_version,
         )?
@@ -94,6 +88,111 @@ pub async fn goto_definition(
     }
 
     Ok(Some(locations))
+}
+
+fn goto_definition_for_project_name(
+    document_tree: &tombi_document_tree::DocumentTree,
+    text_document_uri: &tombi_uri::Uri,
+) -> Vec<tombi_extension::Location> {
+    let Some((_, Value::String(project_name))) = dig_keys(document_tree, &["project", "name"])
+    else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: project_name.unquoted_range(),
+    }]
+}
+
+fn goto_definition_for_dependency_group_name(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+) -> Vec<tombi_extension::Location> {
+    let Some(group_name) = accessors.get(1).and_then(Accessor::as_key) else {
+        return Vec::with_capacity(0);
+    };
+    let Some((key, _)) = dig_keys(document_tree, &["dependency-groups", group_name]) else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: key.unquoted_range(),
+    }]
+}
+
+#[inline]
+fn is_workspace_root_pyproject(pyproject_toml_path: &Path, toml_version: TomlVersion) -> bool {
+    find_workspace_pyproject_toml(pyproject_toml_path, toml_version).is_some_and(
+        |(workspace_pyproject_toml_path, _, _)| {
+            workspace_pyproject_toml_path == pyproject_toml_path
+        },
+    )
+}
+
+fn should_stay_on_dependency_string(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    pyproject_toml_path: &Path,
+    toml_version: TomlVersion,
+) -> bool {
+    let Some((_, Value::String(dep_str))) = dig_accessors(document_tree, accessors) else {
+        return false;
+    };
+    let Some(requirement) = parse_requirement(dep_str.value()) else {
+        return false;
+    };
+    let package_name = requirement.name.as_ref();
+
+    if is_workspace_root_pyproject(pyproject_toml_path, toml_version) {
+        return collect_workspace_project_dependency_definitions(
+            package_name,
+            pyproject_toml_path,
+            toml_version,
+        )
+        .is_empty();
+    }
+
+    if let Some((_, Value::Table(sources))) = dig_keys(document_tree, &["tool", "uv", "sources"])
+        && sources.contains_key(package_name)
+    {
+        return false;
+    }
+
+    if !collect_workspace_project_dependency_definitions(
+        package_name,
+        pyproject_toml_path,
+        toml_version,
+    )
+    .is_empty()
+    {
+        return false;
+    }
+
+    get_workspace_member_package_definition(package_name, pyproject_toml_path, toml_version)
+        .is_none()
+}
+
+fn source_is_workspace_managed(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+) -> bool {
+    let source_accessors = if is_uv_source_workspace_accessors(accessors) {
+        &accessors[..accessors.len().saturating_sub(1)]
+    } else {
+        accessors
+    };
+
+    matches!(
+        dig_accessors(document_tree, source_accessors),
+        Some((_, Value::Table(table)))
+            if matches!(
+                table.get("workspace"),
+                Some(Value::Boolean(is_workspace)) if is_workspace.value()
+            )
+    )
 }
 
 fn goto_definition_for_relative_package(
@@ -154,6 +253,7 @@ fn pyproject_goto_definition_enabled(
 fn goto_definition_for_dependency_package(
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
     pyproject_toml_path: &std::path::Path,
     toml_version: TomlVersion,
 ) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
@@ -209,27 +309,56 @@ fn goto_definition_for_dependency_package(
         }
     }
 
-    let mut locations = IndexSet::new();
-
-    // Package references without version info should jump to workspace definition when available
     if requirement.version_or_url.is_none() {
-        locations.extend(collect_workspace_project_dependency_definitions(
+        let workspace_dependency_definitions = collect_workspace_project_dependency_definitions(
             package_name,
             pyproject_toml_path,
             toml_version,
-        ));
+        );
+        if !workspace_dependency_definitions.is_empty() {
+            return Ok(workspace_dependency_definitions);
+        }
+
+        if let Some(location) =
+            get_workspace_member_package_definition(package_name, pyproject_toml_path, toml_version)
+        {
+            return Ok(vec![location]);
+        }
     }
 
-    if dig_keys(document_tree, &["tool", "uv", "workspace"]).is_some() {
-        locations.extend(get_workspace_member_dependency_definitions(
-            document_tree,
-            pyproject_toml_path,
-            package_name,
-            toml_version,
-        ));
+    Ok(goto_definition_for_dependency_string(
+        document_tree,
+        accessors,
+        text_document_uri,
+        pyproject_toml_path,
+        toml_version,
+    ))
+}
+
+fn goto_definition_for_dependency_string(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    text_document_uri: &tombi_uri::Uri,
+    pyproject_toml_path: &Path,
+    toml_version: TomlVersion,
+) -> Vec<tombi_extension::Location> {
+    if !should_stay_on_dependency_string(
+        document_tree,
+        accessors,
+        pyproject_toml_path,
+        toml_version,
+    ) {
+        return Vec::with_capacity(0);
     }
 
-    Ok(locations.into_iter().collect())
+    let Some((_, Value::String(dependency))) = dig_accessors(document_tree, accessors) else {
+        return Vec::with_capacity(0);
+    };
+
+    vec![tombi_extension::Location {
+        uri: text_document_uri.clone(),
+        range: dependency.unquoted_range(),
+    }]
 }
 
 fn goto_definition_for_include_group(
@@ -253,14 +382,6 @@ fn goto_definition_for_include_group(
         uri,
         range: group_key.unquoted_range(),
     }])
-}
-
-fn goto_definition_for_dependency_group(
-    document_tree: &tombi_document_tree::DocumentTree,
-    accessors: &[Accessor],
-    pyproject_toml_path: &std::path::Path,
-) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    crate::include_group_locations(document_tree, accessors, pyproject_toml_path)
 }
 
 pub(crate) fn collect_workspace_project_dependency_definitions(
@@ -300,6 +421,31 @@ pub(crate) fn collect_workspace_project_dependency_definitions(
             },
         )
         .collect_vec()
+}
+
+pub(crate) fn get_workspace_member_package_definition(
+    package_name: &str,
+    pyproject_toml_path: &std::path::Path,
+    toml_version: TomlVersion,
+) -> Option<tombi_extension::Location> {
+    let (workspace_pyproject_toml_path, _, workspace_document_tree) =
+        find_workspace_pyproject_toml(pyproject_toml_path, toml_version)?;
+    let (member_pyproject_toml_path, _) = find_member_project_toml(
+        package_name,
+        &workspace_document_tree,
+        &workspace_pyproject_toml_path,
+        toml_version,
+    )?;
+
+    let member_document_tree =
+        load_pyproject_toml_document_tree(&member_pyproject_toml_path, toml_version)?;
+    let package_name = get_project_name(&member_document_tree)?;
+    let member_uri = tombi_uri::Uri::from_file_path(&member_pyproject_toml_path).ok()?;
+
+    Some(tombi_extension::Location {
+        uri: member_uri,
+        range: package_name.unquoted_range(),
+    })
 }
 
 pub(crate) fn get_workspace_member_dependency_definitions(

--- a/extensions/tombi-extension-pyproject/src/goto_definition.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_definition.rs
@@ -430,21 +430,17 @@ pub(crate) fn get_workspace_member_package_definition(
 ) -> Option<tombi_extension::Location> {
     let (workspace_pyproject_toml_path, _, workspace_document_tree) =
         find_workspace_pyproject_toml(pyproject_toml_path, toml_version)?;
-    let (member_pyproject_toml_path, _) = find_member_project_toml(
+    let (package_location, _) = find_member_project_toml(
         package_name,
         &workspace_document_tree,
         &workspace_pyproject_toml_path,
         toml_version,
     )?;
-
-    let member_document_tree =
-        load_pyproject_toml_document_tree(&member_pyproject_toml_path, toml_version)?;
-    let package_name = get_project_name(&member_document_tree)?;
-    let member_uri = tombi_uri::Uri::from_file_path(&member_pyproject_toml_path).ok()?;
+    let member_uri = tombi_uri::Uri::from_file_path(&package_location.pyproject_toml_path).ok()?;
 
     Some(tombi_extension::Location {
         uri: member_uri,
-        range: package_name.unquoted_range(),
+        range: package_location.package_name_key_range,
     })
 }
 

--- a/extensions/tombi-extension-pyproject/src/goto_definition.rs
+++ b/extensions/tombi-extension-pyproject/src/goto_definition.rs
@@ -40,9 +40,9 @@ pub async fn goto_definition(
     }
 
     let locations = if is_project_name_accessors(accessors) {
-        goto_definition_for_project_name(document_tree, &text_document_uri)
+        goto_definition_for_project_name(document_tree, text_document_uri)
     } else if is_dependency_group_name_accessors(accessors) {
-        goto_definition_for_dependency_group_name(document_tree, accessors, &text_document_uri)
+        goto_definition_for_dependency_group_name(document_tree, accessors, text_document_uri)
     } else if is_uv_source_path_accessors(accessors) {
         goto_definition_for_relative_package(
             document_tree,
@@ -75,7 +75,7 @@ pub async fn goto_definition(
         goto_definition_for_dependency_package(
             document_tree,
             accessors,
-            &text_document_uri,
+            text_document_uri,
             &pyproject_toml_path,
             toml_version,
         )?

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -174,23 +174,23 @@ fn resolve_workspace_member_metadata(
 ) -> Option<HoverMetadata> {
     let member_pyproject_toml_path =
         if dig_keys(current_document_tree, &["tool", "uv", "workspace"]).is_some() {
-            let (member_pyproject_toml_path, _) = find_member_project_toml(
+            let (package_location, _) = find_member_project_toml(
                 package_name,
                 current_document_tree,
                 pyproject_toml_path,
                 toml_version,
             )?;
-            member_pyproject_toml_path
+            package_location.pyproject_toml_path
         } else {
             let (workspace_pyproject_toml_path, _, workspace_document_tree) =
                 find_workspace_pyproject_toml(pyproject_toml_path, toml_version)?;
-            let (member_pyproject_toml_path, _) = find_member_project_toml(
+            let (package_location, _) = find_member_project_toml(
                 package_name,
                 &workspace_document_tree,
                 &workspace_pyproject_toml_path,
                 toml_version,
             )?;
-            member_pyproject_toml_path
+            package_location.pyproject_toml_path
         };
 
     load_project_metadata(&member_pyproject_toml_path, toml_version)

--- a/extensions/tombi-extension-pyproject/src/lib.rs
+++ b/extensions/tombi-extension-pyproject/src/lib.rs
@@ -1,3 +1,4 @@
+mod accessors;
 mod code_action;
 mod completion;
 mod dependency;
@@ -22,6 +23,10 @@ pub use hover::hover;
 pub use inlay_hint::inlay_hint;
 pub use references::references;
 
+pub(crate) use accessors::{
+    has_uv_sources_accessors, is_dependency_name_accessors, is_project_name_accessors,
+    is_uv_source_path_accessors, is_uv_source_workspace_accessors, is_uv_workspace_accessors,
+};
 pub(crate) use dependency::{
     DependencyRequirement, UV_DEPENDENCY_KEYS,
     collect_all_dependency_requirements_from_document_tree,
@@ -37,7 +42,6 @@ pub(crate) use manifest::{
     load_pyproject_toml_document_tree, resolve_member_pyproject_toml_path,
     resolve_relative_path_uri,
 };
-pub(crate) use references::project_name_reference_locations;
 use tombi_schema_store::matches_accessors;
 pub(crate) use workspace::{
     extract_exclude_patterns, extract_member_patterns, find_member_project_toml,
@@ -51,6 +55,7 @@ pub(crate) enum PyprojectNavigationFeature {
     Path,
 }
 
+#[inline]
 pub(crate) fn classify_pyproject_navigation_feature(
     accessors: &[tombi_schema_store::Accessor],
 ) -> PyprojectNavigationFeature {
@@ -69,6 +74,7 @@ pub(crate) fn classify_pyproject_navigation_feature(
     }
 }
 
+#[inline]
 pub(crate) fn is_pyproject_path_accessors(accessors: &[tombi_schema_store::Accessor]) -> bool {
     matches!(
         accessors.last(),

--- a/extensions/tombi-extension-pyproject/src/references.rs
+++ b/extensions/tombi-extension-pyproject/src/references.rs
@@ -5,8 +5,8 @@ use tombi_schema_store::{Accessor, matches_accessors};
 use crate::{
     collect_workspace_project_dependency_definitions, extract_exclude_patterns,
     extract_member_patterns, find_pyproject_toml_paths, find_workspace_pyproject_toml,
-    get_workspace_member_dependency_definitions, load_pyproject_toml_document_tree,
-    parse_requirement,
+    get_workspace_member_dependency_definitions, is_dependency_name_accessors,
+    is_project_name_accessors, load_pyproject_toml_document_tree, parse_requirement,
 };
 
 pub async fn references(
@@ -27,7 +27,7 @@ pub async fn references(
         return Ok(None);
     }
 
-    if matches_accessors!(accessors, ["project", "name"]) {
+    if is_project_name_accessors(accessors) {
         let locations = project_name_reference_locations(
             document_tree,
             accessors,
@@ -41,10 +41,7 @@ pub async fn references(
         return Ok((!locations.is_empty()).then_some(locations));
     }
 
-    if matches_accessors!(accessors, ["project", "dependencies", _])
-        || matches_accessors!(accessors, ["project", "optional-dependencies", _, _])
-        || matches_accessors!(accessors, ["dependency-groups", _, _])
-    {
+    if is_dependency_name_accessors(accessors) {
         let Some((_, Value::String(dep_str))) = dig_accessors(document_tree, accessors) else {
             return Ok(None);
         };
@@ -83,7 +80,7 @@ pub(crate) fn project_name_reference_locations(
     pyproject_toml_path: &std::path::Path,
     toml_version: TomlVersion,
 ) -> Result<Vec<tombi_extension::Location>, tower_lsp::jsonrpc::Error> {
-    debug_assert!(matches_accessors!(accessors, ["project", "name"]));
+    debug_assert!(is_project_name_accessors(accessors));
 
     let Some((_, Value::String(project_name))) = dig_accessors(document_tree, accessors) else {
         return Ok(Vec::new());

--- a/extensions/tombi-extension-pyproject/src/workspace.rs
+++ b/extensions/tombi-extension-pyproject/src/workspace.rs
@@ -181,7 +181,7 @@ pub(crate) fn goto_workspace_member(
         return Ok(None);
     }
 
-    let Some((package_toml_path, member_range)) = find_member_project_toml(
+    let Some((package_location, member_range)) = find_member_project_toml(
         package_name,
         &workspace_pyproject_toml_document_tree,
         &workspace_pyproject_toml_path,
@@ -191,22 +191,15 @@ pub(crate) fn goto_workspace_member(
     };
 
     if jump_to_package {
-        let Ok(package_pyproject_toml_uri) = tombi_uri::Uri::from_file_path(&package_toml_path)
+        let Ok(package_pyproject_toml_uri) =
+            tombi_uri::Uri::from_file_path(&package_location.pyproject_toml_path)
         else {
-            return Ok(None);
-        };
-        let Some(member_document_tree) =
-            load_pyproject_toml_document_tree(&package_toml_path, toml_version)
-        else {
-            return Ok(None);
-        };
-        let Some(package_name) = get_project_name(&member_document_tree) else {
             return Ok(None);
         };
 
         Ok(Some(tombi_extension::Location {
             uri: package_pyproject_toml_uri,
-            range: package_name.unquoted_range(),
+            range: package_location.package_name_key_range,
         }))
     } else {
         let Ok(workspace_pyproject_toml_uri) =
@@ -267,7 +260,7 @@ pub(crate) fn find_member_project_toml(
     workspace_pyproject_toml_document_tree: &tombi_document_tree::DocumentTree,
     workspace_pyproject_toml_path: &std::path::Path,
     toml_version: TomlVersion,
-) -> Option<(std::path::PathBuf, tombi_text::Range)> {
+) -> Option<(PackageLocation, tombi_text::Range)> {
     let workspace_dir_path = workspace_pyproject_toml_path.parent()?;
 
     let member_patterns = extract_member_patterns(workspace_pyproject_toml_document_tree, &[]);
@@ -285,7 +278,13 @@ pub(crate) fn find_member_project_toml(
         if let Some(name) = get_project_name(&package_project_toml_document_tree)
             && name.value() == package_name
         {
-            return Some((package_project_toml_path, member_item.unquoted_range()));
+            return Some((
+                PackageLocation {
+                    pyproject_toml_path: package_project_toml_path,
+                    package_name_key_range: name.unquoted_range(),
+                },
+                member_item.unquoted_range(),
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary
- improve docs tables and sidebar layout with sticky headers and corrected header offset handling
- refactor cargo and pyproject goto definition/reference logic around workspace-managed dependencies and member packages
- expand LSP tests for goto definition, references, inlay hints, and workspace dependency fixtures

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked
- pnpm --dir docs build