### PR TITLE
Fix hover panic for schema defaults containing null

### DIFF
--- a/crates/tombi-lsp/src/hover/display_value.rs
+++ b/crates/tombi-lsp/src/hover/display_value.rs
@@ -95,12 +95,17 @@ impl TryFrom<&tombi_json::Value> for DisplayValue {
             },
             tombi_json::Value::String(string) => Ok(DisplayValue::String(string.clone())),
             tombi_json::Value::Array(array) => Ok(DisplayValue::Array(
-                array.iter().map(|item| item.try_into().unwrap()).collect(),
+                array
+                    .iter()
+                    .filter_map(|item| item.try_into().ok())
+                    .collect(),
             )),
             tombi_json::Value::Object(object) => Ok(DisplayValue::Table(
                 object
                     .iter()
-                    .map(|(key, value)| (key.clone(), value.try_into().unwrap()))
+                    .filter_map(|(key, value)| {
+                        value.try_into().ok().map(|value| (key.clone(), value))
+                    })
                     .collect(),
             )),
             tombi_json::Value::Null => Err(()),

--- a/crates/tombi-lsp/tests/fixtures/history-hover-null-default.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/history-hover-null-default.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HistoryHoverNullDefault",
+  "type": "object",
+  "properties": {
+    "history": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/History"
+        }
+      ],
+      "default": {
+        "max_bytes": null,
+        "persistence": "save-all"
+      },
+      "description": "Settings that govern if and what will be written to history."
+    }
+  },
+  "definitions": {
+    "History": {
+      "type": "object",
+      "properties": {
+        "max_bytes": {
+          "type": "integer",
+          "default": null,
+          "description": "Maximum size of the history file."
+        },
+        "persistence": {
+          "type": "string",
+          "default": "save-all",
+          "description": "Whether history entries are written to disk."
+        }
+      }
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -38,6 +38,11 @@ fn exact_index_array_values_order_schema_path() -> PathBuf {
         .join("crates/tombi-lsp/tests/fixtures/exact-index-array-values-order.schema.json")
 }
 
+fn history_hover_null_default_schema_path() -> PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("crates/tombi-lsp/tests/fixtures/history-hover-null-default.schema.json")
+}
+
 fn cargo_feature_usage_hover_description(
     project_root: &Path,
     locations: &[(PathBuf, u32)],
@@ -777,6 +782,36 @@ mod hover_keys_value {
                 "Keys": "boolean_all",
                 "Value": "Boolean?",
                 "Enum": ["true"]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn all_of_table_hover_ignores_null_in_default_object(
+                r#"
+                [hist█ory]
+                persistence = "save-all"
+                "#,
+                SchemaPath(history_hover_null_default_schema_path()),
+            ) -> Ok({
+                "Keys": "history",
+                "Value": "Table?",
+                "Default": r#"{ persistence = "save-all" }"#
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn all_of_nested_property_hover_survives_parent_default_with_null(
+                r#"
+                [history]
+                persis█tence = "save-all"
+                "#,
+                SchemaPath(history_hover_null_default_schema_path()),
+            ) -> Ok({
+                "Keys": "history.persistence",
+                "Value": "String?",
+                "Default": "\"save-all\""
             });
         );
     }


### PR DESCRIPTION
## Summary
- ignore null children when rendering hover display values from JSON defaults/examples
- add hover regression tests for allOf table defaults that include null
- cover the history/persistence-style schema shape behind issue #1890

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked

Closes #1890