### PR TITLE
Move LSP store loading from initialize to initialized

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -42,7 +42,7 @@ use crate::{
 
 use tombi_text::EncodingKind;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Backend {
     #[allow(dead_code)]
     pub client: tower_lsp::Client,

--- a/crates/tombi-lsp/src/handler/initialize.rs
+++ b/crates/tombi-lsp/src/handler/initialize.rs
@@ -5,10 +5,10 @@ use tower_lsp::lsp_types::{
     DiagnosticServerCapabilities, DocumentLinkOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
     HoverProviderCapability, InitializeParams, InitializeResult, InlayHintOptions,
-    InlayHintServerCapabilities, MessageType, OneOf, SemanticTokensFullOptions,
-    SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, ServerInfo,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
+    InlayHintServerCapabilities, OneOf, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, ServerCapabilities, ServerInfo, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
+    TypeDefinitionProviderCapability, WorkDoneProgressOptions,
     WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
     WorkspaceServerCapabilities,
 };
@@ -35,18 +35,6 @@ pub async fn handle_initialize(
     if let Some(ClientInfo { name, version }) = client_info {
         let version = version.unwrap_or_default();
         log::info!("{name} version: {version}",);
-    }
-
-    log::info!("Loading config...");
-    if let Err(error) = backend.config_manager.load().await {
-        let error_message = error.to_string();
-
-        log::error!("{error_message}");
-
-        backend
-            .client
-            .show_message(MessageType::ERROR, error_message)
-            .await;
     }
 
     let mut backend_capabilities = backend.capabilities.write().await;

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 use tower_lsp::lsp_types::{
     DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, InitializedParams,
-    Registration, WatchKind,
+    MessageType, Registration, WatchKind,
 };
 
 use crate::{
@@ -18,6 +18,10 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
         log::info!("Loading config in background...");
         if let Err(error) = startup_backend.config_manager.load().await {
             log::warn!("Failed to load config: {error}");
+            startup_backend
+                .client
+                .show_message(MessageType::WARNING, error.to_string())
+                .await;
             return;
         }
 
@@ -28,6 +32,18 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
                 startup_backend.refresh_pull_diagnostics().await;
             }
             DiagnosticMode::Push => {
+                let open_document_uris = startup_backend
+                    .document_sources
+                    .read()
+                    .await
+                    .iter()
+                    .filter_map(|(uri, source)| source.version.is_some().then_some(uri.clone()))
+                    .collect::<Vec<_>>();
+
+                for text_document_uri in open_document_uris {
+                    startup_backend.push_diagnostics(text_document_uri).await;
+                }
+
                 log::info!("Pushing workspace diagnostics after config load...");
                 if let Err(error) = push_workspace_diagnostics(
                     &startup_backend,

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -13,20 +13,36 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
     log::info!("handle_initialized");
     log::trace!("{:?}", params);
 
-    let diagnostic_mode = backend.capabilities.read().await.diagnostic_mode;
-    match diagnostic_mode {
-        DiagnosticMode::Pull => {
-            log::info!("Skip pushing workspace diagnostics in Pull mode");
+    let startup_backend = backend.clone();
+    let startup_task = tokio::spawn(async move {
+        log::info!("Loading config in background...");
+        if let Err(error) = startup_backend.config_manager.load().await {
+            log::warn!("Failed to load config: {error}");
+            return;
         }
-        DiagnosticMode::Push => {
-            log::info!("Pushing workspace diagnostics...");
-            if let Err(error) =
-                push_workspace_diagnostics(backend, &WorkspaceDiagnosticOptions::default()).await
-            {
-                log::warn!("Failed to push workspace diagnostics: {error}");
+
+        let diagnostic_mode = startup_backend.capabilities.read().await.diagnostic_mode;
+        match diagnostic_mode {
+            DiagnosticMode::Pull => {
+                log::info!("Refreshing pull diagnostics after config load...");
+                startup_backend.refresh_pull_diagnostics().await;
+            }
+            DiagnosticMode::Push => {
+                log::info!("Pushing workspace diagnostics after config load...");
+                if let Err(error) = push_workspace_diagnostics(
+                    &startup_backend,
+                    &WorkspaceDiagnosticOptions {
+                        include_open_files: true,
+                    },
+                )
+                .await
+                {
+                    log::warn!("Failed to push workspace diagnostics: {error}");
+                }
             }
         }
-    }
+    });
+    backend.register_background_task(&startup_task);
 
     log::info!("Registering workspace TOML watchers...");
     if let Err(error) = register_workspace_toml_watcher(backend).await {

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 use tower_lsp::lsp_types::{
     DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, InitializedParams,
-    MessageType, Registration, WatchKind,
+    Registration, WatchKind,
 };
 
 use crate::{
@@ -18,10 +18,6 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
         log::info!("Loading config in background...");
         if let Err(error) = startup_backend.config_manager.load().await {
             log::warn!("Failed to load config: {error}");
-            startup_backend
-                .client
-                .show_message(MessageType::WARNING, error.to_string())
-                .await;
             return;
         }
 


### PR DESCRIPTION
## Summary
- remove blocking config/store loading from the  handler
- start config loading in a background task from 
- refresh workspace diagnostics after background config loading for both push and pull modes

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets --locked -- -D warnings
- [x] cargo nextest run --workspace --locked --no-fail-fast
- [x] cargo test --workspace --doc --locked
