### PR TITLE
set Cargo.toml default TOML version to v1.1.0

### DIFF
--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -677,10 +677,13 @@ mod table_keys_order {
             ) -> Ok(
                 r#"
                 [dependencies]
-                serde = { version = "^1.0.0", features = [
-                  "derive",
-                  "std",
-                ] }
+                serde = {
+                  version = "^1.0.0",
+                  features = [
+                    "derive",
+                    "std",
+                  ]
+                }
                 "#
             )
         }
@@ -700,12 +703,15 @@ mod table_keys_order {
             ) -> Ok(
                 r#"
                 [dependencies]
-                serde = { version = "^1.0.0", features = [
-                  # tombi: format.rules.array-values-order.disabled = true
+                serde = {
+                  version = "^1.0.0",
+                  features = [
+                    # tombi: format.rules.array-values-order.disabled = true
 
-                  "std",
-                  "derive",
-                ] }
+                    "std",
+                    "derive",
+                  ]
+                }
                 "#
             )
         }

--- a/www.schemastore.org/cargo.json
+++ b/www.schemastore.org/cargo.json
@@ -1,7 +1,7 @@
 {
   "$id": "tombi://www.schemastore.org/cargo.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "x-tombi-toml-version": "v1.0.0",
+  "x-tombi-toml-version": "v1.1.0",
   "definitions": {
     "Build": {
       "title": "Build",


### PR DESCRIPTION
Starting with Rust 1.94, Cargo supports TOML 1.1 (fully compatible with 1.0 syntax). To maintain consistency, the default TOML version in the bundled schema for Cargo should be updated from v1.0.0 to v1.1.0.