### PR TITLE
feat(serde_tombi): support inline serialization control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -360,7 +360,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -622,7 +622,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1876,7 +1876,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2351,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2738,7 +2738,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.106",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -2886,7 +2886,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2980,7 +2980,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2991,7 +2991,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3026,7 +3026,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3039,6 +3039,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "serde",
+ "serde_tombi_macros",
  "tempfile",
  "textwrap",
  "thiserror 2.0.12",
@@ -3057,6 +3058,15 @@ dependencies = [
  "tombi-toml-version",
  "tombi-validator",
  "typed-builder",
+]
+
+[[package]]
+name = "serde_tombi_macros"
+version = "0.0.0-dev"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3307,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3333,7 +3343,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3397,7 +3407,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3408,7 +3418,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3519,7 +3529,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4388,7 +4398,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4417,7 +4427,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4462,7 +4472,7 @@ checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4674,7 +4684,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4709,7 +4719,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4836,7 +4846,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4847,7 +4857,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5105,7 +5115,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5121,7 +5131,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5256,7 +5266,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5295,7 +5305,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5315,7 +5325,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5336,7 +5346,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5369,7 +5379,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,13 +1748,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2356,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -3064,6 +3071,7 @@ dependencies = [
 name = "serde_tombi_macros"
 version = "0.0.0-dev"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4293,18 +4301,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
  "winnow",
 ]
 
@@ -5057,9 +5078,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,10 @@ serde = { version = "1.0.219", features = [
 ] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_tombi = { path = "rust/serde_tombi", default-features = false }
+serde_tombi_macros = { path = "rust/serde_tombi_macros" }
 similar = { version = "2.7.0" }
 surf = "2.3.2"
+syn = { version = "2.0.110", features = ["full", "extra-traits"] }
 tar = { version = "0.4.44" }
 tempfile = { version = "3.15.0" }
 textwrap = { version = "0.16.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ nu-ansi-term = "0.50.1"
 pep508_rs = "0.9"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.95"
+proc-macro-crate = "3.4.0"
 quote = "1.0.40"
 rayon = "1.10.0"
 reqwest = { version = "0.12.15", default-features = false, features = [

--- a/crates/tombi-document/src/value/table.rs
+++ b/crates/tombi-document/src/value/table.rs
@@ -49,6 +49,11 @@ impl Table {
         &self.key_values
     }
 
+    #[inline]
+    pub fn key_values_mut(&mut self) -> &mut tombi_hashmap::IndexMap<Key, Value> {
+        &mut self.key_values
+    }
+
     pub fn entry(&mut self, key: Key) -> tombi_hashmap::map::Entry<'_, Key, Value> {
         self.key_values.entry(key)
     }

--- a/rust/serde_tombi/Cargo.toml
+++ b/rust/serde_tombi/Cargo.toml
@@ -16,6 +16,7 @@ dirs.workspace = true
 itertools.workspace = true
 log.workspace = true
 serde.workspace = true
+serde_tombi_macros.workspace = true
 textwrap.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/rust/serde_tombi/src/document.rs
+++ b/rust/serde_tombi/src/document.rs
@@ -138,14 +138,8 @@ impl ToTomlString for tombi_document::Table {
                     if i != 0 {
                         result.push_str(", ");
                     }
-                    result.push_str(&format!(
-                        "{} = ",
-                        parent_keys.iter().chain(&[key]).copied().join(".")
-                    ));
-                    value.to_toml_string(
-                        result,
-                        &parent_keys.iter().chain(&[key]).copied().collect_vec(),
-                    );
+                    result.push_str(&format!("{key} = "));
+                    value.to_toml_string(result, &[]);
                 }
                 result.push('}');
             }

--- a/rust/serde_tombi/src/document.rs
+++ b/rust/serde_tombi/src/document.rs
@@ -138,8 +138,7 @@ impl ToTomlString for tombi_document::Table {
                     if i != 0 {
                         result.push_str(", ");
                     }
-                    result.push_str(&format!("{key} = "));
-                    value.to_toml_string(result, &[]);
+                    inline_table_entry_to_toml_string(result, key, value);
                 }
                 result.push('}');
             }
@@ -149,6 +148,29 @@ impl ToTomlString for tombi_document::Table {
                 }
             }
         }
+    }
+}
+
+fn inline_table_entry_to_toml_string(
+    result: &mut std::string::String,
+    key: &tombi_document::Key,
+    value: &tombi_document::Value,
+) {
+    result.push_str(&format!("{key} = "));
+    match value {
+        tombi_document::Value::Table(table)
+            if table.kind() == tombi_document::TableKind::KeyValue =>
+        {
+            result.push('{');
+            for (i, (nested_key, nested_value)) in table.key_values().iter().enumerate() {
+                if i != 0 {
+                    result.push_str(", ");
+                }
+                inline_table_entry_to_toml_string(result, nested_key, nested_value);
+            }
+            result.push('}');
+        }
+        _ => value.to_toml_string(result, &[]),
     }
 }
 
@@ -552,6 +574,39 @@ id = 1
 [[aaa.bbb.ccc.items]]
 id = 2
 "#;
+        toml_text_assert_eq!(toml_string, expected);
+    }
+
+    #[tokio::test]
+    async fn test_inline_table_serialization_with_dotted_keys() {
+        let mut document = Document::new();
+
+        let mut inline_table = Table::new(TableKind::InlineTable);
+        let mut key_value_table = Table::new(TableKind::KeyValue);
+        let mut nested_key_value_table = Table::new(TableKind::KeyValue);
+
+        nested_key_value_table.insert(
+            Key::new(KeyKind::BareKey, "workspace".to_string()),
+            Value::Boolean(Boolean::new(true)),
+        );
+        key_value_table.insert(
+            Key::new(KeyKind::BareKey, "version".to_string()),
+            Value::Table(nested_key_value_table),
+        );
+        inline_table.insert(
+            Key::new(KeyKind::BareKey, "dependency".to_string()),
+            Value::Table(key_value_table),
+        );
+
+        document.insert(
+            Key::new(KeyKind::BareKey, "package".to_string()),
+            Value::Table(inline_table),
+        );
+
+        let mut toml_string = std::string::String::new();
+        document.to_toml_string(&mut toml_string, &[]);
+        let expected = r#"package = {dependency = {version = {workspace = true}}}"#;
+
         toml_text_assert_eq!(toml_string, expected);
     }
 

--- a/rust/serde_tombi/src/lib.rs
+++ b/rust/serde_tombi/src/lib.rs
@@ -86,6 +86,8 @@
 //! }
 //! ```
 //!
+extern crate self as serde_tombi;
+
 pub mod config;
 mod de;
 mod document;
@@ -98,8 +100,33 @@ pub use document::{
 };
 
 pub use ser::{Serializer, to_document, to_string_async};
+pub use serde_tombi_macros::tombi;
 use std::fmt;
 use thiserror::Error;
+
+#[doc(hidden)]
+pub mod private {
+    pub const INLINE_NEWTYPE_NAME: &str = "serde_tombi::Inline";
+
+    pub struct Inline<'a, T: ?Sized>(pub &'a T);
+
+    impl<T: ?Sized + serde::Serialize> serde::Serialize for Inline<'_, T> {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_newtype_struct(INLINE_NEWTYPE_NAME, self.0)
+        }
+    }
+
+    pub fn serialize_inline<T, S>(value: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        T: ?Sized + serde::Serialize,
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(&Inline(value), serializer)
+    }
+}
 
 /// Error that can occur when processing TOML.
 #[derive(Debug, Error)]

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -283,6 +283,17 @@ impl<'a> serde::Serializer for &'a mut ValueSerializer<'a> {
             tombi_date_time::LOCAL_TIME_NEWTYPE_NAME => value
                 .serialize(DateTimeSerializer::new(self.accessors))
                 .map(|dt| Some(tombi_document::Value::LocalTime(dt))),
+            crate::private::INLINE_NEWTYPE_NAME => {
+                let Some(mut value) = value.serialize(&mut ValueSerializer {
+                    accessors: self.accessors,
+                })?
+                else {
+                    return Ok(None);
+                };
+
+                force_inline(&mut value);
+                Ok(Some(value))
+            }
             _ => value.serialize(self),
         }
     }
@@ -494,6 +505,24 @@ impl serde::ser::SerializeTupleVariant for SerializeArray<'_> {
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
         serde::ser::SerializeSeq::end(self)
+    }
+}
+
+fn force_inline(value: &mut tombi_document::Value) {
+    match value {
+        tombi_document::Value::Table(table) => {
+            *table.kind_mut() = tombi_document::TableKind::InlineTable;
+            for child in table.key_values_mut().values_mut() {
+                force_inline(child);
+            }
+        }
+        tombi_document::Value::Array(array) => {
+            *array.kind_mut() = tombi_document::ArrayKind::Array;
+            for child in array.values_mut() {
+                force_inline(child);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1046,6 +1075,172 @@ aaa = "1.0"
 mmm = "1.0"
 zzz = "1.0"
 "#;
+
+        toml_text_assert_eq!(toml, expected);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_inline_table_attribute() {
+        #[derive(Serialize)]
+        struct Package {
+            version: String,
+            edition: String,
+        }
+
+        #[crate::tombi]
+        #[derive(Serialize)]
+        struct Config {
+            #[tombi(inline)]
+            package: Package,
+        }
+
+        let test = Config {
+            package: Package {
+                version: "1.0.0".to_string(),
+                edition: "2024".to_string(),
+            },
+        };
+
+        let toml = to_string_async(&test)
+            .await
+            .expect("TOML serialization failed");
+        let expected = r#"package = { version = "1.0.0", edition = "2024" }"#;
+
+        toml_text_assert_eq!(toml, expected);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_inline_array_of_tables_attribute() {
+        #[derive(Serialize)]
+        struct Dependency {
+            name: String,
+            version: String,
+        }
+
+        #[crate::tombi]
+        #[derive(Serialize)]
+        struct Config {
+            #[tombi(inline)]
+            dependencies: Vec<Dependency>,
+        }
+
+        let test = Config {
+            dependencies: vec![
+                Dependency {
+                    name: "serde".to_string(),
+                    version: "1".to_string(),
+                },
+                Dependency {
+                    name: "tokio".to_string(),
+                    version: "1".to_string(),
+                },
+            ],
+        };
+
+        let toml = to_string_async(&test)
+            .await
+            .expect("TOML serialization failed");
+        let expected = r#"
+dependencies = [
+  { name = "serde", version = "1" },
+  { name = "tokio", version = "1" }
+]
+"#
+        .strip_prefix("\n")
+        .unwrap();
+
+        toml_text_assert_eq!(toml, expected);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_inline_primitive_array_attribute_is_noop() {
+        #[crate::tombi]
+        #[derive(Serialize)]
+        struct Config {
+            #[tombi(inline)]
+            numbers: Vec<u32>,
+        }
+
+        let test = Config {
+            numbers: vec![1, 2, 3],
+        };
+
+        let toml = to_string_async(&test)
+            .await
+            .expect("TOML serialization failed");
+        let expected = r#"numbers = [1, 2, 3]"#;
+
+        toml_text_assert_eq!(toml, expected);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_inline_map_attribute() {
+        #[crate::tombi]
+        #[derive(Serialize)]
+        struct Config {
+            #[tombi(inline)]
+            map: tombi_hashmap::IndexMap<String, u32>,
+        }
+
+        let test = Config {
+            map: tombi_hashmap::indexmap! {
+                "a".to_string() => 1,
+                "b".to_string() => 2,
+            },
+        };
+
+        let toml = to_string_async(&test)
+            .await
+            .expect("TOML serialization failed");
+        let expected = r#"map = { a = 1, b = 2 }"#;
+
+        toml_text_assert_eq!(toml, expected);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_inline_attribute_propagates_through_nested_arrays_and_tables() {
+        #[derive(Serialize)]
+        struct Leaf {
+            value: String,
+        }
+
+        #[derive(Serialize)]
+        struct Entry {
+            leaves: Vec<Leaf>,
+        }
+
+        #[derive(Serialize)]
+        struct Group {
+            entries: Vec<Entry>,
+        }
+
+        #[crate::tombi]
+        #[derive(Serialize)]
+        struct Config {
+            #[tombi(inline)]
+            groups: Vec<Group>,
+        }
+
+        let test = Config {
+            groups: vec![Group {
+                entries: vec![Entry {
+                    leaves: vec![
+                        Leaf {
+                            value: "a".to_string(),
+                        },
+                        Leaf {
+                            value: "b".to_string(),
+                        },
+                    ],
+                }],
+            }],
+        };
+
+        let toml = to_string_async(&test)
+            .await
+            .expect("TOML serialization failed");
+        let expected =
+            r#"groups = [{ entries = [{ leaves = [{ value = "a" }, { value = "b" }] }] }]"#;
 
         toml_text_assert_eq!(toml, expected);
     }

--- a/rust/serde_tombi_macros/Cargo.toml
+++ b/rust/serde_tombi_macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "serde_tombi_macros"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[lints]
+workspace = true

--- a/rust/serde_tombi_macros/Cargo.toml
+++ b/rust/serde_tombi_macros/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
+proc-macro-crate.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/rust/serde_tombi_macros/src/lib.rs
+++ b/rust/serde_tombi_macros/src/lib.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::Span;
 use quote::quote;
 
@@ -12,6 +13,7 @@ pub fn tombi(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn expand(item: TokenStream) -> syn::Result<TokenStream> {
     let mut item = syn::parse::<syn::Item>(item)?;
+    let serde_tombi_path = serde_tombi_path()?;
 
     let struct_item = match &mut item {
         syn::Item::Struct(struct_item) => struct_item,
@@ -22,6 +24,12 @@ fn expand(item: TokenStream) -> syn::Result<TokenStream> {
             ));
         }
     };
+    let struct_ident = struct_item.ident.clone();
+    let helper_mod_ident = syn::Ident::new(
+        &format!("__serde_tombi_{}_helpers", struct_ident),
+        Span::call_site(),
+    );
+    let helper_path = format!("{helper_mod_ident}::serialize_inline");
 
     for field in &mut struct_item.fields {
         let inline = take_tombi_inline_attr(field)?;
@@ -42,14 +50,28 @@ fn expand(item: TokenStream) -> syn::Result<TokenStream> {
                 "#[tombi(inline)] cannot be combined with #[serde(serialize_with = ...)]",
             ));
         }
+        let path = syn::LitStr::new(&helper_path, Span::call_site());
 
-        let path = syn::LitStr::new("serde_tombi::private::serialize_inline", Span::call_site());
         field
             .attrs
             .push(syn::parse_quote!(#[serde(serialize_with = #path)]));
     }
 
-    Ok(quote!(#item).into())
+    Ok(quote!(
+        #[doc(hidden)]
+        mod #helper_mod_ident {
+            pub fn serialize_inline<T, S>(value: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                T: ?Sized + serde::Serialize,
+                S: serde::Serializer,
+            {
+                #serde_tombi_path::private::serialize_inline(value, serializer)
+            }
+        }
+
+        #item
+    )
+    .into())
 }
 
 fn take_tombi_inline_attr(field: &mut syn::Field) -> syn::Result<bool> {
@@ -101,4 +123,18 @@ fn parse_serde_attrs(field: &syn::Field) -> syn::Result<SerdeAttrs> {
     }
 
     Ok(attrs)
+}
+
+fn serde_tombi_path() -> syn::Result<syn::Path> {
+    match crate_name("serde_tombi") {
+        Ok(FoundCrate::Itself) => Ok(syn::parse_quote!(crate)),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = syn::Ident::new(&name, Span::call_site());
+            Ok(syn::parse_quote!(#ident))
+        }
+        Err(error) => Err(syn::Error::new(
+            Span::call_site(),
+            format!("failed to resolve serde_tombi crate name: {error}"),
+        )),
+    }
 }

--- a/rust/serde_tombi_macros/src/lib.rs
+++ b/rust/serde_tombi_macros/src/lib.rs
@@ -1,0 +1,104 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+
+#[proc_macro_attribute]
+pub fn tombi(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    match expand(item) {
+        Ok(tokens) => tokens,
+        Err(error) => error.into_compile_error().into(),
+    }
+}
+
+fn expand(item: TokenStream) -> syn::Result<TokenStream> {
+    let mut item = syn::parse::<syn::Item>(item)?;
+
+    let struct_item = match &mut item {
+        syn::Item::Struct(struct_item) => struct_item,
+        other => {
+            return Err(syn::Error::new_spanned(
+                other,
+                "#[serde_tombi::tombi] can only be applied to structs",
+            ));
+        }
+    };
+
+    for field in &mut struct_item.fields {
+        let inline = take_tombi_inline_attr(field)?;
+        if !inline {
+            continue;
+        }
+
+        let serde_attrs = parse_serde_attrs(field)?;
+        if serde_attrs.flatten {
+            return Err(syn::Error::new_spanned(
+                field,
+                "#[tombi(inline)] cannot be combined with #[serde(flatten)]",
+            ));
+        }
+        if serde_attrs.serialize_with {
+            return Err(syn::Error::new_spanned(
+                field,
+                "#[tombi(inline)] cannot be combined with #[serde(serialize_with = ...)]",
+            ));
+        }
+
+        let path = syn::LitStr::new("serde_tombi::private::serialize_inline", Span::call_site());
+        field
+            .attrs
+            .push(syn::parse_quote!(#[serde(serialize_with = #path)]));
+    }
+
+    Ok(quote!(#item).into())
+}
+
+fn take_tombi_inline_attr(field: &mut syn::Field) -> syn::Result<bool> {
+    let mut inline = false;
+    let mut attrs = Vec::with_capacity(field.attrs.len());
+
+    for attr in field.attrs.drain(..) {
+        if attr.path().is_ident("tombi") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("inline") {
+                    inline = true;
+                    Ok(())
+                } else {
+                    Err(meta.error("unknown tombi attribute"))
+                }
+            })?;
+        } else {
+            attrs.push(attr);
+        }
+    }
+
+    field.attrs = attrs;
+    Ok(inline)
+}
+
+#[derive(Default)]
+struct SerdeAttrs {
+    flatten: bool,
+    serialize_with: bool,
+}
+
+fn parse_serde_attrs(field: &syn::Field) -> syn::Result<SerdeAttrs> {
+    let mut attrs = SerdeAttrs::default();
+
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("flatten") {
+                attrs.flatten = true;
+            } else if meta.path.is_ident("serialize_with") {
+                attrs.serialize_with = true;
+                let _: syn::LitStr = meta.value()?.parse()?;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(attrs)
+}


### PR DESCRIPTION
## Summary
- add a `#[serde_tombi::tombi]` attribute macro and `#[tombi(inline)]` field support for controlling inline table/array serialization
- propagate inline conversion through nested arrays and tables and fix nested inline table TOML rendering
- add serializer tests for inline tables, arrays, maps, and nested propagation

## Testing
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked