### PR TITLE
perf(lsp): cache workspace diagnostics

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -128,16 +128,17 @@ impl Backend {
     }
 
     pub async fn refresh_pull_diagnostics(&self) {
-        let capabilities = self.capabilities.read().await;
-        if capabilities.diagnostic_mode != DiagnosticMode::Pull {
-            return;
-        }
+        {
+            let capabilities = self.capabilities.read().await;
+            if capabilities.diagnostic_mode != DiagnosticMode::Pull {
+                return;
+            }
 
-        if !capabilities.workspace_diagnostic_refresh_support {
-            log::debug!("Client does not support workspace/diagnostic/refresh");
-            return;
+            if !capabilities.workspace_diagnostic_refresh_support {
+                log::debug!("Client does not support workspace/diagnostic/refresh");
+                return;
+            }
         }
-        drop(capabilities);
 
         if let Err(error) = self.client.workspace_diagnostic_refresh().await {
             log::debug!("Failed to request diagnostic refresh: {error}");

--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -38,6 +38,7 @@ use crate::{
         handle_update_config, handle_update_schema, handle_workspace_diagnostic, push_diagnostics,
     },
     references::try_get_reference_locations,
+    workspace_diagnostic::WorkspaceDiagnosticsCache,
 };
 
 use tombi_text::EncodingKind;
@@ -51,6 +52,7 @@ pub struct Backend {
     pub document_sources:
         Arc<tokio::sync::RwLock<tombi_hashmap::HashMap<tombi_uri::Uri, DocumentSource>>>,
     pub config_manager: Arc<ConfigManager>,
+    pub workspace_diagnostics_cache: Arc<tokio::sync::RwLock<WorkspaceDiagnosticsCache>>,
 }
 
 #[derive(Debug)]
@@ -96,6 +98,7 @@ impl Backend {
             background_tasks: Default::default(),
             document_sources: Default::default(),
             config_manager: Arc::new(ConfigManager::new(options)),
+            workspace_diagnostics_cache: Default::default(),
         }
     }
 

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -107,7 +107,15 @@ pub async fn get_diagnostics_result(
 
     {
         let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
-        workspace_diagnostics_cache.set(text_document_uri.clone(), diagnostics_result.clone());
+        if let Ok(document_sources) = backend.document_sources.try_read() {
+            let current_version = document_sources
+                .get(text_document_uri)
+                .and_then(|document_source| document_source.version);
+            if current_version == diagnostics_result.version {
+                workspace_diagnostics_cache
+                    .set(text_document_uri.clone(), diagnostics_result.clone());
+            }
+        }
     }
 
     Some(diagnostics_result)

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -4,25 +4,7 @@ use tombi_text::{IntoLsp, LineIndex};
 
 use crate::{backend::Backend, config_manager::ConfigSchemaStore};
 
-pub async fn publish_diagnostics(backend: &Backend, text_document_uri: tombi_uri::Uri) {
-    let Some(diagnostics_result) = get_diagnostics_result(backend, &text_document_uri).await else {
-        return;
-    };
-
-    log::trace!("{:?}", diagnostics_result);
-
-    let DiagnosticsResult {
-        diagnostics,
-        version,
-    } = diagnostics_result;
-
-    backend
-        .client
-        .publish_diagnostics(text_document_uri.into(), diagnostics, version)
-        .await
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DiagnosticsResult {
     pub diagnostics: Vec<tower_lsp::lsp_types::Diagnostic>,
     pub version: Option<i32>,
@@ -32,6 +14,13 @@ pub async fn get_diagnostics_result(
     backend: &Backend,
     text_document_uri: &tombi_uri::Uri,
 ) -> Option<DiagnosticsResult> {
+    {
+        let workspace_diagnostics_cache = backend.workspace_diagnostics_cache.read().await;
+        if let Some(diagnostics_result) = workspace_diagnostics_cache.get(text_document_uri) {
+            return Some(diagnostics_result.clone());
+        }
+    }
+
     let ConfigSchemaStore {
         config,
         schema_store,
@@ -111,8 +100,15 @@ pub async fn get_diagnostics_result(
         }
     };
 
-    Some(DiagnosticsResult {
+    let diagnostics_result = DiagnosticsResult {
         diagnostics,
         version,
-    })
+    };
+
+    {
+        let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
+        workspace_diagnostics_cache.set(text_document_uri.clone(), diagnostics_result.clone());
+    }
+
+    Some(diagnostics_result)
 }

--- a/crates/tombi-lsp/src/handler/associate_schema.rs
+++ b/crates/tombi-lsp/src/handler/associate_schema.rs
@@ -64,6 +64,12 @@ pub async fn handle_associate_schema(backend: &Backend, params: AssociateSchemaP
         .await;
 
     // Refresh workspace diagnostics after schema association
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .clear_all();
+
     if let Err(err) = push_workspace_diagnostics(
         backend,
         &WorkspaceDiagnosticOptions {

--- a/crates/tombi-lsp/src/handler/diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/diagnostic.rs
@@ -3,10 +3,7 @@ use tower_lsp::lsp_types::{
     FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
 };
 
-use crate::{
-    backend::Backend,
-    diagnostic::{get_diagnostics_result, publish_diagnostics},
-};
+use crate::{backend::Backend, diagnostic::get_diagnostics_result};
 
 /// Pull diagnostics
 pub async fn handle_diagnostic(
@@ -58,5 +55,20 @@ pub async fn push_diagnostics(backend: &Backend, text_document_uri: tombi_uri::U
     log::info!("push_diagnostics");
     log::trace!("{:?}", params);
 
-    publish_diagnostics(backend, params.text_document.uri).await;
+    let Some(diagnostics_result) = get_diagnostics_result(backend, &params.text_document.uri).await
+    else {
+        return;
+    };
+
+    log::trace!("{:?}", diagnostics_result);
+
+    let crate::diagnostic::DiagnosticsResult {
+        diagnostics,
+        version,
+    } = diagnostics_result;
+
+    backend
+        .client
+        .publish_diagnostics(params.text_document.uri.into(), diagnostics, version)
+        .await;
 }

--- a/crates/tombi-lsp/src/handler/did_change.rs
+++ b/crates/tombi-lsp/src/handler/did_change.rs
@@ -44,6 +44,12 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
         need_publish_diagnostics
     };
 
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .clear(&text_document_uri);
+
     if need_publish_diagnostics {
         // Publish diagnostics for the changed document
         backend.push_diagnostics(text_document_uri).await;

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -46,7 +46,7 @@ pub async fn handle_did_change_watched_files(
                         .workspace_diagnostics_cache
                         .write()
                         .await
-                        .clear(&uri);
+                        .untrack(&uri);
 
                     push_diagnostics(backend, uri).await;
                     should_refresh_pull_diagnostics = true;

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -17,7 +17,7 @@ pub async fn handle_did_change_watched_files(
 
     let mut should_refresh_pull_diagnostics = false;
     let home_dir = dirs::home_dir();
-    let workspace_configs = get_workspace_configs(backend).await.unwrap_or_default();
+    let mut workspace_configs: Option<Vec<WorkspaceConfig>> = None;
 
     for change in params.changes {
         let uri: tombi_uri::Uri = change.uri.clone().into();
@@ -48,8 +48,16 @@ pub async fn handle_did_change_watched_files(
             }
             FileChangeType::CREATED => {
                 if upsert_document_source(backend, uri.clone()).await {
-                    let is_workspace_target =
-                        is_workspace_target(&uri, &workspace_configs, home_dir.as_deref());
+                    if workspace_configs.is_none() {
+                        workspace_configs =
+                            Some(get_workspace_configs(backend).await.unwrap_or_default());
+                    }
+
+                    let is_workspace_target = is_workspace_target(
+                        &uri,
+                        workspace_configs.as_deref().unwrap_or(&[]),
+                        home_dir.as_deref(),
+                    );
 
                     backend
                         .workspace_diagnostics_cache

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -1,6 +1,10 @@
 use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType};
 
-use crate::{backend::Backend, workspace_diagnostic::upsert_document_source};
+use crate::{
+    backend::Backend,
+    workspace_config::{WorkspaceConfig, get_workspace_configs},
+    workspace_diagnostic::upsert_document_source,
+};
 
 use super::diagnostic::push_diagnostics;
 
@@ -12,6 +16,8 @@ pub async fn handle_did_change_watched_files(
     log::trace!("{:?}", params);
 
     let mut should_refresh_pull_diagnostics = false;
+    let home_dir = dirs::home_dir();
+    let workspace_configs = get_workspace_configs(backend).await.unwrap_or_default();
 
     for change in params.changes {
         let uri: tombi_uri::Uri = change.uri.clone().into();
@@ -25,12 +31,6 @@ pub async fn handle_did_change_watched_files(
                     document_sources.remove(&uri);
                 }
 
-                backend
-                    .workspace_diagnostics_cache
-                    .write()
-                    .await
-                    .untrack(&uri);
-
                 if backend.is_diagnostic_mode_push().await {
                     backend
                         .client
@@ -39,14 +39,35 @@ pub async fn handle_did_change_watched_files(
                 } else {
                     should_refresh_pull_diagnostics = true;
                 }
+
+                backend
+                    .workspace_diagnostics_cache
+                    .write()
+                    .await
+                    .untrack(&uri);
             }
-            FileChangeType::CREATED | FileChangeType::CHANGED => {
+            FileChangeType::CREATED => {
+                if upsert_document_source(backend, uri.clone()).await {
+                    let is_workspace_target =
+                        is_workspace_target(&uri, &workspace_configs, home_dir.as_deref());
+
+                    backend
+                        .workspace_diagnostics_cache
+                        .write()
+                        .await
+                        .track(uri.clone(), is_workspace_target);
+
+                    push_diagnostics(backend, uri).await;
+                    should_refresh_pull_diagnostics = true;
+                }
+            }
+            FileChangeType::CHANGED => {
                 if upsert_document_source(backend, uri.clone()).await {
                     backend
                         .workspace_diagnostics_cache
                         .write()
                         .await
-                        .untrack(&uri);
+                        .clear(&uri);
 
                     push_diagnostics(backend, uri).await;
                     should_refresh_pull_diagnostics = true;
@@ -61,4 +82,18 @@ pub async fn handle_did_change_watched_files(
     if should_refresh_pull_diagnostics {
         backend.refresh_pull_diagnostics().await;
     }
+}
+
+fn is_workspace_target(
+    text_document_uri: &tombi_uri::Uri,
+    workspace_configs: &[WorkspaceConfig],
+    home_dir: Option<&std::path::Path>,
+) -> bool {
+    let Ok(text_document_path) = tombi_uri::Uri::to_file_path(text_document_uri) else {
+        return false;
+    };
+
+    workspace_configs
+        .iter()
+        .any(|workspace_config| workspace_config.is_workspace_target(&text_document_path, home_dir))
 }

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -25,6 +25,12 @@ pub async fn handle_did_change_watched_files(
                     document_sources.remove(&uri);
                 }
 
+                backend
+                    .workspace_diagnostics_cache
+                    .write()
+                    .await
+                    .untrack(&uri);
+
                 if backend.is_diagnostic_mode_push().await {
                     backend
                         .client
@@ -36,6 +42,12 @@ pub async fn handle_did_change_watched_files(
             }
             FileChangeType::CREATED | FileChangeType::CHANGED => {
                 if upsert_document_source(backend, uri.clone()).await {
+                    backend
+                        .workspace_diagnostics_cache
+                        .write()
+                        .await
+                        .clear(&uri);
+
                     push_diagnostics(backend, uri).await;
                     should_refresh_pull_diagnostics = true;
                 }

--- a/crates/tombi-lsp/src/handler/did_close.rs
+++ b/crates/tombi-lsp/src/handler/did_close.rs
@@ -17,4 +17,10 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
             document.version = None;
         }
     }
+
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .close(&text_document_uri);
 }

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -27,6 +27,12 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
         document_sources.insert(text_document_uri.clone(), document_source);
     }
 
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .clear(&text_document_uri);
+
     let config_schema_store = backend
         .config_manager
         .config_schema_store_for_uri(&text_document_uri)

--- a/crates/tombi-lsp/src/handler/did_save.rs
+++ b/crates/tombi-lsp/src/handler/did_save.rs
@@ -31,6 +31,12 @@ pub async fn handle_did_save(backend: &Backend, params: DidSaveTextDocumentParam
         };
     };
 
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .clear(&text_document_uri);
+
     // Publish diagnostics for the saved document
     if need_publish_diagnostics {
         backend.push_diagnostics(text_document_uri).await

--- a/crates/tombi-lsp/src/handler/update_config.rs
+++ b/crates/tombi-lsp/src/handler/update_config.rs
@@ -20,6 +20,7 @@ pub async fn handle_update_config(
                     .await
                 {
                     Ok(_) => {
+                        backend.workspace_diagnostics_cache.write().await.reset();
                         log::info!("Updated config: {}", text_document_uri);
                         return Ok(true);
                     }

--- a/crates/tombi-lsp/src/handler/update_schema.rs
+++ b/crates/tombi-lsp/src/handler/update_schema.rs
@@ -24,6 +24,12 @@ pub async fn handle_update_schema(
     {
         Ok(is_updated) => {
             if is_updated {
+                backend
+                    .workspace_diagnostics_cache
+                    .write()
+                    .await
+                    .clear_all();
+
                 // Refresh workspace diagnostics after schema update
                 // Include open files to ensure diagnostics are updated for all files, including those open in the editor
                 if let Err(err) = push_workspace_diagnostics(

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{
 use crate::{
     backend::Backend,
     diagnostic::{DiagnosticsResult, get_diagnostics_result},
-    workspace_diagnostic as crate_workspace_diagnostic,
+    workspace_diagnostic::collect_workspace_diagnostic_targets,
 };
 
 pub async fn handle_workspace_diagnostic(
@@ -28,7 +28,7 @@ pub async fn handle_workspace_diagnostic(
         .map(|result| (tombi_uri::Uri::from(result.uri), result.value))
         .collect::<tombi_hashmap::HashMap<_, _>>();
 
-    let targets = crate_workspace_diagnostic::collect_workspace_diagnostic_targets(backend).await;
+    let targets = collect_workspace_diagnostic_targets(backend).await;
     let target_set = targets
         .iter()
         .cloned()

--- a/crates/tombi-lsp/src/workspace_config.rs
+++ b/crates/tombi-lsp/src/workspace_config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 use tombi_config::Config;
+use tombi_glob::{MatchResult, matches_file_patterns};
 
 use crate::Backend;
 
@@ -9,11 +10,46 @@ use crate::Backend;
 pub struct WorkspaceConfig {
     pub workspace_folder_path: PathBuf,
     pub config: Config,
+    pub config_path: Option<PathBuf>,
 }
 
-pub async fn get_workspace_configs(
-    backend: &Backend,
-) -> Option<tombi_hashmap::HashMap<Option<PathBuf>, WorkspaceConfig>> {
+impl WorkspaceConfig {
+    #[inline]
+    pub fn is_workspace_diagnostic_enabled(&self) -> bool {
+        self.config
+            .lsp
+            .as_ref()
+            .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
+            .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
+            .unwrap_or_default()
+            .value()
+    }
+
+    #[inline]
+    pub fn is_workspace_target(
+        &self,
+        text_document_path: &std::path::Path,
+        home_dir: Option<&std::path::Path>,
+    ) -> bool {
+        if !self.is_workspace_diagnostic_enabled() {
+            return false;
+        }
+
+        if let Some(home_dir) = home_dir
+            && self.workspace_folder_path == home_dir
+        {
+            return false;
+        }
+
+        matches_file_patterns(
+            text_document_path,
+            self.config_path.as_deref(),
+            &self.config,
+        ) == MatchResult::Matched
+    }
+}
+
+pub async fn get_workspace_configs(backend: &Backend) -> Option<Vec<WorkspaceConfig>> {
     let workspace_folder_paths =
         backend
             .client
@@ -34,18 +70,17 @@ pub async fn get_workspace_configs(
 
     let workspace_folder_paths = workspace_folder_paths?;
 
-    let mut configs = tombi_hashmap::HashMap::new();
+    let mut configs = Vec::with_capacity(workspace_folder_paths.len());
 
     for workspace_folder_path in workspace_folder_paths {
         if let Ok((config, config_path)) =
             serde_tombi::config::load_with_path(Some(workspace_folder_path.clone()))
         {
-            configs
-                .entry(config_path.clone())
-                .or_insert(WorkspaceConfig {
-                    workspace_folder_path,
-                    config,
-                });
+            configs.push(WorkspaceConfig {
+                workspace_folder_path,
+                config,
+                config_path,
+            });
         };
     }
 

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -77,16 +77,18 @@ pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tomb
     }
 
     let mut targets = Vec::with_capacity(candidates.len());
-    {
-        let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
 
-        for target in &candidates {
-            if upsert_document_source(backend, target.clone()).await {
-                workspace_diagnostics_cache.track(target.clone());
-                targets.push(target.clone());
-            }
+    for target in candidates {
+        if upsert_document_source(backend, target.clone()).await {
+            targets.push(target);
         }
     }
+
+    let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
+    for target in &targets {
+        workspace_diagnostics_cache.track(target.clone());
+    }
+
     targets
 }
 

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -1,3 +1,5 @@
+mod cache;
+
 use tombi_glob::search_pattern_matched_paths;
 
 use crate::{
@@ -6,6 +8,7 @@ use crate::{
     document::DocumentSource,
     workspace_config::{WorkspaceConfig, get_workspace_configs},
 };
+pub use cache::WorkspaceDiagnosticsCache;
 
 #[derive(Debug, Default)]
 pub struct WorkspaceDiagnosticOptions {
@@ -27,11 +30,15 @@ pub async fn push_workspace_diagnostics(
 }
 
 pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {
+    if let Some(targets) = backend.workspace_diagnostics_cache.read().await.tracked() {
+        return targets;
+    }
+
     let Some(configs) = get_workspace_configs(backend).await else {
         return Vec::new();
     };
 
-    let mut targets = tombi_hashmap::HashSet::new();
+    let mut candidates = tombi_hashmap::HashSet::new();
     let home_dir = dirs::home_dir();
 
     for workspace_config in configs.into_values() {
@@ -64,14 +71,23 @@ pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tomb
             };
 
             if let Ok(uri) = tombi_uri::Uri::from_file_path(path) {
-                upsert_document_source(backend, uri.clone()).await;
-
-                targets.insert(uri);
+                candidates.insert(uri);
             }
         }
     }
 
-    targets.into_iter().collect()
+    let mut targets = Vec::with_capacity(candidates.len());
+    {
+        let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
+
+        for target in &candidates {
+            if upsert_document_source(backend, target.clone()).await {
+                workspace_diagnostics_cache.track(target.clone());
+                targets.push(target.clone());
+            }
+        }
+    }
+    targets
 }
 
 async fn publish_workspace_diagnostics(

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -154,7 +154,7 @@ pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_
         if let Some(source) = document_sources.get_mut(&text_document_uri) {
             if source.version.is_some() {
                 log::debug!("Skip diagnostics for open document: {text_document_uri}");
-                return false;
+                return true;
             }
 
             source.set_text(content, toml_version);

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -6,7 +6,7 @@ use crate::{
     Backend,
     diagnostic::{DiagnosticsResult, get_diagnostics_result},
     document::DocumentSource,
-    workspace_config::{WorkspaceConfig, get_workspace_configs},
+    workspace_config::get_workspace_configs,
 };
 pub use cache::WorkspaceDiagnosticsCache;
 
@@ -30,7 +30,12 @@ pub async fn push_workspace_diagnostics(
 }
 
 pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tombi_uri::Uri> {
-    if let Some(targets) = backend.workspace_diagnostics_cache.read().await.tracked() {
+    if let Some(targets) = backend
+        .workspace_diagnostics_cache
+        .read()
+        .await
+        .workspace_targets()
+    {
         return targets;
     }
 
@@ -41,8 +46,8 @@ pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tomb
     let mut candidates = tombi_hashmap::HashSet::new();
     let home_dir = dirs::home_dir();
 
-    for workspace_config in configs.into_values() {
-        if !is_workspace_diagnostic_enabled(&workspace_config) {
+    for workspace_config in configs {
+        if !workspace_config.is_workspace_diagnostic_enabled() {
             log::debug!(
                 "`lsp.workspace-diagnostic.enabled` is false in {}",
                 workspace_config.workspace_folder_path.display()
@@ -84,10 +89,11 @@ pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tomb
         }
     }
 
-    let mut workspace_diagnostics_cache = backend.workspace_diagnostics_cache.write().await;
-    for target in &targets {
-        workspace_diagnostics_cache.track(target.clone());
-    }
+    backend
+        .workspace_diagnostics_cache
+        .write()
+        .await
+        .set_workspace_targets(targets.clone().into_iter().collect());
 
     targets
 }
@@ -119,19 +125,6 @@ async fn publish_workspace_diagnostics(
         .client
         .publish_diagnostics(text_document_uri.into(), diagnostics, version)
         .await
-}
-
-/// Check if workspace diagnostic is enabled for the given workspace config
-#[inline]
-fn is_workspace_diagnostic_enabled(workspace_config: &WorkspaceConfig) -> bool {
-    workspace_config
-        .config
-        .lsp
-        .as_ref()
-        .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
-        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
 }
 
 pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_uri::Uri) -> bool {

--- a/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
@@ -1,0 +1,65 @@
+use crate::diagnostic::DiagnosticsResult;
+
+#[derive(Debug, Default)]
+pub struct WorkspaceDiagnosticsCache(
+    Option<tombi_hashmap::HashMap<tombi_uri::Uri, Option<DiagnosticsResult>>>,
+);
+
+impl WorkspaceDiagnosticsCache {
+    pub fn get(&self, text_document_uri: &tombi_uri::Uri) -> Option<&DiagnosticsResult> {
+        self.0
+            .as_ref()
+            .and_then(|diagnostics_cache| diagnostics_cache.get(text_document_uri))
+            .and_then(|diagnostics_result| diagnostics_result.as_ref())
+    }
+
+    pub fn set(
+        &mut self,
+        text_document_uri: tombi_uri::Uri,
+        diagnostics_result: DiagnosticsResult,
+    ) {
+        let diagnostics_cache = self.0.get_or_insert_default();
+        diagnostics_cache.insert(text_document_uri, Some(diagnostics_result));
+    }
+
+    pub fn tracked(&self) -> Option<Vec<tombi_uri::Uri>> {
+        self.0
+            .as_ref()
+            .map(|diagnostics_cache| diagnostics_cache.keys().cloned().collect())
+    }
+
+    pub fn track(&mut self, text_document_uri: tombi_uri::Uri) {
+        let diagnostics_cache = self.0.get_or_insert_default();
+        diagnostics_cache.entry(text_document_uri).or_insert(None);
+    }
+
+    pub fn untrack(&mut self, text_document_uri: &tombi_uri::Uri) {
+        if let Some(diagnostics_cache) = self.0.as_mut() {
+            diagnostics_cache.remove(text_document_uri);
+        }
+    }
+
+    pub fn clear(&mut self, text_document_uri: &tombi_uri::Uri) {
+        let Some(diagnostics_cache) = self.0.as_mut() else {
+            return;
+        };
+
+        if let Some(entry) = diagnostics_cache.get_mut(text_document_uri) {
+            *entry = None;
+        }
+    }
+
+    pub fn clear_all(&mut self) {
+        let Some(diagnostics_cache) = self.0.as_mut() else {
+            return;
+        };
+
+        for diagnostics_result in diagnostics_cache.values_mut() {
+            *diagnostics_result = None;
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.0 = None;
+    }
+}

--- a/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
@@ -49,6 +49,18 @@ impl WorkspaceDiagnosticsCache {
         }
     }
 
+    pub fn close(&mut self, text_document_uri: &tombi_uri::Uri) {
+        let Some(diagnostics_cache) = self.0.as_mut() else {
+            return;
+        };
+
+        let Some(Some(diagnostics_result)) = diagnostics_cache.get_mut(text_document_uri) else {
+            return;
+        };
+
+        diagnostics_result.version = None;
+    }
+
     pub fn clear_all(&mut self) {
         let Some(diagnostics_cache) = self.0.as_mut() else {
             return;

--- a/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic/cache.rs
@@ -1,16 +1,29 @@
 use crate::diagnostic::DiagnosticsResult;
 
 #[derive(Debug, Default)]
-pub struct WorkspaceDiagnosticsCache(
-    Option<tombi_hashmap::HashMap<tombi_uri::Uri, Option<DiagnosticsResult>>>,
-);
+pub struct WorkspaceDiagnosticsCache {
+    workspace_targets: Option<tombi_hashmap::HashSet<tombi_uri::Uri>>,
+    cache: tombi_hashmap::HashMap<tombi_uri::Uri, Option<DiagnosticsResult>>,
+}
 
 impl WorkspaceDiagnosticsCache {
-    pub fn get(&self, text_document_uri: &tombi_uri::Uri) -> Option<&DiagnosticsResult> {
-        self.0
+    pub fn workspace_targets(&self) -> Option<Vec<tombi_uri::Uri>> {
+        self.workspace_targets
             .as_ref()
-            .and_then(|diagnostics_cache| diagnostics_cache.get(text_document_uri))
-            .and_then(|diagnostics_result| diagnostics_result.as_ref())
+            .map(|tracked_targets| tracked_targets.iter().cloned().collect())
+    }
+
+    pub fn set_workspace_targets(
+        &mut self,
+        workspace_targets: tombi_hashmap::HashSet<tombi_uri::Uri>,
+    ) {
+        self.workspace_targets = Some(workspace_targets);
+    }
+
+    pub fn get(&self, text_document_uri: &tombi_uri::Uri) -> Option<&DiagnosticsResult> {
+        self.cache
+            .get(text_document_uri)
+            .and_then(|result| result.as_ref())
     }
 
     pub fn set(
@@ -18,60 +31,50 @@ impl WorkspaceDiagnosticsCache {
         text_document_uri: tombi_uri::Uri,
         diagnostics_result: DiagnosticsResult,
     ) {
-        let diagnostics_cache = self.0.get_or_insert_default();
-        diagnostics_cache.insert(text_document_uri, Some(diagnostics_result));
+        self.cache
+            .insert(text_document_uri, Some(diagnostics_result));
     }
 
-    pub fn tracked(&self) -> Option<Vec<tombi_uri::Uri>> {
-        self.0
-            .as_ref()
-            .map(|diagnostics_cache| diagnostics_cache.keys().cloned().collect())
-    }
-
-    pub fn track(&mut self, text_document_uri: tombi_uri::Uri) {
-        let diagnostics_cache = self.0.get_or_insert_default();
-        diagnostics_cache.entry(text_document_uri).or_insert(None);
+    pub fn track(&mut self, text_document_uri: tombi_uri::Uri, is_workspace_target: bool) {
+        if is_workspace_target && let Some(tracked_targets) = self.workspace_targets.as_mut() {
+            tracked_targets.insert(text_document_uri.clone());
+        }
+        self.cache.entry(text_document_uri).or_insert(None);
     }
 
     pub fn untrack(&mut self, text_document_uri: &tombi_uri::Uri) {
-        if let Some(diagnostics_cache) = self.0.as_mut() {
-            diagnostics_cache.remove(text_document_uri);
+        if let Some(tracked_targets) = self.workspace_targets.as_mut() {
+            tracked_targets.remove(text_document_uri);
         }
+        self.cache.remove(text_document_uri);
     }
 
     pub fn clear(&mut self, text_document_uri: &tombi_uri::Uri) {
-        let Some(diagnostics_cache) = self.0.as_mut() else {
-            return;
-        };
-
-        if let Some(entry) = diagnostics_cache.get_mut(text_document_uri) {
-            *entry = None;
-        }
+        self.cache.remove(text_document_uri);
     }
 
     pub fn close(&mut self, text_document_uri: &tombi_uri::Uri) {
-        let Some(diagnostics_cache) = self.0.as_mut() else {
-            return;
-        };
-
-        let Some(Some(diagnostics_result)) = diagnostics_cache.get_mut(text_document_uri) else {
-            return;
-        };
-
-        diagnostics_result.version = None;
-    }
-
-    pub fn clear_all(&mut self) {
-        let Some(diagnostics_cache) = self.0.as_mut() else {
-            return;
-        };
-
-        for diagnostics_result in diagnostics_cache.values_mut() {
-            *diagnostics_result = None;
+        if let Some(tracked_targets) = self.workspace_targets.as_mut()
+            && tracked_targets.contains(text_document_uri)
+        {
+            if let Some(diagnostics_result) = self
+                .cache
+                .get_mut(text_document_uri)
+                .and_then(|result| result.as_mut())
+            {
+                diagnostics_result.version = None;
+            }
+        } else {
+            self.cache.remove(text_document_uri);
         }
     }
 
+    pub fn clear_all(&mut self) {
+        self.cache.clear();
+    }
+
     pub fn reset(&mut self) {
-        self.0 = None;
+        self.workspace_targets = None;
+        self.cache.clear();
     }
 }


### PR DESCRIPTION
Related: https://github.com/tombi-toml/tombi/issues/1872

## Summary
- cache tracked workspace diagnostic targets and their diagnostics results in tombi-lsp
- invalidate the cache on document, schema, config, and watched-file updates
- reuse cached diagnostics when publishing push diagnostics and pull diagnostics

## Testing
- cargo fmt --all --check
- cargo check -p tombi-lsp
- cargo test -p tombi-lsp