### PR TITLE
refactor: move TestCacheHome into tombi-test-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,7 +3767,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
  "tombi-ast",
  "tombi-cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,6 +3609,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "tombi-test-lib",
  "tombi-uri",
 ]
 
@@ -3773,6 +3774,7 @@ dependencies = [
  "tombi-document-tree",
  "tombi-hashmap",
  "tombi-schema-store",
+ "tombi-test-lib",
  "tombi-text",
  "tombi-toml-text",
  "tombi-uri",
@@ -3801,6 +3803,7 @@ dependencies = [
  "tombi-hashmap",
  "tombi-parser",
  "tombi-schema-store",
+ "tombi-test-lib",
  "tombi-text",
  "tombi-uri",
  "tombi-version-sort",
@@ -4145,6 +4148,7 @@ version = "0.0.0-dev"
 dependencies = [
  "chrono",
  "env_logger",
+ "tempfile",
  "tombi-uri",
 ]
 

--- a/crates/tombi-cache/Cargo.toml
+++ b/crates/tombi-cache/Cargo.toml
@@ -16,3 +16,4 @@ tombi-uri.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+tombi-test-lib.workspace = true

--- a/crates/tombi-cache/src/lib.rs
+++ b/crates/tombi-cache/src/lib.rs
@@ -153,77 +153,10 @@ async fn ensure_cache_dir(cache_dir_path: std::path::PathBuf) -> Option<std::pat
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        ffi::OsString,
-        str::FromStr,
-        sync::{LazyLock, Mutex, MutexGuard},
-    };
+    use std::str::FromStr;
 
     use super::*;
-
-    static CACHE_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    struct TestCacheHome {
-        _guard: MutexGuard<'static, ()>,
-        previous_tombi: Option<OsString>,
-        previous_xdg: Option<OsString>,
-        temp_dir: std::path::PathBuf,
-    }
-
-    impl TestCacheHome {
-        fn new() -> Self {
-            Self::with_env(None)
-        }
-
-        fn with_env(tombi_cache_home: Option<&std::path::Path>) -> Self {
-            let guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-            let unique = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let temp_dir = std::env::temp_dir().join(format!("tombi-cache-test-{unique}"));
-            std::fs::create_dir_all(&temp_dir).unwrap();
-            let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
-            let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                if let Some(tombi_cache_home) = tombi_cache_home {
-                    std::env::set_var("TOMBI_CACHE_HOME", tombi_cache_home);
-                } else {
-                    std::env::remove_var("TOMBI_CACHE_HOME");
-                }
-                std::env::set_var("XDG_CACHE_HOME", &temp_dir);
-            }
-            Self {
-                _guard: guard,
-                previous_tombi,
-                previous_xdg,
-                temp_dir,
-            }
-        }
-    }
-
-    impl Drop for TestCacheHome {
-        fn drop(&mut self) {
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                if let Some(previous) = &self.previous_tombi {
-                    std::env::set_var("TOMBI_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("TOMBI_CACHE_HOME");
-                }
-
-                if let Some(previous) = &self.previous_xdg {
-                    std::env::set_var("XDG_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("XDG_CACHE_HOME");
-                }
-            }
-            let _ = std::fs::remove_dir_all(&self.temp_dir);
-        }
-    }
+    use tombi_test_lib::TestCacheHome;
 
     #[tokio::test(flavor = "current_thread")]
     async fn appends_index_file_to_non_json_http_paths() {
@@ -260,7 +193,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn prefers_tombi_cache_home_over_xdg_cache_home() {
         let tombi_cache_home = tempfile::tempdir().unwrap();
-        let _cache_home = TestCacheHome::with_env(Some(tombi_cache_home.path()));
+        let _cache_home = TestCacheHome::with_tombi_cache_home(Some(tombi_cache_home.path()));
 
         let cache_path = get_tombi_cache_dir_path().await.unwrap();
 
@@ -273,6 +206,6 @@ mod tests {
 
         let cache_path = get_tombi_cache_dir_path().await.unwrap();
 
-        assert_eq!(cache_path, cache_home.temp_dir.join("tombi"));
+        assert_eq!(cache_path, cache_home.tombi_cache_dir_path());
     }
 }

--- a/crates/tombi-extension/Cargo.toml
+++ b/crates/tombi-extension/Cargo.toml
@@ -22,7 +22,6 @@ tombi-uri.workspace = true
 tower-lsp.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 tombi-schema-store = { workspace = true, features = ["native"] }
 tombi-test-lib.workspace = true

--- a/crates/tombi-extension/Cargo.toml
+++ b/crates/tombi-extension/Cargo.toml
@@ -25,3 +25,4 @@ tower-lsp.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 tombi-schema-store = { workspace = true, features = ["native"] }
+tombi-test-lib.workspace = true

--- a/crates/tombi-extension/src/remote_cache.rs
+++ b/crates/tombi-extension/src/remote_cache.rs
@@ -222,11 +222,9 @@ fn parse_json<T: DeserializeOwned>(url: &str, bytes: &[u8]) -> Option<T> {
 #[cfg(test)]
 mod tests {
     use std::{
-        ffi::OsString,
         io::{Read, Write},
         net::TcpListener,
         sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-        sync::{LazyLock, Mutex, MutexGuard},
         thread,
         time::Duration,
     };
@@ -234,60 +232,11 @@ mod tests {
     use super::*;
     use serde::Deserialize;
     use tombi_cache::CACHE_INDEX_FILE_NAME;
-
-    static CACHE_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use tombi_test_lib::TestCacheHome;
 
     #[derive(Debug, Deserialize, PartialEq, Eq)]
     struct TestMetadata {
         name: String,
-    }
-
-    struct TestCacheHome {
-        _guard: MutexGuard<'static, ()>,
-        previous_tombi: Option<OsString>,
-        previous_xdg: Option<OsString>,
-        _temp_dir: tempfile::TempDir,
-    }
-
-    impl TestCacheHome {
-        fn new() -> Self {
-            let guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-            let temp_dir = tempfile::tempdir().unwrap();
-            let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
-            let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                std::env::remove_var("TOMBI_CACHE_HOME");
-                std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
-            }
-            Self {
-                _guard: guard,
-                previous_tombi,
-                previous_xdg,
-                _temp_dir: temp_dir,
-            }
-        }
-    }
-
-    impl Drop for TestCacheHome {
-        fn drop(&mut self) {
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                if let Some(previous) = &self.previous_tombi {
-                    std::env::set_var("TOMBI_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("TOMBI_CACHE_HOME");
-                }
-
-                if let Some(previous) = &self.previous_xdg {
-                    std::env::set_var("XDG_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("XDG_CACHE_HOME");
-                }
-            }
-        }
     }
 
     fn temp_cache_path(test_name: &str) -> std::path::PathBuf {

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1,16 +1,13 @@
 #![allow(clippy::await_holding_lock)]
 
 use std::{
-    ffi::OsString,
     fs,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{Mutex, MutexGuard, OnceLock},
 };
 
-use tempfile::TempDir;
 use tombi_test_lib::{
-    adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
+    TestCacheHome, adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
     cargo_feature_navigation_fixture_path, cargo_schema_path, exact_index_string_test_schema_path,
     lsp_consistency_test_schema_path, one_of_hover_discriminator_test_schema_path,
     pyproject_schema_path, ref_sibling_annotations_test_schema_path,
@@ -59,57 +56,6 @@ fn cargo_feature_usage_hover_description(
     }
 
     lines.join("\n")
-}
-
-fn test_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-struct TestCacheHome {
-    _guard: MutexGuard<'static, ()>,
-    previous_tombi: Option<OsString>,
-    previous_xdg: Option<OsString>,
-    _temp_dir: TempDir,
-}
-
-impl TestCacheHome {
-    fn new() -> Self {
-        let guard = test_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let temp_dir = tempfile::tempdir().unwrap();
-        let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
-        let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
-        unsafe {
-            std::env::remove_var("TOMBI_CACHE_HOME");
-            std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
-        }
-        Self {
-            _guard: guard,
-            previous_tombi,
-            previous_xdg,
-            _temp_dir: temp_dir,
-        }
-    }
-}
-
-impl Drop for TestCacheHome {
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(previous) = &self.previous_tombi {
-                std::env::set_var("TOMBI_CACHE_HOME", previous);
-            } else {
-                std::env::remove_var("TOMBI_CACHE_HOME");
-            }
-
-            if let Some(previous) = &self.previous_xdg {
-                std::env::set_var("XDG_CACHE_HOME", previous);
-            } else {
-                std::env::remove_var("XDG_CACHE_HOME");
-            }
-        }
-    }
 }
 
 async fn cached_remote_json_file_path(url: &str) -> PathBuf {

--- a/crates/tombi-lsp/tests/test_inlay_hint.rs
+++ b/crates/tombi-lsp/tests/test_inlay_hint.rs
@@ -1,16 +1,15 @@
 #![allow(clippy::await_holding_lock)]
 
 use std::{
-    ffi::OsString,
     fs,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{Mutex, MutexGuard, OnceLock},
+    sync::{Mutex, OnceLock},
     time::Duration,
 };
 
-use tempfile::TempDir;
 use tombi_extension::InlayHint;
+use tombi_test_lib::TestCacheHome;
 use tower_lsp::{
     LspService,
     lsp_types::{
@@ -34,52 +33,6 @@ fn test_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-struct TestCacheHome {
-    _guard: MutexGuard<'static, ()>,
-    previous_tombi: Option<OsString>,
-    previous_xdg: Option<OsString>,
-    _temp_dir: TempDir,
-}
-
-impl TestCacheHome {
-    fn new() -> Self {
-        let guard = test_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let temp_dir = tempfile::tempdir().unwrap();
-        let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
-        let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
-        unsafe {
-            std::env::remove_var("TOMBI_CACHE_HOME");
-            std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
-        }
-        Self {
-            _guard: guard,
-            previous_tombi,
-            previous_xdg,
-            _temp_dir: temp_dir,
-        }
-    }
-}
-
-impl Drop for TestCacheHome {
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(previous) = &self.previous_tombi {
-                std::env::set_var("TOMBI_CACHE_HOME", previous);
-            } else {
-                std::env::remove_var("TOMBI_CACHE_HOME");
-            }
-
-            if let Some(previous) = &self.previous_xdg {
-                std::env::set_var("XDG_CACHE_HOME", previous);
-            } else {
-                std::env::remove_var("XDG_CACHE_HOME");
-            }
-        }
-    }
-}
-
 async fn cached_remote_json_file_path(url: &str) -> PathBuf {
     let uri = tombi_uri::Uri::from_str(url).unwrap();
     tombi_cache::get_cache_file_path(&uri).await.unwrap()
@@ -94,13 +47,13 @@ async fn write_cached_response(url: &str, body: &str) {
 }
 
 struct InlayHintFixture {
-    _temp_dir: Option<TempDir>,
+    _temp_dir: Option<tempfile::TempDir>,
     source: String,
     source_path: PathBuf,
 }
 
 impl InlayHintFixture {
-    fn new(temp_dir: Option<TempDir>, source: &str, source_path: PathBuf) -> Self {
+    fn new(temp_dir: Option<tempfile::TempDir>, source: &str, source_path: PathBuf) -> Self {
         Self {
             _temp_dir: temp_dir,
             source: textwrap::dedent(source).trim().to_string(),

--- a/crates/tombi-test-lib/Cargo.toml
+++ b/crates/tombi-test-lib/Cargo.toml
@@ -9,4 +9,5 @@ license.workspace = true
 [dependencies]
 chrono.workspace = true
 env_logger.workspace = true
+tempfile.workspace = true
 tombi-uri.workspace = true

--- a/crates/tombi-test-lib/src/cache.rs
+++ b/crates/tombi-test-lib/src/cache.rs
@@ -1,0 +1,84 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock},
+};
+
+use tempfile::TempDir;
+
+fn cache_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub struct TestCacheHome {
+    _guard: MutexGuard<'static, ()>,
+    previous_tombi: Option<OsString>,
+    previous_xdg: Option<OsString>,
+    temp_dir: TempDir,
+}
+
+impl TestCacheHome {
+    pub fn new() -> Self {
+        Self::with_tombi_cache_home(None)
+    }
+
+    pub fn with_tombi_cache_home(tombi_cache_home: Option<&Path>) -> Self {
+        let guard = cache_env_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
+        let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
+        // SAFETY: Tests serialize access with a process-wide mutex so env mutation
+        // remains scoped to one test at a time.
+        unsafe {
+            if let Some(tombi_cache_home) = tombi_cache_home {
+                std::env::set_var("TOMBI_CACHE_HOME", tombi_cache_home);
+            } else {
+                std::env::remove_var("TOMBI_CACHE_HOME");
+            }
+            std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        }
+        Self {
+            _guard: guard,
+            previous_tombi,
+            previous_xdg,
+            temp_dir,
+        }
+    }
+
+    pub fn xdg_cache_home_path(&self) -> &Path {
+        self.temp_dir.path()
+    }
+
+    pub fn tombi_cache_dir_path(&self) -> PathBuf {
+        self.temp_dir.path().join("tombi")
+    }
+}
+
+impl Default for TestCacheHome {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TestCacheHome {
+    fn drop(&mut self) {
+        // SAFETY: Tests serialize access with a process-wide mutex so env mutation
+        // remains scoped to one test at a time.
+        unsafe {
+            if let Some(previous) = &self.previous_tombi {
+                std::env::set_var("TOMBI_CACHE_HOME", previous);
+            } else {
+                std::env::remove_var("TOMBI_CACHE_HOME");
+            }
+
+            if let Some(previous) = &self.previous_xdg {
+                std::env::set_var("XDG_CACHE_HOME", previous);
+            } else {
+                std::env::remove_var("XDG_CACHE_HOME");
+            }
+        }
+    }
+}

--- a/crates/tombi-test-lib/src/lib.rs
+++ b/crates/tombi-test-lib/src/lib.rs
@@ -1,5 +1,7 @@
+mod cache;
 mod date_time;
 mod path;
+pub use cache::*;
 pub use date_time::*;
 pub use path::*;
 

--- a/extensions/tombi-extension-cargo/Cargo.toml
+++ b/extensions/tombi-extension-cargo/Cargo.toml
@@ -33,3 +33,4 @@ tower-lsp.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tombi-test-lib.workspace = true

--- a/extensions/tombi-extension-cargo/src/completion.rs
+++ b/extensions/tombi-extension-cargo/src/completion.rs
@@ -874,65 +874,10 @@ async fn fetch_local_crate_features(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        ffi::OsString,
-        fs,
-        str::FromStr,
-        sync::{LazyLock, Mutex, MutexGuard},
-        time::Duration,
-    };
+    use std::{fs, str::FromStr, time::Duration};
 
     use super::*;
-
-    static CACHE_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    struct TestCacheHome {
-        _guard: MutexGuard<'static, ()>,
-        previous_tombi: Option<OsString>,
-        previous_xdg: Option<OsString>,
-        _temp_dir: tempfile::TempDir,
-    }
-
-    impl TestCacheHome {
-        fn new() -> Self {
-            let guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
-            let temp_dir = tempfile::tempdir().unwrap();
-            let previous_tombi = std::env::var_os("TOMBI_CACHE_HOME");
-            let previous_xdg = std::env::var_os("XDG_CACHE_HOME");
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                std::env::remove_var("TOMBI_CACHE_HOME");
-                std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
-            }
-            Self {
-                _guard: guard,
-                previous_tombi,
-                previous_xdg,
-                _temp_dir: temp_dir,
-            }
-        }
-    }
-
-    impl Drop for TestCacheHome {
-        fn drop(&mut self) {
-            // SAFETY: Tests serialize access with a process-wide mutex so env mutation
-            // remains scoped to one test at a time.
-            unsafe {
-                if let Some(previous) = &self.previous_tombi {
-                    std::env::set_var("TOMBI_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("TOMBI_CACHE_HOME");
-                }
-
-                if let Some(previous) = &self.previous_xdg {
-                    std::env::set_var("XDG_CACHE_HOME", previous);
-                } else {
-                    std::env::remove_var("XDG_CACHE_HOME");
-                }
-            }
-        }
-    }
+    use tombi_test_lib::TestCacheHome;
 
     fn cache_options() -> tombi_cache::Options {
         tombi_cache::Options {


### PR DESCRIPTION
## Summary
- move the shared `TestCacheHome` helper into `tombi-test-lib`
- replace duplicated test-only cache env helpers across cache, extension, and LSP tests
- wire the affected crates to use `tombi-test-lib` as a dev-dependency

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked