### PR TITLE
fix: restore cargo document links for standalone dependencies

### DIFF
--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -219,6 +219,27 @@ mod document_link_tests {
 
         test_document_link!(
             #[tokio::test]
+            async fn cargo_dependencies_serde_standalone(
+                r#"
+                [package]
+                name = "standalone"
+                version = "0.1.0"
+
+                [dependencies]
+                serde = "1.0"
+                "#,
+                SourcePath(std::env::temp_dir().join("tombi-issue-1912/Cargo.toml")),
+            ) -> Ok(Some(vec![
+                {
+                    url: "https://crates.io/crates/serde",
+                    range: 5:0..5:5,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CrateIo,
+                }
+            ]));
+        );
+
+        test_document_link!(
+            #[tokio::test]
             async fn cargo_dependencies_serde_toml(
                 r#"
                 [package]
@@ -431,6 +452,16 @@ mod document_link_tests {
                     path: project_root_path().join("crates/tombi-accessor/Cargo.toml"),
                     range: 8:12..8:20,
                     tooltip: tombi_extension_cargo::DocumentLinkToolTip::CargoTomlFirstMember,
+                },
+                {
+                    path: project_root_path().join("crates/tombi-ast/Cargo.toml"),
+                    range: 5:0..5:9,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::CargoToml,
+                },
+                {
+                    path: project_root_path().join("Cargo.toml"),
+                    range: 5:14..5:30,
+                    tooltip: tombi_extension_cargo::DocumentLinkToolTip::WorkspaceCargoToml,
                 },
             ]));
         );

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -240,6 +240,21 @@ mod document_link_tests {
 
         test_document_link!(
             #[tokio::test]
+            async fn cargo_dependencies_custom_registry_standalone_has_no_default_crates_io_fallback(
+                r#"
+                [package]
+                name = "standalone"
+                version = "0.1.0"
+
+                [dependencies]
+                serde = { version = "1.0", registry = "custom" }
+                "#,
+                SourcePath(std::env::temp_dir().join("tombi-issue-1912-custom/Cargo.toml")),
+            ) -> Ok(None);
+        );
+
+        test_document_link!(
+            #[tokio::test]
             async fn cargo_dependencies_serde_toml(
                 r#"
                 [package]

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -312,16 +312,19 @@ fn document_link_for_crate_cargo_toml(
 
     let mut total_document_links = vec![];
     let workspace_cargo_toml = if crate_document_tree.contains_key("workspace") {
-        crate::load_cargo_toml(crate_cargo_toml_path, toml_version)
-            .map(|(root, document_tree)| (crate_cargo_toml_path.to_path_buf(), root, document_tree))
+        Some((
+            crate_cargo_toml_path.to_path_buf(),
+            crate_document_tree.clone(),
+        ))
     } else {
         find_workspace_cargo_toml(
             crate_cargo_toml_path,
             get_workspace_cargo_toml_path(crate_document_tree),
             toml_version,
         )
+        .map(|(path, _, document_tree)| (path, document_tree))
     };
-    if let Some((workspace_cargo_toml_path, _, workspace_document_tree)) = workspace_cargo_toml {
+    if let Some((workspace_cargo_toml_path, workspace_document_tree)) = workspace_cargo_toml {
         let registries =
             get_registries(&workspace_cargo_toml_path, toml_version).unwrap_or_default();
 
@@ -446,7 +449,7 @@ fn document_link_for_crate_cargo_toml(
                 features,
             ) {
                 if document_links.is_empty()
-                    && !dependency_uses_local_path(crate_value)
+                    && dependency_uses_default_registry(crate_value)
                     && let Some(document_link) = crates_io_document_link_enabled(features)
                         .then(|| get_crate_io_crate_link(crate_key, crate_value))
                         .flatten()
@@ -697,6 +700,19 @@ fn dependency_uses_local_path(crate_value: &tombi_document_tree::Value) -> bool 
         crate_value,
         tombi_document_tree::Value::Table(table) if table.contains_key("path")
     )
+}
+
+fn dependency_uses_default_registry(crate_value: &tombi_document_tree::Value) -> bool {
+    match crate_value {
+        tombi_document_tree::Value::String(_) => true,
+        tombi_document_tree::Value::Table(table) => {
+            !table.contains_key("path")
+                && !table.contains_key("git")
+                && !table.contains_key("registry")
+                && !table.contains_key("workspace")
+        }
+        _ => false,
+    }
 }
 
 fn workspace_dependency_target(

--- a/extensions/tombi-extension-cargo/src/document_link.rs
+++ b/extensions/tombi-extension-cargo/src/document_link.rs
@@ -311,11 +311,17 @@ fn document_link_for_crate_cargo_toml(
     }
 
     let mut total_document_links = vec![];
-    if let Some((workspace_cargo_toml_path, _, workspace_document_tree)) = find_workspace_cargo_toml(
-        crate_cargo_toml_path,
-        get_workspace_cargo_toml_path(crate_document_tree),
-        toml_version,
-    ) {
+    let workspace_cargo_toml = if crate_document_tree.contains_key("workspace") {
+        crate::load_cargo_toml(crate_cargo_toml_path, toml_version)
+            .map(|(root, document_tree)| (crate_cargo_toml_path.to_path_buf(), root, document_tree))
+    } else {
+        find_workspace_cargo_toml(
+            crate_cargo_toml_path,
+            get_workspace_cargo_toml_path(crate_document_tree),
+            toml_version,
+        )
+    };
+    if let Some((workspace_cargo_toml_path, _, workspace_document_tree)) = workspace_cargo_toml {
         let registries =
             get_registries(&workspace_cargo_toml_path, toml_version).unwrap_or_default();
 
@@ -431,7 +437,7 @@ fn document_link_for_crate_cargo_toml(
         let registries = get_registries(crate_cargo_toml_path, toml_version).unwrap_or_default();
 
         for (crate_key, crate_value) in total_dependencies {
-            if let Ok(document_links) = document_link_for_dependency(
+            if let Ok(mut document_links) = document_link_for_dependency(
                 crate_key,
                 crate_value,
                 crate_cargo_toml_path,
@@ -439,6 +445,14 @@ fn document_link_for_crate_cargo_toml(
                 toml_version,
                 features,
             ) {
+                if document_links.is_empty()
+                    && !dependency_uses_local_path(crate_value)
+                    && let Some(document_link) = crates_io_document_link_enabled(features)
+                        .then(|| get_crate_io_crate_link(crate_key, crate_value))
+                        .flatten()
+                {
+                    document_links.push(document_link);
+                }
                 total_document_links.extend(document_links);
             }
         }


### PR DESCRIPTION
## Summary
- restore crates.io document links for dependency entries in standalone Cargo.toml files
- treat a workspace root package Cargo.toml as its own workspace when resolving document links
- cover standalone and root-package behavior with document-link tests

Closes #1912