### PR TITLE
feat(hover): show latest package version

### DIFF
--- a/crates/tombi-extension/src/hover.rs
+++ b/crates/tombi-extension/src/hover.rs
@@ -3,3 +3,45 @@ pub struct HoverMetadata {
     pub title: Option<String>,
     pub description: Option<String>,
 }
+
+pub fn append_latest_version(
+    description: Option<String>,
+    latest_version: Option<String>,
+) -> Option<String> {
+    match (description, latest_version) {
+        (Some(description), Some(latest_version)) => Some(format!(
+            "{description}\n\nLatest Version: `{latest_version}`"
+        )),
+        (None, Some(latest_version)) => Some(format!("Latest Version: `{latest_version}`")),
+        (description, None) => description,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::append_latest_version;
+
+    #[test]
+    fn appends_latest_version_to_description() {
+        assert_eq!(
+            append_latest_version(Some("serde".to_string()), Some("1.0.228".to_string())),
+            Some("serde\n\nLatest Version: `1.0.228`".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_latest_version_without_description() {
+        assert_eq!(
+            append_latest_version(None, Some("1.0.228".to_string())),
+            Some("Latest Version: `1.0.228`".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_description_when_latest_version_is_missing() {
+        assert_eq!(
+            append_latest_version(Some("serde".to_string()), None),
+            Some("serde".to_string())
+        );
+    }
+}

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -345,7 +345,10 @@ async fn fetch_crates_io_metadata(
         return Ok(None);
     };
 
-    if response.crate_info.name.is_none() && response.crate_info.description.is_none() {
+    if response.crate_info.name.is_none()
+        && response.crate_info.description.is_none()
+        && response.crate_info.max_version.is_none()
+    {
         return Ok(None);
     }
 

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use serde::Deserialize;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, fetch_cached_remote_json};
+use tombi_extension::{HoverMetadata, append_latest_version, fetch_cached_remote_json};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
@@ -23,6 +23,7 @@ struct CratesIoCrateResponse {
 struct CratesIoCrate {
     name: Option<String>,
     description: Option<String>,
+    max_version: Option<String>,
 }
 
 pub async fn hover(
@@ -350,7 +351,10 @@ async fn fetch_crates_io_metadata(
 
     Ok(Some(HoverMetadata {
         title: response.crate_info.name,
-        description: response.crate_info.description,
+        description: append_latest_version(
+            response.crate_info.description,
+            response.crate_info.max_version,
+        ),
     }))
 }
 
@@ -367,7 +371,8 @@ mod tests {
             r#"{
                 "crate": {
                     "name": "serde",
-                    "description": "A generic serialization/deserialization framework"
+                    "description": "A generic serialization/deserialization framework",
+                    "max_version": "1.0.228"
                 }
             }"#,
         )
@@ -378,6 +383,7 @@ mod tests {
             response.crate_info.description.as_deref(),
             Some("A generic serialization/deserialization framework")
         );
+        assert_eq!(response.crate_info.max_version.as_deref(), Some("1.0.228"));
     }
 
     #[test]

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -230,7 +230,10 @@ async fn fetch_pypi_metadata(
         return Ok(None);
     };
 
-    if response.info.name.is_none() && response.info.summary.is_none() {
+    if response.info.name.is_none()
+        && response.info.summary.is_none()
+        && response.info.version.is_none()
+    {
         return Ok(None);
     }
 

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -4,7 +4,7 @@ use pep508_rs::VersionOrUrl;
 use serde::Deserialize;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, fetch_cached_remote_json};
+use tombi_extension::{HoverMetadata, append_latest_version, fetch_cached_remote_json};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
@@ -22,6 +22,7 @@ struct PypiProjectResponse {
 struct PypiProjectInfo {
     name: Option<String>,
     summary: Option<String>,
+    version: Option<String>,
 }
 
 pub async fn hover(
@@ -235,7 +236,7 @@ async fn fetch_pypi_metadata(
 
     Ok(Some(HoverMetadata {
         title: response.info.name,
-        description: response.info.summary,
+        description: append_latest_version(response.info.summary, response.info.version),
     }))
 }
 
@@ -252,7 +253,8 @@ mod tests {
             r#"{
                 "info": {
                     "name": "requests",
-                    "summary": "Python HTTP for Humans."
+                    "summary": "Python HTTP for Humans.",
+                    "version": "2.33.1"
                 }
             }"#,
         )
@@ -263,6 +265,7 @@ mod tests {
             response.info.summary.as_deref(),
             Some("Python HTTP for Humans.")
         );
+        assert_eq!(response.info.version.as_deref(), Some("2.33.1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a shared hover helper that appends the latest package version to remote metadata
- show latest crate version in Cargo dependency hover content
- show latest PyPI version in pyproject dependency hover content and cover the helper with tests

## Testing
- cargo fmt --all
- cargo test -p tombi-extension -p tombi-extension-cargo -p tombi-extension-pyproject --locked