### PR TITLE
Add files option to respect ignore files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "log",
  "rayon",
  "serde_tombi",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tombi-config",

--- a/crates/tombi-config/src/files.rs
+++ b/crates/tombi-config/src/files.rs
@@ -24,7 +24,7 @@ pub struct FilesOptions {
 
     /// # Respect repository ignore files
     ///
-    /// Whether to respect `.ignore` and `.gitignore` and `.git/info/exclude` while discovering files.
+    /// Whether to respect `.ignore`, `.gitignore`, and `.git/info/exclude` while discovering files.
     #[cfg_attr(feature = "serde", serde(default))]
     pub respect_ignore_files: BoolDefaultTrue,
 }

--- a/crates/tombi-config/src/files.rs
+++ b/crates/tombi-config/src/files.rs
@@ -1,4 +1,4 @@
-use crate::GlobPattern;
+use crate::{BoolDefaultTrue, GlobPattern};
 
 /// # Files options
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -21,6 +21,12 @@ pub struct FilesOptions {
     /// The file match pattern to exclude from formatting and linting.
     /// Supports glob pattern.
     pub exclude: Option<Vec<GlobPattern>>,
+
+    /// # Respect repository ignore files
+    ///
+    /// Whether to respect `.ignore` and `.gitignore` and `.git/info/exclude` while discovering files.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub respect_ignore_files: BoolDefaultTrue,
 }
 
 fn default_include_patterns() -> Option<Vec<GlobPattern>> {
@@ -32,6 +38,7 @@ impl Default for FilesOptions {
         Self {
             include: default_include_patterns(),
             exclude: None,
+            respect_ignore_files: BoolDefaultTrue::default(),
         }
     }
 }

--- a/crates/tombi-glob/Cargo.toml
+++ b/crates/tombi-glob/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 tombi-config.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/tombi-glob/src/bin/profile.rs
+++ b/crates/tombi-glob/src/bin/profile.rs
@@ -23,10 +23,7 @@ async fn main() {
         }
     };
 
-    let files_options = config.files.clone().unwrap_or_else(|| FilesOptions {
-        include: Some(vec!["**/*.toml".into()]),
-        exclude: None,
-    });
+    let files_options = config.files.clone().unwrap_or_default();
 
     println!("Include patterns: {:?}", files_options.include);
     println!("Exclude patterns: {:?}", files_options.exclude);

--- a/crates/tombi-glob/src/file_search.rs
+++ b/crates/tombi-glob/src/file_search.rs
@@ -76,6 +76,7 @@ impl FileSearch {
                                 FilesOptions {
                                     include: Some(vec![file_path.into()]),
                                     exclude: files_options.exclude.clone(),
+                                    respect_ignore_files: files_options.respect_ignore_files,
                                 },
                             )
                             .await,

--- a/crates/tombi-glob/src/walk_dir.rs
+++ b/crates/tombi-glob/src/walk_dir.rs
@@ -49,10 +49,14 @@ impl WalkDir {
         let results = Arc::new(Mutex::new(Vec::new()));
 
         let mut builder = WalkBuilder::new(root_path);
+        let respect_ignore_files = self.options.respect_ignore_files.value();
         builder
             .hidden(false)
             .follow_links(false)
-            .ignore(false)
+            .parents(respect_ignore_files)
+            .ignore(respect_ignore_files)
+            .git_ignore(respect_ignore_files)
+            .git_exclude(respect_ignore_files)
             .git_global(false)
             .threads(rayon::current_num_threads());
 
@@ -114,6 +118,19 @@ impl WalkDir {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn make_git_root(root: &Path) {
+        fs::create_dir_all(root.join(".git")).unwrap();
+    }
 
     // Convenience functions using the new API
     fn find_rust_files<P: AsRef<Path>>(root: P) -> Result<Vec<PathBuf>, crate::Error> {
@@ -122,6 +139,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.rs".into()]),
                 exclude: None,
+                respect_ignore_files: true.into(),
             },
         );
         // Note: This is a blocking version, async version would need tokio runtime
@@ -190,6 +208,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.toml".into()]),
                 exclude: None,
+                respect_ignore_files: true.into(),
             },
         );
         // Similar blocking implementation as find_rust_files
@@ -266,6 +285,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.rs".into(), "*.toml".into()]),
                 exclude: None,
+                respect_ignore_files: true.into(),
             },
         );
         assert_eq!(
@@ -282,6 +302,7 @@ mod tests {
             FilesOptions {
                 include: None,
                 exclude: Some(vec!["target/**".into(), "node_modules/**".into()]),
+                respect_ignore_files: true.into(),
             },
         );
         assert_eq!(
@@ -298,6 +319,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.rs".into()]),
                 exclude: Some(vec!["target/**".into()]),
+                respect_ignore_files: true.into(),
             },
         );
         assert_eq!(walker.options.include, Some(vec!["*.rs".into()]));
@@ -312,6 +334,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["invalid[pattern".into()]),
                 exclude: None,
+                respect_ignore_files: true.into(),
             },
         );
         // Invalid patterns will cause panic at runtime, not compile time
@@ -326,6 +349,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.rs".into()]),
                 exclude: None,
+                respect_ignore_files: true.into(),
             },
         );
         let result = walker.walk().await;
@@ -340,6 +364,7 @@ mod tests {
             FilesOptions {
                 include: Some(vec!["*.toml".into()]),
                 exclude: Some(vec!["target/**".into()]),
+                respect_ignore_files: true.into(),
             },
         );
         let result = walker.walk().await;
@@ -358,5 +383,73 @@ mod tests {
     fn test_error_handling() {
         let result = find_rust_files("/nonexistent/path");
         assert!(matches!(result, Err(crate::Error::RootPathNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_walkdir_respects_gitignore_when_enabled() {
+        let tempdir = tempdir().unwrap();
+        let root = tempdir.path();
+        make_git_root(root);
+        write_file(&root.join(".gitignore"), "ignored.toml\n");
+        write_file(&root.join("included.toml"), "key = 1\n");
+        write_file(&root.join("ignored.toml"), "key = 2\n");
+
+        let walker = WalkDir::new_with_options(
+            root,
+            FilesOptions {
+                include: Some(vec!["**/*.toml".into()]),
+                exclude: None,
+                respect_ignore_files: true.into(),
+            },
+        );
+
+        let result = walker.walk().await.unwrap();
+        assert!(result.iter().any(|path| path.ends_with("included.toml")));
+        assert!(!result.iter().any(|path| path.ends_with("ignored.toml")));
+    }
+
+    #[tokio::test]
+    async fn test_walkdir_ignores_gitignore_when_disabled() {
+        let tempdir = tempdir().unwrap();
+        let root = tempdir.path();
+        make_git_root(root);
+        write_file(&root.join(".gitignore"), "ignored.toml\n");
+        write_file(&root.join("included.toml"), "key = 1\n");
+        write_file(&root.join("ignored.toml"), "key = 2\n");
+
+        let walker = WalkDir::new_with_options(
+            root,
+            FilesOptions {
+                include: Some(vec!["**/*.toml".into()]),
+                exclude: None,
+                respect_ignore_files: false.into(),
+            },
+        );
+
+        let result = walker.walk().await.unwrap();
+        assert!(result.iter().any(|path| path.ends_with("included.toml")));
+        assert!(result.iter().any(|path| path.ends_with("ignored.toml")));
+    }
+
+    #[tokio::test]
+    async fn test_walkdir_respects_dot_ignore_when_enabled() {
+        let tempdir = tempdir().unwrap();
+        let root = tempdir.path();
+        write_file(&root.join(".ignore"), "ignored.toml\n");
+        write_file(&root.join("included.toml"), "key = 1\n");
+        write_file(&root.join("ignored.toml"), "key = 2\n");
+
+        let walker = WalkDir::new_with_options(
+            root,
+            FilesOptions {
+                include: Some(vec!["**/*.toml".into()]),
+                exclude: None,
+                respect_ignore_files: true.into(),
+            },
+        );
+
+        let result = walker.walk().await.unwrap();
+        assert!(result.iter().any(|path| path.ends_with("included.toml")));
+        assert!(!result.iter().any(|path| path.ends_with("ignored.toml")));
     }
 }

--- a/crates/tombi-glob/src/walk_dir.rs
+++ b/crates/tombi-glob/src/walk_dir.rs
@@ -432,6 +432,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_walkdir_respects_git_exclude_when_enabled() {
+        let tempdir = tempdir().unwrap();
+        let root = tempdir.path();
+        make_git_root(root);
+        write_file(&root.join(".git/info/exclude"), "ignored.toml\n");
+        write_file(&root.join("included.toml"), "key = 1\n");
+        write_file(&root.join("ignored.toml"), "key = 2\n");
+
+        let walker = WalkDir::new_with_options(
+            root,
+            FilesOptions {
+                include: Some(vec!["**/*.toml".into()]),
+                exclude: None,
+                respect_ignore_files: true.into(),
+            },
+        );
+
+        let result = walker.walk().await.unwrap();
+        assert!(result.iter().any(|path| path.ends_with("included.toml")));
+        assert!(!result.iter().any(|path| path.ends_with("ignored.toml")));
+    }
+
+    #[tokio::test]
+    async fn test_walkdir_ignores_git_exclude_when_disabled() {
+        let tempdir = tempdir().unwrap();
+        let root = tempdir.path();
+        make_git_root(root);
+        write_file(&root.join(".git/info/exclude"), "ignored.toml\n");
+        write_file(&root.join("included.toml"), "key = 1\n");
+        write_file(&root.join("ignored.toml"), "key = 2\n");
+
+        let walker = WalkDir::new_with_options(
+            root,
+            FilesOptions {
+                include: Some(vec!["**/*.toml".into()]),
+                exclude: None,
+                respect_ignore_files: false.into(),
+            },
+        );
+
+        let result = walker.walk().await.unwrap();
+        assert!(result.iter().any(|path| path.ends_with("included.toml")));
+        assert!(result.iter().any(|path| path.ends_with("ignored.toml")));
+    }
+
+    #[tokio::test]
     async fn test_walkdir_respects_dot_ignore_when_enabled() {
         let tempdir = tempdir().unwrap();
         let root = tempdir.path();

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -149,6 +149,16 @@
           "items": {
             "$ref": "#/definitions/GlobPattern"
           }
+        },
+        "respect-ignore-files": {
+          "title": "Respect repository ignore files",
+          "description": "Whether to respect `.ignore` and `.gitignore` and `.git/info/exclude` while discovering files.",
+          "default": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -158,6 +168,10 @@
       "description": "Glob pattern used by config include/exclude lists.",
       "type": "string",
       "minLength": 1
+    },
+    "BoolDefaultTrue": {
+      "type": "boolean",
+      "default": true
     },
     "FormatOptions": {
       "title": "Formatter options",
@@ -750,10 +764,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "BoolDefaultTrue": {
-      "type": "boolean",
-      "default": true
     },
     "LspCompletion": {
       "type": "object",

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -152,7 +152,7 @@
         },
         "respect-ignore-files": {
           "title": "Respect repository ignore files",
-          "description": "Whether to respect `.ignore` and `.gitignore` and `.git/info/exclude` while discovering files.",
+          "description": "Whether to respect `.ignore`, `.gitignore`, and `.git/info/exclude` while discovering files.",
           "default": true,
           "allOf": [
             {


### PR DESCRIPTION
Support: https://github.com/tombi-toml/tombi/issues/1869

## Summary
- add `files.respect-ignore-files` to the config schema with a default of `true`
- make `tombi-glob` honor `.ignore`, `.gitignore`, and `.git/info/exclude` when the option is enabled
- add walker tests covering enabled and disabled ignore-file behavior

## Testing
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked