### PR TITLE
Avoid holding document source locks in LSP handlers

### DIFF
--- a/crates/tombi-lsp/src/handler/did_change.rs
+++ b/crates/tombi-lsp/src/handler/did_change.rs
@@ -12,6 +12,19 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
     } = params;
 
     let text_document_uri = text_document.uri.into();
+    let mut latest_content_change = None;
+
+    for content_change in content_changes {
+        if let Some(range) = content_change.range {
+            log::warn!("Range change is not supported: {:?}", range);
+        } else {
+            let toml_version = backend
+                .text_document_toml_version(&text_document_uri, &content_change.text)
+                .await;
+
+            latest_content_change = Some((content_change.text, toml_version));
+        }
+    }
 
     let need_publish_diagnostics = {
         let mut document_sources = backend.document_sources.write().await;
@@ -23,16 +36,8 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
             .version
             .is_none_or(|version| version < text_document.version);
 
-        for content_change in content_changes {
-            if let Some(range) = content_change.range {
-                log::warn!("Range change is not supported: {:?}", range);
-            } else {
-                let toml_version = backend
-                    .text_document_toml_version(&text_document_uri, &content_change.text)
-                    .await;
-
-                document.set_text(content_change.text, toml_version);
-            }
+        if let Some((text, toml_version)) = latest_content_change {
+            document.set_text(text, toml_version);
         }
         document.version = Some(text_document.version);
 

--- a/crates/tombi-lsp/src/handler/did_change.rs
+++ b/crates/tombi-lsp/src/handler/did_change.rs
@@ -12,29 +12,32 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
     } = params;
 
     let text_document_uri = text_document.uri.into();
-    let mut document_sources = backend.document_sources.write().await;
-    let Some(document) = document_sources.get_mut(&text_document_uri) else {
-        return;
-    };
 
-    let need_publish_diagnostics = document
-        .version
-        .is_none_or(|version| version < text_document.version);
+    let need_publish_diagnostics = {
+        let mut document_sources = backend.document_sources.write().await;
+        let Some(document) = document_sources.get_mut(&text_document_uri) else {
+            return;
+        };
 
-    for content_change in content_changes {
-        if let Some(range) = content_change.range {
-            log::warn!("Range change is not supported: {:?}", range);
-        } else {
-            let toml_version = backend
-                .text_document_toml_version(&text_document_uri, &content_change.text)
-                .await;
+        let need_publish_diagnostics = document
+            .version
+            .is_none_or(|version| version < text_document.version);
 
-            document.set_text(content_change.text, toml_version);
+        for content_change in content_changes {
+            if let Some(range) = content_change.range {
+                log::warn!("Range change is not supported: {:?}", range);
+            } else {
+                let toml_version = backend
+                    .text_document_toml_version(&text_document_uri, &content_change.text)
+                    .await;
+
+                document.set_text(content_change.text, toml_version);
+            }
         }
-    }
-    document.version = Some(text_document.version);
+        document.version = Some(text_document.version);
 
-    drop(document_sources);
+        need_publish_diagnostics
+    };
 
     if need_publish_diagnostics {
         // Publish diagnostics for the changed document

--- a/crates/tombi-lsp/src/handler/did_close.rs
+++ b/crates/tombi-lsp/src/handler/did_close.rs
@@ -9,9 +9,12 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
     let DidCloseTextDocumentParams { text_document } = params;
 
     let text_document_uri = text_document.uri.into();
-    let mut document_sources = backend.document_sources.write().await;
 
-    if let Some(document) = document_sources.get_mut(&text_document_uri) {
-        document.version = None;
+    {
+        let mut document_sources = backend.document_sources.write().await;
+
+        if let Some(document) = document_sources.get_mut(&text_document_uri) {
+            document.version = None;
+        }
     }
 }

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -21,10 +21,11 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
     );
     let document_tree = document_source.document_tree();
 
-    let mut document_sources = backend.document_sources.write().await;
+    {
+        let mut document_sources = backend.document_sources.write().await;
 
-    document_sources.insert(text_document_uri.clone(), document_source);
-    drop(document_sources);
+        document_sources.insert(text_document_uri.clone(), document_source);
+    }
 
     let config_schema_store = backend
         .config_manager

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -82,7 +82,6 @@ pub async fn handle_workspace_diagnostic(
                     },
                 },
             ));
-            continue;
         } else {
             items.push(WorkspaceDocumentDiagnosticReport::Full(
                 WorkspaceFullDocumentDiagnosticReport {

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -83,18 +83,18 @@ pub async fn handle_workspace_diagnostic(
                 },
             ));
             continue;
-        }
-
-        items.push(WorkspaceDocumentDiagnosticReport::Full(
-            WorkspaceFullDocumentDiagnosticReport {
-                uri: text_document_uri.into(),
-                version: version.map(i64::from),
-                full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                    result_id: Some(result_id),
-                    items: diagnostics,
+        } else {
+            items.push(WorkspaceDocumentDiagnosticReport::Full(
+                WorkspaceFullDocumentDiagnosticReport {
+                    uri: text_document_uri.into(),
+                    version: version.map(i64::from),
+                    full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                        result_id: Some(result_id),
+                        items: diagnostics,
+                    },
                 },
-            },
-        ));
+            ));
+        }
     }
 
     for previous_text_document_uri in previous_result_ids.keys() {

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -243,19 +243,21 @@ pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_
         .await;
     let encoding_kind = backend.capabilities.read().await.encoding_kind;
 
-    let mut document_sources = backend.document_sources.write().await;
-    if let Some(source) = document_sources.get_mut(&text_document_uri) {
-        if source.version.is_some() {
-            log::debug!("Skip diagnostics for open document: {text_document_uri}");
-            return false;
-        }
+    {
+        let mut document_sources = backend.document_sources.write().await;
+        if let Some(source) = document_sources.get_mut(&text_document_uri) {
+            if source.version.is_some() {
+                log::debug!("Skip diagnostics for open document: {text_document_uri}");
+                return false;
+            }
 
-        source.set_text(content, toml_version);
-    } else {
-        document_sources.insert(
-            text_document_uri.clone(),
-            DocumentSource::new(content, None, toml_version, encoding_kind),
-        );
+            source.set_text(content, toml_version);
+        } else {
+            document_sources.insert(
+                text_document_uri.clone(),
+                DocumentSource::new(content, None, toml_version, encoding_kind),
+            );
+        }
     }
 
     true


### PR DESCRIPTION
## Summary
- narrow `document_sources` write lock scopes in LSP open/close/change handlers
- keep workspace diagnostic source updates inside a small scoped lock block
- preserve existing diagnostic behavior while reducing long-lived lock ownership around follow-up async work

## Testing
- cargo fmt --all --check
- cargo check -p tombi-lsp
- cargo test -p tombi-lsp