### PR TITLE
Fix docs table sticky header path

### DIFF
--- a/crates/tombi-validator/src/validate/if_then_else.rs
+++ b/crates/tombi-validator/src/validate/if_then_else.rs
@@ -18,7 +18,7 @@ pub async fn validate_if_then_else<T>(
 where
     T: Validate + ValueImpl + Sync + Send,
 {
-    #[expect(clippy::result_large_err)]
+    #[allow(clippy::result_large_err)]
     let merge_if_result =
         |branch_result: Result<crate::EvaluatedLocations, crate::Error>,
          if_result: Result<crate::EvaluatedLocations, crate::Error>| match if_result {

--- a/docs/src/routes/docs/reference/difference-taplo.mdx
+++ b/docs/src/routes/docs/reference/difference-taplo.mdx
@@ -1,3 +1,5 @@
+import { Table } from "~/components/Table";
+
 # Differences from Taplo
 
 [Taplo](https://github.com/tamasfe/taplo) is already famous as a TOML Language Server.
@@ -50,7 +52,7 @@ Tombi's formatting policy is to avoid deleting user data.
 Tombi provides several formatting options to make it easy for Taplo users to migrate.  
 The following table shows the correspondence between [Taplo's options](https://taplo.tamasfe.dev/configuration/formatter-options.html) and [Tombi's options](/docs/configuration#available-options):
 
-<table>
+<Table>
   <thead>
     <tr>
       <th>Taplo Option</th>
@@ -167,7 +169,7 @@ The following table shows the correspondence between [Taplo's options](https://t
       <td></td>
     </tr>
   </tbody>
-</table>
+</Table>
 
 ### Override Config
 


### PR DESCRIPTION
## Summary
- replace the raw HTML table in `docs/src/routes/docs/reference/difference-taplo.mdx` with the shared `Table` component so sticky headers work consistently
- keep docs tables on the shared rendering path used by MDX tables
- fix an existing `clippy -D warnings` failure in `tombi-validator` by replacing an unfulfilled lint expectation with an allow

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check -p tombi-validator --all-targets --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`