### PR TITLE
ci: sync setup-tombi release automation

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -415,7 +415,6 @@ jobs:
           set -euo pipefail
           if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
-            echo "stable_version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
           else
             echo "Skipping setup-tombi update for non-stable tag: ${REF_NAME}"
             echo "stable_tag=" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -536,7 +536,7 @@ jobs:
             core.info(`Created ${repo}@${tag} on ${runSha} after update-version completed.`);
 
   publish-winget:
-    needs: [release-notes, update-install-script-version]
+    needs: [release-notes]
     if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
     runs-on: windows-latest
     permissions:

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -464,6 +464,9 @@ jobs:
               repo,
               workflow_id: "update-version.yml",
               ref: "main",
+              inputs: {
+                version: tag,
+              },
             });
 
             core.info("Triggered setup-tombi update-version.yml on main.");
@@ -517,24 +520,20 @@ jobs:
               return;
             }
 
-            const {
-              data: {
-                object: { sha: mainSha },
-              },
-            } = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: "heads/main",
-            });
+            const runSha = workflowRun.head_sha;
+            if (!runSha) {
+              core.setFailed("setup-tombi update-version workflow did not report a head SHA.");
+              return;
+            }
 
             await github.rest.git.createRef({
               owner,
               repo,
               ref: `refs/tags/${tag}`,
-              sha: mainSha,
+              sha: runSha,
             });
 
-            core.info(`Created ${repo}@${tag} on ${mainSha} after update-version completed.`);
+            core.info(`Created ${repo}@${tag} on ${runSha} after update-version completed.`);
 
   publish-winget:
     needs: [release-notes, update-install-script-version]

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -434,7 +434,7 @@ jobs:
           permission-contents: write
           permission-actions: write
 
-      - name: Tag setup-tombi and trigger version sync
+      - name: Update setup-tombi before tagging
         if: steps.stable-version.outputs.stable_tag != ''
         uses: actions/github-script@v7
         with:
@@ -450,32 +450,15 @@ jobs:
                 repo,
                 ref: `tags/${tag}`,
               });
-              core.info(`setup-tombi already has tag ${tag}.`);
+              core.info(`setup-tombi already has tag ${tag}. Skipping update and tagging.`);
+              return;
             } catch (error) {
               if (error.status !== 404) {
                 throw error;
               }
-
-              const {
-                data: {
-                  object: { sha: mainSha },
-                },
-              } = await github.rest.git.getRef({
-                owner,
-                repo,
-                ref: "heads/main",
-              });
-
-              await github.rest.git.createRef({
-                owner,
-                repo,
-                ref: `refs/tags/${tag}`,
-                sha: mainSha,
-              });
-
-              core.info(`Created ${repo}@${tag} on ${mainSha}.`);
             }
 
+            const dispatchedAfter = new Date().toISOString();
             await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,
@@ -484,6 +467,74 @@ jobs:
             });
 
             core.info("Triggered setup-tombi update-version.yml on main.");
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const maxAttempts = 60;
+            let workflowRun;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: "update-version.yml",
+                branch: "main",
+                event: "workflow_dispatch",
+                per_page: 10,
+              });
+
+              workflowRun = data.workflow_runs.find(
+                (run) => run.created_at >= dispatchedAfter,
+              );
+
+              if (workflowRun) {
+                core.info(
+                  `Found setup-tombi update-version run ${workflowRun.id} with status ${workflowRun.status}.`,
+                );
+                if (workflowRun.status === "completed") {
+                  break;
+                }
+              } else {
+                core.info("Waiting for setup-tombi update-version run to appear.");
+              }
+
+              if (attempt === maxAttempts) {
+                core.setFailed("Timed out waiting for setup-tombi update-version workflow to complete.");
+                return;
+              }
+
+              await sleep(10000);
+            }
+
+            if (!workflowRun) {
+              core.setFailed("setup-tombi update-version workflow run was not found.");
+              return;
+            }
+
+            if (workflowRun.conclusion !== "success") {
+              core.setFailed(
+                `setup-tombi update-version workflow concluded with ${workflowRun.conclusion}.`,
+              );
+              return;
+            }
+
+            const {
+              data: {
+                object: { sha: mainSha },
+              },
+            } = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: "heads/main",
+            });
+
+            await github.rest.git.createRef({
+              owner,
+              repo,
+              ref: `refs/tags/${tag}`,
+              sha: mainSha,
+            });
+
+            core.info(`Created ${repo}@${tag} on ${mainSha} after update-version completed.`);
 
   publish-winget:
     needs: [release-notes, update-install-script-version]

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -399,6 +399,132 @@ jobs:
             fi
           done
 
+  tag-setup-tombi:
+    needs: [release-notes]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
+            echo "stable_version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Skipping setup-tombi tagging for non-stable tag: ${REF_NAME}"
+            echo "stable_tag=" >> "${GITHUB_OUTPUT}"
+            echo "stable_version=" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create GitHub App token for setup-tombi
+        id: app-token
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            setup-tombi
+          permission-contents: write
+
+      - name: Tag setup-tombi main with the release version
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = "setup-tombi";
+            const tag = "${{ steps.stable-version.outputs.stable_tag }}";
+
+            try {
+              await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${tag}`,
+              });
+              core.info(`setup-tombi already has tag ${tag}. Skipping.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const {
+              data: {
+                object: { sha: mainSha },
+              },
+            } = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: "heads/main",
+            });
+
+            await github.rest.git.createRef({
+              owner,
+              repo,
+              ref: `refs/tags/${tag}`,
+              sha: mainSha,
+            });
+
+            core.info(`Created ${repo}@${tag} on ${mainSha}.`);
+
+  update-setup-tombi-version:
+    needs: [tag-setup-tombi]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Detect stable release tag
+        id: stable-version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Skipping setup-tombi version update for non-stable tag: ${REF_NAME}"
+            echo "stable_tag=" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create GitHub App token for setup-tombi
+        id: app-token
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            setup-tombi
+          permission-actions: write
+
+      - name: Trigger setup-tombi version sync
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: "setup-tombi",
+              workflow_id: "update-version.yml",
+              ref: "main",
+            });
+
+            core.info("Triggered setup-tombi update-version.yml on main.");
+
   publish-winget:
     needs: [release-notes, update-install-script-version]
     if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -399,7 +399,7 @@ jobs:
             fi
           done
 
-  tag-setup-tombi:
+  update-setup-tombi:
     needs: [release-notes]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -417,9 +417,8 @@ jobs:
             echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
             echo "stable_version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
           else
-            echo "Skipping setup-tombi tagging for non-stable tag: ${REF_NAME}"
+            echo "Skipping setup-tombi update for non-stable tag: ${REF_NAME}"
             echo "stable_tag=" >> "${GITHUB_OUTPUT}"
-            echo "stable_version=" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Create GitHub App token for setup-tombi
@@ -433,8 +432,9 @@ jobs:
           repositories: |
             setup-tombi
           permission-contents: write
+          permission-actions: write
 
-      - name: Tag setup-tombi main with the release version
+      - name: Tag setup-tombi and trigger version sync
         if: steps.stable-version.outputs.stable_tag != ''
         uses: actions/github-script@v7
         with:
@@ -450,75 +450,35 @@ jobs:
                 repo,
                 ref: `tags/${tag}`,
               });
-              core.info(`setup-tombi already has tag ${tag}. Skipping.`);
-              return;
+              core.info(`setup-tombi already has tag ${tag}.`);
             } catch (error) {
               if (error.status !== 404) {
                 throw error;
               }
+
+              const {
+                data: {
+                  object: { sha: mainSha },
+                },
+              } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: "heads/main",
+              });
+
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/tags/${tag}`,
+                sha: mainSha,
+              });
+
+              core.info(`Created ${repo}@${tag} on ${mainSha}.`);
             }
 
-            const {
-              data: {
-                object: { sha: mainSha },
-              },
-            } = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: "heads/main",
-            });
-
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${tag}`,
-              sha: mainSha,
-            });
-
-            core.info(`Created ${repo}@${tag} on ${mainSha}.`);
-
-  update-setup-tombi-version:
-    needs: [tag-setup-tombi]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Detect stable release tag
-        id: stable-version
-        shell: bash
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "Skipping setup-tombi version update for non-stable tag: ${REF_NAME}"
-            echo "stable_tag=" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Create GitHub App token for setup-tombi
-        id: app-token
-        if: steps.stable-version.outputs.stable_tag != ''
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            setup-tombi
-          permission-actions: write
-
-      - name: Trigger setup-tombi version sync
-        if: steps.stable-version.outputs.stable_tag != ''
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
             await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: "setup-tombi",
+              owner,
+              repo,
               workflow_id: "update-version.yml",
               ref: "main",
             });

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -274,14 +274,3 @@ jobs:
               workflow_id: 'main.yml',
               ref: 'main',
             })
-      - name: "Update tombi-setup readme"
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.TOMBI_PRE_COMMIT_PAT }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: 'setup-tombi',
-              workflow_id: 'update-readme-version.yml',
-              ref: 'main',
-            })


### PR DESCRIPTION
## Summary
- create the `setup-tombi` release tag from tombi release aggregation using the version-update GitHub App credentials
- trigger `setup-tombi`'s renamed `update-version.yml` after tagging so README/package version sync runs in the new order
- remove the old PyPI-side dispatch to `update-readme-version.yml`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_cli_vscode.yml"); YAML.load_file(".github/workflows/release_pypi.yml"); puts "yaml ok"'`
- `git diff --check`