### PR TITLE
test: consolidate tombi-lsp ad hoc cases

### DIFF
--- a/crates/tombi-lsp/src/document.rs
+++ b/crates/tombi-lsp/src/document.rs
@@ -139,3 +139,26 @@ impl DocumentSource {
         &self.document_tree_errors
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tombi_config::TomlVersion;
+    use tombi_text::EncodingKind;
+
+    use super::DocumentSource;
+
+    #[test]
+    fn line_index_arc_keeps_original_text_alive() {
+        let mut document_source = DocumentSource::new(
+            "name = \"before\"\nversion = \"1.0.0\"",
+            Some(1),
+            TomlVersion::default(),
+            EncodingKind::Utf16,
+        );
+        let line_index = document_source.line_index_arc();
+
+        document_source.set_text("name = \"after\"", TomlVersion::default());
+
+        assert_eq!(line_index.line_text(1), Some("version = \"1.0.0\""));
+    }
+}

--- a/crates/tombi-lsp/src/document.rs
+++ b/crates/tombi-lsp/src/document.rs
@@ -139,26 +139,3 @@ impl DocumentSource {
         &self.document_tree_errors
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use tombi_config::TomlVersion;
-    use tombi_text::EncodingKind;
-
-    use super::DocumentSource;
-
-    #[test]
-    fn line_index_arc_keeps_original_text_alive() {
-        let mut document_source = DocumentSource::new(
-            "name = \"before\"\nversion = \"1.0.0\"",
-            Some(1),
-            TomlVersion::default(),
-            EncodingKind::Utf16,
-        );
-        let line_index = document_source.line_index_arc();
-
-        document_source.set_text("name = \"after\"", TomlVersion::default());
-
-        assert_eq!(line_index.line_text(1), Some("version = \"1.0.0\""));
-    }
-}

--- a/crates/tombi-lsp/src/handler/code_action.rs
+++ b/crates/tombi-lsp/src/handler/code_action.rs
@@ -144,76 +144,103 @@ mod tests {
     use tombi_schema_store::AccessorKeyKind;
     use tombi_text::Position;
 
-    #[tokio::test]
-    async fn test_get_completion_keys_with_context_simple_keyvalue() {
-        let src = r#"foo = 1\nbar = 2\n"#;
-        let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
-        let pos = Position::new(0, 2); // somewhere in 'foo'
-        let toml_version = TomlVersion::V1_0_0;
-        let result = get_completion_keys_with_context(&root, pos, toml_version).await;
-        assert!(result.is_some());
-        let (keys, contexts) = result.unwrap();
-        assert_eq!(keys.len(), 1);
-        assert_eq!(contexts.len(), 1);
-        assert_eq!(contexts[0].kind, AccessorKeyKind::KeyValue);
+    macro_rules! test_get_completion_keys_with_context {
+        (#[tokio::test] async fn $name:ident($src:expr, $pos:expr) -> None;) => {
+            #[tokio::test]
+            async fn $name() {
+                let src = $src.trim();
+                let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
+                let result =
+                    get_completion_keys_with_context(&root, $pos, TomlVersion::V1_0_0).await;
+
+                assert!(result.is_none());
+            }
+        };
+
+        (#[tokio::test] async fn $name:ident($src:expr, $pos:expr) -> Some(($keys:ident, $contexts:ident) $assertions:block);) => {
+            #[tokio::test]
+            async fn $name() {
+                let src = $src.trim();
+                let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
+                let result =
+                    get_completion_keys_with_context(&root, $pos, TomlVersion::V1_0_0).await;
+
+                assert!(result.is_some());
+                let ($keys, $contexts) = result.unwrap();
+                $assertions
+            }
+        };
     }
 
-    #[tokio::test]
-    async fn test_get_completion_keys_with_context_table_header() {
-        let src = r#"[table]\nfoo = 1\n"#;
-        let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
-        let pos = Position::new(0, 2); // somewhere in 'table'
-        let toml_version = TomlVersion::V1_0_0;
-        let result = get_completion_keys_with_context(&root, pos, toml_version).await;
-        assert!(result.is_some());
-        let (keys, contexts) = result.unwrap();
-        assert!(!keys.is_empty());
-
-        assert!(contexts.iter().any(|c| c.kind == AccessorKeyKind::Header));
+    test_get_completion_keys_with_context! {
+        #[tokio::test]
+        async fn test_get_completion_keys_with_context_simple_keyvalue(
+            r#"
+            foo = 1
+            bar = 2
+            "#,
+            Position::new(0, 2)
+        ) -> Some((keys, contexts) {
+            assert_eq!(keys.len(), 1);
+            assert_eq!(contexts.len(), 1);
+            assert_eq!(contexts[0].kind, AccessorKeyKind::KeyValue);
+        });
     }
 
-    #[tokio::test]
-    async fn test_get_completion_keys_with_context_empty() {
-        let src = r#"# just a comment\n"#;
-        let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
-        let pos = Position::new(0, 0);
-        let toml_version = TomlVersion::V1_0_0;
-        let result = get_completion_keys_with_context(&root, pos, toml_version).await;
-
-        assert!(result.is_none());
+    test_get_completion_keys_with_context! {
+        #[tokio::test]
+        async fn test_get_completion_keys_with_context_table_header(
+            r#"
+            [table]
+            foo = 1
+            "#,
+            Position::new(0, 2)
+        ) -> Some((keys, contexts) {
+            assert!(!keys.is_empty());
+            assert!(contexts.iter().any(|c| c.kind == AccessorKeyKind::Header));
+        });
     }
 
-    #[tokio::test]
-    async fn test_get_completion_keys_with_context_simple_keyvalue_range() {
-        let src = "foo = 1\nbar = 2\n";
-        let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
-        let pos = Position::new(0, 2); // somewhere in 'foo'
-        let toml_version = TomlVersion::V1_0_0;
-        let result = get_completion_keys_with_context(&root, pos, toml_version).await;
-        assert!(result.is_some());
-        let (keys, contexts) = result.unwrap();
-
-        pretty_assertions::assert_eq!(keys.len(), 1);
-        pretty_assertions::assert_eq!(keys.len(), contexts.len());
-
-        for (key, ctx) in keys.iter().zip(contexts.iter()) {
-            pretty_assertions::assert_eq!(ctx.range, key.range());
-        }
+    test_get_completion_keys_with_context! {
+        #[tokio::test]
+        async fn test_get_completion_keys_with_context_empty(
+            "# just a comment",
+            Position::new(0, 0)
+        ) -> None;
     }
 
-    #[tokio::test]
-    async fn test_get_completion_keys_with_context_table_header_range() {
-        let src = "[table]\nfoo = 1\n";
-        let root = tombi_ast::Root::cast(parse(src).into_syntax_node()).unwrap();
-        let pos = Position::new(0, 2); // somewhere in 'table'
-        let toml_version = TomlVersion::V1_0_0;
-        let result = get_completion_keys_with_context(&root, pos, toml_version).await;
-        assert!(result.is_some());
-        let (keys, contexts) = result.unwrap();
-        assert!(!keys.is_empty());
+    test_get_completion_keys_with_context! {
+        #[tokio::test]
+        async fn test_get_completion_keys_with_context_simple_keyvalue_range(
+            r#"
+            foo = 1
+            bar = 2
+            "#,
+            Position::new(0, 2)
+        ) -> Some((keys, contexts) {
+            pretty_assertions::assert_eq!(keys.len(), 1);
+            pretty_assertions::assert_eq!(keys.len(), contexts.len());
 
-        for (key, ctx) in keys.iter().zip(contexts.iter()) {
-            pretty_assertions::assert_eq!(ctx.range, key.range());
-        }
+            for (key, ctx) in keys.iter().zip(contexts.iter()) {
+                pretty_assertions::assert_eq!(ctx.range, key.range());
+            }
+        });
+    }
+
+    test_get_completion_keys_with_context! {
+        #[tokio::test]
+        async fn test_get_completion_keys_with_context_table_header_range(
+            r#"
+            [table]
+            foo = 1
+            "#,
+            Position::new(0, 2)
+        ) -> Some((keys, contexts) {
+            assert!(!keys.is_empty());
+
+            for (key, ctx) in keys.iter().zip(contexts.iter()) {
+                pretty_assertions::assert_eq!(ctx.range, key.range());
+            }
+        });
     }
 }

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -829,21 +829,4 @@ mod tests {
             "#,
         ) -> Ok(((2, 2), (3, 11)));
     }
-
-    #[test]
-    fn apply_hover_text_change_replaces_and_appends() {
-        let mut target = Some("base".to_string());
-
-        apply_hover_text_change(
-            &mut target,
-            Some(HoverTextChange::Append("extra".to_string())),
-        );
-        assert_eq!(target.as_deref(), Some("base\n\nextra"));
-
-        apply_hover_text_change(
-            &mut target,
-            Some(HoverTextChange::Replace("override".to_string())),
-        );
-        assert_eq!(target.as_deref(), Some("override"));
-    }
 }

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -247,6 +247,7 @@ fn markdown_code(value: impl std::fmt::Display, strike: bool) -> String {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use tombi_schema_store::{ResolvedFormatOrder, XTombiArrayValuesOrder, XTombiTableKeysOrder};
     use tombi_x_keyword::{ArrayValuesOrder, TableKeysOrder};
 
@@ -266,8 +267,16 @@ mod tests {
             ..Default::default()
         };
 
-        let rendered = constraints.to_string();
-        assert!(rendered.contains("Values Order: ~~`descending`~~"));
-        assert!(rendered.contains("Keys Order: ~~`ascending`~~"));
+        assert_eq!(
+            constraints.to_string().trim(),
+            textwrap::dedent(
+                r#"
+                Values Order: ~~`descending`~~
+
+                Keys Order: ~~`ascending`~~
+                "#
+            )
+            .trim()
+        );
     }
 }

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -50,6 +50,25 @@ mod completion_edit {
         new_text
     }
 
+    #[test]
+    fn apply_text_edit_uses_grapheme_columns_for_unicode() {
+        let text = r#"lsp = { "日本語" = "値", comp }"#;
+        let start = text.find("comp").unwrap();
+        let end = start + "comp".len();
+        let text_edit = tombi_extension::TextEdit {
+            range: tombi_text::Range::new(
+                tombi_text::Position::default() + tombi_text::RelativePosition::of(&text[..start]),
+                tombi_text::Position::default() + tombi_text::RelativePosition::of(&text[..end]),
+            ),
+            new_text: "completion".to_string(),
+        };
+
+        pretty_assertions::assert_eq!(
+            apply_text_edit(text, &text_edit),
+            r#"lsp = { "日本語" = "値", completion }"#
+        );
+    }
+
     mod tombi_schema {
         use tombi_test_lib::tombi_schema_path;
 

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -50,24 +50,6 @@ mod completion_edit {
         new_text
     }
 
-    #[test]
-    fn apply_text_edit_uses_grapheme_columns_for_unicode() {
-        let text = r#"lsp = { "日本語" = "値", comp }"#;
-        let start = text.find("comp").unwrap();
-        let end = start + "comp".len();
-        let text_edit = tombi_extension::TextEdit {
-            range: tombi_text::Range::new(
-                tombi_text::Position::default() + tombi_text::RelativePosition::of(&text[..start]),
-                tombi_text::Position::default() + tombi_text::RelativePosition::of(&text[..end]),
-            ),
-            new_text: "completion".to_string(),
-        };
-
-        let actual = apply_text_edit(text, &text_edit);
-
-        pretty_assertions::assert_eq!(actual, r#"lsp = { "日本語" = "値", completion }"#);
-    }
-
     mod tombi_schema {
         use tombi_test_lib::tombi_schema_path;
 


### PR DESCRIPTION
## Summary
- replace repetitive `code_action` completion context tests with a shared test macro
- tighten the hover constraints assertion to compare the full rendered output
- drop redundant ad hoc tests that are now covered elsewhere in tombi-lsp

## Testing
- cargo fmt --all --check
- cargo test -p tombi-lsp --locked