### PR TITLE
fix: expand optional dependency definition range

### DIFF
--- a/crates/tombi-lsp/tests/test_goto_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_definition.rs
@@ -616,7 +616,7 @@ mod goto_definition_tests {
 
         test_goto_definition!(
             #[tokio::test]
-            async fn optional_dependency_definition_returns_optional_field_range(
+            async fn optional_dependency_definition_returns_optional_key_value_range(
                 r#"
                 [package]
                 name = "explicit-feature"
@@ -633,7 +633,7 @@ mod goto_definition_tests {
             ) -> Ok([
                 (
                     cargo_feature_navigation_fixture_path().join("explicit/Cargo.toml"),
-                    ((5, 41), (5, 45))
+                    ((5, 30), (5, 45))
                 )
             ]);
         );

--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -370,7 +370,7 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
-            async fn target_optional_dependency_include_declaration_adds_optional_value(
+            async fn target_optional_dependency_include_declaration_adds_optional_key_value(
                 r#"
                 [package]
                 name = "example"
@@ -391,7 +391,7 @@ mod references_tests {
                 ),
                 (
                     project_root_path().join("crates/example/Cargo.toml"),
-                    ((5, 41), (5, 45))
+                    ((5, 30), (5, 45))
                 ),
             ]);
         );

--- a/extensions/tombi-extension-cargo/src/goto_declaration.rs
+++ b/extensions/tombi-extension-cargo/src/goto_declaration.rs
@@ -85,12 +85,12 @@ pub fn get_current_declaration(
     else {
         return None;
     };
-    let Value::Boolean(optional) = table.get("optional")? else {
+    let (optional_key, Value::Boolean(optional)) = table.get_key_value("optional")? else {
         return None;
     };
 
     Some(tombi_extension::Location {
         uri: cargo_toml_uri.clone(),
-        range: optional.range(),
+        range: optional_key.range() + optional.range(),
     })
 }

--- a/extensions/tombi-extension-cargo/src/goto_definition.rs
+++ b/extensions/tombi-extension-cargo/src/goto_definition.rs
@@ -151,13 +151,13 @@ fn goto_definition_for_optional_dependency(
     else {
         return Vec::with_capacity(0);
     };
-    let Some(Value::Boolean(optional)) = table.get("optional") else {
+    let Some((optional_key, Value::Boolean(optional))) = table.get_key_value("optional") else {
         return Vec::with_capacity(0);
     };
 
     vec![tombi_extension::Location {
         uri: text_document_uri.clone(),
-        range: optional.range(),
+        range: optional_key.range() + optional.range(),
     }]
 }
 


### PR DESCRIPTION
## Summary
- return the full `optional = true` key-value range for optional dependency definition navigation
- align goto-definition and includeDeclaration behavior
- update LSP regression tests for the expanded range

## Testing
- cargo fmt --all
- cargo test -p tombi-lsp optional_dependency -- --nocapture
- cargo test -p tombi-lsp target_optional_dependency_include_declaration_adds_optional_key_value -- --nocapture