### PR TITLE
ci: move winget publish after install script update

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -252,55 +252,6 @@ jobs:
         run: |
           gh release create ${{ github.ref_name }} --generate-notes ${{ env.ASSETS }}
 
-  publish-winget:
-    needs: [release-notes]
-    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
-    runs-on: windows-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Detect stable release tag
-        id: stable-version
-        shell: pwsh
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
-            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          } else {
-            Write-Host "Skipping winget submission for non-stable tag: $env:REF_NAME"
-            "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          }
-
-      - name: Submit winget manifest update
-        if: steps.stable-version.outputs.stable_version != ''
-        shell: pwsh
-        env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-          REF_NAME: ${{ github.ref_name }}
-          VERSION: ${{ steps.stable-version.outputs.stable_version }}
-          WINGETCREATE_VERSION: 1.12.8.0
-        run: |
-          if (-not $env:WINGET_TOKEN) {
-            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
-            exit 0
-          }
-
-          $installerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
-          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
-          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
-
-          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
-          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
-
-          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
-          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
-          if ($actualHash -ne $expectedHash) {
-            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
-          }
-
-          .\wingetcreate.exe update tombi-toml.tombi -u $installerUrl -v $env:VERSION -t $env:WINGET_TOKEN --submit
-
   update-install-script-version:
     needs: [release-notes]
     if: startsWith(github.ref, 'refs/tags/v')
@@ -447,3 +398,52 @@ jobs:
               exit 1
             fi
           done
+
+  publish-winget:
+    needs: [release-notes, update-install-script-version]
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: pwsh
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
+            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "Skipping winget submission for non-stable tag: $env:REF_NAME"
+            "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Submit winget manifest update
+        if: steps.stable-version.outputs.stable_version != ''
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          VERSION: ${{ steps.stable-version.outputs.stable_version }}
+          WINGETCREATE_VERSION: 1.12.8.0
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
+            exit 0
+          }
+
+          $installerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
+
+          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
+          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
+
+          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
+          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
+          }
+
+          .\wingetcreate.exe update tombi-toml.tombi -u $installerUrl -v $env:VERSION -t $env:WINGET_TOKEN --submit


### PR DESCRIPTION
## Summary
- move `publish-winget` below `update-install-script-version` in the workflow definition
- keep `publish-winget` dependent on `update-install-script-version`
- ensure winget submission remains the last release step in this workflow

## Testing
- git diff --check