### PR TITLE
Fix root table ordering when schema rule is disabled

### DIFF
--- a/crates/tombi-ast-editor/src/edit/root.rs
+++ b/crates/tombi-ast-editor/src/edit/root.rs
@@ -26,10 +26,7 @@ impl crate::Edit for tombi_ast::Root {
             let mut changes = vec![];
             let mut key_value_groups = vec![];
             let mut table_or_array_of_tables = vec![];
-            let mut table_order_overrides = schema_context
-                .root_table_order_overrides()
-                .cloned()
-                .unwrap_or_default();
+            let mut table_order_overrides = tombi_schema_store::TableOrderOverrides::default();
 
             // Detect document comment directives.
             // If dangling comments exist, directives should already be there.

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -31,7 +31,6 @@ pub async fn root_table_keys_order<'a>(
     {
         return Vec::with_capacity(0);
     }
-
     let comment_directive_order = comment_directive
         .as_ref()
         .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
@@ -74,7 +73,7 @@ pub async fn root_table_keys_order<'a>(
     let schema_order_enabled = schema_override.is_some_and(|override_item| !override_item.disabled)
         || schema_context.schema_table_keys_order_enabled(current_schema);
 
-    if !schema_order_enabled {
+    if root_order.is_none() && !schema_order_enabled {
         return changes;
     }
 

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -32,7 +32,7 @@ pub async fn root_table_keys_order<'a>(
         return Vec::with_capacity(0);
     }
 
-    let order = comment_directive
+    let comment_directive_order = comment_directive
         .as_ref()
         .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
 
@@ -67,6 +67,17 @@ pub async fn root_table_keys_order<'a>(
         return changes;
     }
 
+    let schema_override = schema_context.table_order_override(current_schema, &[]);
+    let root_order = schema_override
+        .and_then(|override_item| override_item.order)
+        .or(comment_directive_order);
+    let schema_order_enabled = schema_override.is_some_and(|override_item| !override_item.disabled)
+        || schema_context.schema_table_keys_order_enabled(current_schema);
+
+    if !schema_order_enabled {
+        return changes;
+    }
+
     let old = std::ops::RangeInclusive::new(
         SyntaxElement::Node(table_or_array_of_tables.first().unwrap().syntax().clone()),
         SyntaxElement::Node(table_or_array_of_tables.last().unwrap().syntax().clone()),
@@ -93,7 +104,7 @@ pub async fn root_table_keys_order<'a>(
             .collect_vec(),
         current_schema,
         schema_context,
-        order,
+        root_order,
         table_order_overrides,
     )
     .await

--- a/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/root_table_keys_order.rs
@@ -67,9 +67,8 @@ pub async fn root_table_keys_order<'a>(
     }
 
     let schema_override = schema_context.table_order_override(current_schema, &[]);
-    let root_order = schema_override
-        .and_then(|override_item| override_item.order)
-        .or(comment_directive_order);
+    let root_order =
+        comment_directive_order.or(schema_override.and_then(|override_item| override_item.order));
     let schema_order_enabled = schema_override.is_some_and(|override_item| !override_item.disabled)
         || schema_context.schema_table_keys_order_enabled(current_schema);
 

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -833,6 +833,46 @@ mod table_keys_order {
                 "#
             )
         }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_cargo_root_tables_not_sorted_when_schema_table_keys_order_disabled(
+                r#"
+                [workspace]
+
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.dependencies]
+
+                [workspace.lints.rust]
+                "#,
+                ConfigText(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/cargo.json"
+                    include = ["Cargo.toml"]
+                    [schemas.format.rules.array-values-order]
+                    enabled = false
+                    [schemas.format.rules.table-keys-order]
+                    enabled = false
+                    "#
+                ),
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+            ) -> Ok(
+                r#"
+                [workspace]
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.dependencies]
+
+                [workspace.lints.rust]
+                "#
+            )
+        }
     }
 
     mod tombi {

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -951,6 +951,50 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
+            async fn test_cargo_root_comment_directive_precedes_schema_override_order(
+                r#"
+                # tombi: format.rules.table-keys-order = "ascending"
+
+                [workspace]
+
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                ConfigText(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/cargo.json"
+                    include = ["Cargo.toml"]
+
+                    [[schemas.overrides]]
+                    targets = [""]
+                    format.rules.table-keys-order = "descending"
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                # tombi: format.rules.table-keys-order = "ascending"
+
+                [profile.release]
+
+                [workspace]
+                [workspace.dependencies]
+
+                [workspace.lints.rust]
+
+                [workspace.package]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_cargo_root_tables_not_sorted_when_schema_overrides_table_keys_order_disabled(
                 r#"
                 [workspace]
@@ -969,14 +1013,10 @@ mod table_keys_order {
                     [[schemas]]
                     path = "tombi://www.schemastore.org/cargo.json"
                     include = ["Cargo.toml"]
-                    overrides = [
-                      {
-                        targets = [""]
-                        format.rules = {
-                          table-keys-order.enabled = false
-                        }
-                      }
-                    ]
+
+                    [[schemas.overrides]]
+                    targets = [""]
+                    format.rules.table-keys-order.enabled = false
                     "#
                 ),
             ) -> Ok(

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -836,6 +836,41 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
+            async fn test_cargo_root_tables_sorted_when_schema_disabled(
+                r#"
+                [workspace]
+
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                ConfigText(
+                    r#"
+                    [schema]
+                    enabled = false
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [workspace]
+                [workspace.package]
+
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+
+                [profile.release]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_cargo_root_tables_not_sorted_when_schema_table_keys_order_disabled(
                 r#"
                 [workspace]
@@ -844,22 +879,20 @@ mod table_keys_order {
 
                 [profile.release]
 
-                [workspace.dependencies]
-
                 [workspace.lints.rust]
+
+                [workspace.dependencies]
                 "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
                 ConfigText(
                     r#"
                     [[schemas]]
                     path = "tombi://www.schemastore.org/cargo.json"
                     include = ["Cargo.toml"]
-                    [schemas.format.rules.array-values-order]
-                    enabled = false
                     [schemas.format.rules.table-keys-order]
                     enabled = false
                     "#
                 ),
-                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
             ) -> Ok(
                 r#"
                 [workspace]
@@ -867,9 +900,53 @@ mod table_keys_order {
 
                 [profile.release]
 
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_cargo_root_tables_not_sorted_when_schema_overrides_table_keys_order_disabled(
+                r#"
+                [workspace]
+
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                ConfigText(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/cargo.json"
+                    include = ["Cargo.toml"]
+                    overrides = [
+                      {
+                        targets = [""]
+                        format.rules = {
+                          table-keys-order.enabled = false
+                        }
+                      }
+                    ]
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                [workspace]
+                [workspace.package]
+
                 [workspace.dependencies]
 
                 [workspace.lints.rust]
+
+                [profile.release]
                 "#
             )
         }

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -909,6 +909,48 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
+            async fn test_cargo_root_tables_sorted_by_comment_directive_when_schema_table_keys_order_disabled(
+                r#"
+                # tombi: format.rules.table-keys-order = "ascending"
+
+                [workspace]
+
+                [workspace.package]
+
+                [profile.release]
+
+                [workspace.lints.rust]
+
+                [workspace.dependencies]
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                ConfigText(
+                    r#"
+                    [[schemas]]
+                    path = "tombi://www.schemastore.org/cargo.json"
+                    include = ["Cargo.toml"]
+                    [schemas.format.rules.table-keys-order]
+                    enabled = false
+                    "#
+                ),
+            ) -> Ok(
+                r#"
+                # tombi: format.rules.table-keys-order = "ascending"
+
+                [profile.release]
+
+                [workspace]
+                [workspace.dependencies]
+
+                [workspace.lints.rust]
+
+                [workspace.package]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_cargo_root_tables_not_sorted_when_schema_overrides_table_keys_order_disabled(
                 r#"
                 [workspace]


### PR DESCRIPTION
Fix: https://github.com/tombi-toml/tombi/pull/1830

## Summary
- stop reordering root tables when schema table-keys-order is disabled
- keep schema override order if present, otherwise fall back to comment directive order
- add a formatter regression test for Cargo.toml schema config

## Testing
- cargo fmt --all
- cargo test -p tombi-ast-editor
- cargo test -p tombi-formatter --test test_x_tombi_order test_cargo_root_tables_not_sorted_when_schema_table_keys_order_disabled