### PR TITLE
Split winget release workflow from PR #1866

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -254,7 +254,7 @@ jobs:
 
   publish-winget:
     needs: [release-notes]
-    if: startsWith(github.ref, 'refs/tags/v') && inputs.skip_winget != true
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
     runs-on: windows-latest
     permissions:
       contents: read
@@ -279,6 +279,7 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
           VERSION: ${{ steps.stable-version.outputs.stable_version }}
+          WINGETCREATE_VERSION: 1.12.8.0
         run: |
           if (-not $env:WINGET_TOKEN) {
             Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
@@ -286,8 +287,18 @@ jobs:
           }
 
           $installerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
 
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
+          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
+
+          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
+          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
+          }
+
           .\wingetcreate.exe update tombi-toml.tombi -u $installerUrl -v $env:VERSION -t $env:WINGET_TOKEN --submit
 
   update-install-script-version:

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      skip_winget:
+        description: "Skip submitting the Windows Package Manager manifest update"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -245,6 +251,44 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && needs.check-release-notes.outputs.exists == 'false'
         run: |
           gh release create ${{ github.ref_name }} --generate-notes ${{ env.ASSETS }}
+
+  publish-winget:
+    needs: [release-notes]
+    if: startsWith(github.ref, 'refs/tags/v') && inputs.skip_winget != true
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: pwsh
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
+            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "Skipping winget submission for non-stable tag: $env:REF_NAME"
+            "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Submit winget manifest update
+        if: steps.stable-version.outputs.stable_version != ''
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          VERSION: ${{ steps.stable-version.outputs.stable_version }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
+            exit 0
+          }
+
+          $installerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update tombi-toml.tombi -u $installerUrl -v $env:VERSION -t $env:WINGET_TOKEN --submit
 
   update-install-script-version:
     needs: [release-notes]


### PR DESCRIPTION
## Summary
- split the winget release automation work out of #1866
- add a manual `skip_winget` workflow_dispatch input to the CLI/VSCode release workflow
- submit winget manifest updates after stable GitHub releases when `WINGET_TOKEN` is configured

## Scope
This PR intentionally excludes the documentation updates from #1866 so the release automation can be reviewed independently.

## Validation
- not run (workflow-only change)
