### PR TITLE
refactor(lsp): extract workspace diagnostic modules

### DIFF
--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -1,7 +1,4 @@
-use std::path::PathBuf;
-
 use itertools::{Either, Itertools};
-use tombi_config::Config;
 use tombi_glob::{MatchResult, matches_file_patterns};
 use tombi_text::{IntoLsp, LineIndex};
 
@@ -118,51 +115,4 @@ pub async fn get_diagnostics_result(
         diagnostics,
         version,
     })
-}
-
-#[derive(Debug)]
-pub struct WorkspaceConfig {
-    pub workspace_folder_path: PathBuf,
-    pub config: Config,
-}
-
-pub async fn get_workspace_configs(
-    backend: &Backend,
-) -> Option<tombi_hashmap::HashMap<Option<PathBuf>, WorkspaceConfig>> {
-    let workspace_folder_paths =
-        backend
-            .client
-            .workspace_folders()
-            .await
-            .ok()
-            .flatten()
-            .map(|workspace_folders| {
-                workspace_folders
-                    .into_iter()
-                    .filter_map(|workspace| {
-                        tombi_uri::Uri::to_file_path(&workspace.uri.into()).ok()
-                    })
-                    .collect_vec()
-            });
-
-    log::debug!("workspace_folder_paths: {:?}", workspace_folder_paths);
-
-    let workspace_folder_paths = workspace_folder_paths?;
-
-    let mut configs = tombi_hashmap::HashMap::new();
-
-    for workspace_folder_path in workspace_folder_paths {
-        if let Ok((config, config_path)) =
-            serde_tombi::config::load_with_path(Some(workspace_folder_path.clone()))
-        {
-            configs
-                .entry(config_path.clone())
-                .or_insert(WorkspaceConfig {
-                    workspace_folder_path,
-                    config,
-                });
-        };
-    }
-
-    Some(configs)
 }

--- a/crates/tombi-lsp/src/handler/associate_schema.rs
+++ b/crates/tombi-lsp/src/handler/associate_schema.rs
@@ -4,7 +4,7 @@ use tombi_config::TomlVersion;
 
 use crate::{
     Backend,
-    handler::workspace_diagnostic::{WorkspaceDiagnosticOptions, push_workspace_diagnostics},
+    workspace_diagnostic::{WorkspaceDiagnosticOptions, push_workspace_diagnostics},
 };
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType};
 
-use crate::{backend::Backend, handler::workspace_diagnostic::upsert_document_source};
+use crate::{backend::Backend, workspace_diagnostic::upsert_document_source};
 
 use super::diagnostic::push_diagnostics;
 

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -6,7 +6,7 @@ use tower_lsp::lsp_types::{
 
 use crate::{
     backend::{Backend, DiagnosticMode},
-    handler::{push_workspace_diagnostics, workspace_diagnostic::WorkspaceDiagnosticOptions},
+    workspace_diagnostic::{WorkspaceDiagnosticOptions, push_workspace_diagnostics},
 };
 
 pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {

--- a/crates/tombi-lsp/src/handler/update_schema.rs
+++ b/crates/tombi-lsp/src/handler/update_schema.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{
 
 use crate::{
     backend::Backend,
-    handler::workspace_diagnostic::{WorkspaceDiagnosticOptions, push_workspace_diagnostics},
+    workspace_diagnostic::{WorkspaceDiagnosticOptions, push_workspace_diagnostics},
 };
 
 pub async fn handle_update_schema(

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -3,7 +3,6 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use tombi_glob::search_pattern_matched_paths;
 use tower_lsp::lsp_types::{
     FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport, WorkspaceDiagnosticParams,
     WorkspaceDiagnosticReport, WorkspaceDiagnosticReportResult, WorkspaceDocumentDiagnosticReport,
@@ -12,30 +11,9 @@ use tower_lsp::lsp_types::{
 
 use crate::{
     backend::Backend,
-    diagnostic::{
-        DiagnosticsResult, WorkspaceConfig, get_diagnostics_result, get_workspace_configs,
-    },
-    document::DocumentSource,
+    diagnostic::{DiagnosticsResult, get_diagnostics_result},
+    workspace_diagnostic::collect_workspace_diagnostic_targets,
 };
-
-#[derive(Debug, Default)]
-pub struct WorkspaceDiagnosticOptions {
-    pub include_open_files: bool,
-}
-
-pub async fn push_workspace_diagnostics(
-    backend: &Backend,
-    options: &WorkspaceDiagnosticOptions,
-) -> Result<(), tower_lsp::jsonrpc::Error> {
-    log::info!("push_workspace_diagnostics");
-    log::trace!("{:?}", options);
-
-    for text_document_uri in collect_workspace_diagnostic_targets(backend).await {
-        publish_workspace_diagnostics(backend, text_document_uri, options).await;
-    }
-
-    Ok(())
-}
 
 pub async fn handle_workspace_diagnostic(
     backend: &Backend,
@@ -118,7 +96,7 @@ pub async fn handle_workspace_diagnostic(
     ))
 }
 
-fn workspace_diagnostic_result_id(
+pub fn workspace_diagnostic_result_id(
     version: Option<i32>,
     diagnostics: &[tower_lsp::lsp_types::Diagnostic],
 ) -> String {
@@ -128,136 +106,4 @@ fn workspace_diagnostic_result_id(
         .unwrap_or_default()
         .hash(&mut hasher);
     format!("{:x}", hasher.finish())
-}
-
-async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {
-    let Some(configs) = get_workspace_configs(backend).await else {
-        return Vec::new();
-    };
-
-    let mut targets = tombi_hashmap::HashSet::new();
-    let home_dir = dirs::home_dir();
-
-    for workspace_config in configs.into_values() {
-        if !is_workspace_diagnostic_enabled(&workspace_config) {
-            log::debug!(
-                "`lsp.workspace-diagnostic.enabled` is false in {}",
-                workspace_config.workspace_folder_path.display()
-            );
-            continue;
-        }
-
-        if let Some(home_dir) = &home_dir
-            && &workspace_config.workspace_folder_path == home_dir
-        {
-            log::debug!(
-                "Skip diagnostics for workspace folder matching $HOME: {:?}",
-                workspace_config.workspace_folder_path
-            );
-            continue;
-        }
-
-        let files_options = workspace_config.config.files.clone().unwrap_or_default();
-
-        for matched_path in
-            search_pattern_matched_paths(workspace_config.workspace_folder_path, files_options)
-                .await
-        {
-            let tombi_glob::FileSearchEntry::Found(path) = matched_path else {
-                continue;
-            };
-
-            if let Ok(uri) = tombi_uri::Uri::from_file_path(path) {
-                upsert_document_source(backend, uri.clone()).await;
-
-                targets.insert(uri);
-            }
-        }
-    }
-
-    targets.into_iter().collect()
-}
-
-async fn publish_workspace_diagnostics(
-    backend: &Backend,
-    text_document_uri: tombi_uri::Uri,
-    options: &WorkspaceDiagnosticOptions,
-) {
-    let Some(diagnostics_result) = get_diagnostics_result(backend, &text_document_uri).await else {
-        return;
-    };
-
-    log::trace!("{:?}", diagnostics_result);
-
-    let DiagnosticsResult {
-        diagnostics,
-        version,
-    } = diagnostics_result;
-
-    if !options.include_open_files && version.is_some() {
-        log::debug!(
-            "Skip publishing workspace diagnostics because version is some: {text_document_uri}"
-        );
-        return;
-    }
-
-    backend
-        .client
-        .publish_diagnostics(text_document_uri.into(), diagnostics, version)
-        .await
-}
-
-/// Check if workspace diagnostic is enabled for the given workspace config
-#[inline]
-fn is_workspace_diagnostic_enabled(workspace_config: &WorkspaceConfig) -> bool {
-    workspace_config
-        .config
-        .lsp
-        .as_ref()
-        .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
-        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
-}
-
-pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_uri::Uri) -> bool {
-    let text_document_path = match text_document_uri.to_file_path() {
-        Ok(text_document_path) => text_document_path,
-        Err(_) => {
-            log::warn!("Watcher event for non-file URI: {text_document_uri}");
-            return false;
-        }
-    };
-
-    let Ok(content) = tokio::fs::read_to_string(&text_document_path).await else {
-        log::warn!(
-            "Failed to read file for diagnostics: {:?}",
-            text_document_path
-        );
-        return false;
-    };
-
-    let toml_version = backend
-        .text_document_toml_version(&text_document_uri, &content)
-        .await;
-    let encoding_kind = backend.capabilities.read().await.encoding_kind;
-
-    {
-        let mut document_sources = backend.document_sources.write().await;
-        if let Some(source) = document_sources.get_mut(&text_document_uri) {
-            if source.version.is_some() {
-                log::debug!("Skip diagnostics for open document: {text_document_uri}");
-                return false;
-            }
-
-            source.set_text(content, toml_version);
-        } else {
-            document_sources.insert(
-                text_document_uri.clone(),
-                DocumentSource::new(content, None, toml_version, encoding_kind),
-            );
-        }
-    }
-
-    true
 }

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{
 use crate::{
     backend::Backend,
     diagnostic::{DiagnosticsResult, get_diagnostics_result},
-    workspace_diagnostic::collect_workspace_diagnostic_targets,
+    workspace_diagnostic as crate_workspace_diagnostic,
 };
 
 pub async fn handle_workspace_diagnostic(
@@ -28,7 +28,7 @@ pub async fn handle_workspace_diagnostic(
         .map(|result| (tombi_uri::Uri::from(result.uri), result.value))
         .collect::<tombi_hashmap::HashMap<_, _>>();
 
-    let targets = collect_workspace_diagnostic_targets(backend).await;
+    let targets = crate_workspace_diagnostic::collect_workspace_diagnostic_targets(backend).await;
     let target_set = targets
         .iter()
         .cloned()

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -13,6 +13,8 @@ mod references;
 mod remote_file;
 mod schema_resolver;
 mod semantic_tokens;
+mod workspace_config;
+mod workspace_diagnostic;
 
 pub mod handler {
     mod associate_schema;
@@ -79,7 +81,7 @@ pub mod handler {
     pub use shutdown::handle_shutdown;
     pub use update_config::handle_update_config;
     pub use update_schema::handle_update_schema;
-    pub use workspace_diagnostic::{handle_workspace_diagnostic, push_workspace_diagnostics};
+    pub use workspace_diagnostic::handle_workspace_diagnostic;
 }
 
 pub use backend::Backend;

--- a/crates/tombi-lsp/src/workspace_config.rs
+++ b/crates/tombi-lsp/src/workspace_config.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use itertools::Itertools;
+use tombi_config::Config;
+
+use crate::Backend;
+
+#[derive(Debug)]
+pub struct WorkspaceConfig {
+    pub workspace_folder_path: PathBuf,
+    pub config: Config,
+}
+
+pub async fn get_workspace_configs(
+    backend: &Backend,
+) -> Option<tombi_hashmap::HashMap<Option<PathBuf>, WorkspaceConfig>> {
+    let workspace_folder_paths =
+        backend
+            .client
+            .workspace_folders()
+            .await
+            .ok()
+            .flatten()
+            .map(|workspace_folders| {
+                workspace_folders
+                    .into_iter()
+                    .filter_map(|workspace| {
+                        tombi_uri::Uri::to_file_path(&workspace.uri.into()).ok()
+                    })
+                    .collect_vec()
+            });
+
+    log::debug!("workspace_folder_paths: {:?}", workspace_folder_paths);
+
+    let workspace_folder_paths = workspace_folder_paths?;
+
+    let mut configs = tombi_hashmap::HashMap::new();
+
+    for workspace_folder_path in workspace_folder_paths {
+        if let Ok((config, config_path)) =
+            serde_tombi::config::load_with_path(Some(workspace_folder_path.clone()))
+        {
+            configs
+                .entry(config_path.clone())
+                .or_insert(WorkspaceConfig {
+                    workspace_folder_path,
+                    config,
+                });
+        };
+    }
+
+    Some(configs)
+}

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -1,0 +1,159 @@
+use tombi_glob::search_pattern_matched_paths;
+
+use crate::{
+    Backend,
+    diagnostic::{DiagnosticsResult, get_diagnostics_result},
+    document::DocumentSource,
+    workspace_config::{WorkspaceConfig, get_workspace_configs},
+};
+
+#[derive(Debug, Default)]
+pub struct WorkspaceDiagnosticOptions {
+    pub include_open_files: bool,
+}
+
+pub async fn push_workspace_diagnostics(
+    backend: &Backend,
+    options: &WorkspaceDiagnosticOptions,
+) -> Result<(), tower_lsp::jsonrpc::Error> {
+    log::info!("push_workspace_diagnostics");
+    log::trace!("{:?}", options);
+
+    for text_document_uri in collect_workspace_diagnostic_targets(backend).await {
+        publish_workspace_diagnostics(backend, text_document_uri, options).await;
+    }
+
+    Ok(())
+}
+
+pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {
+    let Some(configs) = get_workspace_configs(backend).await else {
+        return Vec::new();
+    };
+
+    let mut targets = tombi_hashmap::HashSet::new();
+    let home_dir = dirs::home_dir();
+
+    for workspace_config in configs.into_values() {
+        if !is_workspace_diagnostic_enabled(&workspace_config) {
+            log::debug!(
+                "`lsp.workspace-diagnostic.enabled` is false in {}",
+                workspace_config.workspace_folder_path.display()
+            );
+            continue;
+        }
+
+        if let Some(home_dir) = &home_dir
+            && &workspace_config.workspace_folder_path == home_dir
+        {
+            log::debug!(
+                "Skip diagnostics for workspace folder matching $HOME: {:?}",
+                workspace_config.workspace_folder_path
+            );
+            continue;
+        }
+
+        let files_options = workspace_config.config.files.clone().unwrap_or_default();
+
+        for matched_path in
+            search_pattern_matched_paths(workspace_config.workspace_folder_path, files_options)
+                .await
+        {
+            let tombi_glob::FileSearchEntry::Found(path) = matched_path else {
+                continue;
+            };
+
+            if let Ok(uri) = tombi_uri::Uri::from_file_path(path) {
+                upsert_document_source(backend, uri.clone()).await;
+
+                targets.insert(uri);
+            }
+        }
+    }
+
+    targets.into_iter().collect()
+}
+
+async fn publish_workspace_diagnostics(
+    backend: &Backend,
+    text_document_uri: tombi_uri::Uri,
+    options: &WorkspaceDiagnosticOptions,
+) {
+    let Some(diagnostics_result) = get_diagnostics_result(backend, &text_document_uri).await else {
+        return;
+    };
+
+    log::trace!("{:?}", diagnostics_result);
+
+    let DiagnosticsResult {
+        diagnostics,
+        version,
+    } = diagnostics_result;
+
+    if !options.include_open_files && version.is_some() {
+        log::debug!(
+            "Skip publishing workspace diagnostics because version is some: {text_document_uri}"
+        );
+        return;
+    }
+
+    backend
+        .client
+        .publish_diagnostics(text_document_uri.into(), diagnostics, version)
+        .await
+}
+
+/// Check if workspace diagnostic is enabled for the given workspace config
+#[inline]
+fn is_workspace_diagnostic_enabled(workspace_config: &WorkspaceConfig) -> bool {
+    workspace_config
+        .config
+        .lsp
+        .as_ref()
+        .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
+        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
+        .unwrap_or_default()
+        .value()
+}
+
+pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_uri::Uri) -> bool {
+    let text_document_path = match text_document_uri.to_file_path() {
+        Ok(text_document_path) => text_document_path,
+        Err(_) => {
+            log::warn!("Watcher event for non-file URI: {text_document_uri}");
+            return false;
+        }
+    };
+
+    let Ok(content) = tokio::fs::read_to_string(&text_document_path).await else {
+        log::warn!(
+            "Failed to read file for diagnostics: {:?}",
+            text_document_path
+        );
+        return false;
+    };
+
+    let toml_version = backend
+        .text_document_toml_version(&text_document_uri, &content)
+        .await;
+    let encoding_kind = backend.capabilities.read().await.encoding_kind;
+
+    {
+        let mut document_sources = backend.document_sources.write().await;
+        if let Some(source) = document_sources.get_mut(&text_document_uri) {
+            if source.version.is_some() {
+                log::debug!("Skip diagnostics for open document: {text_document_uri}");
+                return false;
+            }
+
+            source.set_text(content, toml_version);
+        } else {
+            document_sources.insert(
+                text_document_uri.clone(),
+                DocumentSource::new(content, None, toml_version, encoding_kind),
+            );
+        }
+    }
+
+    true
+}


### PR DESCRIPTION
## Summary
- move workspace config loading out of `diagnostic.rs` into `workspace_config.rs`
- move workspace diagnostic collection and publishing logic into `workspace_diagnostic.rs`
- update LSP handlers and exports to use the new module boundaries

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked