### PR TITLE
Add winget installation support and release workflow

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      skip_winget:
+        description: "Skip submitting the Windows Package Manager manifest update"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -245,6 +251,44 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && needs.check-release-notes.outputs.exists == 'false'
         run: |
           gh release create ${{ github.ref_name }} --generate-notes ${{ env.ASSETS }}
+
+  publish-winget:
+    needs: [release-notes]
+    if: startsWith(github.ref, 'refs/tags/v') && inputs.skip_winget != true
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: pwsh
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
+            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "Skipping winget submission for non-stable tag: $env:REF_NAME"
+            "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Submit winget manifest update
+        if: steps.stable-version.outputs.stable_version != ''
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          VERSION: ${{ steps.stable-version.outputs.stable_version }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
+            exit 0
+          }
+
+          $installerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update tombi-toml.tombi -u $installerUrl -v $env:VERSION -t $env:WINGET_TOKEN --submit
 
   update-install-script-version:
     needs: [release-notes]

--- a/docs/doc-index.json
+++ b/docs/doc-index.json
@@ -6,7 +6,7 @@
   },
   {
     "title": "Installation",
-    "description": "Install via CLI, Homebrew, pip, npm, or IDE extensions.",
+    "description": "Install via CLI, winget, Homebrew, pip, npm, or IDE extensions.",
     "path": "/docs/installation"
   },
   {

--- a/docs/src/components/InstallationMethodGrid.tsx
+++ b/docs/src/components/InstallationMethodGrid.tsx
@@ -21,6 +21,12 @@ const installationMethods: InstallationMethod[] = [
     image: "/terminal.svg",
   },
   {
+    id: "windows-package-manager",
+    name: "winget",
+    image: "/terminal.svg",
+    category: "package-manager",
+  },
+  {
     id: "homebrew",
     name: "Homebrew",
     image: "/homebrew.svg",

--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -41,6 +41,12 @@ Install to a specific directory:
 curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --install-dir /custom/path
 ```
 
+## Windows Package Manager
+
+```powershell
+winget install --id tombi-toml.tombi --exact
+```
+
 ## Homebrew
 
 ```sh


### PR DESCRIPTION
Adds release-side automation for publishing Tombi CLI updates to winget, and documents winget as a recommended Windows installation method.

## Details

- Add a `publish-winget` job to the CLI/VSCode release workflow.
- Use `wingetcreate update tombi-toml.tombi --submit` after GitHub Release assets are available.
- Skip winget submission when `WINGET_TOKEN` is not configured, so releases are not blocked before the first winget setup is complete.
- Add `winget install --id tombi-toml.tombi --exact` to the installation docs and installation method grid.

## Maintainer setup required

The first `tombi-toml.tombi` manifest still needs to be submitted manually to `microsoft/winget-pkgs` from a maintainer-owned GitHub account/token. After that first manifest is merged, this workflow can submit future winget updates automatically using a `WINGET_TOKEN` repository secret.

closes #1767 