### PR TITLE
Show latest version in Cargo version hover

### DIFF
--- a/crates/tombi-extension/src/hover.rs
+++ b/crates/tombi-extension/src/hover.rs
@@ -1,7 +1,13 @@
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HoverMetadata {
-    pub title: Option<String>,
-    pub description: Option<String>,
+    pub title: Option<HoverTextChange>,
+    pub description: Option<HoverTextChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HoverTextChange {
+    Replace(String),
+    Append(String),
 }
 
 pub fn append_latest_version(

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -1,6 +1,7 @@
 use itertools::{Either, Itertools};
 use tombi_ast::{AstNode, DanglingCommentGroupOr, algo::ancestors_at_position};
 use tombi_document_tree::IntoDocumentTreeAndErrors;
+use tombi_extension::{HoverMetadata, HoverTextChange};
 use tombi_schema_store::SchemaContext;
 use tombi_text::IntoLsp;
 use tower_lsp::lsp_types::{HoverParams, TextDocumentPositionParams};
@@ -173,15 +174,33 @@ pub async fn handle_hover(
         };
 
         if let Some(metadata) = extension_hover {
-            if metadata.title.is_some() {
-                hover_value_content.title = metadata.title;
-            }
-            if metadata.description.is_some() {
-                hover_value_content.description = metadata.description;
-            }
+            apply_hover_metadata(hover_value_content, metadata);
         }
     }
     Ok(hover_content)
+}
+
+fn apply_hover_metadata(
+    hover_value_content: &mut crate::hover::HoverValueContent,
+    metadata: HoverMetadata,
+) {
+    apply_hover_text_change(&mut hover_value_content.title, metadata.title);
+    apply_hover_text_change(&mut hover_value_content.description, metadata.description);
+}
+
+fn apply_hover_text_change(target: &mut Option<String>, change: Option<HoverTextChange>) {
+    match change {
+        Some(HoverTextChange::Replace(text)) => *target = Some(text),
+        Some(HoverTextChange::Append(text)) => match target {
+            Some(existing) if !existing.is_empty() => {
+                existing.push_str("\n\n");
+                existing.push_str(&text);
+            }
+            Some(existing) => existing.push_str(&text),
+            None => *target = Some(text),
+        },
+        None => {}
+    }
 }
 
 pub async fn get_hover_keys_with_range(
@@ -797,5 +816,22 @@ mod tests {
             ]
             "#,
         ) -> Ok(((2, 2), (3, 11)));
+    }
+
+    #[test]
+    fn apply_hover_text_change_replaces_and_appends() {
+        let mut target = Some("base".to_string());
+
+        apply_hover_text_change(
+            &mut target,
+            Some(HoverTextChange::Append("extra".to_string())),
+        );
+        assert_eq!(target.as_deref(), Some("base\n\nextra"));
+
+        apply_hover_text_change(
+            &mut target,
+            Some(HoverTextChange::Replace("override".to_string())),
+        );
+        assert_eq!(target.as_deref(), Some("override"));
     }
 }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -557,6 +557,40 @@ mod hover_keys_value {
 
         test_hover_keys_value!(
             #[tokio::test]
+            async fn cargo_dependency_version_hover_appends_latest_version(
+                r#"
+                [dependencies]
+                serde = { version = "█1.0", features = ["derive"] }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                UseTestCacheHome,
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                SchemaPath(cargo_schema_path()),
+                CachedRemoteJson {
+                    url: "https://crates.io/api/v1/crates/serde",
+                    body: r#"{
+                        "crate": {
+                            "name": "serde",
+                            "description": "A generic serialization/deserialization framework",
+                            "max_version": "1.0.228"
+                        }
+                    }"#,
+                },
+            ) -> Ok({
+                "Keys": "dependencies.serde.version",
+                "Value": "String?",
+                "Title": Some("Semantic Version Requirement"),
+                "Description": Some(
+                    "The [version requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) of the target dependency.\n\nLatest Version: `1.0.228`"
+                ),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
             async fn cargo_feature_key_hover_lists_project_references(
                 r#"
                 [package]
@@ -1723,6 +1757,8 @@ mod hover_keys_value {
                     schema_file_path: Option<std::path::PathBuf>,
                     schema_items: Vec<tombi_config::SchemaItem>,
                     subschemas: Vec<SubSchemaPath>,
+                    use_test_cache_home: bool,
+                    cached_remote_json: Vec<CachedRemoteJson>,
                     backend_options: tombi_lsp::backend::Options,
                 }
 
@@ -1770,6 +1806,27 @@ mod hover_keys_value {
                     }
                 }
 
+                #[allow(unused)]
+                struct UseTestCacheHome;
+
+                impl ApplyTestArg for UseTestCacheHome {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.use_test_cache_home = true;
+                    }
+                }
+
+                #[allow(unused)]
+                struct CachedRemoteJson {
+                    url: &'static str,
+                    body: &'static str,
+                }
+
+                impl ApplyTestArg for CachedRemoteJson {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.cached_remote_json.push(self);
+                    }
+                }
+
                 impl ApplyTestArg for tombi_lsp::backend::Options {
                     fn apply(self, args: &mut TestArgs) {
                         args.backend_options = self;
@@ -1779,6 +1836,13 @@ mod hover_keys_value {
                 #[allow(unused_mut)]
                 let mut args = TestArgs::default();
                 $(ApplyTestArg::apply($arg, &mut args);)*
+
+                let _cache_home = args
+                    .use_test_cache_home
+                    .then(TestCacheHome::new);
+                for cached_remote_json in &args.cached_remote_json {
+                    write_cached_response(cached_remote_json.url, cached_remote_json.body).await;
+                }
 
                 let (service, _) = LspService::new(|client| {
                     Backend::new(client, &args.backend_options)

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, append_latest_version};
+use tombi_extension::{HoverMetadata, HoverTextChange, append_latest_version};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
@@ -41,13 +41,20 @@ pub async fn hover(
         return Ok(Some(metadata));
     }
 
-    let Some(dependency_accessors) = get_dependency_accessors(accessors) else {
-        return Ok(None);
-    };
-
-    if !is_hovering_dependency_key(document_tree, dependency_accessors, position) {
-        return Ok(None);
-    }
+    let (dependency_accessors, version_accessor) =
+        if let Some(dependency_accessors) = get_dependency_accessors(accessors) {
+            if !is_hovering_dependency_key(document_tree, dependency_accessors, position) {
+                return Ok(None);
+            }
+            (dependency_accessors, false)
+        } else if is_dependency_version_accessor(accessors) {
+            if !is_hovering_dependency_version(document_tree, accessors, position) {
+                return Ok(None);
+            }
+            (&accessors[..accessors.len().saturating_sub(1)], true)
+        } else {
+            return Ok(None);
+        };
 
     let Some(Accessor::Key(dependency_key)) = dependency_accessors.last() else {
         return Ok(None);
@@ -57,14 +64,16 @@ pub async fn hover(
         return Ok(None);
     };
 
-    if let Some(metadata) = resolve_local_dependency_metadata(
-        document_tree,
-        dependency_accessors,
-        dependency_key,
-        dependency_value,
-        &cargo_toml_path,
-        toml_version,
-    ) {
+    if !version_accessor
+        && let Some(metadata) = resolve_local_dependency_metadata(
+            document_tree,
+            dependency_accessors,
+            dependency_key,
+            dependency_value,
+            &cargo_toml_path,
+            toml_version,
+        )
+    {
         return Ok(Some(metadata));
     }
 
@@ -73,7 +82,34 @@ pub async fn hover(
     }
 
     let package_name = dependency_package_name(dependency_key, dependency_value);
-    fetch_crates_io_metadata(package_name, offline, cache_options).await
+
+    let Some(response) = fetch_crates_io_crate(package_name, offline, cache_options).await? else {
+        return Ok(None);
+    };
+
+    if response.crate_info.name.is_none()
+        && response.crate_info.description.is_none()
+        && response.crate_info.max_version.is_none()
+    {
+        return Ok(None);
+    }
+
+    if version_accessor {
+        return Ok(Some(HoverMetadata {
+            title: None,
+            description: append_latest_version(None, response.crate_info.max_version)
+                .map(HoverTextChange::Append),
+        }));
+    }
+
+    Ok(Some(HoverMetadata {
+        title: response.crate_info.name.map(HoverTextChange::Replace),
+        description: append_latest_version(
+            response.crate_info.description,
+            response.crate_info.max_version,
+        )
+        .map(HoverTextChange::Replace),
+    }))
 }
 
 async fn feature_key_hover_metadata(
@@ -98,12 +134,12 @@ async fn feature_key_hover_metadata(
 
     Some(HoverMetadata {
         title: None,
-        description: Some(render_feature_usage_links(
+        description: Some(HoverTextChange::Replace(render_feature_usage_links(
             document_tree,
             cargo_toml_path,
             usage_locations.as_slice(),
             toml_version,
-        )),
+        ))),
     })
 }
 
@@ -183,16 +219,21 @@ fn get_dependency_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
     }
 }
 
+fn is_dependency_version_accessor(accessors: &[Accessor]) -> bool {
+    matches!(accessors.last(), Some(Accessor::Key(key)) if key == "version")
+        && is_any_dependency_accessor(&accessors[..accessors.len().saturating_sub(1)])
+}
+
 fn is_hovering_dependency_key(
     document_tree: &tombi_document_tree::DocumentTree,
     dependency_accessors: &[Accessor],
     position: tombi_text::Position,
 ) -> bool {
-    let dependency_keys = dependency_accessors
+    let Some(dependency_keys) = dependency_accessors
         .iter()
         .map(Accessor::as_key)
-        .collect::<Option<Vec<_>>>();
-    let Some(dependency_keys) = dependency_keys else {
+        .collect::<Option<Vec<_>>>()
+    else {
         return false;
     };
     let Some((dependency_key, _)) = dig_keys(document_tree, &dependency_keys) else {
@@ -200,6 +241,25 @@ fn is_hovering_dependency_key(
     };
 
     dependency_key.range().contains(position)
+}
+
+fn is_hovering_dependency_version(
+    document_tree: &tombi_document_tree::DocumentTree,
+    version_accessors: &[Accessor],
+    position: tombi_text::Position,
+) -> bool {
+    let Some(version_keys) = version_accessors
+        .iter()
+        .map(Accessor::as_key)
+        .collect::<Option<Vec<_>>>()
+    else {
+        return false;
+    };
+    let Some((version_key, version_value)) = dig_keys(document_tree, &version_keys) else {
+        return false;
+    };
+
+    version_key.range().contains(position) || version_value.range().contains(position)
 }
 
 fn resolve_local_dependency_metadata(
@@ -314,34 +374,9 @@ fn load_package_metadata(
     }
 
     Some(HoverMetadata {
-        title: package_name,
-        description,
+        title: package_name.map(HoverTextChange::Replace),
+        description: description.map(HoverTextChange::Replace),
     })
-}
-
-async fn fetch_crates_io_metadata(
-    package_name: &str,
-    offline: bool,
-    cache_options: Option<&tombi_cache::Options>,
-) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
-    let Some(response) = fetch_crates_io_crate(package_name, offline, cache_options).await? else {
-        return Ok(None);
-    };
-
-    if response.crate_info.name.is_none()
-        && response.crate_info.description.is_none()
-        && response.crate_info.max_version.is_none()
-    {
-        return Ok(None);
-    }
-
-    Ok(Some(HoverMetadata {
-        title: response.crate_info.name,
-        description: append_latest_version(
-            response.crate_info.description,
-            response.crate_info.max_version,
-        ),
-    }))
 }
 
 #[cfg(test)]
@@ -374,22 +409,30 @@ mod tests {
     }
 
     #[test]
-    fn only_matches_exact_dependency_paths() {
+    fn dependency_accessors_match_only_exact_dependency_paths() {
         let dependency_accessors = [
             Accessor::Key("dependencies".into()),
             Accessor::Key("serde".into()),
         ];
-        let nested_accessors = [
+        let version_accessors = [
             Accessor::Key("dependencies".into()),
             Accessor::Key("serde".into()),
             Accessor::Key("version".into()),
+        ];
+        let feature_accessors = [
+            Accessor::Key("dependencies".into()),
+            Accessor::Key("serde".into()),
+            Accessor::Key("features".into()),
         ];
 
         assert_eq!(
             get_dependency_accessors(&dependency_accessors),
             Some(&dependency_accessors[..])
         );
-        assert_eq!(get_dependency_accessors(&nested_accessors), None);
+        assert_eq!(get_dependency_accessors(&version_accessors), None);
+        assert_eq!(get_dependency_accessors(&feature_accessors), None);
+        assert!(is_dependency_version_accessor(&version_accessors));
+        assert!(!is_dependency_version_accessor(&feature_accessors));
     }
 
     #[test]
@@ -416,6 +459,27 @@ mod tests {
             &document_tree,
             &dependency_accessors,
             value_position,
+        ));
+    }
+
+    #[test]
+    fn hovering_dependency_version_value_counts_as_hover_target() {
+        let source = "[dependencies]\nserde = { version = \"1.0\" }\n";
+        let root = tombi_ast::Root::cast(tombi_parser::parse(source).into_syntax_node()).unwrap();
+        let document_tree = root.try_into_document_tree(TomlVersion::V1_0_0).unwrap();
+        let version_accessors = [
+            Accessor::Key("dependencies".into()),
+            Accessor::Key("serde".into()),
+            Accessor::Key("version".into()),
+        ];
+
+        let version_value_position = tombi_text::Position::default()
+            + tombi_text::RelativePosition::of("[dependencies]\nserde = { version = \"1");
+
+        assert!(is_hovering_dependency_version(
+            &document_tree,
+            &version_accessors,
+            version_value_position,
         ));
     }
 }

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -95,9 +95,13 @@ pub async fn hover(
     }
 
     if version_accessor {
+        let Some(max_version) = response.crate_info.max_version else {
+            return Ok(None);
+        };
+
         return Ok(Some(HoverMetadata {
             title: None,
-            description: append_latest_version(None, response.crate_info.max_version)
+            description: append_latest_version(None, Some(max_version))
                 .map(HoverTextChange::Append),
         }));
     }

--- a/extensions/tombi-extension-pyproject/src/code_action.rs
+++ b/extensions/tombi-extension-pyproject/src/code_action.rs
@@ -161,7 +161,7 @@ pub async fn code_action(
         actions.push(CodeActionOrCommand::CodeAction(action));
     }
 
-    if !dig_keys(document_tree, &["tool", "uv", "workspace"]).is_some() {
+    if dig_keys(document_tree, &["tool", "uv", "workspace"]).is_none() {
         let Some((workspace_path, workspace_root, workspace_document_tree)) =
             find_workspace_pyproject_toml(&pyproject_toml_path, toml_version)
         else {
@@ -907,7 +907,11 @@ dependencies = ["pydantic>=2.10"]
                 _ => None,
             })
             .collect::<Vec<_>>();
-        assert!(!titles.iter().any(|title| title == "Use Workspace Dependency"));
+        assert!(
+            !titles
+                .iter()
+                .any(|title| title == "Use Workspace Dependency")
+        );
         assert!(
             !titles
                 .iter()

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pep508_rs::VersionOrUrl;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
-use tombi_extension::{HoverMetadata, append_latest_version};
+use tombi_extension::{HoverMetadata, HoverTextChange, append_latest_version};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
@@ -200,8 +200,8 @@ fn load_project_metadata(
     }
 
     Some(HoverMetadata {
-        title: project_name,
-        description,
+        title: project_name.map(HoverTextChange::Replace),
+        description: description.map(HoverTextChange::Replace),
     })
 }
 
@@ -222,8 +222,9 @@ async fn fetch_pypi_metadata(
     }
 
     Ok(Some(HoverMetadata {
-        title: response.info.name,
-        description: append_latest_version(response.info.summary, response.info.version),
+        title: response.info.name.map(HoverTextChange::Replace),
+        description: append_latest_version(response.info.summary, response.info.version)
+            .map(HoverTextChange::Replace),
     }))
 }
 


### PR DESCRIPTION
## Summary
- add replace/append modes for extension hover metadata so schema hover text can be preserved while appending extra details
- append `Latest Version` to Cargo dependency `version` hover while keeping schema metadata intact
- extend hover tests and fix a pyproject clippy issue encountered after merging the latest `main`

## Verification
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked