### PR TITLE
Fix format --check on read-only files

### DIFF
--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -206,7 +206,7 @@ where
                                 continue;
                             };
 
-                            match FormatFile::from_file(&source_path, !args.check).await {
+                            match FormatFile::from_file(&source_path, args.check).await {
                                 Ok(file) => {
                                     let printer = printer.clone();
                                     let schema_store = schema_store.clone();
@@ -467,10 +467,10 @@ impl FormatFile {
         }
     }
 
-    async fn from_file(path: &std::path::Path, write: bool) -> std::io::Result<Self> {
+    async fn from_file(path: &std::path::Path, read_only: bool) -> std::io::Result<Self> {
         let mut options = tokio::fs::OpenOptions::new();
         options.read(true);
-        if write {
+        if !read_only {
             options.write(true);
         }
 

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -206,7 +206,7 @@ where
                                 continue;
                             };
 
-                            match FormatFile::from_file(&source_path).await {
+                            match FormatFile::from_file(&source_path, !args.check).await {
                                 Ok(file) => {
                                     let printer = printer.clone();
                                     let schema_store = schema_store.clone();
@@ -467,14 +467,16 @@ impl FormatFile {
         }
     }
 
-    async fn from_file(path: &std::path::Path) -> std::io::Result<Self> {
+    async fn from_file(path: &std::path::Path, write: bool) -> std::io::Result<Self> {
+        let mut options = tokio::fs::OpenOptions::new();
+        options.read(true);
+        if write {
+            options.write(true);
+        }
+
         Ok(Self::File {
             path: path.to_owned(),
-            file: tokio::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)
-                .await?,
+            file: options.open(path).await?,
         })
     }
 


### PR DESCRIPTION
## Summary
- open files in read-only mode when `tombi format --check` runs
- keep writable open mode for in-place formatting paths
- allow format checking of read-only TOML files without copying to a temp file

Closes #1901.

## Testing
- `cargo check -p tombi-cli`
- `cargo test -p tombi-cli --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo fmt --all --check` *(currently reports an unrelated formatting diff in `crates/tombi-accessor/src/schema_accessor.rs`)*