### PR TITLE
Add default feature hover support for Cargo dependencies

### DIFF
--- a/crates/tombi-accessor/src/schema_accessor.rs
+++ b/crates/tombi-accessor/src/schema_accessor.rs
@@ -341,9 +341,8 @@ mod tests {
 
     #[test]
     fn test_markdown_schema_accessors_display_key_containing_backtick() {
-        let accessors = MarkdownSchemaAccessors::from(vec![
-            SchemaAccessor::Key("key`name".to_string()),
-        ]);
+        let accessors =
+            MarkdownSchemaAccessors::from(vec![SchemaAccessor::Key("key`name".to_string())]);
         assert_eq!(format!("{accessors}"), "``\"key`name\"``");
     }
 }

--- a/crates/tombi-config/src/extensions/cargo.rs
+++ b/crates/tombi-config/src/extensions/cargo.rs
@@ -78,6 +78,41 @@ mod tests {
     }
 
     #[test]
+    fn cargo_hover_feature_tree_deserializes_default_features_key() {
+        let features: super::CargoHoverFeatureTree = serde_json::from_value(serde_json::json!({
+            "default-features": {
+                "enabled": false
+            }
+        }))
+        .expect("default-features should deserialize");
+
+        assert_eq!(
+            features.default_features,
+            Some(ToggleFeatureDefaultTrue {
+                enabled: Some(false.into()),
+            })
+        );
+    }
+
+    #[test]
+    fn cargo_hover_feature_tree_serializes_default_features_key() {
+        let value = serde_json::to_value(super::CargoHoverFeatureTree {
+            dependency_detail: None,
+            default_features: Some(ToggleFeatureDefaultTrue {
+                enabled: Some(false.into()),
+            }),
+        })
+        .expect("default-features should serialize");
+
+        assert_eq!(
+            value.get("default-features"),
+            Some(&serde_json::json!({
+                "enabled": false
+            }))
+        );
+    }
+
+    #[test]
     fn cargo_document_link_feature_tree_deserializes_workspace_key() {
         let features: CargoDocumentLinkFeatureTree = serde_json::from_value(serde_json::json!({
             "workspace": {

--- a/crates/tombi-config/src/extensions/cargo/lsp/hover.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/hover.rs
@@ -34,5 +34,10 @@ toggle_features! {
         ///
         /// Whether hover shows detailed dependency metadata.
         pub dependency_detail: Option<ToggleFeatureDefaultTrue>,
+
+        /// # Default features hover feature
+        ///
+        /// Whether hover shows default Cargo dependency features.
+        pub default_features: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-linter/tests/integration/tombi_schema.rs
+++ b/crates/tombi-linter/tests/integration/tombi_schema.rs
@@ -175,7 +175,7 @@ test_lint! {
         r#"
         [extensions]
         "tombi-toml/tombi" = { lsp.document-link.path.enabled = false, lsp.hover.enabled = false }
-        "tombi-toml/cargo" = { lsp.hover.dependency-detail.enabled = false }
+        "tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.dependency-detail.enabled = false }
         "tombi-toml/pyproject" = { lsp.hover.dependency-detail.enabled = false }
         "#,
         SchemaPath(tombi_schema_path()),

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -118,6 +118,14 @@ pub async fn handle_hover(
             .map(|dependency_detail| dependency_detail.enabled())
             .unwrap_or_default()
             .value();
+        let cargo_default_features_hover_enabled = config
+            .cargo_extension_features()
+            .and_then(|features| features.lsp())
+            .and_then(|lsp| lsp.hover())
+            .and_then(|hover| hover.default_features())
+            .map(|default_features| default_features.enabled())
+            .unwrap_or_default()
+            .value();
         let pyproject_dependency_detail_hover_enabled = config
             .pyproject_extension_features()
             .and_then(|features| features.lsp())
@@ -142,7 +150,9 @@ pub async fn handle_hover(
         };
         let extension_hover = match extension_hover {
             some @ Some(_) => some,
-            None if cargo_dependency_detail_hover_enabled => {
+            None if cargo_dependency_detail_hover_enabled
+                || cargo_default_features_hover_enabled =>
+            {
                 tombi_extension_cargo::hover(
                     &text_document_uri,
                     &document_tree,

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -161,6 +161,8 @@ pub async fn handle_hover(
                     toml_version,
                     offline,
                     cache_options,
+                    cargo_dependency_detail_hover_enabled,
+                    cargo_default_features_hover_enabled,
                 )
                 .await?
             }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = ["member"]
+
+[workspace.dependencies]
+member = { path = "member" }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/member/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/member/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "member"
+version = "0.1.0"
+edition = "2024"
+description = "fixture cargo member"
+
+[dependencies]

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.dependency-detail.enabled = true }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = ["member"]
+
+[workspace.dependencies]
+member = { path = "member" }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/member/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/member/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "member"
+version = "0.1.0"
+edition = "2024"
+description = "fixture cargo member"
+
+[dependencies]

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/cargo" = { lsp.hover.default-features.enabled = true, lsp.hover.dependency-detail.enabled = false }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-disabled/tombi.toml
@@ -1,2 +1,2 @@
 [extensions]
-"tombi-toml/cargo" = { lsp.hover.dependency-detail.enabled = false }
+"tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.dependency-detail.enabled = false }

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -510,6 +510,44 @@ mod hover_keys_value {
 
         test_hover_keys_value!(
             #[tokio::test]
+            async fn cargo_registry_dependency_feature_item_skips_default_feature_list_when_disabled_by_extensions(
+                r#"
+                [dependencies]
+                serde = { version = "=1.0.228", features = ["derive█"] }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-default-features-disabled/Cargo.toml"
+                )),
+                UseTestCacheHome,
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                SchemaPath(cargo_schema_path()),
+                CachedRemoteJson {
+                    url: "https://crates.io/api/v1/crates/serde/1.0.228",
+                    body: r#"{
+                        "version": {
+                            "num": "1.0.228",
+                            "features": {
+                                "alloc": [],
+                                "default": ["std"],
+                                "derive": ["serde_derive"],
+                                "rc": [],
+                                "std": ["serde_core/std"]
+                            }
+                        }
+                    }"#,
+                },
+            ) -> Ok({
+                "Keys": "dependencies.serde.features[0]",
+                "Value": "String",
+                "Description": Some("List of features to activate in the dependency."),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
             async fn cargo_profile_release_strip_debuginfo(
                 r#"
                 [profile.release]
@@ -593,6 +631,24 @@ mod hover_keys_value {
                 "#,
                 SourcePath(tombi_test_lib::project_root_path().join(
                     "crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-disabled/member/Cargo.toml"
+                )),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok({
+                "Keys": "dependencies.member",
+                "Value": "(String | Table)?",
+                "Title": Some("Dependency"),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn cargo_workspace_dependency_hover_metadata_skips_dependency_detail_when_disabled_by_extensions(
+                r#"
+                [dependencies]
+                member█ = { workspace = true }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-dependency-detail-disabled/member/Cargo.toml"
                 )),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok({

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -411,8 +411,9 @@ mod hover_keys_value {
             async fn cargo_dependencies_features(
                 r#"
                 [dependencies]
-                serde = { version = "^1.0.0", features█ = ["derive"] }
+                serde = { version = "^1.0.0", default-features = false, features█ = ["derive"] }
                 "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok({
                 "Keys": "dependencies.serde.features",
@@ -425,8 +426,9 @@ mod hover_keys_value {
             async fn cargo_dependencies_features_item(
                 r#"
                 [dependencies]
-                serde = { version = "^1.0.0", features = ["derive█"] }
+                serde = { version = "^1.0.0", default-features = false, features = ["derive█"] }
                 "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
                 SchemaPath(cargo_schema_path()),
             ) -> Ok({
                 "Keys": "dependencies.serde.features[0]",
@@ -444,6 +446,65 @@ mod hover_keys_value {
             ) -> Ok({
                 "Keys": "dependencies.serde.features[0]",
                 "Value": "String"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn cargo_path_dependency_features_append_default_feature_list(
+                r#"
+                [dependencies]
+                local-path-crate = { path = "local-path-crate", default-features = true, features█ = ["default"] }
+                "#,
+                SourcePath(
+                    tombi_test_lib::project_root_path()
+                        .join("crates/tombi-lsp/tests/fixtures/cargo/path-dependency-with-features/Cargo.toml")
+                ),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok({
+                "Keys": "dependencies.local-path-crate.features",
+                "Value": "Array?",
+                "Description": Some(
+                    "List of features to activate in the dependency.\n\nDefault Features:\n  - extras"
+                ),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn cargo_registry_dependency_feature_item_appends_default_feature_list(
+                r#"
+                [dependencies]
+                serde = { version = "=1.0.228", features = ["derive█"] }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join("Cargo.toml")),
+                UseTestCacheHome,
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                SchemaPath(cargo_schema_path()),
+                    CachedRemoteJson {
+                        url: "https://crates.io/api/v1/crates/serde/1.0.228",
+                        body: r#"{
+	                        "version": {
+                                "num": "1.0.228",
+	                            "features": {
+	                                "alloc": [],
+	                                "default": ["std"],
+                                "derive": ["serde_derive"],
+                                "rc": [],
+                                "std": ["serde_core/std"]
+                            }
+                        }
+                    }"#,
+                },
+            ) -> Ok({
+                "Keys": "dependencies.serde.features[0]",
+                "Value": "String",
+                "Description": Some(
+                    "List of features to activate in the dependency.\n\nDefault Features:\n  - std"
+                ),
             });
         );
 

--- a/crates/tombi-lsp/tests/test_inlay_hint.rs
+++ b/crates/tombi-lsp/tests/test_inlay_hint.rs
@@ -308,7 +308,7 @@ async fn inlay_hint_for_registry_default_features_is_rendered()
 
     write_cached_response(
         "https://crates.io/api/v1/crates/serde_json/1.0.142",
-        r#"{"version":{"features":{"default":["std","alloc"],"preserve_order":["indexmap","std"],"std":["memchr/std","serde/std"]}}}"#,
+        r#"{"version":{"num":"1.0.142","features":{"default":["std","alloc"],"preserve_order":["indexmap","std"],"std":["memchr/std","serde/std"]}}}"#,
     )
     .await;
 
@@ -377,7 +377,7 @@ async fn inlay_hint_for_registry_default_features_is_not_rendered_when_disabled_
 
     write_cached_response(
         "https://crates.io/api/v1/crates/serde_json/1.0.140",
-        r#"{"version":{"features":{"default":["std"],"preserve_order":["indexmap","std"],"std":["memchr/std","serde/std"]}}}"#,
+        r#"{"version":{"num":"1.0.140","features":{"default":["std"],"preserve_order":["indexmap","std"],"std":["memchr/std","serde/std"]}}}"#,
     )
     .await;
 

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -1673,6 +1673,21 @@ Enable or disable dependency detail hover for Cargo dependencies.
 - Type: `Boolean`
 - Default: `true`
 
+### extensions."tombi-toml/cargo".lsp.hover.default-features
+
+Configure default feature hover for Cargo dependencies.
+
+See [Cargo Extension > Hover](/docs/extensions/tombi-extension-cargo#hover).
+
+- Type: `Table`
+
+### extensions."tombi-toml/cargo".lsp.hover.default-features.enabled
+
+Enable or disable default feature hover for Cargo dependencies.
+
+- Type: `Boolean`
+- Default: `true`
+
 ### extensions."tombi-toml/cargo".lsp.inlay-hint
 
 Configure Cargo-specific inlay hints.

--- a/extensions/tombi-extension-cargo/src/completion.rs
+++ b/extensions/tombi-extension-cargo/src/completion.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use serde::Deserialize;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{dig_accessors, dig_keys};
 use tombi_extension::CommentContext;
@@ -21,6 +20,9 @@ use tower_lsp::lsp_types::InsertTextFormat;
 
 use crate::cargo_lock::{exact_crates_io_version, load_cached_cargo_lock};
 use crate::{
+    crates_io::{
+        CratesIoCrateVersionsResponse, CratesIoVersionDetailResponse, CratesIoVersionsResponse,
+    },
     find_cargo_toml, find_workspace_cargo_toml, get_workspace_cargo_toml_path,
     is_any_dependency_path_accessor, is_dependency_accessor,
 };
@@ -29,28 +31,6 @@ enum CargoCompletionFeature {
     DependencyVersion,
     DependencyFeature,
     Path,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoVersionsResponse {
-    versions: Vec<CratesIoVersion>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoVersion {
-    num: String,
-    features: tombi_hashmap::HashMap<String, Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoCrateResponse {
-    #[serde(default)]
-    versions: Vec<CratesIoVersion>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoVersionDetailResponse {
-    version: CratesIoVersion,
 }
 
 pub async fn completion(
@@ -807,7 +787,8 @@ async fn fetch_crate_features(
         // so we can read them directly from the latest version without a second fetch.
         let url = format!("https://crates.io/api/v1/crates/{crate_name}");
         let resp =
-            fetch_cached_remote_json::<CratesIoCrateResponse>(&url, offline, cache_options).await?;
+            fetch_cached_remote_json::<CratesIoCrateVersionsResponse>(&url, offline, cache_options)
+                .await?;
         resp.versions.into_iter().next().map(|v| v.features)
     }
 }

--- a/extensions/tombi-extension-cargo/src/crates_io.rs
+++ b/extensions/tombi-extension-cargo/src/crates_io.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use tombi_extension::fetch_cached_remote_json;
+use tombi_hashmap::HashMap;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct CratesIoCrateResponse {
@@ -12,6 +13,28 @@ pub(crate) struct CratesIoCrate {
     pub(crate) name: Option<String>,
     pub(crate) description: Option<String>,
     pub(crate) max_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoVersionsResponse {
+    pub(crate) versions: Vec<CratesIoVersion>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoVersion {
+    pub(crate) num: String,
+    pub(crate) features: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoCrateVersionsResponse {
+    #[serde(default)]
+    pub(crate) versions: Vec<CratesIoVersion>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CratesIoVersionDetailResponse {
+    pub(crate) version: CratesIoVersion,
 }
 
 pub(crate) async fn fetch_crates_io_crate(

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -127,6 +127,7 @@ async fn collect_prefetch_urls(
     let lsp = features.and_then(|features| features.lsp());
     let (
         dependency_detail_hover_enabled,
+        default_features_hover_enabled,
         dependency_version_completion_enabled,
         dependency_feature_completion_enabled,
         dependency_version_inlay_hint_enabled,
@@ -141,6 +142,11 @@ async fn collect_prefetch_urls(
                     hover
                         .dependency_detail()
                         .map(|dependency_detail| dependency_detail.enabled())
+                }),
+                hover.as_ref().and_then(|hover| {
+                    hover
+                        .default_features()
+                        .map(|default_features| default_features.enabled())
                 }),
                 completion
                     .as_ref()
@@ -163,6 +169,7 @@ async fn collect_prefetch_urls(
         .unwrap_or_default();
 
     let warm_hover = dependency_detail_hover_enabled.unwrap_or_default().value();
+    let warm_default_features_hover = default_features_hover_enabled.unwrap_or_default().value();
     let warm_versions = dependency_version_completion_enabled
         .unwrap_or_default()
         .value();
@@ -176,13 +183,18 @@ async fn collect_prefetch_urls(
         .unwrap_or_default()
         .value();
 
-    if !warm_hover && !warm_versions && !warm_feature_details && !prioritize_inlay_hint {
+    if !warm_hover
+        && !warm_default_features_hover
+        && !warm_versions
+        && !warm_feature_details
+        && !prioritize_inlay_hint
+    {
         return PrefetchUrls::default();
     }
 
     let workspace_path = get_workspace_cargo_toml_path(document_tree);
     let cargo_lock_fut = async {
-        if warm_feature_details || prioritize_inlay_hint {
+        if warm_feature_details || warm_default_features_hover || prioritize_inlay_hint {
             load_cached_cargo_lock(cargo_toml_path, toml_version).await
         } else {
             None
@@ -486,6 +498,7 @@ mod tests {
                 )),
                 hover: Some(CargoHoverFeatures::Features(CargoHoverFeatureTree {
                     dependency_detail: Some(disabled_toggle()),
+                    default_features: None,
                 })),
                 ..Default::default()
             })),

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -2,14 +2,18 @@ use std::path::Path;
 
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
+use tombi_extension::fetch_cached_remote_json;
 use tombi_extension::{HoverMetadata, HoverTextChange, append_latest_version};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
-    collect_feature_usage_locations, dependency_package_name, feature_key_at_accessors,
-    feature_usage_target_for_feature_key, fetch_crates_io_crate, find_cargo_toml,
-    find_workspace_cargo_toml, get_workspace_cargo_toml_path, is_any_dependency_accessor,
-    load_cargo_toml, sanitize_dependency_key,
+    cargo_lock::{exact_crates_io_version, load_cached_cargo_lock},
+    collect_feature_usage_locations,
+    crates_io::CratesIoVersionDetailResponse,
+    dependency_package_name, feature_key_at_accessors, feature_usage_target_for_feature_key,
+    fetch_crates_io_crate, find_cargo_toml, find_workspace_cargo_toml,
+    get_workspace_cargo_toml_path, is_any_dependency_accessor, load_cargo_toml,
+    sanitize_dependency_key,
 };
 
 pub async fn hover(
@@ -37,6 +41,20 @@ pub async fn hover(
         toml_version,
     )
     .await
+    {
+        return Ok(Some(metadata));
+    }
+
+    if let Some(metadata) = dependency_features_hover_metadata(
+        document_tree,
+        accessors,
+        position,
+        &cargo_toml_path,
+        toml_version,
+        offline,
+        cache_options,
+    )
+    .await?
     {
         return Ok(Some(metadata));
     }
@@ -230,6 +248,264 @@ fn format_feature_usage_label(project_root: &Path, cargo_toml_path: &Path, line:
         .replace('\\', "/");
 
     format!("{relative_path}:{line}")
+}
+
+async fn dependency_features_hover_metadata(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+    _position: tombi_text::Position,
+    cargo_toml_path: &Path,
+    toml_version: TomlVersion,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
+    let Some(dependency_accessors) = dependency_features_parent_accessors(accessors) else {
+        return Ok(None);
+    };
+    let Some((_, dependency_value)) = dig_accessors(document_tree, dependency_accessors) else {
+        return Ok(None);
+    };
+    let Value::Table(table) = dependency_value else {
+        return Ok(None);
+    };
+    let Some((_, _)) = table.get_key_value("features") else {
+        return Ok(None);
+    };
+
+    if dependency_table_default_features_disabled(table) {
+        return Ok(None);
+    }
+
+    let Some(Accessor::Key(dependency_key)) = dependency_accessors.last() else {
+        return Ok(None);
+    };
+
+    let Some(default_features) = dependency_default_features(
+        document_tree,
+        dependency_key,
+        dependency_value,
+        cargo_toml_path,
+        toml_version,
+        offline,
+        cache_options,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(HoverMetadata {
+        title: None,
+        description: Some(HoverTextChange::Append(format_default_features_tooltip(
+            &default_features,
+        ))),
+    }))
+}
+
+fn dependency_features_parent_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
+    if matches_accessors!(accessors, ["workspace", "dependencies", _, "features"])
+        || matches_accessors!(accessors, ["dependencies", _, "features"])
+        || matches_accessors!(accessors, ["dev-dependencies", _, "features"])
+        || matches_accessors!(accessors, ["build-dependencies", _, "features"])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _, "features"])
+        || matches_accessors!(accessors, ["target", _, "dev-dependencies", _, "features"])
+        || matches_accessors!(
+            accessors,
+            ["target", _, "build-dependencies", _, "features"]
+        )
+    {
+        return Some(&accessors[..accessors.len().saturating_sub(1)]);
+    }
+
+    if matches_accessors!(accessors, ["workspace", "dependencies", _, "features", _])
+        || matches_accessors!(accessors, ["dependencies", _, "features", _])
+        || matches_accessors!(accessors, ["dev-dependencies", _, "features", _])
+        || matches_accessors!(accessors, ["build-dependencies", _, "features", _])
+        || matches_accessors!(accessors, ["target", _, "dependencies", _, "features", _])
+        || matches_accessors!(
+            accessors,
+            ["target", _, "dev-dependencies", _, "features", _]
+        )
+        || matches_accessors!(
+            accessors,
+            ["target", _, "build-dependencies", _, "features", _]
+        )
+    {
+        return Some(&accessors[..accessors.len().saturating_sub(2)]);
+    }
+
+    None
+}
+
+async fn dependency_default_features(
+    document_tree: &tombi_document_tree::DocumentTree,
+    dependency_key: &str,
+    dependency_value: &Value,
+    cargo_toml_path: &Path,
+    toml_version: TomlVersion,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<Vec<String>>, tower_lsp::jsonrpc::Error> {
+    let Value::Table(table) = dependency_value else {
+        return Ok(None);
+    };
+
+    if let Some(Value::String(path)) = table.get("path") {
+        let Some((_, _, dependency_document_tree)) =
+            find_cargo_toml(cargo_toml_path, Path::new(path.value()), toml_version)
+        else {
+            return Ok(None);
+        };
+        return Ok(package_default_features(&dependency_document_tree));
+    }
+
+    if table.contains_key("git") || table.contains_key("registry") {
+        return Ok(None);
+    }
+
+    if let Some(Value::String(version)) = table.get("version") {
+        return registry_dependency_default_features(
+            dependency_package_name(dependency_key, dependency_value),
+            version.value(),
+            cargo_toml_path,
+            toml_version,
+            offline,
+            cache_options,
+        )
+        .await;
+    }
+
+    let Some(Value::Boolean(workspace)) = table.get("workspace") else {
+        return Ok(None);
+    };
+    if !workspace.value() {
+        return Ok(None);
+    }
+
+    let Some((workspace_cargo_toml_path, _, workspace_document_tree)) = find_workspace_cargo_toml(
+        cargo_toml_path,
+        get_workspace_cargo_toml_path(document_tree),
+        toml_version,
+    ) else {
+        return Ok(None);
+    };
+    let Some((_, workspace_dependency_value)) = dig_keys(
+        &workspace_document_tree,
+        &["workspace", "dependencies", dependency_key],
+    ) else {
+        return Ok(None);
+    };
+    let Value::Table(workspace_dependency_table) = workspace_dependency_value else {
+        return Ok(None);
+    };
+
+    if dependency_table_default_features_disabled(workspace_dependency_table) {
+        return Ok(None);
+    }
+
+    if let Some(Value::String(path)) = workspace_dependency_table.get("path") {
+        let Some((_, _, dependency_document_tree)) = find_cargo_toml(
+            &workspace_cargo_toml_path,
+            Path::new(path.value()),
+            toml_version,
+        ) else {
+            return Ok(None);
+        };
+        return Ok(package_default_features(&dependency_document_tree));
+    }
+
+    if workspace_dependency_table.contains_key("git")
+        || workspace_dependency_table.contains_key("registry")
+    {
+        return Ok(None);
+    }
+
+    let Some(Value::String(version)) = workspace_dependency_table.get("version") else {
+        return Ok(None);
+    };
+
+    registry_dependency_default_features(
+        dependency_package_name(dependency_key, workspace_dependency_value),
+        version.value(),
+        cargo_toml_path,
+        toml_version,
+        offline,
+        cache_options,
+    )
+    .await
+}
+
+async fn registry_dependency_default_features(
+    crate_name: &str,
+    version_requirement: &str,
+    cargo_toml_path: &Path,
+    toml_version: TomlVersion,
+    offline: bool,
+    cache_options: Option<&tombi_cache::Options>,
+) -> Result<Option<Vec<String>>, tower_lsp::jsonrpc::Error> {
+    let Some(version) = (if let Some(version) = exact_crates_io_version(version_requirement) {
+        Some(version)
+    } else {
+        load_cached_cargo_lock(cargo_toml_path, toml_version)
+            .await
+            .and_then(|lock| lock.resolve_dependency_version(crate_name, version_requirement))
+    }) else {
+        return Ok(None);
+    };
+
+    let url = format!("https://crates.io/api/v1/crates/{crate_name}/{version}");
+    let Some(mut resp) =
+        fetch_cached_remote_json::<CratesIoVersionDetailResponse>(&url, offline, cache_options)
+            .await
+    else {
+        return Ok(None);
+    };
+
+    Ok(resp.version.features.remove("default"))
+}
+
+fn dependency_table_default_features_disabled(table: &tombi_document_tree::Table) -> bool {
+    table
+        .get("default-features")
+        .is_some_and(|value| match value {
+            Value::Boolean(boolean) => !boolean.value(),
+            _ => false,
+        })
+}
+
+fn format_default_features_tooltip(default_features: &[String]) -> String {
+    let mut default_features = default_features.to_vec();
+    default_features.sort();
+
+    format!(
+        "Default Features:\n{}",
+        default_features
+            .iter()
+            .map(|feature| format!("  - {feature}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+fn package_default_features(
+    dependency_document_tree: &tombi_document_tree::DocumentTree,
+) -> Option<Vec<String>> {
+    let (_, Value::Array(default_features)) =
+        dig_keys(dependency_document_tree, &["features", "default"])?
+    else {
+        return None;
+    };
+
+    let default_features = default_features
+        .values()
+        .iter()
+        .filter_map(|value| match value {
+            Value::String(feature) => Some(feature.value().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    (!default_features.is_empty()).then_some(default_features)
 }
 
 fn get_dependency_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
@@ -513,5 +789,44 @@ mod tests {
             &version_accessors,
             version_value_position,
         ));
+    }
+
+    #[tokio::test]
+    async fn dependency_features_hover_metadata_skips_disabled_default_features() {
+        let source = "[dependencies]\nserde = { version = \"1.0\", default-features = false, features = [\"derive\"] }\n";
+        let root = tombi_ast::Root::cast(tombi_parser::parse(source).into_syntax_node()).unwrap();
+        let document_tree = root.try_into_document_tree(TomlVersion::V1_0_0).unwrap();
+        let accessors = [
+            Accessor::Key("dependencies".into()),
+            Accessor::Key("serde".into()),
+            Accessor::Key("features".into()),
+        ];
+        let position = tombi_text::Position::default()
+            + tombi_text::RelativePosition::of(
+                "[dependencies]\nserde = { version = \"1.0\", default-features = false, fe",
+            );
+
+        assert_eq!(
+            dependency_features_hover_metadata(
+                &document_tree,
+                &accessors,
+                position,
+                Path::new("Cargo.toml"),
+                TomlVersion::V1_0_0,
+                true,
+                None,
+            )
+            .await
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn format_default_features_tooltip_renders_sorted_feature_list() {
+        assert_eq!(
+            format_default_features_tooltip(&["bbb".to_string(), "aaa".to_string()]),
+            "Default Features:\n  - aaa\n  - bbb"
+        );
     }
 }

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -24,6 +24,8 @@ pub async fn hover(
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
+    dependency_detail_hover_enabled: bool,
+    default_features_hover_enabled: bool,
 ) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
     if !text_document_uri.path().ends_with("Cargo.toml") {
         return Ok(None);
@@ -33,30 +35,36 @@ pub async fn hover(
         return Ok(None);
     };
 
-    if let Some(metadata) = feature_key_hover_metadata(
-        document_tree,
-        accessors,
-        position,
-        &cargo_toml_path,
-        toml_version,
-    )
-    .await
+    if dependency_detail_hover_enabled
+        && let Some(metadata) = feature_key_hover_metadata(
+            document_tree,
+            accessors,
+            position,
+            &cargo_toml_path,
+            toml_version,
+        )
+        .await
     {
         return Ok(Some(metadata));
     }
 
-    if let Some(metadata) = dependency_features_hover_metadata(
-        document_tree,
-        accessors,
-        position,
-        &cargo_toml_path,
-        toml_version,
-        offline,
-        cache_options,
-    )
-    .await?
+    if default_features_hover_enabled
+        && let Some(metadata) = dependency_features_hover_metadata(
+            document_tree,
+            accessors,
+            position,
+            &cargo_toml_path,
+            toml_version,
+            offline,
+            cache_options,
+        )
+        .await?
     {
         return Ok(Some(metadata));
+    }
+
+    if !dependency_detail_hover_enabled {
+        return Ok(None);
     }
 
     let (dependency_accessors, hover_target) =

--- a/extensions/tombi-extension-cargo/src/inlay_hint.rs
+++ b/extensions/tombi-extension-cargo/src/inlay_hint.rs
@@ -16,6 +16,7 @@ use crate::{
         CARGO_EXTENSION_ID, CargoLock, CargoLockPackage, find_cargo_lock_path,
         load_cached_cargo_lock, load_cargo_lock_from_path,
     },
+    crates_io::CratesIoVersionDetailResponse,
     dependency_package_name, find_workspace_cargo_toml, get_workspace_cargo_toml_path,
     load_cargo_toml,
     workspace::{extract_exclude_patterns, find_package_cargo_toml_paths},
@@ -142,16 +143,6 @@ impl WorkspaceDocumentTree<'_> {
             Self::External(document_tree) => document_tree,
         }
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoVersionDetailResponse {
-    version: CratesIoVersion,
-}
-
-#[derive(Debug, Deserialize)]
-struct CratesIoVersion {
-    features: HashMap<String, Vec<String>>,
 }
 
 pub async fn inlay_hint(

--- a/tombi.toml
+++ b/tombi.toml
@@ -75,6 +75,7 @@ overrides = [
       path.enabled = true,
     },
     hover = {
+      default-features.enabled = true,
       dependency-detail.enabled = true,
     },
     inlay-hint = {

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -2160,6 +2160,18 @@
               "type": "null"
             }
           ]
+        },
+        "default-features": {
+          "title": "Default features hover feature",
+          "description": "Whether hover shows default Cargo dependency features.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add `extensions."tombi-toml/cargo".lsp.hover.default-features.enabled` to the Cargo extension config and schema/docs output
- enable Cargo hover and prefetch paths to respect the new default-features toggle alongside existing dependency detail behavior
- fix crates.io version-detail test fixtures used by hover and inlay-hint tests so cached responses match the current deserialization shape

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`