### PR TITLE
clippy: fix collapsible_match lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ zed_extension_api = "0.7.0"
 zip = { version = "2.3.0" }
 
 [workspace.lints.clippy]
+collapsible_match = "warn"
 explicit_counter_loop = "warn"
 
 [workspace.lints.rust]

--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -191,10 +191,8 @@ impl Cursor<'_> {
 
                     return Ok(Token::new(SyntaxKind::STRING, self.pop_span_range()));
                 }
-                '\u{0000}'..='\u{001F}' => {
-                    if first_error.is_none() {
-                        first_error = Some(InvalidString);
-                    }
+                '\u{0000}'..='\u{001F}' if first_error.is_none() => {
+                    first_error = Some(InvalidString);
                 }
                 '\\' => match self.bump() {
                     Some(escape_char) => match escape_char {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match

- Explicitly enable the `clippy::collapsible_match` lint, even though it is set to warn by default.