### PR TITLE
Add dependency update code actions

### DIFF
--- a/crates/tombi-config/src/extensions/cargo/lsp/code_action.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/code_action.rs
@@ -43,5 +43,10 @@ toggle_features! {
         ///
         /// Whether code actions can add a dependency to the workspace and inherit it.
         pub add_to_workspace_and_inherit_dependency: Option<ToggleFeatureDefaultTrue>,
+
+        /// # Update-dependency-to-latest-version code action feature
+        ///
+        /// Whether code actions can rewrite dependency versions to the latest published version.
+        pub update_dependency_to_latest_version: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-config/src/extensions/pyproject/lsp/code_action.rs
+++ b/crates/tombi-config/src/extensions/pyproject/lsp/code_action.rs
@@ -33,5 +33,10 @@ toggle_features! {
         ///
         /// Whether code actions can add a dependency to the workspace and reuse it.
         pub add_to_workspace_and_use_workspace_dependency: Option<ToggleFeatureDefaultTrue>,
+
+        /// # Update-dependency-to-latest-version code action feature
+        ///
+        /// Whether code actions can rewrite dependency versions to the latest published version.
+        pub update_dependency_to_latest_version: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-lsp/src/handler/code_action.rs
+++ b/crates/tombi-lsp/src/handler/code_action.rs
@@ -24,7 +24,11 @@ pub async fn handle_code_action(
 
     let text_document_uri = text_document.uri.into();
 
-    let ConfigSchemaStore { config, .. } = backend
+    let ConfigSchemaStore {
+        config,
+        schema_store,
+        ..
+    } = backend
         .config_manager
         .config_schema_store_for_uri(&text_document_uri)
         .await;
@@ -99,7 +103,10 @@ pub async fn handle_code_action(
             &accessor_contexts,
             document_source.toml_version,
             config.cargo_extension_features(),
-        )?
+            schema_store.offline(),
+            schema_store.cache_options(),
+        )
+        .await?
     {
         code_actions.extend(extension_code_actions);
     }
@@ -113,7 +120,10 @@ pub async fn handle_code_action(
             document_source.toml_version,
             line_index,
             config.pyproject_extension_features(),
-        )?
+            schema_store.offline(),
+            schema_store.cache_options(),
+        )
+        .await?
     {
         code_actions.extend(extension_code_actions);
     }

--- a/crates/tombi-lsp/tests/test_code_action_refactor_rewrite.rs
+++ b/crates/tombi-lsp/tests/test_code_action_refactor_rewrite.rs
@@ -1,3 +1,91 @@
+use std::{
+    ffi::OsString,
+    fs,
+    path::PathBuf,
+    str::FromStr,
+    sync::{Mutex, MutexGuard, OnceLock},
+};
+
+use tempfile::TempDir;
+
+fn test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct TestCacheHome {
+    _guard: MutexGuard<'static, ()>,
+    previous_tombi: Option<OsString>,
+    previous_xdg: Option<OsString>,
+    _temp_dir: TempDir,
+}
+
+impl TestCacheHome {
+    fn new() -> Self {
+        let guard = test_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
+        let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
+        unsafe {
+            std::env::remove_var("TOMBI_CACHE_HOME");
+            std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        }
+        Self {
+            _guard: guard,
+            previous_tombi,
+            previous_xdg,
+            _temp_dir: temp_dir,
+        }
+    }
+}
+
+impl Drop for TestCacheHome {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(previous) = &self.previous_tombi {
+                std::env::set_var("TOMBI_CACHE_HOME", previous);
+            } else {
+                std::env::remove_var("TOMBI_CACHE_HOME");
+            }
+
+            if let Some(previous) = &self.previous_xdg {
+                std::env::set_var("XDG_CACHE_HOME", previous);
+            } else {
+                std::env::remove_var("XDG_CACHE_HOME");
+            }
+        }
+    }
+}
+
+async fn cached_remote_json_file_path(url: &str) -> PathBuf {
+    let uri = tombi_uri::Uri::from_str(url).unwrap();
+    tombi_cache::get_cache_file_path(&uri).await.unwrap()
+}
+
+async fn write_cached_response(url: &str, body: &str) {
+    let cache_path = cached_remote_json_file_path(url).await;
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&cache_path, body).unwrap();
+}
+
+#[derive(Clone)]
+pub struct CachedResponseSpec {
+    url: &'static str,
+    body: &'static str,
+}
+
+impl CachedResponseSpec {
+    pub const fn new(url: &'static str, body: &'static str) -> Self {
+        Self { url, body }
+    }
+}
+
+pub struct UseCacheResponses(pub Vec<CachedResponseSpec>);
+
 mod refactor_rewrite {
     mod common {
         use tombi_lsp::code_action::CodeActionRefactorRewriteName;
@@ -147,7 +235,7 @@ mod refactor_rewrite {
         use tombi_extension_cargo::CodeActionRefactorRewriteName;
         use tombi_test_lib::project_root_path;
 
-        use crate::test_code_action_refactor_rewrite;
+        use crate::{CachedResponseSpec, UseCacheResponses, test_code_action_refactor_rewrite};
 
         test_code_action_refactor_rewrite! {
             #[tokio::test]
@@ -476,6 +564,100 @@ mod refactor_rewrite {
                 "#
             ));
         }
+
+        test_code_action_refactor_rewrite! {
+            #[tokio::test]
+            async fn cargo_toml_dependencies_update_to_latest_version(
+                r#"
+                [dependencies]
+                serde = "1.0█"
+                "#,
+                project_root_path().join("crates/subcrate/Cargo.toml"),
+                Select(CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion),
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                UseCacheResponses(vec![CachedResponseSpec::new(
+                    "https://crates.io/api/v1/crates/serde",
+                    r#"{
+                        "crate": {
+                            "max_version": "1.0.228"
+                        }
+                    }"#,
+                )]),
+            ) -> Ok(Some(
+                r#"
+                [dependencies]
+                serde = "1.0.228"
+                "#
+            ));
+        }
+
+        test_code_action_refactor_rewrite! {
+            #[tokio::test]
+            async fn cargo_toml_dependencies_inline_table_update_to_latest_version(
+                r#"
+                [dependencies]
+                serde = { version = "1.0█", features = ["derive"] }
+                "#,
+                Select(CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion),
+                project_root_path().join("crates/subcrate/Cargo.toml"),
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                UseCacheResponses(vec![CachedResponseSpec::new(
+                    "https://crates.io/api/v1/crates/serde",
+                    r#"{
+                        "crate": {
+                            "max_version": "1.0.228"
+                        }
+                    }"#,
+                )]),
+            ) -> Ok(Some(
+                r#"
+                [dependencies]
+                serde = { version = "1.0.228", features = ["derive"] }
+                "#
+            ));
+        }
+    }
+
+    mod pyproject_toml {
+        use tombi_extension_pyproject::CodeActionRefactorRewriteName;
+        use tombi_test_lib::project_root_path;
+
+        use crate::{CachedResponseSpec, UseCacheResponses, test_code_action_refactor_rewrite};
+
+        test_code_action_refactor_rewrite! {
+            #[tokio::test]
+            async fn pyproject_dependencies_update_to_latest_version(
+                r#"
+                [project]
+                dependencies = ["requests█>=2.0; python_version < '3.13'"]
+                "#,
+                Select(CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion),
+                project_root_path().join("pyproject.toml"),
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                UseCacheResponses(vec![CachedResponseSpec::new(
+                    "https://pypi.org/pypi/requests/json",
+                    r#"{
+                        "info": {
+                            "version": "2.33.1"
+                        }
+                    }"#,
+                )]),
+            ) -> Ok(Some(
+                r#"
+                [project]
+                dependencies = ["requests==2.33.1; python_version < '3.13'"]
+                "#
+            ));
+        }
     }
 
     #[macro_export]
@@ -513,6 +695,7 @@ mod refactor_rewrite {
                     select: Option<String>,
                     toml_file_path: Option<std::path::PathBuf>,
                     backend_options: tombi_lsp::backend::Options,
+                    cached_responses: Vec<$crate::CachedResponseSpec>,
                 }
 
                 #[allow(unused)]
@@ -542,6 +725,12 @@ mod refactor_rewrite {
                     }
                 }
 
+                impl ApplyTestArg for $crate::UseCacheResponses {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.cached_responses = self.0;
+                    }
+                }
+
                 #[allow(unused_mut)]
                 let mut args = TestArgs::default();
                 $(ApplyTestArg::apply($arg, &mut args);)*
@@ -550,6 +739,11 @@ mod refactor_rewrite {
                     Backend::new(client, &args.backend_options)
                 });
                 let backend = service.inner();
+                let _cache_home =
+                    (!args.cached_responses.is_empty()).then($crate::TestCacheHome::new);
+                for response in &args.cached_responses {
+                    $crate::write_cached_response(response.url, response.body).await;
+                }
                 let temp_file = tempfile::NamedTempFile::with_suffix_in(
                     ".toml",
                     std::env::current_dir().expect("failed to get current directory"),

--- a/crates/tombi-lsp/tests/test_code_action_refactor_rewrite.rs
+++ b/crates/tombi-lsp/tests/test_code_action_refactor_rewrite.rs
@@ -658,6 +658,65 @@ mod refactor_rewrite {
                 "#
             ));
         }
+
+        test_code_action_refactor_rewrite! {
+            #[tokio::test]
+            async fn pyproject_dependencies_update_to_latest_version_noop(
+                r#"
+                [project]
+                dependencies = ["requests█==2.33.1; python_version < '3.13'"]
+                "#,
+                Select(CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion),
+                project_root_path().join("pyproject.toml"),
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                UseCacheResponses(vec![CachedResponseSpec::new(
+                    "https://pypi.org/pypi/requests/json",
+                    r#"{
+                        "info": {
+                            "version": "2.33.1"
+                        }
+                    }"#,
+                )]),
+            ) -> Ok(None);
+        }
+
+        test_code_action_refactor_rewrite! {
+            #[tokio::test]
+            async fn pyproject_workspace_root_updates_dependency_to_latest_version(
+                r#"
+                [tool.uv.workspace]
+                members = ["member1"]
+
+                [project]
+                dependencies = ["requests█>=2.0"]
+                "#,
+                Select(CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion),
+                project_root_path().join("pyproject.toml"),
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                UseCacheResponses(vec![CachedResponseSpec::new(
+                    "https://pypi.org/pypi/requests/json",
+                    r#"{
+                        "info": {
+                            "version": "2.33.1"
+                        }
+                    }"#,
+                )]),
+            ) -> Ok(Some(
+                r#"
+                [tool.uv.workspace]
+                members = ["member1"]
+
+                [project]
+                dependencies = ["requests==2.33.1"]
+                "#
+            ));
+        }
     }
 
     #[macro_export]

--- a/extensions/tombi-extension-cargo/src/code_action.rs
+++ b/extensions/tombi-extension-cargo/src/code_action.rs
@@ -1,4 +1,4 @@
-use tombi_document_tree::{TableKind, dig_accessors, dig_keys};
+use tombi_document_tree::{TableKind, Value, dig_accessors, dig_keys};
 use tombi_extension::CodeActionOrCommand;
 use tombi_schema_store::{Accessor, AccessorContext, matches_accessors};
 use tombi_text::IntoLsp;
@@ -7,7 +7,10 @@ use tower_lsp::lsp_types::{
     TextDocumentEdit, TextEdit, WorkspaceEdit,
 };
 
-use crate::{find_workspace_cargo_toml, get_workspace_cargo_toml_path};
+use crate::{
+    dependency_parent_accessors, fetch_latest_crates_io_version, find_workspace_cargo_toml,
+    get_workspace_cargo_toml_path, is_any_dependency_accessor,
+};
 
 pub enum CodeActionRefactorRewriteName {
     /// Inherit from Workspace
@@ -98,6 +101,23 @@ pub enum CodeActionRefactorRewriteName {
     /// serde.workspace = true
     /// ```
     AddToWorkspaceAndInheritDependency,
+
+    /// Update Dependency to Latest Version
+    ///
+    /// Before
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// serde = "1.0"
+    /// ```
+    ///
+    /// After applying "Update Dependency to Latest Version"
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// serde = "1.0.228"
+    /// ```
+    UpdateDependencyToLatestVersion,
 }
 
 impl std::fmt::Display for CodeActionRefactorRewriteName {
@@ -115,11 +135,14 @@ impl std::fmt::Display for CodeActionRefactorRewriteName {
             CodeActionRefactorRewriteName::AddToWorkspaceAndInheritDependency => {
                 write!(f, "Add to Workspace and Inherit Dependency")
             }
+            CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion => {
+                write!(f, "Update Dependency to Latest Version")
+            }
         }
     }
 }
 
-pub fn code_action(
+pub async fn code_action(
     text_document_uri: &tombi_uri::Uri,
     line_index: &tombi_text::LineIndex,
     root: &tombi_ast::Root,
@@ -128,6 +151,8 @@ pub fn code_action(
     contexts: &[AccessorContext],
     toml_version: tombi_config::TomlVersion,
     features: Option<&tombi_config::CargoExtensionFeatures>,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
 ) -> Result<Option<Vec<CodeActionOrCommand>>, tower_lsp::jsonrpc::Error> {
     if !text_document_uri.path().ends_with("Cargo.toml") {
         return Ok(None);
@@ -149,37 +174,49 @@ pub fn code_action(
     let mut code_actions = Vec::new();
 
     if document_tree.contains_key("workspace") {
-        code_actions.extend(code_actions_for_workspace_cargo_toml(
-            text_document_uri,
-            line_index,
-            document_tree,
-            accessors,
-            features,
-        ))
+        code_actions.extend(
+            code_actions_for_workspace_cargo_toml(
+                text_document_uri,
+                line_index,
+                document_tree,
+                accessors,
+                offline,
+                cache_options,
+                features,
+            )
+            .await?,
+        )
     } else {
-        code_actions.extend(code_actions_for_crate_cargo_toml(
-            text_document_uri,
-            line_index,
-            root,
-            document_tree,
-            &cargo_toml_path,
-            accessors,
-            contexts,
-            toml_version,
-            features,
-        ));
+        code_actions.extend(
+            code_actions_for_crate_cargo_toml(
+                text_document_uri,
+                line_index,
+                root,
+                document_tree,
+                &cargo_toml_path,
+                accessors,
+                contexts,
+                toml_version,
+                offline,
+                cache_options,
+                features,
+            )
+            .await?,
+        );
     }
 
     Ok((!code_actions.is_empty()).then_some(code_actions))
 }
 
-fn code_actions_for_workspace_cargo_toml(
+async fn code_actions_for_workspace_cargo_toml(
     text_document_uri: &tombi_uri::Uri,
     line_index: &tombi_text::LineIndex,
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[Accessor],
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
     features: Option<&tombi_config::CargoExtensionFeatures>,
-) -> Vec<CodeActionOrCommand> {
+) -> Result<Vec<CodeActionOrCommand>, tower_lsp::jsonrpc::Error> {
     let mut code_actions = Vec::new();
 
     let code_action_features = features
@@ -187,6 +224,7 @@ fn code_actions_for_workspace_cargo_toml(
         .and_then(|lsp| lsp.code_action());
 
     if code_action_features
+        .as_ref()
         .and_then(|code_action| code_action.convert_dependency_to_table_format())
         .map(|feature| feature.enabled())
         .unwrap_or_default()
@@ -201,10 +239,29 @@ fn code_actions_for_workspace_cargo_toml(
         code_actions.push(CodeActionOrCommand::CodeAction(action));
     }
 
-    code_actions
+    if code_action_features
+        .as_ref()
+        .and_then(|code_action| code_action.update_dependency_to_latest_version())
+        .map(|feature| feature.enabled())
+        .unwrap_or_default()
+        .value()
+        && let Some(action) = update_dependency_to_latest_version_code_action(
+            text_document_uri,
+            line_index,
+            document_tree,
+            accessors,
+            offline,
+            cache_options,
+        )
+        .await?
+    {
+        code_actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    Ok(code_actions)
 }
 
-fn code_actions_for_crate_cargo_toml(
+async fn code_actions_for_crate_cargo_toml(
     text_document_uri: &tombi_uri::Uri,
     line_index: &tombi_text::LineIndex,
     _root: &tombi_ast::Root,
@@ -213,8 +270,10 @@ fn code_actions_for_crate_cargo_toml(
     accessors: &[Accessor],
     contexts: &[AccessorContext],
     toml_version: tombi_config::TomlVersion,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
     features: Option<&tombi_config::CargoExtensionFeatures>,
-) -> Vec<CodeActionOrCommand> {
+) -> Result<Vec<CodeActionOrCommand>, tower_lsp::jsonrpc::Error> {
     let mut code_actions = Vec::new();
 
     let code_action_features = features
@@ -230,7 +289,7 @@ fn code_actions_for_crate_cargo_toml(
     {
         // Load workspace text and create line index for workspace document
         let Ok(workspace_text) = std::fs::read_to_string(&workspace_cargo_toml_path) else {
-            return code_actions;
+            return Ok(code_actions);
         };
         let workspace_line_index =
             tombi_text::LineIndex::new(&workspace_text, line_index.encoding_kind);
@@ -314,7 +373,107 @@ fn code_actions_for_crate_cargo_toml(
         code_actions.push(CodeActionOrCommand::CodeAction(action));
     }
 
-    code_actions
+    if code_action_features
+        .as_ref()
+        .and_then(|code_action| code_action.update_dependency_to_latest_version())
+        .map(|feature| feature.enabled())
+        .unwrap_or_default()
+        .value()
+        && let Some(action) = update_dependency_to_latest_version_code_action(
+            text_document_uri,
+            line_index,
+            document_tree,
+            accessors,
+            offline,
+            cache_options,
+        )
+        .await?
+    {
+        code_actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    Ok(code_actions)
+}
+
+async fn update_dependency_to_latest_version_code_action(
+    text_document_uri: &tombi_uri::Uri,
+    line_index: &tombi_text::LineIndex,
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<CodeAction>, tower_lsp::jsonrpc::Error> {
+    let dependency_accessors = if is_any_dependency_accessor(accessors) {
+        accessors
+    } else if matches!(accessors.last(), Some(Accessor::Key(key)) if key == "version")
+        && let parent_accessors = dependency_parent_accessors(accessors)
+        && is_any_dependency_accessor(parent_accessors)
+    {
+        parent_accessors
+    } else {
+        return Ok(None);
+    };
+
+    let Some((Accessor::Key(dependency_key), dependency_value)) =
+        dig_accessors(document_tree, dependency_accessors)
+    else {
+        return Ok(None);
+    };
+
+    let (crate_name, version) = match dependency_value {
+        tombi_document_tree::Value::String(version) => (dependency_key.as_str(), version),
+        tombi_document_tree::Value::Table(table)
+            if !(table.get("path").is_some()
+                || table.get("git").is_some()
+                || matches!(
+                    table.get("workspace"),
+                    Some(Value::Boolean(workspace)) if workspace.value()
+                )) =>
+        {
+            match table.get("version") {
+                Some(tombi_document_tree::Value::String(version)) => {
+                    let crate_name = match table.get("package") {
+                        Some(tombi_document_tree::Value::String(package)) => package.value(),
+                        _ => dependency_key.as_str(),
+                    };
+                    (crate_name, version)
+                }
+                _ => return Ok(None),
+            }
+        }
+        _ => return Ok(None),
+    };
+
+    let Some(latest_version) =
+        fetch_latest_crates_io_version(crate_name, offline, cache_options).await?
+    else {
+        return Ok(None);
+    };
+
+    if latest_version == version.value() {
+        return Ok(None); // Already at latest version
+    }
+
+    Ok(Some(CodeAction {
+        title: CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion.to_string(),
+        kind: Some(CodeActionKind::REFACTOR_REWRITE.clone()),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: text_document_uri.to_owned().into(),
+                    version: None,
+                },
+                edits: vec![OneOf::Left(TextEdit {
+                    range: version.range().into_lsp(line_index),
+                    new_text: format!("\"{latest_version}\""),
+                })],
+            }])),
+            change_annotations: None,
+        }),
+        ..Default::default()
+    }))
 }
 
 /// Convert a package field to inherit from workspace configuration.

--- a/extensions/tombi-extension-cargo/src/crates_io.rs
+++ b/extensions/tombi-extension-cargo/src/crates_io.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use tombi_extension::fetch_cached_remote_json;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoCrateResponse {
+    #[serde(rename = "crate")]
+    pub(crate) crate_info: CratesIoCrate,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoCrate {
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) max_version: Option<String>,
+}
+
+pub(crate) async fn fetch_crates_io_crate(
+    crate_name: &str,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<CratesIoCrateResponse>, tower_lsp::jsonrpc::Error> {
+    let url = format!("https://crates.io/api/v1/crates/{crate_name}");
+    Ok(fetch_cached_remote_json::<CratesIoCrateResponse>(&url, offline, cache_options).await)
+}
+
+pub(crate) async fn fetch_latest_crates_io_version(
+    crate_name: &str,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<String>, tower_lsp::jsonrpc::Error> {
+    let Some(response) = fetch_crates_io_crate(crate_name, offline, cache_options).await? else {
+        return Ok(None);
+    };
+
+    Ok(response.crate_info.max_version)
+}

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -1,30 +1,16 @@
 use std::path::Path;
 
-use serde::Deserialize;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, append_latest_version, fetch_cached_remote_json};
+use tombi_extension::{HoverMetadata, append_latest_version};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
     collect_feature_usage_locations, dependency_package_name, feature_key_at_accessors,
-    feature_usage_target_for_feature_key, find_cargo_toml, find_workspace_cargo_toml,
-    get_workspace_cargo_toml_path, is_any_dependency_accessor, load_cargo_toml,
-    sanitize_dependency_key,
+    feature_usage_target_for_feature_key, fetch_crates_io_crate, find_cargo_toml,
+    find_workspace_cargo_toml, get_workspace_cargo_toml_path, is_any_dependency_accessor,
+    load_cargo_toml, sanitize_dependency_key,
 };
-
-#[derive(Debug, Deserialize)]
-struct CratesIoCrateResponse {
-    #[serde(rename = "crate")]
-    crate_info: CratesIoCrate,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoCrate {
-    name: Option<String>,
-    description: Option<String>,
-    max_version: Option<String>,
-}
 
 pub async fn hover(
     text_document_uri: &tombi_uri::Uri,
@@ -338,10 +324,7 @@ async fn fetch_crates_io_metadata(
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
 ) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
-    let url = format!("https://crates.io/api/v1/crates/{package_name}");
-    let Some(response) =
-        fetch_cached_remote_json::<CratesIoCrateResponse>(&url, offline, cache_options).await
-    else {
+    let Some(response) = fetch_crates_io_crate(package_name, offline, cache_options).await? else {
         return Ok(None);
     };
 
@@ -367,6 +350,7 @@ mod tests {
     use tombi_document_tree::TryIntoDocumentTree;
 
     use super::*;
+    use crate::crates_io::CratesIoCrateResponse;
 
     #[test]
     fn parses_crates_io_metadata_response() {

--- a/extensions/tombi-extension-cargo/src/lib.rs
+++ b/extensions/tombi-extension-cargo/src/lib.rs
@@ -3,6 +3,7 @@ mod cargo_lock;
 mod cargo_toml;
 mod code_action;
 mod completion;
+mod crates_io;
 mod did_open;
 mod document_link;
 mod feature_navigation;
@@ -35,6 +36,7 @@ pub(crate) use cargo_toml::{
     CrateLocation, dependency_package_name, find_cargo_toml, get_uri_relative_to_cargo_toml,
     load_cargo_toml,
 };
+pub(crate) use crates_io::{fetch_crates_io_crate, fetch_latest_crates_io_version};
 pub(crate) use feature_navigation::{
     CargoTargetLocation, collect_feature_usage_locations, dependency_feature_string_context,
     feature_key_at_accessors, feature_table_string_at_accessors,

--- a/extensions/tombi-extension-pyproject/src/code_action.rs
+++ b/extensions/tombi-extension-pyproject/src/code_action.rs
@@ -3,6 +3,7 @@ use pep508_rs::{
     pep440_rs::{Version, VersionSpecifier},
 };
 use tombi_ast::AstNode;
+use tombi_document_tree::dig_keys;
 use tombi_extension::CodeActionOrCommand;
 use tombi_schema_store::Accessor;
 use tombi_text::IntoLsp;
@@ -129,6 +130,8 @@ pub async fn code_action(
         return Ok(None);
     };
 
+    let mut actions = Vec::new();
+
     // Try to find workspace pyproject.toml
     let Ok(pyproject_toml_path) = text_document_uri.to_file_path() else {
         log::warn!(
@@ -155,80 +158,81 @@ pub async fn code_action(
         )
         .await?
     {
-        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
+        actions.push(CodeActionOrCommand::CodeAction(action));
     }
 
-    let Some((workspace_path, workspace_root, workspace_document_tree)) =
-        find_workspace_pyproject_toml(&pyproject_toml_path, toml_version)
-    else {
-        log::debug!(
-            "No workspace pyproject.toml found: {:?}",
-            pyproject_toml_path.display()
-        );
-        return Ok(None);
-    };
+    if !dig_keys(document_tree, &["tool", "uv", "workspace"]).is_some() {
+        let Some((workspace_path, workspace_root, workspace_document_tree)) =
+            find_workspace_pyproject_toml(&pyproject_toml_path, toml_version)
+        else {
+            log::debug!(
+                "No workspace pyproject.toml found: {:?}",
+                pyproject_toml_path.display()
+            );
+            return Ok(None);
+        };
 
-    // Load workspace text and create line index for workspace document
-    let Ok(workspace_text) = std::fs::read_to_string(&workspace_path) else {
-        log::warn!(
-            "Failed to read workspace pyproject.toml: {:?}",
-            workspace_path.display()
-        );
-        return Ok(None);
-    };
-    let workspace_line_index =
-        tombi_text::LineIndex::new(&workspace_text, line_index.encoding_kind);
+        // Load workspace text and create line index for workspace document
+        let Ok(workspace_text) = std::fs::read_to_string(&workspace_path) else {
+            log::warn!(
+                "Failed to read workspace pyproject.toml: {:?}",
+                workspace_path.display()
+            );
+            return Ok(None);
+        };
+        let workspace_line_index =
+            tombi_text::LineIndex::new(&workspace_text, line_index.encoding_kind);
 
-    // Try to provide code actions
-    // Try "Use Workspace Dependency" (when dependency exists in workspace)
-    if features
-        .and_then(|features| features.lsp())
-        .and_then(|lsp| lsp.code_action())
-        .and_then(|code_action| code_action.use_workspace_dependency())
-        .map(|use_workspace_dependency| use_workspace_dependency.enabled())
-        .unwrap_or_default()
-        .value()
-        && let Some(action) = use_workspace_dependency_code_action(
-            text_document_uri,
-            line_index,
-            document_tree,
-            dependency_accessors,
-            &workspace_document_tree,
-        )
-    {
-        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
+        // Try "Use Workspace Dependency" (when dependency exists in workspace)
+        if features
+            .and_then(|features| features.lsp())
+            .and_then(|lsp| lsp.code_action())
+            .and_then(|code_action| code_action.use_workspace_dependency())
+            .map(|use_workspace_dependency| use_workspace_dependency.enabled())
+            .unwrap_or_default()
+            .value()
+            && let Some(action) = use_workspace_dependency_code_action(
+                text_document_uri,
+                line_index,
+                document_tree,
+                dependency_accessors,
+                &workspace_document_tree,
+            )
+        {
+            actions.push(CodeActionOrCommand::CodeAction(action));
+        }
+
+        // Try "Add to Workspace and Use Workspace Dependency" (when dependency doesn't exist in workspace)
+        if features
+            .and_then(|features| features.lsp())
+            .and_then(|lsp| lsp.code_action())
+            .and_then(|code_action| code_action.add_to_workspace_and_use_workspace_dependency())
+            .map(|add_to_workspace_and_use_workspace_dependency| {
+                add_to_workspace_and_use_workspace_dependency.enabled()
+            })
+            .unwrap_or_default()
+            .value()
+            && let Some(action) = add_workspace_dependency_code_action(
+                text_document_uri,
+                line_index,
+                document_tree,
+                dependency_accessors,
+                &workspace_path,
+                &workspace_line_index,
+                &workspace_root,
+                &workspace_document_tree,
+            )
+        {
+            log::debug!(
+                "Providing 'Add to Workspace and Use Workspace Dependency' code action: action={:?}, uri={:?}",
+                action.title,
+                text_document_uri
+            );
+            actions.push(CodeActionOrCommand::CodeAction(action));
+        }
     }
 
-    // Try "Add to Workspace and Use Workspace Dependency" (when dependency doesn't exist in workspace)
-    if features
-        .and_then(|features| features.lsp())
-        .and_then(|lsp| lsp.code_action())
-        .and_then(|code_action| code_action.add_to_workspace_and_use_workspace_dependency())
-        .map(|add_to_workspace_and_use_workspace_dependency| {
-            add_to_workspace_and_use_workspace_dependency.enabled()
-        })
-        .unwrap_or_default()
-        .value()
-        && let Some(action) = add_workspace_dependency_code_action(
-            text_document_uri,
-            line_index,
-            document_tree,
-            dependency_accessors,
-            &workspace_path,
-            &workspace_line_index,
-            &workspace_root,
-            &workspace_document_tree,
-        )
-    {
-        log::debug!(
-            "Providing 'Add to Workspace and Use Workspace Dependency' code action: action={:?}, uri={:?}",
-            action.title,
-            text_document_uri
-        );
-        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
-    }
-
-    Ok(None)
+    Ok((!actions.is_empty()).then_some(actions))
 }
 
 async fn update_dependency_to_latest_version_code_action(
@@ -270,6 +274,12 @@ async fn update_dependency_to_latest_version_code_action(
         return Ok(None);
     };
     let new_version_specifier = format_exact_pinned_dependency(&latest_version);
+    let current_version_specifier =
+        &dep_str.value()[version_range.start.column as usize..version_range.end.column as usize];
+
+    if current_version_specifier.trim() == new_version_specifier {
+        return Ok(None);
+    }
 
     Ok(Some(CodeAction {
         title: CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion.to_string(),
@@ -352,7 +362,10 @@ fn find_version_specifier_range(dependency: &str) -> Option<tombi_text::Range> {
         return None;
     }
 
-    if !dependency_without_marker[cursor..].starts_with(['<', '>', '=', '!', '~']) {
+    if !matches!(
+        dependency_without_marker[cursor..].chars().next(),
+        Some('<' | '>' | '=' | '!' | '~')
+    ) {
         return None;
     }
 
@@ -850,7 +863,7 @@ name = "test"
     }
 
     #[tokio::test]
-    async fn test_code_action_workspace_root_returns_none() {
+    async fn test_code_action_workspace_root_skips_workspace_actions() {
         let uri = tombi_uri::Uri::from_file_path("/path/to/pyproject.toml").unwrap();
         let toml_text = r#"
 [tool.uv.workspace]
@@ -874,6 +887,7 @@ dependencies = ["pydantic>=2.10"]
             &[
                 Accessor::Key("project".to_string()),
                 Accessor::Key("dependencies".to_string()),
+                Accessor::Index(0),
             ],
             tombi_config::TomlVersion::default(),
             &line_index,
@@ -884,7 +898,21 @@ dependencies = ["pydantic>=2.10"]
         .await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let titles = result
+            .unwrap()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|action| match action {
+                CodeActionOrCommand::CodeAction(action) => Some(action.title),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(!titles.iter().any(|title| title == "Use Workspace Dependency"));
+        assert!(
+            !titles
+                .iter()
+                .any(|title| title == "Add to Workspace and Use Workspace Dependency")
+        );
     }
 
     #[tokio::test]

--- a/extensions/tombi-extension-pyproject/src/code_action.rs
+++ b/extensions/tombi-extension-pyproject/src/code_action.rs
@@ -1,7 +1,10 @@
-use pep508_rs::{Requirement, VerbatimUrl};
+use pep508_rs::{
+    Requirement, VerbatimUrl, VersionOrUrl,
+    pep440_rs::{Version, VersionSpecifier},
+};
 use tombi_ast::AstNode;
 use tombi_extension::CodeActionOrCommand;
-use tombi_schema_store::{Accessor, matches_accessors};
+use tombi_schema_store::Accessor;
 use tombi_text::IntoLsp;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
@@ -9,8 +12,9 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::{
-    DependencyRequirement, collect_dependency_requirements_from_document_tree,
-    find_workspace_pyproject_toml, parse_dependency_requirement, parse_requirement,
+    DependencyRequirement, collect_dependency_requirements_from_document_tree, fetch_pypi_project,
+    find_workspace_pyproject_toml, get_dependency_accessors, parse_dependency_requirement,
+    parse_requirement,
 };
 
 pub enum CodeActionRefactorRewriteName {
@@ -60,6 +64,21 @@ pub enum CodeActionRefactorRewriteName {
     /// dependencies = ["pydantic"]
     /// ```
     AddToWorkspaceAndUseWorkspaceDependency,
+
+    /// Update Dependency to Latest Version
+    ///
+    /// Before:
+    /// ```toml
+    /// [project]
+    /// dependencies = ["requests>=2.0"]
+    /// ```
+    ///
+    /// After applying "Update Dependency to Latest Version":
+    /// ```toml
+    /// [project]
+    /// dependencies = ["requests==2.33.1"]
+    /// ```
+    UpdateDependencyToLatestVersion,
 }
 
 impl CodeActionRefactorRewriteName {
@@ -69,6 +88,7 @@ impl CodeActionRefactorRewriteName {
             Self::AddToWorkspaceAndUseWorkspaceDependency => {
                 "Add to Workspace and Use Workspace Dependency"
             }
+            Self::UpdateDependencyToLatestVersion => "Update Dependency to Latest Version",
         }
     }
 }
@@ -79,7 +99,7 @@ impl std::fmt::Display for CodeActionRefactorRewriteName {
     }
 }
 
-pub fn code_action(
+pub async fn code_action(
     text_document_uri: &tombi_uri::Uri,
     _root: &tombi_ast::Root,
     document_tree: &tombi_document_tree::DocumentTree,
@@ -87,6 +107,8 @@ pub fn code_action(
     toml_version: tombi_config::TomlVersion,
     line_index: &tombi_text::LineIndex,
     features: Option<&tombi_config::PyprojectExtensionFeatures>,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
 ) -> Result<Option<Vec<CodeActionOrCommand>>, tower_lsp::jsonrpc::Error> {
     // Check if the file is pyproject.toml
     if !text_document_uri.path().ends_with("pyproject.toml") {
@@ -103,51 +125,38 @@ pub fn code_action(
         return Ok(None);
     }
 
-    // Check if this is a workspace root (has [tool.uv.workspace] section)
-    if document_tree.contains_key("tool")
-        && let Some((_, tool_value)) = tombi_document_tree::dig_keys(document_tree, &["tool"])
-        && let tombi_document_tree::Value::Table(tool_table) = tool_value
-        && let Some((_, pyproject_value)) = tool_table.get_key_value("uv")
-        && let tombi_document_tree::Value::Table(pyproject_table) = pyproject_value
-        && pyproject_table.contains_key("workspace")
-    {
-        // This is a workspace root, don't provide code actions
+    let Some(dependency_accessors) = get_dependency_accessors(accessors) else {
         return Ok(None);
-    }
+    };
 
-    if matches_accessors!(accessors, ["project", "dependencies", _])
-        || matches_accessors!(accessors, ["project", "optional-dependencies", _, _])
-        || matches_accessors!(accessors, ["dependency-groups", _, _])
-    {
-        Ok(code_action_for_dependency_package(
-            text_document_uri,
-            document_tree,
-            accessors,
-            toml_version,
-            line_index,
-            features,
-        ))
-    } else {
-        Ok(None)
-    }
-}
-
-fn code_action_for_dependency_package(
-    text_document_uri: &tombi_uri::Uri,
-    document_tree: &tombi_document_tree::DocumentTree,
-    accessors: &[Accessor],
-    toml_version: tombi_config::TomlVersion,
-    line_index: &tombi_text::LineIndex,
-    features: Option<&tombi_config::PyprojectExtensionFeatures>,
-) -> Option<Vec<CodeActionOrCommand>> {
     // Try to find workspace pyproject.toml
     let Ok(pyproject_toml_path) = text_document_uri.to_file_path() else {
         log::warn!(
             "Failed to convert URI to file path: {:?}",
             text_document_uri
         );
-        return None;
+        return Ok(None);
     };
+
+    if features
+        .and_then(|features| features.lsp())
+        .and_then(|lsp| lsp.code_action())
+        .and_then(|code_action| code_action.update_dependency_to_latest_version())
+        .map(|feature| feature.enabled())
+        .unwrap_or_default()
+        .value()
+        && let Some(action) = update_dependency_to_latest_version_code_action(
+            text_document_uri,
+            line_index,
+            document_tree,
+            dependency_accessors,
+            offline,
+            cache_options,
+        )
+        .await?
+    {
+        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
+    }
 
     let Some((workspace_path, workspace_root, workspace_document_tree)) =
         find_workspace_pyproject_toml(&pyproject_toml_path, toml_version)
@@ -156,7 +165,7 @@ fn code_action_for_dependency_package(
             "No workspace pyproject.toml found: {:?}",
             pyproject_toml_path.display()
         );
-        return None;
+        return Ok(None);
     };
 
     // Load workspace text and create line index for workspace document
@@ -165,14 +174,12 @@ fn code_action_for_dependency_package(
             "Failed to read workspace pyproject.toml: {:?}",
             workspace_path.display()
         );
-        return None;
+        return Ok(None);
     };
     let workspace_line_index =
         tombi_text::LineIndex::new(&workspace_text, line_index.encoding_kind);
 
     // Try to provide code actions
-    let mut actions = Vec::new();
-
     // Try "Use Workspace Dependency" (when dependency exists in workspace)
     if features
         .and_then(|features| features.lsp())
@@ -185,11 +192,11 @@ fn code_action_for_dependency_package(
             text_document_uri,
             line_index,
             document_tree,
-            accessors,
+            dependency_accessors,
             &workspace_document_tree,
         )
     {
-        actions.push(CodeActionOrCommand::CodeAction(action));
+        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
     }
 
     // Try "Add to Workspace and Use Workspace Dependency" (when dependency doesn't exist in workspace)
@@ -206,7 +213,7 @@ fn code_action_for_dependency_package(
             text_document_uri,
             line_index,
             document_tree,
-            accessors,
+            dependency_accessors,
             &workspace_path,
             &workspace_line_index,
             &workspace_root,
@@ -218,10 +225,73 @@ fn code_action_for_dependency_package(
             action.title,
             text_document_uri
         );
-        actions.push(CodeActionOrCommand::CodeAction(action));
+        return Ok(Some(vec![CodeActionOrCommand::CodeAction(action)]));
     }
 
-    (!actions.is_empty()).then_some(actions)
+    Ok(None)
+}
+
+async fn update_dependency_to_latest_version_code_action(
+    text_document_uri: &tombi_uri::Uri,
+    line_index: &tombi_text::LineIndex,
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<CodeAction>, tower_lsp::jsonrpc::Error> {
+    let Some((_, dependency_value)) = tombi_document_tree::dig_accessors(document_tree, accessors)
+    else {
+        return Ok(None);
+    };
+
+    let tombi_document_tree::Value::String(dep_str) = dependency_value else {
+        return Ok(None);
+    };
+
+    let Some(dependency_requirement) = parse_dependency_requirement(dep_str) else {
+        return Ok(None);
+    };
+
+    let Some(VersionOrUrl::VersionSpecifier(_)) = dependency_requirement.version_or_url() else {
+        return Ok(None);
+    };
+
+    let Some(latest_version) = fetch_pypi_project(
+        dependency_requirement.requirement.name.as_ref(),
+        offline,
+        cache_options,
+    )
+    .await?
+    .and_then(|response| response.info.version) else {
+        return Ok(None);
+    };
+
+    let Some(version_range) = find_version_specifier_range(dep_str.value()) else {
+        return Ok(None);
+    };
+    let new_version_specifier = format_exact_pinned_dependency(&latest_version);
+
+    Ok(Some(CodeAction {
+        title: CodeActionRefactorRewriteName::UpdateDependencyToLatestVersion.to_string(),
+        kind: Some(CodeActionKind::REFACTOR_REWRITE.clone()),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: text_document_uri.to_owned().into(),
+                    version: None,
+                },
+                edits: vec![OneOf::Left(TextEdit {
+                    range: offset_range(dep_str.unquoted_range(), version_range)
+                        .into_lsp(line_index),
+                    new_text: new_version_specifier,
+                })],
+            }])),
+            change_annotations: None,
+        }),
+        ..Default::default()
+    }))
 }
 
 fn format_dependency_without_version(requirement: &Requirement<VerbatimUrl>) -> String {
@@ -232,6 +302,80 @@ fn format_dependency_without_version(requirement: &Requirement<VerbatimUrl>) -> 
         let extras: Vec<String> = requirement.extras.iter().map(|e| e.to_string()).collect();
         format!("{}[{}]", name, extras.join(","))
     }
+}
+
+fn format_exact_pinned_dependency(latest_version: &str) -> String {
+    let Ok(version) = latest_version.parse::<Version>() else {
+        return format!("=={latest_version}");
+    };
+
+    VersionOrUrl::<VerbatimUrl>::VersionSpecifier(VersionSpecifier::equals_version(version).into())
+        .to_string()
+}
+
+fn find_version_specifier_range(dependency: &str) -> Option<tombi_text::Range> {
+    let marker_start = dependency.find(';').unwrap_or(dependency.len());
+    let dependency_without_marker = &dependency[..marker_start];
+    let mut cursor = 0;
+
+    while let Some(ch) = dependency_without_marker[cursor..].chars().next() {
+        if ch.is_whitespace() || matches!(ch, '[' | '@' | '<' | '>' | '=' | '!' | '~') {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+
+    if cursor == 0 {
+        return None;
+    }
+
+    while let Some(ch) = dependency_without_marker[cursor..].chars().next() {
+        if !ch.is_whitespace() {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+
+    if dependency_without_marker[cursor..].starts_with('[') {
+        let extras_relative_end = dependency_without_marker[cursor..].find(']')?;
+        cursor += extras_relative_end + 1;
+    }
+
+    while let Some(ch) = dependency_without_marker[cursor..].chars().next() {
+        if !ch.is_whitespace() {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+
+    if dependency_without_marker[cursor..].starts_with('@') {
+        return None;
+    }
+
+    if !dependency_without_marker[cursor..].starts_with(['<', '>', '=', '!', '~']) {
+        return None;
+    }
+
+    let version_start = cursor;
+    let version_end = dependency_without_marker
+        .trim_end_matches(char::is_whitespace)
+        .len();
+
+    if version_start >= version_end {
+        return None;
+    }
+
+    Some(tombi_text::Range::new(
+        tombi_text::Position::new(0, version_start as u32),
+        tombi_text::Position::new(0, version_end as u32),
+    ))
+}
+
+fn offset_range(base: tombi_text::Range, relative: tombi_text::Range) -> tombi_text::Range {
+    tombi_text::Range::new(
+        base.start + tombi_text::RelativePosition::from(relative.start),
+        base.start + tombi_text::RelativePosition::from(relative.end),
+    )
 }
 
 fn calculate_insertion_index(existing_package_names: &[&str], new_package_name: &str) -> usize {
@@ -648,7 +792,33 @@ mod tests {
     }
 
     #[test]
-    fn test_code_action_non_pyproject_toml_returns_none() {
+    fn test_find_version_specifier_range_with_marker() {
+        let dependency = "requests>=2.0; python_version < '3.13'";
+        let range = find_version_specifier_range(dependency).unwrap();
+        assert_eq!(
+            &dependency[range.start.column as usize..range.end.column as usize],
+            ">=2.0"
+        );
+    }
+
+    #[test]
+    fn test_find_version_specifier_range_with_extras() {
+        let dependency = "requests[security] >= 2.0, < 3";
+        let range = find_version_specifier_range(dependency).unwrap();
+        assert_eq!(
+            &dependency[range.start.column as usize..range.end.column as usize],
+            ">= 2.0, < 3"
+        );
+    }
+
+    #[test]
+    fn test_find_version_specifier_range_returns_none_for_url() {
+        let dependency = "requests @ https://example.com/requests.whl";
+        assert!(find_version_specifier_range(dependency).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_code_action_non_pyproject_toml_returns_none() {
         let uri = tombi_uri::Uri::from_file_path("/path/to/Cargo.toml").unwrap();
         let toml_text = r#"
 [package]
@@ -670,14 +840,17 @@ name = "test"
             tombi_config::TomlVersion::default(),
             &line_index,
             None,
-        );
+            true,
+            None,
+        )
+        .await;
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
 
-    #[test]
-    fn test_code_action_workspace_root_returns_none() {
+    #[tokio::test]
+    async fn test_code_action_workspace_root_returns_none() {
         let uri = tombi_uri::Uri::from_file_path("/path/to/pyproject.toml").unwrap();
         let toml_text = r#"
 [tool.uv.workspace]
@@ -705,14 +878,17 @@ dependencies = ["pydantic>=2.10"]
             tombi_config::TomlVersion::default(),
             &line_index,
             None,
-        );
+            true,
+            None,
+        )
+        .await;
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
 
-    #[test]
-    fn test_code_action_invalid_accessor_returns_none() {
+    #[tokio::test]
+    async fn test_code_action_invalid_accessor_returns_none() {
         let uri = tombi_uri::Uri::from_file_path("/path/to/pyproject.toml").unwrap();
         let toml_text = r#"
 [project]
@@ -738,7 +914,10 @@ name = "test"
             tombi_config::TomlVersion::default(),
             &line_index,
             None,
-        );
+            true,
+            None,
+        )
+        .await;
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -1,29 +1,16 @@
 use std::path::Path;
 
 use pep508_rs::VersionOrUrl;
-use serde::Deserialize;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, append_latest_version, fetch_cached_remote_json};
+use tombi_extension::{HoverMetadata, append_latest_version};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
-    find_member_project_toml, find_workspace_pyproject_toml, get_dependency_accessors,
-    get_project_name, load_pyproject_toml_document_tree, parse_requirement,
-    resolve_member_pyproject_toml_path,
+    fetch_pypi_project, find_member_project_toml, find_workspace_pyproject_toml,
+    get_dependency_accessors, get_project_name, load_pyproject_toml_document_tree,
+    parse_requirement, resolve_member_pyproject_toml_path,
 };
-
-#[derive(Debug, Deserialize)]
-struct PypiProjectResponse {
-    info: PypiProjectInfo,
-}
-
-#[derive(Debug, Deserialize)]
-struct PypiProjectInfo {
-    name: Option<String>,
-    summary: Option<String>,
-    version: Option<String>,
-}
 
 pub async fn hover(
     text_document_uri: &tombi_uri::Uri,
@@ -223,10 +210,7 @@ async fn fetch_pypi_metadata(
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
 ) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
-    let url = format!("https://pypi.org/pypi/{package_name}/json");
-    let Some(response) =
-        fetch_cached_remote_json::<PypiProjectResponse>(&url, offline, cache_options).await
-    else {
+    let Some(response) = fetch_pypi_project(package_name, offline, cache_options).await? else {
         return Ok(None);
     };
 
@@ -248,6 +232,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::pypi_org::PypiProjectResponse;
     use pep508_rs::{Requirement, VerbatimUrl};
 
     #[test]

--- a/extensions/tombi-extension-pyproject/src/lib.rs
+++ b/extensions/tombi-extension-pyproject/src/lib.rs
@@ -9,10 +9,11 @@ mod goto_definition;
 mod hover;
 mod inlay_hint;
 mod manifest;
+mod pypi_org;
 mod references;
 mod workspace;
 
-pub use code_action::code_action;
+pub use code_action::{CodeActionRefactorRewriteName, code_action};
 pub use completion::completion;
 pub use did_open::did_open;
 pub use document_link::document_link;
@@ -42,6 +43,7 @@ pub(crate) use manifest::{
     load_pyproject_toml_document_tree, resolve_member_pyproject_toml_path,
     resolve_relative_path_uri,
 };
+pub(crate) use pypi_org::fetch_pypi_project;
 use tombi_schema_store::matches_accessors;
 pub(crate) use workspace::{
     extract_exclude_patterns, extract_member_patterns, find_member_project_toml,

--- a/extensions/tombi-extension-pyproject/src/pypi_org.rs
+++ b/extensions/tombi-extension-pyproject/src/pypi_org.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+use tombi_extension::fetch_cached_remote_json;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PypiProjectResponse {
+    pub(crate) info: PypiProjectInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PypiProjectInfo {
+    pub(crate) name: Option<String>,
+    pub(crate) summary: Option<String>,
+    pub(crate) version: Option<String>,
+}
+
+pub(crate) async fn fetch_pypi_project(
+    package_name: &str,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<PypiProjectResponse>, tower_lsp::jsonrpc::Error> {
+    let url = format!("https://pypi.org/pypi/{package_name}/json");
+    Ok(fetch_cached_remote_json::<PypiProjectResponse>(&url, offline, cache_options).await)
+}


### PR DESCRIPTION
## Summary
- add Cargo and Pyproject code actions to update dependencies to the latest published version
- reuse shared crates.io and PyPI fetch helpers across hover and code action paths
- add config toggles and LSP tests for the new update action behavior

## Testing
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --doc --locked
- cargo test -p tombi-lsp --test test_code_action_refactor_rewrite -- --nocapture
