### PR TITLE
docs: remove sticky table header gap

### DIFF
--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -3,7 +3,7 @@
 
 :root {
   --docs-fixed-header-height: 80px;
-  --docs-sticky-table-offset: 20px;
+  --docs-sticky-table-offset: 0px;
 }
 
 html {

--- a/docs/src/utils/anchor-scroll.ts
+++ b/docs/src/utils/anchor-scroll.ts
@@ -2,15 +2,24 @@
  * Utility functions for handling anchor link scrolling with header offset
  */
 
-const HEADER_HEIGHT = 80; // h-20 = 5rem = 80px
-const SCROLL_OFFSET = 20; // Additional offset for better visual spacing
+const FALLBACK_HEADER_HEIGHT = 80; // h-20 = 5rem = 80px
+const readCssLength = (name: string, fallback = 0) => {
+  const value = Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue(name),
+  );
+  return Number.isFinite(value) ? value : fallback;
+};
+
+const getScrollOffset = () =>
+  readCssLength("--docs-fixed-header-height", FALLBACK_HEADER_HEIGHT) +
+  readCssLength("--docs-sticky-table-offset");
 
 /**
  * Scrolls to an element with proper header offset
  */
 export function scrollToElement(element: HTMLElement, smooth = true) {
   const elementTop = element.getBoundingClientRect().top + window.scrollY;
-  const scrollTop = elementTop - HEADER_HEIGHT - SCROLL_OFFSET;
+  const scrollTop = elementTop - getScrollOffset();
 
   window.scrollTo({
     top: Math.max(0, scrollTop),


### PR DESCRIPTION
## Summary
- remove the extra sticky table header offset in docs
- keep the sticky table header flush with the global header on desktop and mobile

## Testing
- not run (CSS-only change)