### PR TITLE
fix(lsp): refresh workspace pull diagnostics

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -13,6 +13,7 @@ use tower_lsp::lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
     InitializeResult, InitializedParams, InlayHint, InlayHintParams, ReferenceParams,
     SemanticTokensParams, SemanticTokensResult, TextDocumentIdentifier, Url,
+    WorkspaceDiagnosticParams, WorkspaceDiagnosticReportResult,
     request::{
         GotoDeclarationParams, GotoDeclarationResponse, GotoTypeDefinitionParams,
         GotoTypeDefinitionResponse,
@@ -34,7 +35,7 @@ use crate::{
         handle_goto_declaration, handle_goto_definition, handle_goto_type_definition, handle_hover,
         handle_initialize, handle_initialized, handle_inlay_hint, handle_list_schemas,
         handle_references, handle_refresh_cache, handle_semantic_tokens_full, handle_shutdown,
-        handle_update_config, handle_update_schema, push_diagnostics,
+        handle_update_config, handle_update_schema, handle_workspace_diagnostic, push_diagnostics,
     },
     references::try_get_reference_locations,
 };
@@ -56,6 +57,7 @@ pub struct Backend {
 pub struct BackendCapabilities {
     pub encoding_kind: EncodingKind,
     pub diagnostic_mode: DiagnosticMode,
+    pub workspace_diagnostic_refresh_support: bool,
 }
 
 /// Diagnostic Type
@@ -89,6 +91,7 @@ impl Backend {
             capabilities: Arc::new(tokio::sync::RwLock::new(BackendCapabilities {
                 encoding_kind: EncodingKind::default(),
                 diagnostic_mode: DiagnosticMode::Push,
+                workspace_diagnostic_refresh_support: false,
             })),
             background_tasks: Default::default(),
             document_sources: Default::default(),
@@ -119,6 +122,23 @@ impl Backend {
     #[inline]
     pub async fn is_diagnostic_mode_push(&self) -> bool {
         self.capabilities.read().await.diagnostic_mode == DiagnosticMode::Push
+    }
+
+    pub async fn refresh_pull_diagnostics(&self) {
+        let capabilities = self.capabilities.read().await;
+        if capabilities.diagnostic_mode != DiagnosticMode::Pull {
+            return;
+        }
+
+        if !capabilities.workspace_diagnostic_refresh_support {
+            log::debug!("Client does not support workspace/diagnostic/refresh");
+            return;
+        }
+        drop(capabilities);
+
+        if let Err(error) = self.client.workspace_diagnostic_refresh().await {
+            log::debug!("Failed to request diagnostic refresh: {error}");
+        }
     }
 
     #[inline]
@@ -467,5 +487,12 @@ impl tower_lsp::LanguageServer for Backend {
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult, tower_lsp::jsonrpc::Error> {
         handle_diagnostic(self, params).await
+    }
+
+    async fn workspace_diagnostic(
+        &self,
+        params: WorkspaceDiagnosticParams,
+    ) -> Result<WorkspaceDiagnosticReportResult, tower_lsp::jsonrpc::Error> {
+        handle_workspace_diagnostic(self, params).await
     }
 }

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -23,14 +23,19 @@ pub async fn handle_did_change_watched_files(
                     document_sources.remove(&uri);
                 }
 
-                backend
-                    .client
-                    .publish_diagnostics(change.uri, Vec::new(), None)
-                    .await;
+                if backend.is_diagnostic_mode_push().await {
+                    backend
+                        .client
+                        .publish_diagnostics(change.uri, Vec::new(), None)
+                        .await;
+                } else {
+                    backend.refresh_pull_diagnostics().await;
+                }
             }
             FileChangeType::CREATED | FileChangeType::CHANGED => {
                 if upsert_document_source(backend, uri.clone()).await {
                     push_diagnostics(backend, uri).await;
+                    backend.refresh_pull_diagnostics().await;
                 }
             }
             _ => {

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -11,6 +11,8 @@ pub async fn handle_did_change_watched_files(
     log::info!("handle_did_change_watched_files");
     log::trace!("{:?}", params);
 
+    let mut should_refresh_pull_diagnostics = false;
+
     for change in params.changes {
         let uri: tombi_uri::Uri = change.uri.clone().into();
 
@@ -29,18 +31,22 @@ pub async fn handle_did_change_watched_files(
                         .publish_diagnostics(change.uri, Vec::new(), None)
                         .await;
                 } else {
-                    backend.refresh_pull_diagnostics().await;
+                    should_refresh_pull_diagnostics = true;
                 }
             }
             FileChangeType::CREATED | FileChangeType::CHANGED => {
                 if upsert_document_source(backend, uri.clone()).await {
                     push_diagnostics(backend, uri).await;
-                    backend.refresh_pull_diagnostics().await;
+                    should_refresh_pull_diagnostics = true;
                 }
             }
             _ => {
                 log::debug!("Ignored file change type {:?} for URI: {}", change.typ, uri);
             }
         }
+    }
+
+    if should_refresh_pull_diagnostics {
+        backend.refresh_pull_diagnostics().await;
     }
 }

--- a/crates/tombi-lsp/src/handler/initialize.rs
+++ b/crates/tombi-lsp/src/handler/initialize.rs
@@ -51,6 +51,12 @@ pub async fn handle_initialize(
 
     let mut backend_capabilities = backend.capabilities.write().await;
     backend_capabilities.encoding_kind = negotiated_wide_encoding(&client_capabilities);
+    backend_capabilities.workspace_diagnostic_refresh_support = client_capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.diagnostic.as_ref())
+        .and_then(|diagnostic| diagnostic.refresh_support)
+        .unwrap_or_default();
     if let Some(text_document_capabilities) = client_capabilities.text_document.as_ref()
         && let Some(diagnostic_capabilities) = text_document_capabilities.diagnostic.as_ref()
         && diagnostic_capabilities.dynamic_registration == Some(true)
@@ -178,7 +184,7 @@ pub fn server_capabilities(
         diagnostic_provider: if backend_capabilities.diagnostic_mode == DiagnosticMode::Pull {
             Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
                 inter_file_dependencies: false,
-                workspace_diagnostics: false,
+                workspace_diagnostics: true,
                 ..Default::default()
             }))
         } else {

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::{
-    backend::Backend,
+    backend::{Backend, DiagnosticMode},
     handler::{push_workspace_diagnostics, workspace_diagnostic::WorkspaceDiagnosticOptions},
 };
 
@@ -13,11 +13,19 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
     log::info!("handle_initialized");
     log::trace!("{:?}", params);
 
-    log::info!("Pushing workspace diagnostics...");
-    if let Err(error) =
-        push_workspace_diagnostics(backend, &WorkspaceDiagnosticOptions::default()).await
-    {
-        log::warn!("Failed to push workspace diagnostics: {error}");
+    let diagnostic_mode = backend.capabilities.read().await.diagnostic_mode;
+    match diagnostic_mode {
+        DiagnosticMode::Pull => {
+            log::info!("Skip pushing workspace diagnostics in Pull mode");
+        }
+        DiagnosticMode::Push => {
+            log::info!("Pushing workspace diagnostics...");
+            if let Err(error) =
+                push_workspace_diagnostics(backend, &WorkspaceDiagnosticOptions::default()).await
+            {
+                log::warn!("Failed to push workspace diagnostics: {error}");
+            }
+        }
     }
 
     log::info!("Registering workspace TOML watchers...");

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -1,8 +1,13 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use tombi_glob::search_pattern_matched_paths;
 use tower_lsp::lsp_types::{
-    FullDocumentDiagnosticReport, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
-    WorkspaceDiagnosticReportResult, WorkspaceDocumentDiagnosticReport,
-    WorkspaceFullDocumentDiagnosticReport,
+    FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport, WorkspaceDiagnosticParams,
+    WorkspaceDiagnosticReport, WorkspaceDiagnosticReportResult, WorkspaceDocumentDiagnosticReport,
+    WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport,
 };
 
 use crate::{
@@ -39,9 +44,20 @@ pub async fn handle_workspace_diagnostic(
     log::info!("handle_workspace_diagnostic");
     log::trace!("{:?}", params);
 
+    let previous_result_ids = params
+        .previous_result_ids
+        .into_iter()
+        .map(|result| (tombi_uri::Uri::from(result.uri), result.value))
+        .collect::<tombi_hashmap::HashMap<_, _>>();
+
+    let targets = collect_workspace_diagnostic_targets(backend).await;
+    let target_set = targets
+        .iter()
+        .cloned()
+        .collect::<tombi_hashmap::HashSet<_>>();
     let mut items = Vec::new();
 
-    for text_document_uri in collect_workspace_diagnostic_targets(backend).await {
+    for text_document_uri in targets {
         let Some(diagnostics_result) = get_diagnostics_result(backend, &text_document_uri).await
         else {
             continue;
@@ -51,14 +67,48 @@ pub async fn handle_workspace_diagnostic(
             diagnostics,
             version,
         } = diagnostics_result;
+        let result_id = workspace_diagnostic_result_id(version, &diagnostics);
+
+        if previous_result_ids
+            .get(&text_document_uri)
+            .is_some_and(|previous_result_id| previous_result_id == &result_id)
+        {
+            items.push(WorkspaceDocumentDiagnosticReport::Unchanged(
+                WorkspaceUnchangedDocumentDiagnosticReport {
+                    uri: text_document_uri.into(),
+                    version: version.map(i64::from),
+                    unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
+                        result_id,
+                    },
+                },
+            ));
+            continue;
+        }
 
         items.push(WorkspaceDocumentDiagnosticReport::Full(
             WorkspaceFullDocumentDiagnosticReport {
                 uri: text_document_uri.into(),
                 version: version.map(i64::from),
                 full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                    result_id: None,
+                    result_id: Some(result_id),
                     items: diagnostics,
+                },
+            },
+        ));
+    }
+
+    for previous_text_document_uri in previous_result_ids.keys() {
+        if target_set.contains(previous_text_document_uri) {
+            continue;
+        }
+
+        items.push(WorkspaceDocumentDiagnosticReport::Full(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: previous_text_document_uri.clone().into(),
+                version: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: Some(workspace_diagnostic_result_id(None, &[])),
+                    items: Vec::new(),
                 },
             },
         ));
@@ -67,6 +117,18 @@ pub async fn handle_workspace_diagnostic(
     Ok(WorkspaceDiagnosticReportResult::Report(
         WorkspaceDiagnosticReport { items },
     ))
+}
+
+fn workspace_diagnostic_result_id(
+    version: Option<i32>,
+    diagnostics: &[tower_lsp::lsp_types::Diagnostic],
+) -> String {
+    let mut hasher = DefaultHasher::new();
+    version.hash(&mut hasher);
+    serde_json::to_string(diagnostics)
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    format!("{:x}", hasher.finish())
 }
 
 async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -1,4 +1,9 @@
 use tombi_glob::search_pattern_matched_paths;
+use tower_lsp::lsp_types::{
+    FullDocumentDiagnosticReport, WorkspaceDiagnosticParams, WorkspaceDiagnosticReport,
+    WorkspaceDiagnosticReportResult, WorkspaceDocumentDiagnosticReport,
+    WorkspaceFullDocumentDiagnosticReport,
+};
 
 use crate::{
     backend::Backend,
@@ -25,6 +30,43 @@ pub async fn push_workspace_diagnostics(
     }
 
     Ok(())
+}
+
+pub async fn handle_workspace_diagnostic(
+    backend: &Backend,
+    params: WorkspaceDiagnosticParams,
+) -> Result<WorkspaceDiagnosticReportResult, tower_lsp::jsonrpc::Error> {
+    log::info!("handle_workspace_diagnostic");
+    log::trace!("{:?}", params);
+
+    let mut items = Vec::new();
+
+    for text_document_uri in collect_workspace_diagnostic_targets(backend).await {
+        let Some(diagnostics_result) = get_diagnostics_result(backend, &text_document_uri).await
+        else {
+            continue;
+        };
+
+        let DiagnosticsResult {
+            diagnostics,
+            version,
+        } = diagnostics_result;
+
+        items.push(WorkspaceDocumentDiagnosticReport::Full(
+            WorkspaceFullDocumentDiagnosticReport {
+                uri: text_document_uri.into(),
+                version: version.map(i64::from),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: diagnostics,
+                },
+            },
+        ));
+    }
+
+    Ok(WorkspaceDiagnosticReportResult::Report(
+        WorkspaceDiagnosticReport { items },
+    ))
 }
 
 async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -79,7 +79,7 @@ pub mod handler {
     pub use shutdown::handle_shutdown;
     pub use update_config::handle_update_config;
     pub use update_schema::handle_update_schema;
-    pub use workspace_diagnostic::push_workspace_diagnostics;
+    pub use workspace_diagnostic::{handle_workspace_diagnostic, push_workspace_diagnostics};
 }
 
 pub use backend::Backend;


### PR DESCRIPTION
Fix: https://github.com/tombi-toml/tombi/issues/1839

## Summary
- implement `workspace/diagnostic` handling for pull-diagnostic clients
- request `workspace/diagnostic/refresh` after watched file updates when pull mode is active
- avoid pushing initial workspace diagnostics in pull mode and advertise workspace diagnostic support

## Testing
- cargo fmt --all --check
- cargo test -p tombi-lsp --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked