### PR TITLE
fix: pin Cargo.toml schema to TOML 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,24 +57,15 @@ proc-macro-crate = "3.4.0"
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 rayon = "1.10.0"
-reqwest = {
-  version = "0.12.15",
-  default-features = false,
-  features = [
-    "json",
-    "rustls-tls-native-roots",
-  ]
-}
+reqwest = { version = "0.12.15", default-features = false, features = [
+  "json",
+  "rustls-tls-native-roots",
+] }
 rstest = { version = "0.25.0" }
 rustc-hash = { version = "2.1.1" }
 schemars = { version = "1.2.1", features = ["preserve_order", "url2"] }
 semver = "1.0.17"
-serde = {
-  version = "1.0.219",
-  features = [
-    "derive",
-  ]
-}
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_tombi = { path = "rust/serde_tombi", default-features = false }
 serde_tombi_macros = { path = "rust/serde_tombi_macros" }
@@ -93,12 +84,8 @@ tombi-ast-editor = { path = "crates/tombi-ast-editor" }
 tombi-cache = { path = "crates/tombi-cache" }
 tombi-cli-options = { path = "crates/tombi-cli-options" }
 tombi-comment-directive = { path = "crates/tombi-comment-directive" }
-tombi-comment-directive-serde = {
-  path = "crates/tombi-comment-directive-serde"
-}
-tombi-comment-directive-store = {
-  path = "crates/tombi-comment-directive-store"
-}
+tombi-comment-directive-serde = { path = "crates/tombi-comment-directive-serde" }
+tombi-comment-directive-store = { path = "crates/tombi-comment-directive-store" }
 tombi-config = { path = "crates/tombi-config" }
 tombi-date-time = { path = "crates/tombi-date-time" }
 tombi-diagnostic = { path = "crates/tombi-diagnostic" }
@@ -123,10 +110,7 @@ tombi-lsp = { path = "crates/tombi-lsp", default-features = false }
 tombi-parser = { path = "crates/tombi-parser" }
 tombi-regex = { path = "crates/tombi-regex" }
 tombi-rg-tree = { path = "crates/tombi-rg-tree" }
-tombi-schema-store = {
-  path = "crates/tombi-schema-store",
-  default-features = false
-}
+tombi-schema-store = { path = "crates/tombi-schema-store", default-features = false }
 tombi-severity-level = { path = "crates/tombi-severity-level" }
 tombi-syntax = { path = "crates/tombi-syntax" }
 tombi-test-lib = { path = "crates/tombi-test-lib" }

--- a/crates/tombi-lsp/tests/fixtures/cargo/path-dependency-no-features/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/cargo/path-dependency-no-features/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-local-path-no-features = {
-  path = "local-path-no-features",
-  features = ["default"]
-}
+local-path-no-features = { path = "local-path-no-features", features = [
+  "default"
+] }

--- a/rust/tombi-wasm/Cargo.toml
+++ b/rust/tombi-wasm/Cargo.toml
@@ -14,11 +14,7 @@ console_error_panic_hook.workspace = true
 itertools.workspace = true
 js-sys.workspace = true
 serde.workspace = true
-serde_tombi = {
-  workspace = true,
-  default-features = false,
-  features = ["wasm"]
-}
+serde_tombi = { workspace = true, default-features = false, features = ["wasm"] }
 serde-wasm-bindgen = "0.6.5"
 tombi-config.workspace = true
 tombi-diagnostic = { workspace = true, features = ["wasm"] }

--- a/tombi.toml
+++ b/tombi.toml
@@ -34,6 +34,12 @@ path = "schemas/type-test.schema.json"
 include = ["type-test.toml"]
 
 [[schemas]]
+# Keep Cargo.toml on TOML v1.0.0 for Nix builtins.fromTOML compatibility.
+toml-version = "v1.0.0"
+path = "tombi://www.schemastore.org/cargo.json"
+include = ["Cargo.toml"]
+
+[[schemas]]
 path = "tombi://www.schemastore.org/tombi.json"
 include = [".tombi.toml", "tombi.toml", "tombi/config.toml"]
 format.rules = {


### PR DESCRIPTION
## Summary
- pin the Cargo schema in `tombi.toml` to TOML v1.0.0 so Cargo.toml formatting stays compatible with Nix `builtins.fromTOML`
- update the affected Cargo fixture and workspace Cargo manifests to match the v1.0.0 formatter output

## Testing
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked