### PR TITLE
fix: align optional dependency definitions with optional value

### DIFF
--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -640,6 +640,25 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
+            async fn optional_false_dependency_definition_returns_none(
+                r#"
+                [package]
+                name = "explicit-feature"
+                version = "0.1.0"
+
+                [dependencies]
+                schemars = { version = "1.0", optional█ = false }
+
+                [features]
+                local = []
+                bundle = ["local", "schemars", "dep:schemars"]
+                "#,
+                SourcePath(cargo_feature_navigation_fixture_path().join("explicit/Cargo.toml")),
+            ) -> Ok([]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
             async fn optional_dependency_definition_collects_dep_syntax_usages_for_workspace_dependency(
                 r#"
                 [package]
@@ -1105,6 +1124,262 @@ mod goto_definition_tests {
         );
     }
 
+    #[derive(Default)]
+    struct TestArgs {
+        source_file_path: Option<std::path::PathBuf>,
+        schema_file_path: Option<std::path::PathBuf>,
+        subschemas: Vec<SubSchemaPath>,
+        backend_options: tombi_lsp::backend::Options,
+    }
+
+    trait ApplyTestArg {
+        fn apply(self, args: &mut TestArgs);
+    }
+
+    struct SourcePath(std::path::PathBuf);
+
+    impl ApplyTestArg for SourcePath {
+        fn apply(self, args: &mut TestArgs) {
+            args.source_file_path = Some(self.0);
+        }
+    }
+
+    #[allow(unused)]
+    struct SchemaPath(std::path::PathBuf);
+
+    impl ApplyTestArg for SchemaPath {
+        fn apply(self, args: &mut TestArgs) {
+            args.schema_file_path = Some(self.0);
+        }
+    }
+
+    #[allow(unused)]
+    struct SubSchemaPath {
+        pub root: String,
+        pub path: std::path::PathBuf,
+    }
+
+    impl ApplyTestArg for SubSchemaPath {
+        fn apply(self, args: &mut TestArgs) {
+            args.subschemas.push(self);
+        }
+    }
+
+    impl ApplyTestArg for tombi_lsp::backend::Options {
+        fn apply(self, args: &mut TestArgs) {
+            args.backend_options = self;
+        }
+    }
+
+    trait ToUri {
+        fn to_uri(&self) -> tombi_uri::Uri;
+    }
+
+    impl ToUri for tombi_uri::Uri {
+        fn to_uri(&self) -> tombi_uri::Uri {
+            self.clone()
+        }
+    }
+
+    impl ToUri for std::path::PathBuf {
+        fn to_uri(&self) -> tombi_uri::Uri {
+            tombi_uri::Uri::from_file_path(self).unwrap()
+        }
+    }
+
+    impl ToUri for &str {
+        fn to_uri(&self) -> tombi_uri::Uri {
+            use std::str::FromStr;
+
+            tombi_uri::Uri::from_str(self).unwrap()
+        }
+    }
+
+    enum ExpectedGotoDefinition {
+        Paths(Vec<tombi_uri::Uri>),
+        Locations(Vec<(tombi_uri::Uri, tombi_text::Range)>),
+    }
+
+    async fn run_goto_definition_test(
+        source: &str,
+        args: TestArgs,
+        expected: ExpectedGotoDefinition,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use itertools::Itertools;
+        use tombi_lsp::Backend;
+        use tombi_lsp::handler::{handle_did_open, handle_goto_definition};
+        use tombi_text::IntoLsp;
+        use tower_lsp::{
+            LspService,
+            lsp_types::{
+                DidOpenTextDocumentParams, GotoDefinitionParams, PartialResultParams,
+                TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Url,
+                WorkDoneProgressParams,
+            },
+        };
+
+        tombi_test_lib::init_log();
+
+        let (service, _) = LspService::new(|client| Backend::new(client, &args.backend_options));
+        let backend = service.inner();
+        let mut schema_items = Vec::new();
+
+        if let Some(schema_file_path) = args.schema_file_path.as_ref() {
+            let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "failed to convert schema path to URL: {}",
+                        schema_file_path.display()
+                    )
+                });
+
+            schema_items.push(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: schema_uri.to_string(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                lint: None,
+                format: None,
+                overrides: None,
+            }));
+        }
+
+        for subschema in &args.subschemas {
+            let subschema_uri = tombi_schema_store::SchemaUri::from_file_path(&subschema.path)
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "failed to convert subschema path to URL: {}",
+                        subschema.path.display()
+                    )
+                });
+
+            schema_items.push(tombi_config::SchemaItem::Sub(tombi_config::SubSchema {
+                path: subschema_uri.to_string(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                root: subschema.root.clone(),
+                lint: None,
+                format: None,
+                overrides: None,
+            }));
+        }
+
+        let source_path = args
+            .source_file_path
+            .as_ref()
+            .ok_or("SourcePath must be provided for goto_definition tests")?;
+
+        if !schema_items.is_empty() {
+            let config_schema_store = backend
+                .config_manager
+                .config_schema_store_for_file(source_path)
+                .await;
+
+            let mut test_config = config_schema_store.config;
+            let mut existing_schemas = test_config.schemas.take().unwrap_or_default();
+            existing_schemas.extend(schema_items);
+            test_config.schemas = Some(existing_schemas);
+
+            if let Some(config_path) = config_schema_store.config_path {
+                backend
+                    .config_manager
+                    .update_config_with_path(test_config, &config_path)
+                    .await
+                    .map_err(|e| {
+                        format!("failed to update config {}: {}", config_path.display(), e)
+                    })?;
+            } else {
+                backend
+                    .config_manager
+                    .update_editor_config(test_config)
+                    .await;
+            }
+        }
+
+        let toml_file_url =
+            Url::from_file_path(source_path).expect("failed to convert source file path to URL");
+
+        let mut toml_text = textwrap::dedent(source).trim().to_string();
+        let Some(index) = toml_text.as_str().find("█") else {
+            return Err("failed to find position marker (█) in the test data".into());
+        };
+        toml_text.remove(index);
+        let line_index = tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
+
+        handle_did_open(
+            backend,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: toml_file_url.clone(),
+                    language_id: "toml".to_string(),
+                    version: 0,
+                    text: toml_text.clone(),
+                },
+            },
+        )
+        .await;
+
+        let params = GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri: toml_file_url },
+                position: (tombi_text::Position::default()
+                    + tombi_text::RelativePosition::of(&toml_text[..index]))
+                .into_lsp(&line_index),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        let Ok(result) = handle_goto_definition(backend, params).await else {
+            return Err("failed to handle goto_definition".into());
+        };
+
+        log::debug!("goto_definition result: {:#?}", result);
+
+        match expected {
+            ExpectedGotoDefinition::Paths(expected_paths) => match result {
+                Some(definition_links) => {
+                    pretty_assertions::assert_eq!(
+                        definition_links
+                            .into_iter()
+                            .map(|link| link.uri.to_uri())
+                            .collect_vec(),
+                        expected_paths,
+                    );
+                }
+                None => {
+                    if !expected_paths.is_empty() {
+                        panic!(
+                            "No definition link was returned, but expected paths: {:?}",
+                            expected_paths
+                        );
+                    }
+                }
+            },
+            ExpectedGotoDefinition::Locations(expected_locations) => match result {
+                Some(definition_links) => {
+                    pretty_assertions::assert_eq!(
+                        definition_links
+                            .into_iter()
+                            .map(|link| (link.uri.to_uri(), link.range))
+                            .collect_vec(),
+                        expected_locations,
+                    );
+                }
+                None => {
+                    if !expected_locations.is_empty() {
+                        panic!(
+                            "No definition link was returned, but expected locations: {:?}",
+                            expected_locations
+                        );
+                    }
+                }
+            },
+        }
+
+        Ok(())
+    }
+
     #[macro_export]
     macro_rules! test_goto_definition {
         (#[tokio::test] async fn $name:ident(
@@ -1112,246 +1387,21 @@ mod goto_definition_tests {
         ) -> Ok([$(($expected_file_path:expr, (($start_line:literal, $start_char:literal), ($end_line:literal, $end_char:literal)))),*$(,)?]);) => {
             #[tokio::test]
             async fn $name() -> Result<(), Box<dyn std::error::Error>> {
-                use std::str::FromStr;
-
-                use itertools::Itertools;
-                use tombi_lsp::handler::{handle_did_open, handle_goto_definition};
-                use tombi_lsp::Backend;
-                use tower_lsp::{
-                    lsp_types::{
-                        DidOpenTextDocumentParams, GotoDefinitionParams, PartialResultParams,
-                        TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
-                        Url, WorkDoneProgressParams,
-                    },
-                    LspService,
-                };
-                use tombi_text::IntoLsp;
-
-                tombi_test_lib::init_log();
-
-                #[allow(unused)]
-                #[derive(Default)]
-                struct TestArgs {
-                    source_file_path: Option<std::path::PathBuf>,
-                    schema_file_path: Option<std::path::PathBuf>,
-                    subschemas: Vec<SubSchemaPath>,
-                    backend_options: tombi_lsp::backend::Options,
-                }
-
-                #[allow(unused)]
-                trait ApplyTestArg {
-                    fn apply(self, args: &mut TestArgs);
-                }
-
-                #[allow(unused)]
-                struct SourcePath(std::path::PathBuf);
-
-                impl ApplyTestArg for SourcePath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.source_file_path = Some(self.0);
-                    }
-                }
-
-                #[allow(unused)]
-                struct SchemaPath(std::path::PathBuf);
-
-                impl ApplyTestArg for SchemaPath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.schema_file_path = Some(self.0);
-                    }
-                }
-
-                #[allow(unused)]
-                struct SubSchemaPath {
-                    pub root: String,
-                    pub path: std::path::PathBuf,
-                }
-
-                impl ApplyTestArg for SubSchemaPath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.subschemas.push(self);
-                    }
-                }
-
-                impl ApplyTestArg for tombi_lsp::backend::Options {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.backend_options = self;
-                    }
-                }
-
-                #[allow(unused_mut)]
                 let mut args = TestArgs::default();
                 $(ApplyTestArg::apply($arg, &mut args);)*
-
-                let (service, _) = LspService::new(|client| Backend::new(client, &args.backend_options));
-                let backend = service.inner();
-                let mut schema_items = Vec::new();
-
-                if let Some(schema_file_path) = args.schema_file_path.as_ref() {
-                    let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
-                        .expect(
-                            format!(
-                                "failed to convert schema path to URL: {}",
-                                schema_file_path.display()
+                run_goto_definition_test(
+                    $source,
+                    args,
+                    ExpectedGotoDefinition::Locations(vec![
+                        $(
+                            (
+                                $expected_file_path.to_uri(),
+                                tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
                             )
-                            .as_str(),
-                        );
-
-                    schema_items.push(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
-                        toml_version: None,
-                        path: schema_uri.to_string(),
-                        include: vec!["*.toml".into()],
-                        exclude: None,
-                        lint: None,
-                        format: None,
-                        overrides: None,
-                    }));
-                }
-
-                for subschema in &args.subschemas {
-                    let subschema_uri = tombi_schema_store::SchemaUri::from_file_path(&subschema.path)
-                        .expect(
-                            format!(
-                                "failed to convert subschema path to URL: {}",
-                                subschema.path.display()
-                            )
-                            .as_str(),
-                        );
-
-                    schema_items.push(tombi_config::SchemaItem::Sub(tombi_config::SubSchema {
-                        path: subschema_uri.to_string(),
-                        include: vec!["*.toml".into()],
-                        exclude: None,
-                        root: subschema.root.clone(),
-                        lint: None,
-                        format: None,
-                        overrides: None,
-                    }));
-                }
-
-                let source_path = args
-                    .source_file_path
-                    .as_ref()
-                    .ok_or("SourcePath must be provided for goto_definition tests")?;
-
-                if !schema_items.is_empty() {
-                    let config_schema_store = backend
-                        .config_manager
-                        .config_schema_store_for_file(source_path)
-                        .await;
-
-                    let mut test_config = config_schema_store.config;
-                    let mut existing_schemas = test_config.schemas.take().unwrap_or_default();
-                    existing_schemas.extend(schema_items);
-                    test_config.schemas = Some(existing_schemas);
-
-                    if let Some(config_path) = config_schema_store.config_path {
-                        backend
-                            .config_manager
-                            .update_config_with_path(test_config, &config_path)
-                            .await
-                            .map_err(|e| {
-                                format!(
-                                    "failed to update config {}: {}",
-                                    config_path.display(),
-                                    e
-                                )
-                            })?;
-                    } else {
-                        backend.config_manager.update_editor_config(test_config).await;
-                    }
-                }
-
-                let toml_file_url = Url::from_file_path(source_path)
-                    .expect("failed to convert source file path to URL");
-
-                let mut toml_text = textwrap::dedent($source).trim().to_string();
-                let Some(index) = toml_text.as_str().find("█") else {
-                    return Err("failed to find position marker (█) in the test data".into());
-                };
-                toml_text.remove(index);
-                let line_index =
-                    tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
-
-                handle_did_open(
-                    backend,
-                    DidOpenTextDocumentParams {
-                        text_document: TextDocumentItem {
-                            uri: toml_file_url.clone(),
-                            language_id: "toml".to_string(),
-                            version: 0,
-                            text: toml_text.clone(),
-                        },
-                    },
+                        ),*
+                    ]),
                 )
-                .await;
-
-                let params = GotoDefinitionParams {
-                    text_document_position_params: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier { uri: toml_file_url },
-                        position: (tombi_text::Position::default()
-                            + tombi_text::RelativePosition::of(&toml_text[..index]))
-                        .into_lsp(&line_index),
-                    },
-                    work_done_progress_params: WorkDoneProgressParams::default(),
-                    partial_result_params: PartialResultParams::default(),
-                };
-
-                let Ok(result) = handle_goto_definition(&backend, params).await else {
-                    return Err("failed to handle goto_definition".into());
-                };
-
-                log::debug!("goto_definition result: {:#?}", result);
-
-                trait ToUri {
-                    fn to_uri(&self) -> tombi_uri::Uri;
-                }
-
-                impl ToUri for tombi_uri::Uri {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        self.clone()
-                    }
-                }
-
-                impl ToUri for std::path::PathBuf {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        tombi_uri::Uri::from_file_path(self).unwrap()
-                    }
-                }
-
-                impl ToUri for &str {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        tombi_uri::Uri::from_str(self).unwrap()
-                    }
-                }
-
-                let expected_locations: Vec<(tombi_uri::Uri, tombi_text::Range)> = vec![
-                    $(
-                        (
-                            $expected_file_path.to_uri(),
-                            tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
-                        )
-                    ),*
-                ];
-
-                match result {
-                    Some(definition_links) => {
-                        pretty_assertions::assert_eq!(
-                            definition_links
-                                .into_iter()
-                                .map(|link| (link.uri.to_uri(), link.range))
-                                .collect_vec(),
-                            expected_locations,
-                        );
-                    }
-                    None => {
-                        if !expected_locations.is_empty() {
-                            panic!("No definition link was returned, but expected locations: {:?}", expected_locations);
-                        }
-                    }
-                }
-
-                Ok(())
+                .await
             }
         };
         (#[tokio::test] async fn $name:ident(
@@ -1359,239 +1409,14 @@ mod goto_definition_tests {
         ) -> Ok([$($expected_file_path:expr),*$(,)?]);) => {
             #[tokio::test]
             async fn $name() -> Result<(), Box<dyn std::error::Error>> {
-                use std::str::FromStr;
-
-                use itertools::Itertools;
-                use tombi_lsp::handler::{handle_did_open, handle_goto_definition};
-                use tombi_lsp::Backend;
-                use tower_lsp::{
-                    lsp_types::{
-                        DidOpenTextDocumentParams, GotoDefinitionParams,
-                        PartialResultParams, TextDocumentIdentifier, TextDocumentItem,
-                        TextDocumentPositionParams, Url, WorkDoneProgressParams,
-                    },
-                    LspService,
-                };
-                use tombi_text::IntoLsp;
-
-                tombi_test_lib::init_log();
-
-                #[allow(unused)]
-                #[derive(Default)]
-                struct TestArgs {
-                    source_file_path: Option<std::path::PathBuf>,
-                    schema_file_path: Option<std::path::PathBuf>,
-                    subschemas: Vec<SubSchemaPath>,
-                    backend_options: tombi_lsp::backend::Options,
-                }
-
-                #[allow(unused)]
-                trait ApplyTestArg {
-                    fn apply(self, args: &mut TestArgs);
-                }
-
-                #[allow(unused)]
-                struct SourcePath(std::path::PathBuf);
-
-                impl ApplyTestArg for SourcePath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.source_file_path = Some(self.0);
-                    }
-                }
-
-                #[allow(unused)]
-                struct SchemaPath(std::path::PathBuf);
-
-                impl ApplyTestArg for SchemaPath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.schema_file_path = Some(self.0);
-                    }
-                }
-
-                #[allow(unused)]
-                struct SubSchemaPath {
-                    pub root: String,
-                    pub path: std::path::PathBuf,
-                }
-
-                impl ApplyTestArg for SubSchemaPath {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.subschemas.push(self);
-                    }
-                }
-
-                impl ApplyTestArg for tombi_lsp::backend::Options {
-                    fn apply(self, args: &mut TestArgs) {
-                        args.backend_options = self;
-                    }
-                }
-
-                #[allow(unused_mut)]
                 let mut args = TestArgs::default();
                 $(ApplyTestArg::apply($arg, &mut args);)*
-
-                let (service, _) = LspService::new(|client| {
-                    Backend::new(client, &args.backend_options)
-                });
-
-                let backend = service.inner();
-                let mut schema_items = Vec::new();
-
-                if let Some(schema_file_path) = args.schema_file_path.as_ref() {
-                    let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
-                        .expect(
-                            format!(
-                                "failed to convert schema path to URL: {}",
-                                schema_file_path.display()
-                            )
-                            .as_str(),
-                        );
-
-                    schema_items.push(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
-                        toml_version: None,
-                        path: schema_uri.to_string(),
-                        include: vec!["*.toml".into()],
-                        exclude: None,
-                        lint: None,
-                        format: None,
-                        overrides: None,
-                    }));
-                }
-
-                for subschema in &args.subschemas {
-                    let subschema_uri = tombi_schema_store::SchemaUri::from_file_path(&subschema.path)
-                        .expect(
-                            format!(
-                                "failed to convert subschema path to URL: {}",
-                                subschema.path.display()
-                            )
-                            .as_str(),
-                        );
-
-                    schema_items.push(tombi_config::SchemaItem::Sub(tombi_config::SubSchema {
-                        path: subschema_uri.to_string(),
-                        include: vec!["*.toml".into()],
-                        exclude: None,
-                        root: subschema.root.clone(),
-                        lint: None,
-                        format: None,
-                        overrides: None,
-                    }));
-                }
-
-                let source_path = args
-                    .source_file_path
-                    .as_ref()
-                    .ok_or("SourcePath must be provided for goto_definition tests")?;
-
-                if !schema_items.is_empty() {
-                    let config_schema_store = backend
-                        .config_manager
-                        .config_schema_store_for_file(source_path)
-                        .await;
-
-                    let mut test_config = config_schema_store.config;
-                    let mut existing_schemas = test_config.schemas.take().unwrap_or_default();
-                    existing_schemas.extend(schema_items);
-                    test_config.schemas = Some(existing_schemas);
-
-                    if let Some(config_path) = config_schema_store.config_path {
-                        backend
-                            .config_manager
-                            .update_config_with_path(test_config, &config_path)
-                            .await
-                            .map_err(|e| {
-                                format!(
-                                    "failed to update config {}: {}",
-                                    config_path.display(),
-                                    e
-                                )
-                            })?;
-                    } else {
-                        backend.config_manager.update_editor_config(test_config).await;
-                    }
-                }
-
-                let toml_file_url = Url::from_file_path(source_path)
-                    .expect("failed to convert source file path to URL");
-
-                let mut toml_text = textwrap::dedent($source).trim().to_string();
-                let Some(index) = toml_text.as_str().find("█") else {
-                    return Err("failed to find position marker (█) in the test data".into());
-                };
-                toml_text.remove(index);
-                let line_index =
-                tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
-
-                handle_did_open(
-                    backend,
-                    DidOpenTextDocumentParams {
-                        text_document: TextDocumentItem {
-                            uri: toml_file_url.clone(),
-                            language_id: "toml".to_string(),
-                            version: 0,
-                            text: toml_text.clone(),
-                        },
-                    },
+                run_goto_definition_test(
+                    $source,
+                    args,
+                    ExpectedGotoDefinition::Paths(vec![$($expected_file_path.to_uri()),*]),
                 )
-                .await;
-
-                let params = GotoDefinitionParams {
-                    text_document_position_params: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier { uri: toml_file_url },
-                        position: (tombi_text::Position::default()
-                            + tombi_text::RelativePosition::of(&toml_text[..index]))
-                        .into_lsp(&line_index),
-                    },
-                    work_done_progress_params: WorkDoneProgressParams::default(),
-                    partial_result_params: PartialResultParams::default(),
-                };
-
-                let Ok(result) = handle_goto_definition(&backend, params).await else {
-                    return Err("failed to handle goto_definition".into());
-                };
-
-                log::debug!("goto_definition result: {:#?}", result);
-
-                trait ToUri {
-                    fn to_uri(&self) -> tombi_uri::Uri;
-                }
-
-                impl ToUri for tombi_uri::Uri {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        self.clone()
-                    }
-                }
-
-                impl ToUri for std::path::PathBuf {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        tombi_uri::Uri::from_file_path(self).unwrap()
-                    }
-                }
-
-                impl ToUri for &str {
-                    fn to_uri(&self) -> tombi_uri::Uri {
-                        tombi_uri::Uri::from_str(self).unwrap()
-                    }
-                }
-
-                let expected_paths: Vec<tombi_uri::Uri> = vec![$($expected_file_path.to_uri()),*];
-
-                match result {
-                    Some(definition_links) => {
-                        pretty_assertions::assert_eq!(
-                            definition_links.into_iter().map(|link| link.uri.to_uri()).collect_vec(),
-                            expected_paths,
-                        );
-                    },
-                    None => {
-                        if !expected_paths.is_empty() {
-                            panic!("No definition link was returned, but expected paths: {:?}", expected_paths);
-                        }
-                    }
-                }
-
-                Ok(())
+                .await
             }
         };
     }

--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -616,6 +616,30 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
+            async fn optional_dependency_definition_returns_optional_field_range(
+                r#"
+                [package]
+                name = "explicit-feature"
+                version = "0.1.0"
+
+                [dependencies]
+                schemars = { version = "1.0", optional█ = true }
+
+                [features]
+                local = []
+                bundle = ["local", "schemars", "dep:schemars"]
+                "#,
+                SourcePath(cargo_feature_navigation_fixture_path().join("explicit/Cargo.toml")),
+            ) -> Ok([
+                (
+                    cargo_feature_navigation_fixture_path().join("explicit/Cargo.toml"),
+                    ((5, 41), (5, 45))
+                )
+            ]);
+        );
+
+        test_goto_definition!(
+            #[tokio::test]
             async fn optional_dependency_definition_collects_dep_syntax_usages_for_workspace_dependency(
                 r#"
                 [package]
@@ -1083,6 +1107,253 @@ mod goto_definition_tests {
 
     #[macro_export]
     macro_rules! test_goto_definition {
+        (#[tokio::test] async fn $name:ident(
+            $source:expr $(, $arg:expr )* $(,)?
+        ) -> Ok([$(($expected_file_path:expr, (($start_line:literal, $start_char:literal), ($end_line:literal, $end_char:literal)))),*$(,)?]);) => {
+            #[tokio::test]
+            async fn $name() -> Result<(), Box<dyn std::error::Error>> {
+                use std::str::FromStr;
+
+                use itertools::Itertools;
+                use tombi_lsp::handler::{handle_did_open, handle_goto_definition};
+                use tombi_lsp::Backend;
+                use tower_lsp::{
+                    lsp_types::{
+                        DidOpenTextDocumentParams, GotoDefinitionParams, PartialResultParams,
+                        TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
+                        Url, WorkDoneProgressParams,
+                    },
+                    LspService,
+                };
+                use tombi_text::IntoLsp;
+
+                tombi_test_lib::init_log();
+
+                #[allow(unused)]
+                #[derive(Default)]
+                struct TestArgs {
+                    source_file_path: Option<std::path::PathBuf>,
+                    schema_file_path: Option<std::path::PathBuf>,
+                    subschemas: Vec<SubSchemaPath>,
+                    backend_options: tombi_lsp::backend::Options,
+                }
+
+                #[allow(unused)]
+                trait ApplyTestArg {
+                    fn apply(self, args: &mut TestArgs);
+                }
+
+                #[allow(unused)]
+                struct SourcePath(std::path::PathBuf);
+
+                impl ApplyTestArg for SourcePath {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.source_file_path = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct SchemaPath(std::path::PathBuf);
+
+                impl ApplyTestArg for SchemaPath {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.schema_file_path = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct SubSchemaPath {
+                    pub root: String,
+                    pub path: std::path::PathBuf,
+                }
+
+                impl ApplyTestArg for SubSchemaPath {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.subschemas.push(self);
+                    }
+                }
+
+                impl ApplyTestArg for tombi_lsp::backend::Options {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.backend_options = self;
+                    }
+                }
+
+                #[allow(unused_mut)]
+                let mut args = TestArgs::default();
+                $(ApplyTestArg::apply($arg, &mut args);)*
+
+                let (service, _) = LspService::new(|client| Backend::new(client, &args.backend_options));
+                let backend = service.inner();
+                let mut schema_items = Vec::new();
+
+                if let Some(schema_file_path) = args.schema_file_path.as_ref() {
+                    let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
+                        .expect(
+                            format!(
+                                "failed to convert schema path to URL: {}",
+                                schema_file_path.display()
+                            )
+                            .as_str(),
+                        );
+
+                    schema_items.push(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                        toml_version: None,
+                        path: schema_uri.to_string(),
+                        include: vec!["*.toml".into()],
+                        exclude: None,
+                        lint: None,
+                        format: None,
+                        overrides: None,
+                    }));
+                }
+
+                for subschema in &args.subschemas {
+                    let subschema_uri = tombi_schema_store::SchemaUri::from_file_path(&subschema.path)
+                        .expect(
+                            format!(
+                                "failed to convert subschema path to URL: {}",
+                                subschema.path.display()
+                            )
+                            .as_str(),
+                        );
+
+                    schema_items.push(tombi_config::SchemaItem::Sub(tombi_config::SubSchema {
+                        path: subschema_uri.to_string(),
+                        include: vec!["*.toml".into()],
+                        exclude: None,
+                        root: subschema.root.clone(),
+                        lint: None,
+                        format: None,
+                        overrides: None,
+                    }));
+                }
+
+                let source_path = args
+                    .source_file_path
+                    .as_ref()
+                    .ok_or("SourcePath must be provided for goto_definition tests")?;
+
+                if !schema_items.is_empty() {
+                    let config_schema_store = backend
+                        .config_manager
+                        .config_schema_store_for_file(source_path)
+                        .await;
+
+                    let mut test_config = config_schema_store.config;
+                    let mut existing_schemas = test_config.schemas.take().unwrap_or_default();
+                    existing_schemas.extend(schema_items);
+                    test_config.schemas = Some(existing_schemas);
+
+                    if let Some(config_path) = config_schema_store.config_path {
+                        backend
+                            .config_manager
+                            .update_config_with_path(test_config, &config_path)
+                            .await
+                            .map_err(|e| {
+                                format!(
+                                    "failed to update config {}: {}",
+                                    config_path.display(),
+                                    e
+                                )
+                            })?;
+                    } else {
+                        backend.config_manager.update_editor_config(test_config).await;
+                    }
+                }
+
+                let toml_file_url = Url::from_file_path(source_path)
+                    .expect("failed to convert source file path to URL");
+
+                let mut toml_text = textwrap::dedent($source).trim().to_string();
+                let Some(index) = toml_text.as_str().find("█") else {
+                    return Err("failed to find position marker (█) in the test data".into());
+                };
+                toml_text.remove(index);
+                let line_index =
+                    tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
+
+                handle_did_open(
+                    backend,
+                    DidOpenTextDocumentParams {
+                        text_document: TextDocumentItem {
+                            uri: toml_file_url.clone(),
+                            language_id: "toml".to_string(),
+                            version: 0,
+                            text: toml_text.clone(),
+                        },
+                    },
+                )
+                .await;
+
+                let params = GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri: toml_file_url },
+                        position: (tombi_text::Position::default()
+                            + tombi_text::RelativePosition::of(&toml_text[..index]))
+                        .into_lsp(&line_index),
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                };
+
+                let Ok(result) = handle_goto_definition(&backend, params).await else {
+                    return Err("failed to handle goto_definition".into());
+                };
+
+                log::debug!("goto_definition result: {:#?}", result);
+
+                trait ToUri {
+                    fn to_uri(&self) -> tombi_uri::Uri;
+                }
+
+                impl ToUri for tombi_uri::Uri {
+                    fn to_uri(&self) -> tombi_uri::Uri {
+                        self.clone()
+                    }
+                }
+
+                impl ToUri for std::path::PathBuf {
+                    fn to_uri(&self) -> tombi_uri::Uri {
+                        tombi_uri::Uri::from_file_path(self).unwrap()
+                    }
+                }
+
+                impl ToUri for &str {
+                    fn to_uri(&self) -> tombi_uri::Uri {
+                        tombi_uri::Uri::from_str(self).unwrap()
+                    }
+                }
+
+                let expected_locations: Vec<(tombi_uri::Uri, tombi_text::Range)> = vec![
+                    $(
+                        (
+                            $expected_file_path.to_uri(),
+                            tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
+                        )
+                    ),*
+                ];
+
+                match result {
+                    Some(definition_links) => {
+                        pretty_assertions::assert_eq!(
+                            definition_links
+                                .into_iter()
+                                .map(|link| (link.uri.to_uri(), link.range))
+                                .collect_vec(),
+                            expected_locations,
+                        );
+                    }
+                    None => {
+                        if !expected_locations.is_empty() {
+                            panic!("No definition link was returned, but expected locations: {:?}", expected_locations);
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        };
         (#[tokio::test] async fn $name:ident(
             $source:expr $(, $arg:expr )* $(,)?
         ) -> Ok([$($expected_file_path:expr),*$(,)?]);) => {

--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -1,192 +1,221 @@
 use tombi_test_lib::{cargo_feature_navigation_fixture_path, project_root_path};
 
+#[derive(Default)]
+struct TestArgs {
+    source_file_path: Option<std::path::PathBuf>,
+    config_file_path: Option<std::path::PathBuf>,
+    include_declaration: bool,
+    backend_options: tombi_lsp::backend::Options,
+}
+
+trait ApplyTestArg {
+    fn apply(self, args: &mut TestArgs);
+}
+
+struct SourcePath(std::path::PathBuf);
+
+impl ApplyTestArg for SourcePath {
+    fn apply(self, args: &mut TestArgs) {
+        args.source_file_path = Some(self.0);
+    }
+}
+
+#[allow(unused)]
+struct ConfigPath(std::path::PathBuf);
+
+impl ApplyTestArg for ConfigPath {
+    fn apply(self, args: &mut TestArgs) {
+        args.config_file_path = Some(self.0);
+    }
+}
+
+#[allow(unused)]
+struct IncludeDeclaration(bool);
+
+impl ApplyTestArg for IncludeDeclaration {
+    fn apply(self, args: &mut TestArgs) {
+        args.include_declaration = self.0;
+    }
+}
+
+impl ApplyTestArg for tombi_lsp::backend::Options {
+    fn apply(self, args: &mut TestArgs) {
+        args.backend_options = self;
+    }
+}
+
+enum ExpectedReferences {
+    Paths(Vec<std::path::PathBuf>),
+    Locations(Vec<(std::path::PathBuf, tombi_text::Range)>),
+}
+
+async fn run_references_test(
+    source: &str,
+    args: TestArgs,
+    expected: ExpectedReferences,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use itertools::Itertools;
+    use tombi_lsp::Backend;
+    use tombi_lsp::handler::{handle_did_open, handle_references};
+    use tombi_text::IntoLsp;
+    use tower_lsp::{
+        LspService,
+        lsp_types::{
+            DidOpenTextDocumentParams, PartialResultParams, ReferenceContext, ReferenceParams,
+            TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Url,
+            WorkDoneProgressParams,
+        },
+    };
+
+    tombi_test_lib::init_log();
+
+    let (service, _) = LspService::new(|client| Backend::new(client, &args.backend_options));
+    let backend = service.inner();
+    let source_path = args
+        .source_file_path
+        .as_ref()
+        .ok_or("SourcePath must be provided for references tests")?;
+
+    if let Some(config_file_path) = args.config_file_path.as_ref() {
+        let config_content = std::fs::read_to_string(config_file_path).map_err(|e| {
+            format!(
+                "failed to read config file {}: {}",
+                config_file_path.display(),
+                e
+            )
+        })?;
+        let config: tombi_config::Config = serde_tombi::from_str_async(&config_content)
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to parse config file {}: {}",
+                    config_file_path.display(),
+                    e
+                )
+            })?;
+
+        let config_schema_store = backend
+            .config_manager
+            .config_schema_store_for_file(source_path)
+            .await;
+
+        if let Some(config_path) = config_schema_store.config_path {
+            backend
+                .config_manager
+                .update_config_with_path(config, &config_path)
+                .await
+                .map_err(|e| format!("failed to update config {}: {}", config_path.display(), e))?;
+        } else {
+            backend.config_manager.update_editor_config(config).await;
+        }
+    }
+
+    let toml_file_url =
+        Url::from_file_path(source_path).expect("failed to convert source file path to URL");
+
+    let mut toml_text = textwrap::dedent(source).trim().to_string();
+    let Some(index) = toml_text.as_str().find("█") else {
+        return Err("failed to find position marker (█) in the test data".into());
+    };
+    toml_text.remove(index);
+    let line_index = tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
+
+    handle_did_open(
+        backend,
+        DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: toml_file_url.clone(),
+                language_id: "toml".to_string(),
+                version: 0,
+                text: toml_text.clone(),
+            },
+        },
+    )
+    .await;
+
+    let params = ReferenceParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: toml_file_url },
+            position: (tombi_text::Position::default()
+                + tombi_text::RelativePosition::of(&toml_text[..index]))
+            .into_lsp(&line_index),
+        },
+        context: ReferenceContext {
+            include_declaration: args.include_declaration,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+
+    let Ok(result) = handle_references(backend, params).await else {
+        return Err("failed to handle references".into());
+    };
+
+    match expected {
+        ExpectedReferences::Paths(expected_paths) => match result {
+            Some(definition_links) => {
+                pretty_assertions::assert_eq!(
+                    definition_links
+                        .into_iter()
+                        .map(|link| link.uri.to_file_path().unwrap())
+                        .collect_vec(),
+                    expected_paths,
+                );
+            }
+            None => {
+                if !expected_paths.is_empty() {
+                    panic!(
+                        "No references were returned, but expected paths: {:?}",
+                        expected_paths
+                    );
+                }
+            }
+        },
+        ExpectedReferences::Locations(expected_locations) => match result {
+            Some(definition_links) => {
+                pretty_assertions::assert_eq!(
+                    definition_links
+                        .into_iter()
+                        .map(|link| (link.uri.to_file_path().unwrap(), link.range))
+                        .collect_vec(),
+                    expected_locations,
+                );
+            }
+            None => {
+                if !expected_locations.is_empty() {
+                    panic!(
+                        "No references were returned, but expected locations: {:?}",
+                        expected_locations
+                    );
+                }
+            }
+        },
+    }
+
+    Ok(())
+}
+
 macro_rules! test_references {
     (#[tokio::test] async fn $name:ident(
         $source:expr $(, $arg:expr )* $(,)?
     ) -> Ok([$(($expected_file_path:expr, (($start_line:literal, $start_char:literal), ($end_line:literal, $end_char:literal)))),*$(,)?]);) => {
         #[tokio::test]
         async fn $name() -> Result<(), Box<dyn std::error::Error>> {
-            use itertools::Itertools;
-            use tombi_lsp::handler::{handle_did_open, handle_references};
-            use tombi_lsp::Backend;
-            use tower_lsp::{
-                lsp_types::{
-                    DidOpenTextDocumentParams, PartialResultParams, ReferenceContext,
-                    ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
-                    TextDocumentPositionParams, Url, WorkDoneProgressParams,
-                },
-                LspService,
-            };
-            use tombi_text::IntoLsp;
-
-            tombi_test_lib::init_log();
-
-            #[allow(unused)]
-            #[derive(Default)]
-            struct TestArgs {
-                source_file_path: Option<std::path::PathBuf>,
-                config_file_path: Option<std::path::PathBuf>,
-                include_declaration: bool,
-                backend_options: tombi_lsp::backend::Options,
-            }
-
-            trait ApplyTestArg {
-                fn apply(self, args: &mut TestArgs);
-            }
-
-            struct SourcePath(std::path::PathBuf);
-
-            impl ApplyTestArg for SourcePath {
-                fn apply(self, args: &mut TestArgs) {
-                    args.source_file_path = Some(self.0);
-                }
-            }
-
-            #[allow(unused)]
-            struct ConfigPath(std::path::PathBuf);
-
-            impl ApplyTestArg for ConfigPath {
-                fn apply(self, args: &mut TestArgs) {
-                    args.config_file_path = Some(self.0);
-                }
-            }
-
-            #[allow(unused)]
-            struct IncludeDeclaration(bool);
-
-            impl ApplyTestArg for IncludeDeclaration {
-                fn apply(self, args: &mut TestArgs) {
-                    args.include_declaration = self.0;
-                }
-            }
-
-            impl ApplyTestArg for tombi_lsp::backend::Options {
-                fn apply(self, args: &mut TestArgs) {
-                    args.backend_options = self;
-                }
-            }
-
             let mut args = TestArgs::default();
             $(ApplyTestArg::apply($arg, &mut args);)*
-
-            let (service, _) = LspService::new(|client| {
-                Backend::new(client, &args.backend_options)
-            });
-
-            let backend = service.inner();
-            let source_path = args
-                .source_file_path
-                .as_ref()
-                .ok_or("SourcePath must be provided for references tests")?;
-
-            if let Some(config_file_path) = args.config_file_path.as_ref() {
-                let config_content = std::fs::read_to_string(config_file_path).map_err(|e| {
-                    format!(
-                        "failed to read config file {}: {}",
-                        config_file_path.display(),
-                        e
-                    )
-                })?;
-                let config: tombi_config::Config =
-                    serde_tombi::from_str_async(&config_content).await.map_err(|e| {
-                        format!(
-                            "failed to parse config file {}: {}",
-                            config_file_path.display(),
-                            e
+            run_references_test(
+                $source,
+                args,
+                ExpectedReferences::Locations(vec![
+                    $(
+                        (
+                            $expected_file_path.to_owned(),
+                            tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
                         )
-                    })?;
-
-                let config_schema_store = backend
-                    .config_manager
-                    .config_schema_store_for_file(source_path)
-                    .await;
-
-                if let Some(config_path) = config_schema_store.config_path {
-                    backend
-                        .config_manager
-                        .update_config_with_path(config, &config_path)
-                        .await
-                        .map_err(|e| {
-                            format!(
-                                "failed to update config {}: {}",
-                                config_path.display(),
-                                e
-                            )
-                        })?;
-                } else {
-                    backend.config_manager.update_editor_config(config).await;
-                }
-            }
-
-            let toml_file_url = Url::from_file_path(source_path)
-                .expect("failed to convert source file path to URL");
-
-            let mut toml_text = textwrap::dedent($source).trim().to_string();
-            let Some(index) = toml_text.as_str().find("█") else {
-                return Err("failed to find position marker (█) in the test data".into());
-            };
-            toml_text.remove(index);
-            let line_index =
-                tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
-
-            handle_did_open(
-                backend,
-                DidOpenTextDocumentParams {
-                    text_document: TextDocumentItem {
-                        uri: toml_file_url.clone(),
-                        language_id: "toml".to_string(),
-                        version: 0,
-                        text: toml_text.clone(),
-                    },
-                },
+                    ),*
+                ]),
             )
-            .await;
-
-            let params = ReferenceParams {
-                text_document_position: TextDocumentPositionParams {
-                    text_document: TextDocumentIdentifier { uri: toml_file_url },
-                    position: (tombi_text::Position::default()
-                        + tombi_text::RelativePosition::of(&toml_text[..index]))
-                    .into_lsp(&line_index),
-                },
-                context: ReferenceContext {
-                    include_declaration: args.include_declaration,
-                },
-                work_done_progress_params: WorkDoneProgressParams::default(),
-                partial_result_params: PartialResultParams::default(),
-            };
-
-            let Ok(result) = handle_references(&backend, params).await else {
-                return Err("failed to handle references".into());
-            };
-
-            let expected_locations: Vec<(std::path::PathBuf, tombi_text::Range)> = vec![
-                $(
-                    (
-                        $expected_file_path.to_owned(),
-                        tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
-                    )
-                ),*
-            ];
-
-            match result {
-                Some(definition_links) => {
-                    pretty_assertions::assert_eq!(
-                        definition_links
-                            .into_iter()
-                            .map(|link| (link.uri.to_file_path().unwrap(), link.range))
-                            .collect_vec(),
-                        expected_locations,
-                    );
-                },
-                None => {
-                    if !expected_locations.is_empty() {
-                        panic!("No references were returned, but expected locations: {:?}", expected_locations);
-                    }
-                }
-            }
-
-            Ok(())
+            .await
         }
     };
     (#[tokio::test] async fn $name:ident(
@@ -194,177 +223,14 @@ macro_rules! test_references {
     ) -> Ok([$($expected_file_path:expr),*$(,)?]);) => {
         #[tokio::test]
         async fn $name() -> Result<(), Box<dyn std::error::Error>> {
-            use itertools::Itertools;
-            use tombi_lsp::handler::{handle_did_open, handle_references};
-            use tombi_lsp::Backend;
-            use tower_lsp::{
-                lsp_types::{
-                    DidOpenTextDocumentParams, PartialResultParams, ReferenceContext,
-                    ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
-                    TextDocumentPositionParams, Url, WorkDoneProgressParams,
-                },
-                LspService,
-            };
-            use tombi_text::IntoLsp;
-
-            tombi_test_lib::init_log();
-
-            #[allow(unused)]
-            #[derive(Default)]
-            struct TestArgs {
-                source_file_path: Option<std::path::PathBuf>,
-                config_file_path: Option<std::path::PathBuf>,
-                include_declaration: bool,
-                backend_options: tombi_lsp::backend::Options,
-            }
-
-            trait ApplyTestArg {
-                fn apply(self, args: &mut TestArgs);
-            }
-
-            struct SourcePath(std::path::PathBuf);
-
-            impl ApplyTestArg for SourcePath {
-                fn apply(self, args: &mut TestArgs) {
-                    args.source_file_path = Some(self.0);
-                }
-            }
-
-            #[allow(unused)]
-            struct ConfigPath(std::path::PathBuf);
-
-            impl ApplyTestArg for ConfigPath {
-                fn apply(self, args: &mut TestArgs) {
-                    args.config_file_path = Some(self.0);
-                }
-            }
-
-            #[allow(unused)]
-            struct IncludeDeclaration(bool);
-
-            impl ApplyTestArg for IncludeDeclaration {
-                fn apply(self, args: &mut TestArgs) {
-                    args.include_declaration = self.0;
-                }
-            }
-
-            impl ApplyTestArg for tombi_lsp::backend::Options {
-                fn apply(self, args: &mut TestArgs) {
-                    args.backend_options = self;
-                }
-            }
-
             let mut args = TestArgs::default();
             $(ApplyTestArg::apply($arg, &mut args);)*
-
-            let (service, _) = LspService::new(|client| {
-                Backend::new(client, &args.backend_options)
-            });
-
-            let backend = service.inner();
-            let source_path = args
-                .source_file_path
-                .as_ref()
-                .ok_or("SourcePath must be provided for references tests")?;
-
-            if let Some(config_file_path) = args.config_file_path.as_ref() {
-                let config_content = std::fs::read_to_string(config_file_path).map_err(|e| {
-                    format!(
-                        "failed to read config file {}: {}",
-                        config_file_path.display(),
-                        e
-                    )
-                })?;
-                let config: tombi_config::Config =
-                    serde_tombi::from_str_async(&config_content).await.map_err(|e| {
-                        format!(
-                            "failed to parse config file {}: {}",
-                            config_file_path.display(),
-                            e
-                        )
-                    })?;
-
-                let config_schema_store = backend
-                    .config_manager
-                    .config_schema_store_for_file(source_path)
-                    .await;
-
-                if let Some(config_path) = config_schema_store.config_path {
-                    backend
-                        .config_manager
-                        .update_config_with_path(config, &config_path)
-                        .await
-                        .map_err(|e| {
-                            format!(
-                                "failed to update config {}: {}",
-                                config_path.display(),
-                                e
-                            )
-                        })?;
-                } else {
-                    backend.config_manager.update_editor_config(config).await;
-                }
-            }
-
-            let toml_file_url = Url::from_file_path(source_path)
-                .expect("failed to convert source file path to URL");
-
-            let mut toml_text = textwrap::dedent($source).trim().to_string();
-            let Some(index) = toml_text.as_str().find("█") else {
-                return Err("failed to find position marker (█) in the test data".into());
-            };
-            toml_text.remove(index);
-            let line_index =
-                tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
-
-            handle_did_open(
-                backend,
-                DidOpenTextDocumentParams {
-                    text_document: TextDocumentItem {
-                        uri: toml_file_url.clone(),
-                        language_id: "toml".to_string(),
-                        version: 0,
-                        text: toml_text.clone(),
-                    },
-                },
+            run_references_test(
+                $source,
+                args,
+                ExpectedReferences::Paths(vec![$($expected_file_path.to_owned()),*]),
             )
-            .await;
-
-            let params = ReferenceParams {
-                text_document_position: TextDocumentPositionParams {
-                    text_document: TextDocumentIdentifier { uri: toml_file_url },
-                    position: (tombi_text::Position::default()
-                        + tombi_text::RelativePosition::of(&toml_text[..index]))
-                    .into_lsp(&line_index),
-                },
-                context: ReferenceContext {
-                    include_declaration: args.include_declaration,
-                },
-                work_done_progress_params: WorkDoneProgressParams::default(),
-                partial_result_params: PartialResultParams::default(),
-            };
-
-            let Ok(result) = handle_references(&backend, params).await else {
-                return Err("failed to handle references".into());
-            };
-
-            let expected_paths: Vec<std::path::PathBuf> = vec![$($expected_file_path.to_owned()),*];
-
-            match result {
-                Some(definition_links) => {
-                    pretty_assertions::assert_eq!(
-                        definition_links.into_iter().map(|link| link.uri.to_file_path().unwrap()).collect_vec(),
-                        expected_paths,
-                    );
-                },
-                None => {
-                    if !expected_paths.is_empty() {
-                        panic!("No references were returned, but expected paths: {:?}", expected_paths);
-                    }
-                }
-            }
-
-            Ok(())
+            .await
         }
     };
 }

--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -3,6 +3,194 @@ use tombi_test_lib::{cargo_feature_navigation_fixture_path, project_root_path};
 macro_rules! test_references {
     (#[tokio::test] async fn $name:ident(
         $source:expr $(, $arg:expr )* $(,)?
+    ) -> Ok([$(($expected_file_path:expr, (($start_line:literal, $start_char:literal), ($end_line:literal, $end_char:literal)))),*$(,)?]);) => {
+        #[tokio::test]
+        async fn $name() -> Result<(), Box<dyn std::error::Error>> {
+            use itertools::Itertools;
+            use tombi_lsp::handler::{handle_did_open, handle_references};
+            use tombi_lsp::Backend;
+            use tower_lsp::{
+                lsp_types::{
+                    DidOpenTextDocumentParams, PartialResultParams, ReferenceContext,
+                    ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
+                    TextDocumentPositionParams, Url, WorkDoneProgressParams,
+                },
+                LspService,
+            };
+            use tombi_text::IntoLsp;
+
+            tombi_test_lib::init_log();
+
+            #[allow(unused)]
+            #[derive(Default)]
+            struct TestArgs {
+                source_file_path: Option<std::path::PathBuf>,
+                config_file_path: Option<std::path::PathBuf>,
+                include_declaration: bool,
+                backend_options: tombi_lsp::backend::Options,
+            }
+
+            trait ApplyTestArg {
+                fn apply(self, args: &mut TestArgs);
+            }
+
+            struct SourcePath(std::path::PathBuf);
+
+            impl ApplyTestArg for SourcePath {
+                fn apply(self, args: &mut TestArgs) {
+                    args.source_file_path = Some(self.0);
+                }
+            }
+
+            #[allow(unused)]
+            struct ConfigPath(std::path::PathBuf);
+
+            impl ApplyTestArg for ConfigPath {
+                fn apply(self, args: &mut TestArgs) {
+                    args.config_file_path = Some(self.0);
+                }
+            }
+
+            #[allow(unused)]
+            struct IncludeDeclaration(bool);
+
+            impl ApplyTestArg for IncludeDeclaration {
+                fn apply(self, args: &mut TestArgs) {
+                    args.include_declaration = self.0;
+                }
+            }
+
+            impl ApplyTestArg for tombi_lsp::backend::Options {
+                fn apply(self, args: &mut TestArgs) {
+                    args.backend_options = self;
+                }
+            }
+
+            let mut args = TestArgs::default();
+            $(ApplyTestArg::apply($arg, &mut args);)*
+
+            let (service, _) = LspService::new(|client| {
+                Backend::new(client, &args.backend_options)
+            });
+
+            let backend = service.inner();
+            let source_path = args
+                .source_file_path
+                .as_ref()
+                .ok_or("SourcePath must be provided for references tests")?;
+
+            if let Some(config_file_path) = args.config_file_path.as_ref() {
+                let config_content = std::fs::read_to_string(config_file_path).map_err(|e| {
+                    format!(
+                        "failed to read config file {}: {}",
+                        config_file_path.display(),
+                        e
+                    )
+                })?;
+                let config: tombi_config::Config =
+                    serde_tombi::from_str_async(&config_content).await.map_err(|e| {
+                        format!(
+                            "failed to parse config file {}: {}",
+                            config_file_path.display(),
+                            e
+                        )
+                    })?;
+
+                let config_schema_store = backend
+                    .config_manager
+                    .config_schema_store_for_file(source_path)
+                    .await;
+
+                if let Some(config_path) = config_schema_store.config_path {
+                    backend
+                        .config_manager
+                        .update_config_with_path(config, &config_path)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "failed to update config {}: {}",
+                                config_path.display(),
+                                e
+                            )
+                        })?;
+                } else {
+                    backend.config_manager.update_editor_config(config).await;
+                }
+            }
+
+            let toml_file_url = Url::from_file_path(source_path)
+                .expect("failed to convert source file path to URL");
+
+            let mut toml_text = textwrap::dedent($source).trim().to_string();
+            let Some(index) = toml_text.as_str().find("█") else {
+                return Err("failed to find position marker (█) in the test data".into());
+            };
+            toml_text.remove(index);
+            let line_index =
+                tombi_text::LineIndex::new(&toml_text, tombi_text::EncodingKind::Utf16);
+
+            handle_did_open(
+                backend,
+                DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: toml_file_url.clone(),
+                        language_id: "toml".to_string(),
+                        version: 0,
+                        text: toml_text.clone(),
+                    },
+                },
+            )
+            .await;
+
+            let params = ReferenceParams {
+                text_document_position: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri: toml_file_url },
+                    position: (tombi_text::Position::default()
+                        + tombi_text::RelativePosition::of(&toml_text[..index]))
+                    .into_lsp(&line_index),
+                },
+                context: ReferenceContext {
+                    include_declaration: args.include_declaration,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            };
+
+            let Ok(result) = handle_references(&backend, params).await else {
+                return Err("failed to handle references".into());
+            };
+
+            let expected_locations: Vec<(std::path::PathBuf, tombi_text::Range)> = vec![
+                $(
+                    (
+                        $expected_file_path.to_owned(),
+                        tombi_text::Range::from((($start_line, $start_char), ($end_line, $end_char))),
+                    )
+                ),*
+            ];
+
+            match result {
+                Some(definition_links) => {
+                    pretty_assertions::assert_eq!(
+                        definition_links
+                            .into_iter()
+                            .map(|link| (link.uri.to_file_path().unwrap(), link.range))
+                            .collect_vec(),
+                        expected_locations,
+                    );
+                },
+                None => {
+                    if !expected_locations.is_empty() {
+                        panic!("No references were returned, but expected locations: {:?}", expected_locations);
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    };
+    (#[tokio::test] async fn $name:ident(
+        $source:expr $(, $arg:expr )* $(,)?
     ) -> Ok([$($expected_file_path:expr),*$(,)?]);) => {
         #[tokio::test]
         async fn $name() -> Result<(), Box<dyn std::error::Error>> {
@@ -316,7 +504,7 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
-            async fn target_optional_dependency_include_declaration_adds_dependency_key(
+            async fn target_optional_dependency_include_declaration_adds_optional_value(
                 r#"
                 [package]
                 name = "example"
@@ -331,8 +519,14 @@ mod references_tests {
                 SourcePath(project_root_path().join("crates/example/Cargo.toml")),
                 IncludeDeclaration(true),
             ) -> Ok([
-                project_root_path().join("crates/example/Cargo.toml"),
-                project_root_path().join("crates/example/Cargo.toml"),
+                (
+                    project_root_path().join("crates/example/Cargo.toml"),
+                    ((8, 11), (8, 23))
+                ),
+                (
+                    project_root_path().join("crates/example/Cargo.toml"),
+                    ((5, 41), (5, 45))
+                ),
             ]);
         );
 

--- a/extensions/tombi-extension-cargo/src/goto_declaration.rs
+++ b/extensions/tombi-extension-cargo/src/goto_declaration.rs
@@ -3,7 +3,7 @@ use crate::{
     feature_key_at_accessors, goto_workspace_managed_dependency_locations, is_optional_dependency,
 };
 use tombi_config::TomlVersion;
-use tombi_document_tree::dig_keys;
+use tombi_document_tree::{Value, dig_accessors};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 pub async fn goto_declaration(
@@ -80,15 +80,17 @@ pub fn get_current_declaration(
         return None;
     }
 
-    let parent_keys = dependency_parent_accessors(accessors)
-        .iter()
-        .map(Accessor::as_key)
-        .collect::<Option<Vec<_>>>()?;
-
-    let (dependency_key, _) = dig_keys(document_tree, &parent_keys)?;
+    let (_, Value::Table(table)) =
+        dig_accessors(document_tree, dependency_parent_accessors(accessors))?
+    else {
+        return None;
+    };
+    let Value::Boolean(optional) = table.get("optional")? else {
+        return None;
+    };
 
     Some(tombi_extension::Location {
         uri: cargo_toml_uri.clone(),
-        range: dependency_key.unquoted_range(),
+        range: optional.range(),
     })
 }

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -9,7 +9,7 @@ use crate::{
     resolve_feature_table_string,
 };
 use tombi_config::TomlVersion;
-use tombi_document_tree::{Value, dig_keys};
+use tombi_document_tree::{Value, dig_accessors, dig_keys};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 pub async fn goto_definition(
@@ -142,22 +142,18 @@ fn goto_definition_for_optional_dependency(
     accessors: &[Accessor],
     text_document_uri: &tombi_uri::Uri,
 ) -> Vec<tombi_extension::Location> {
-    let dependency_accessors = dependency_parent_accessors(accessors);
-    let Some(dependency_names) = dependency_accessors
-        .iter()
-        .map(Accessor::as_key)
-        .collect::<Option<Vec<_>>>()
+    let Some((_, Value::Table(table))) =
+        dig_accessors(document_tree, dependency_parent_accessors(accessors))
     else {
         return Vec::with_capacity(0);
     };
-
-    let Some((dependency_key, _)) = dig_keys(document_tree, &dependency_names) else {
+    let Some(Value::Boolean(optional)) = table.get("optional") else {
         return Vec::with_capacity(0);
     };
 
     vec![tombi_extension::Location {
         uri: text_document_uri.clone(),
-        range: dependency_key.unquoted_range(),
+        range: optional.range(),
     }]
 }
 

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -3,8 +3,8 @@ use crate::{
     dependency_parent_accessors, feature_table_string_at_accessors, find_workspace_cargo_toml,
     get_workspace_cargo_toml_path, goto_definition_for_workspace_cargo_toml,
     goto_workspace_managed_dependency_locations, is_dependency_accessor, is_feature_key_accessor,
-    is_optional_dependency_accessor, is_package_name_accessor, is_workspace_definition_accessor,
-    is_workspace_dependency_accessor, is_workspace_flag_accessor,
+    is_optional_dependency, is_optional_dependency_accessor, is_package_name_accessor,
+    is_workspace_definition_accessor, is_workspace_dependency_accessor, is_workspace_flag_accessor,
     is_workspace_managed_dependency_accessor, resolve_dependency_feature_string,
     resolve_feature_table_string,
 };
@@ -142,6 +142,10 @@ fn goto_definition_for_optional_dependency(
     accessors: &[Accessor],
     text_document_uri: &tombi_uri::Uri,
 ) -> Vec<tombi_extension::Location> {
+    if !is_optional_dependency(document_tree, accessors) {
+        return Vec::with_capacity(0);
+    }
+
     let Some((_, Value::Table(table))) =
         dig_accessors(document_tree, dependency_parent_accessors(accessors))
     else {


### PR DESCRIPTION
## Summary
- return the `optional = true` value range for cargo optional dependency definition/declaration
- keep `goto-references` includeDeclaration aligned with the same optional value location
- add range-aware LSP tests for goto-definition and references around optional dependencies

## Verification
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked