### PR TITLE
fix: limit optional dependency reference scope

### DIFF
--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -347,7 +347,7 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
-            async fn optional_dependency_lists_workspace_usages(
+            async fn optional_dependency_lists_same_manifest_usages(
                 r#"
                 [package]
                 name = "nagi-config"

--- a/extensions/tombi-extension-cargo/src/references.rs
+++ b/extensions/tombi-extension-cargo/src/references.rs
@@ -1,3 +1,4 @@
+use crate::feature_navigation::collect_feature_usage_locations_in_manifest;
 use crate::{
     collect_feature_usage_locations, dependency_package_name, feature_usage_target_for_feature_key,
     feature_usage_target_for_optional_dependency, get_workspace_cargo_toml_path,
@@ -40,11 +41,15 @@ pub async fn references(
         && let Some(target) =
             feature_usage_target_for_optional_dependency(&cargo_toml_path, accessors)
     {
-        collect_feature_usage_locations(document_tree, &cargo_toml_path, &target, toml_version)
-            .await
-            .into_iter()
-            .filter_map(|location| location.get_location())
-            .collect_vec()
+        collect_feature_usage_locations_in_manifest(
+            document_tree,
+            &cargo_toml_path,
+            &target,
+            toml_version,
+        )
+        .into_iter()
+        .filter_map(|location| location.get_location())
+        .collect_vec()
     } else if is_workspace_dependency_accessor(accessors) {
         workspace_dependency_usage_locations(
             document_tree,


### PR DESCRIPTION
## Summary
- keep `optional = true` reference search within the current `Cargo.toml`
- avoid workspace-wide manifest traversal for optional dependency references
- rename the regression test to reflect same-manifest behavior

## Testing
- cargo fmt --all
- cargo test -p tombi-lsp --test test_references optional_dependency -- --nocapture
- cargo test -p tombi-lsp target_optional_dependency_include_declaration_adds_optional_key_value -- --nocapture