### PR TITLE
fix: statically link Windows MSVC CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,5 +6,11 @@ tombi-flamegraph = "flamegraph --output .tmp/flamegraph.svg --package tombi-cli 
 xtask = "run --package xtask --bin xtask --"
 parse-jsonschema = "run --package tombi-schema-store --example parse_jsonschema --"
 
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", 'getrandom_backend="wasm_js"']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,10 +6,7 @@ tombi-flamegraph = "flamegraph --output .tmp/flamegraph.svg --package tombi-cli 
 xtask = "run --package xtask --bin xtask --"
 parse-jsonschema = "run --package tombi-schema-store --example parse_jsonschema --"
 
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.aarch64-pc-windows-msvc]
+[target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.wasm32-unknown-unknown]


### PR DESCRIPTION
## Summary
- statically link the CRT for Windows MSVC targets
- apply the flag through a single cfg-based Cargo target table
- avoid `STATUS_DLL_NOT_FOUND` in winget portable validation

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked
- cargo check -p tombi-cli

## Context
- addresses the Windows runtime failure reported in https://github.com/microsoft/winget-pkgs/pull/379439#issuecomment-4549195664