### PR TITLE
docs: clarify TestCacheHome usage in agent rules

### DIFF
--- a/.claude/rules/test-macro-policy.md
+++ b/.claude/rules/test-macro-policy.md
@@ -7,5 +7,6 @@ paths: "**/*"
 - 自動テストを追加・拡張するときは、その領域で既に使われている宣言的テストマクロを必ず再利用する
 - formatter 系では `test_format!`、lexer 系では既存の `test_...!` マクロ群、LSP 系でも同様に既存パターンへ合わせる
 - 同種テストが複数あるのに専用 helper や手書き harness を新設しない
+- `TestCacheHome` が必要な場合は `tombi-test-lib::TestCacheHome` を使い、各テストファイルで同等の struct / cleanup 実装を再定義しない
 - 新しいテストマクロが本当に必要な場合は、同じ crate の既存テストから再利用できる位置に定義し、以後のケースもそこへ寄せる
 - 比較系テストでは、repo の既存慣習に従って可読性の高い assertion を選ぶ

--- a/.claude/rules/test-macro-policy.md
+++ b/.claude/rules/test-macro-policy.md
@@ -7,6 +7,6 @@ paths: "**/*"
 - 自動テストを追加・拡張するときは、その領域で既に使われている宣言的テストマクロを必ず再利用する
 - formatter 系では `test_format!`、lexer 系では既存の `test_...!` マクロ群、LSP 系でも同様に既存パターンへ合わせる
 - 同種テストが複数あるのに専用 helper や手書き harness を新設しない
-- `TestCacheHome` が必要な場合は `tombi-test-lib::TestCacheHome` を使い、各テストファイルで同等の struct / cleanup 実装を再定義しない
+- `TestCacheHome` が必要な場合は `tombi-test-lib` crate の `tombi_test_lib::TestCacheHome` を使い、各テストファイルで同等の struct / cleanup 実装を再定義しない
 - 新しいテストマクロが本当に必要な場合は、同じ crate の既存テストから再利用できる位置に定義し、以後のケースもそこへ寄せる
 - 比較系テストでは、repo の既存慣習に従って可読性の高い assertion を選ぶ

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ TOML toolkit (parser / formatter / linter / LSP) の polyglot repository。Rust 
 ## 必須ルール
 
 - Think in English, but generate responses in Japanese
+- `TestCacheHome` が必要なテストでは `tombi-test-lib` の `TestCacheHome` を利用し、同等のローカル実装を持ち込まない
 - 自動テストには既存の宣言的テストマクロ（例: `test_format!`）を必ず再利用する
 
 ## 補助設定

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ TOML toolkit (parser / formatter / linter / LSP) の polyglot repository。Rust 
 ## 必須ルール
 
 - Think in English, but generate responses in Japanese
-- `TestCacheHome` が必要なテストでは `tombi-test-lib` の `TestCacheHome` を利用し、同等のローカル実装を持ち込まない
+- `TestCacheHome` が必要なテストでは `tombi-test-lib` の `tombi_test_lib::TestCacheHome` を利用し、同等のローカル実装を持ち込まない
 - 自動テストには既存の宣言的テストマクロ（例: `test_format!`）を必ず再利用する
 
 ## 補助設定

--- a/extensions/tombi-extension-pyproject/src/code_action.rs
+++ b/extensions/tombi-extension-pyproject/src/code_action.rs
@@ -759,18 +759,15 @@ mod tests {
             #[tokio::test]
             async fn $name() {
                 let uri = tombi_uri::Uri::from_file_path("/path/to/pyproject.toml").unwrap();
-                let root = tombi_ast::Root::cast(
-                    tombi_parser::parse($toml_text).into_syntax_node(),
-                )
-                .unwrap();
+                let root =
+                    tombi_ast::Root::cast(tombi_parser::parse($toml_text).into_syntax_node())
+                        .unwrap();
                 let document_tree = root
                     .clone()
                     .try_into_document_tree(tombi_config::TomlVersion::default())
                     .unwrap();
-                let line_index = tombi_text::LineIndex::new(
-                    $toml_text,
-                    tombi_text::EncodingKind::default(),
-                );
+                let line_index =
+                    tombi_text::LineIndex::new($toml_text, tombi_text::EncodingKind::default());
 
                 let _cache_home = TestCacheHome::new();
                 let cache_options = tombi_cache::Options {


### PR DESCRIPTION
## Summary
- add an agent-facing rule to use  instead of local reimplementations
- document that tests should continue to reuse existing declarative test macros
- include the formatter-only cleanup picked up after merging latest 

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --locked -- -D warnings
