### PR TITLE
Use editor formatting options when config is absent

### DIFF
--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -21,13 +21,13 @@ pub async fn handle_formatting(
 
     let DocumentFormattingParams {
         text_document,
-        options: _editor_formatting_options,
+        options: editor_formatting_options,
         ..
     } = params;
     let text_document_uri = text_document.uri.into();
 
     let ConfigSchemaStore {
-        config,
+        mut config,
         schema_store,
         config_path,
     } = backend
@@ -47,15 +47,11 @@ pub async fn handle_formatting(
         return Ok(None);
     }
 
-    // NOTE: It is not desirable to use `editor_formatting_options`
-    //       because it causes inconsistent behavior
-    //       between the Editor side and the CLI side.
-    //
-    // use_editor_formatting_options(
-    //     &mut config,
-    //     config_path.as_deref(),
-    //     &editor_formatting_options,
-    // );
+    use_editor_formatting_options(
+        &mut config,
+        config_path.as_deref(),
+        &editor_formatting_options,
+    );
 
     if let Ok(text_document_path) = text_document_uri.to_file_path() {
         match matches_file_patterns(&text_document_path, config_path.as_deref(), &config) {

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -161,7 +161,7 @@ fn use_editor_formatting_options(
         let override_options = OverrideFormatOptions {
             rules: Some(FormatRules {
                 indent_width: Some(IndentWidth::from(
-                    editor_formatting_options.tab_size.clamp(1, u8::MAX as u32) as u8,
+                    editor_formatting_options.tab_size.clamp(0, u8::MAX as u32) as u8,
                 )),
                 indent_style: if editor_formatting_options.insert_spaces {
                     Some(IndentStyle::Space)
@@ -308,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn use_editor_formatting_options_clamps_zero_tab_size_to_one() {
+    fn use_editor_formatting_options_keeps_zero_tab_size() {
         let mut config = Config::default();
         let editor_formatting_options = FormattingOptions {
             tab_size: 0,
@@ -323,7 +323,7 @@ mod tests {
             .as_ref()
             .and_then(|format| format.rules.as_ref())
             .expect("format rules should be set");
-        pretty_assertions::assert_eq!(rules.indent_width, Some(IndentWidth::from(1)));
+        pretty_assertions::assert_eq!(rules.indent_width, Some(IndentWidth::from(0)));
         pretty_assertions::assert_eq!(rules.indent_style, Some(IndentStyle::Space));
     }
 

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -161,7 +161,7 @@ fn use_editor_formatting_options(
         let override_options = OverrideFormatOptions {
             rules: Some(FormatRules {
                 indent_width: Some(IndentWidth::from(
-                    editor_formatting_options.tab_size.clamp(0, u8::MAX as u32) as u8,
+                    editor_formatting_options.tab_size.clamp(1, u8::MAX as u32) as u8,
                 )),
                 indent_style: if editor_formatting_options.insert_spaces {
                     Some(IndentStyle::Space)
@@ -265,7 +265,67 @@ fn position_at_offset(line_index: &tombi_text::LineIndex, offset: usize) -> Posi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tombi_config::Config;
     use tombi_text::{EncodingKind, LineIndex, Range};
+    use tower_lsp::lsp_types::FormattingOptions;
+
+    #[test]
+    fn use_editor_formatting_options_uses_lsp_values_when_config_is_absent() {
+        let mut config = Config::default();
+        let editor_formatting_options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: false,
+            ..Default::default()
+        };
+
+        use_editor_formatting_options(&mut config, None, &editor_formatting_options);
+
+        let rules = config
+            .format
+            .as_ref()
+            .and_then(|format| format.rules.as_ref())
+            .expect("format rules should be set");
+        pretty_assertions::assert_eq!(rules.indent_width, Some(IndentWidth::from(4)));
+        pretty_assertions::assert_eq!(rules.indent_style, Some(IndentStyle::Tab));
+    }
+
+    #[test]
+    fn use_editor_formatting_options_ignores_lsp_values_when_config_exists() {
+        let mut config = Config::default();
+        let editor_formatting_options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: false,
+            ..Default::default()
+        };
+
+        use_editor_formatting_options(
+            &mut config,
+            Some(std::path::Path::new("/tmp/tombi.toml")),
+            &editor_formatting_options,
+        );
+
+        pretty_assertions::assert_eq!(config.format, None);
+    }
+
+    #[test]
+    fn use_editor_formatting_options_clamps_zero_tab_size_to_one() {
+        let mut config = Config::default();
+        let editor_formatting_options = FormattingOptions {
+            tab_size: 0,
+            insert_spaces: true,
+            ..Default::default()
+        };
+
+        use_editor_formatting_options(&mut config, None, &editor_formatting_options);
+
+        let rules = config
+            .format
+            .as_ref()
+            .and_then(|format| format.rules.as_ref())
+            .expect("format rules should be set");
+        pretty_assertions::assert_eq!(rules.indent_width, Some(IndentWidth::from(1)));
+        pretty_assertions::assert_eq!(rules.indent_style, Some(IndentStyle::Space));
+    }
 
     #[test]
     fn test_compute_text_edits_no_changes() {


### PR DESCRIPTION
## Summary
- use LSP document formatting options when no Tombi config file is present
- keep explicit Tombi config as the source of truth when a config file exists
- make editor formatting behavior work without project config files

Fixes #1888

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked