### PR TITLE
Fix goto type definition for annotation-only schemas

### DIFF
--- a/crates/tombi-lsp/src/goto_type_definition/value.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value.rs
@@ -9,7 +9,7 @@ mod offset_date_time;
 mod string;
 mod table;
 
-use super::GetTypeDefinition;
+use super::{GetTypeDefinition, schema_type_definition};
 use tombi_future::Boxable;
 
 impl GetTypeDefinition for tombi_document_tree::Value {
@@ -38,7 +38,7 @@ impl GetTypeDefinition for tombi_document_tree::Value {
                     .await;
             }
 
-            match self {
+            let type_definition = match self {
                 Self::Boolean(boolean) => {
                     boolean
                         .get_type_definition(
@@ -164,7 +164,31 @@ impl GetTypeDefinition for tombi_document_tree::Value {
                     }
                     None => None,
                 },
+            };
+
+            if type_definition.is_some() {
+                return type_definition;
             }
+
+            if let Some(current_schema) = current_schema
+                && matches!(
+                    current_schema.value_schema.as_ref(),
+                    tombi_schema_store::ValueSchema::Anything(_)
+                )
+            {
+                return current_schema
+                    .value_schema
+                    .get_type_definition(
+                        position,
+                        keys,
+                        accessors,
+                        Some(current_schema),
+                        schema_context,
+                    )
+                    .await;
+            }
+
+            None
         }
         .boxed()
     }
@@ -324,7 +348,10 @@ impl GetTypeDefinition for tombi_schema_store::ValueSchema {
                         )
                         .await
                 }
-                Self::Anything(_) | Self::Nothing(_) | Self::Null => None,
+                Self::Anything(schema) => current_schema.map(|current_schema| {
+                    schema_type_definition(&current_schema.schema_uri, accessors, schema.range)
+                }),
+                Self::Nothing(_) | Self::Null => None,
             }
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value.rs
@@ -349,7 +349,11 @@ impl GetTypeDefinition for tombi_schema_store::ValueSchema {
                         .await
                 }
                 Self::Anything(schema) => current_schema.map(|current_schema| {
-                    schema_type_definition(&current_schema.schema_uri, accessors, schema.range)
+                    schema_type_definition(
+                        current_schema.schema_uri.as_ref(),
+                        accessors,
+                        schema.range,
+                    )
                 }),
                 Self::Nothing(_) | Self::Null => None,
             }

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -2,7 +2,8 @@ mod goto_type_definition_tests {
     use super::*;
     use tombi_test_lib::{
         adjacent_applicators_test_schema_path, adjacent_one_of_hover_test_schema_path,
-        exact_index_string_test_schema_path, lsp_consistency_test_schema_path,
+        exact_index_string_test_schema_path, issue_1895_rustfmt_like_schema_path,
+        lsp_consistency_test_schema_path,
     };
 
     mod tombi_schema {
@@ -264,6 +265,21 @@ mod goto_type_definition_tests {
                     path: exact_index_string_test_schema_path(),
                 },
             ) -> Ok(exact_index_string_test_schema_path());
+        );
+    }
+
+    mod issue_1895_schema {
+        use super::*;
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn annotation_only_property_key_goto_type_definition(
+                r#"
+                max_width = 120
+                igno█re = ["*_capnp.rs"]
+                "#,
+                SchemaPath(issue_1895_rustfmt_like_schema_path()),
+            ) -> Ok(issue_1895_rustfmt_like_schema_path());
         );
     }
 


### PR DESCRIPTION
## Summary
- return a schema type definition for annotation-only `Anything` schemas
- let value dispatch fall back to the current schema when a typed value handler returns no type definition
- add an LSP regression test for rustfmt-like `ignore` keys

## Testing
- `cargo fmt --all --check` *(fails due to unrelated existing formatting in `crates/tombi-accessor/src/schema_accessor.rs`)*
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`