### PR TITLE
fix(formatter): scope trailing comment alignment in nested collections

### DIFF
--- a/crates/tombi-formatter/src/format/comment.rs
+++ b/crates/tombi-formatter/src/format/comment.rs
@@ -190,11 +190,13 @@ fn format_comment(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
+
     use itertools::Itertools;
     use tombi_ast::AstNode;
     use tombi_config::FormatRules;
 
-    use crate::{Formatter, test_format};
+    use crate::{Format, Formatter, test_format};
 
     test_format! {
         #[tokio::test]
@@ -346,6 +348,57 @@ mod tests {
             formatted.contains("key2"),
             "item group content should be formatted even when comments are skipped"
         );
+    }
+
+    #[test]
+    fn format_to_string_without_comment_restores_nested_skip_comment_state() {
+        struct NestedSkipCommentProbe;
+
+        impl Format for NestedSkipCommentProbe {
+            fn format(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+                write!(f, "value")?;
+                let nested_root = tombi_ast::Root::cast(
+                    tombi_parser::parse("key = 1 # nested").into_syntax_node(),
+                )
+                .unwrap();
+                let nested_comment = nested_root
+                    .key_values()
+                    .next()
+                    .and_then(|key_value| key_value.trailing_comment())
+                    .unwrap();
+                let nested = f.format_to_string_without_comment(&nested_comment)?;
+                assert!(
+                    nested.is_empty(),
+                    "nested trailing comment should stay skipped during measurement"
+                );
+                let outer_root = tombi_ast::Root::cast(
+                    tombi_parser::parse("key = 1 # outer").into_syntax_node(),
+                )
+                .unwrap();
+                let outer_comment = outer_root
+                    .key_values()
+                    .next()
+                    .and_then(|key_value| key_value.trailing_comment())
+                    .unwrap();
+                outer_comment.format(f)
+            }
+        }
+
+        let schema_store = tombi_schema_store::SchemaStore::new();
+        let options = tombi_config::FormatOptions::default();
+        let source_path = tombi_test_lib::project_root_path().join("test.toml");
+        let mut formatter = Formatter::new(
+            tombi_config::TomlVersion::V1_0_0,
+            &options,
+            Some(itertools::Either::Right(source_path.as_path())),
+            &schema_store,
+        );
+
+        let formatted = formatter
+            .format_to_string_without_comment(&NestedSkipCommentProbe)
+            .unwrap();
+
+        assert_eq!(formatted, "value");
     }
 
     test_format! {

--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -4,7 +4,11 @@ use itertools::Itertools;
 use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{Format, format::write_trailing_comment_alignment_space, types::WithAlignmentHint};
+use crate::{
+    Format,
+    format::write_trailing_comment_alignment_space,
+    types::{AlignmentWidth, WithAlignmentHint},
+};
 
 impl Format for tombi_ast::Array {
     #[inline]
@@ -98,6 +102,8 @@ fn format_multiline_array(
 
     f.inc_indent();
 
+    let local_trailing_comment_alignment_width = array_trailing_comment_alignment_width(array, f)?;
+
     let groups = array
         .dangling_comment_groups()
         .map(DanglingCommentGroupOr::DanglingCommentGroup)
@@ -105,7 +111,7 @@ fn format_multiline_array(
             WithAlignmentHint::new_with_dangling_comment_group_or(
                 group,
                 None,
-                *trailing_comment_alignment_width,
+                local_trailing_comment_alignment_width,
             )
         }))
         .collect_vec();
@@ -127,6 +133,27 @@ fn format_multiline_array(
     }
 
     Ok(())
+}
+
+fn array_trailing_comment_alignment_width(
+    array: &tombi_ast::Array,
+    f: &mut crate::Formatter,
+) -> Result<Option<AlignmentWidth>, std::fmt::Error> {
+    if !f.trailing_comment_alignment() || array.values().next().is_none() {
+        return Ok(None);
+    }
+
+    let groups =
+        array
+            .dangling_comment_groups()
+            .map(DanglingCommentGroupOr::DanglingCommentGroup)
+            .chain(array.value_with_comma_groups().map(|group| {
+                WithAlignmentHint::new_with_dangling_comment_group_or(group, None, None)
+            }))
+            .collect_vec();
+
+    let formatted = f.format_to_string_without_comment(&groups)?;
+    Ok(Some(AlignmentWidth::new(&formatted)))
 }
 
 fn format_singleline_array(

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -5,7 +5,11 @@ use tombi_ast::{AstNode, DanglingCommentGroupOr};
 use tombi_config::TomlVersion;
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{Format, format::write_trailing_comment_alignment_space, types::WithAlignmentHint};
+use crate::{
+    Format,
+    format::write_trailing_comment_alignment_space,
+    types::{AlignmentWidth, WithAlignmentHint},
+};
 
 impl Format for tombi_ast::InlineTable {
     #[inline]
@@ -107,6 +111,8 @@ fn format_multiline_inline_table(
 
     let key_values = table.key_values().collect_vec();
     let equal_alignment_width = f.key_value_equal_alignment_width(key_values.iter());
+    let local_trailing_comment_alignment_width =
+        inline_table_trailing_comment_alignment_width(table, equal_alignment_width, f)?;
 
     let groups = table
         .dangling_comment_groups()
@@ -115,7 +121,7 @@ fn format_multiline_inline_table(
             WithAlignmentHint::new_with_dangling_comment_group_or(
                 group,
                 equal_alignment_width,
-                *trailing_comment_alignment_width,
+                local_trailing_comment_alignment_width,
             )
         }))
         .collect_vec();
@@ -137,6 +143,31 @@ fn format_multiline_inline_table(
     }
 
     Ok(())
+}
+
+fn inline_table_trailing_comment_alignment_width(
+    table: &tombi_ast::InlineTable,
+    equal_alignment_width: Option<AlignmentWidth>,
+    f: &mut crate::Formatter,
+) -> Result<Option<AlignmentWidth>, std::fmt::Error> {
+    if !f.trailing_comment_alignment() || table.key_values().next().is_none() {
+        return Ok(None);
+    }
+
+    let groups = table
+        .dangling_comment_groups()
+        .map(DanglingCommentGroupOr::DanglingCommentGroup)
+        .chain(table.key_value_with_comma_groups().map(|group| {
+            WithAlignmentHint::new_with_dangling_comment_group_or(
+                group,
+                equal_alignment_width,
+                None,
+            )
+        }))
+        .collect_vec();
+
+    let formatted = f.format_to_string_without_comment(&groups)?;
+    Ok(Some(AlignmentWidth::new(&formatted)))
 }
 
 fn format_singleline_inline_table(

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -294,6 +294,11 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
+    pub(crate) const fn trailing_comment_alignment(&self) -> bool {
+        self.definitions.trailing_comment_alignment
+    }
+
+    #[inline]
     pub(crate) fn trailing_comment_space(&self) -> &'static str {
         // SAFETY: The lifetime of `trailing_comment_space` is `'static`.
         //         It is guaranteed by the `FormatDefinitions` struct.

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -193,9 +193,10 @@ impl<'a> Formatter<'a> {
         &mut self,
         node: &T,
     ) -> Result<String, std::fmt::Error> {
+        let old_skip_comment = self.skip_comment;
         self.skip_comment = true;
         let result = self.format_to_string(node)?;
-        self.skip_comment = false;
+        self.skip_comment = old_skip_comment;
         Ok(result)
     }
 

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -1611,13 +1611,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"        # comment 1
-                key2 = "value2"      # comment 2
+                key = "value"    # comment 1
+                key2 = "value2"  # comment 2
                 key3.key4 = [
                   1,  # comment 3-1
                   2,  # comment 3-2
                   3   # comment 3-3
-                ]                    # comment 4
+                ]                # comment 4
                 "#
             )
         }
@@ -1642,13 +1642,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"        # comment 1
-                key2 = "value2"      # comment 2
+                key = "value"    # comment 1
+                key2 = "value2"  # comment 2
                 key3.key4 = [
                   1,  # comment 3-1
                   2,  # comment 3-2
                   3,  # comment 3-3
-                ]                    # comment 4
+                ]                # comment 4
                 "#
             )
         }
@@ -1705,13 +1705,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"            # comment 1
-                key2 = "value2"          # comment 2
+                key = "value"    # comment 1
+                key2 = "value2"  # comment 2
                 key3.key4 = {
                   a = 1,  # comment 3-1
                   b = 2,  # comment 3-2
                   c = 3   # comment 3-3
-                }                        # comment 4
+                }                # comment 4
                 "#
             )
         }
@@ -1737,13 +1737,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"            # comment 1
-                key2 = "value2"          # comment 2
+                key = "value"    # comment 1
+                key2 = "value2"  # comment 2
                 key3.key4 = {
                   a = 1,  # comment 3-1
                   b = 2,  # comment 3-2
                   c = 3,  # comment 3-3
-                }                        # comment 4
+                }                # comment 4
                 "#
             )
         }
@@ -1804,13 +1804,13 @@ mod format_options {
             ) -> Ok(
                 r#"
                 [table]
-                  key = "value"            # comment 1
-                  key2 = "value2"          # comment 2
+                  key = "value"    # comment 1
+                  key2 = "value2"  # comment 2
                   key3.key4 = {
                     a = 1,  # comment 3-1
                     b = 2,  # comment 3-2
                     c = 3,  # comment 3-3
-                  }                        # comment 4
+                  }                # comment 4
                 "#
             )
         }

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -1611,13 +1611,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"    # comment 1
-                key2 = "value2"  # comment 2
+                key = "value"        # comment 1
+                key2 = "value2"      # comment 2
                 key3.key4 = [
-                  1,             # comment 3-1
-                  2,             # comment 3-2
-                  3              # comment 3-3
-                ]                # comment 4
+                  1,  # comment 3-1
+                  2,  # comment 3-2
+                  3   # comment 3-3
+                ]                    # comment 4
                 "#
             )
         }
@@ -1642,13 +1642,44 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"    # comment 1
-                key2 = "value2"  # comment 2
+                key = "value"        # comment 1
+                key2 = "value2"      # comment 2
                 key3.key4 = [
-                  1,             # comment 3-1
-                  2,             # comment 3-2
-                  3,             # comment 3-3
-                ]                # comment 4
+                  1,  # comment 3-1
+                  2,  # comment 3-2
+                  3,  # comment 3-3
+                ]                    # comment 4
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_trailing_comment_alignment_true_in_array_is_scoped_locally(
+                r#"
+                [group]
+                a_very_long_long_long_long_long_table_key = 42
+                list = [
+                  "A", # comment 1
+                  "BB", # comment 2
+                  "CCC", # comment 3
+                ]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        trailing_comment_alignment: Some(true),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [group]
+                a_very_long_long_long_long_long_table_key = 42
+                list = [
+                  "A",    # comment 1
+                  "BB",   # comment 2
+                  "CCC",  # comment 3
+                ]
                 "#
             )
         }
@@ -1674,13 +1705,13 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"    # comment 1
-                key2 = "value2"  # comment 2
+                key = "value"            # comment 1
+                key2 = "value2"          # comment 2
                 key3.key4 = {
-                  a = 1,         # comment 3-1
-                  b = 2,         # comment 3-2
-                  c = 3          # comment 3-3
-                }                # comment 4
+                  a = 1,  # comment 3-1
+                  b = 2,  # comment 3-2
+                  c = 3   # comment 3-3
+                }                        # comment 4
                 "#
             )
         }
@@ -1706,13 +1737,45 @@ mod format_options {
                 }
             ) -> Ok(
                 r#"
-                key = "value"    # comment 1
-                key2 = "value2"  # comment 2
+                key = "value"            # comment 1
+                key2 = "value2"          # comment 2
                 key3.key4 = {
-                  a = 1,         # comment 3-1
-                  b = 2,         # comment 3-2
-                  c = 3,         # comment 3-3
-                }                # comment 4
+                  a = 1,  # comment 3-1
+                  b = 2,  # comment 3-2
+                  c = 3,  # comment 3-3
+                }                        # comment 4
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_trailing_comment_alignment_true_in_inline_table_is_scoped_locally(
+                r#"
+                [group]
+                a_very_long_long_long_long_long_table_key = 42
+                value = {
+                    a = 1, # comment 1
+                    bb = 2, # comment 2
+                    ccc = 3, # comment 3
+                }
+                "#,
+                TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        trailing_comment_alignment: Some(true),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                [group]
+                a_very_long_long_long_long_long_table_key = 42
+                value = {
+                  a = 1,    # comment 1
+                  bb = 2,   # comment 2
+                  ccc = 3,  # comment 3
+                }
                 "#
             )
         }
@@ -1741,13 +1804,13 @@ mod format_options {
             ) -> Ok(
                 r#"
                 [table]
-                  key = "value"    # comment 1
-                  key2 = "value2"  # comment 2
+                  key = "value"            # comment 1
+                  key2 = "value2"          # comment 2
                   key3.key4 = {
-                    a = 1,         # comment 3-1
-                    b = 2,         # comment 3-2
-                    c = 3,         # comment 3-3
-                  }                # comment 4
+                    a = 1,  # comment 3-1
+                    b = 2,  # comment 3-2
+                    c = 3,  # comment 3-3
+                  }                        # comment 4
                 "#
             )
         }


### PR DESCRIPTION
## Summary
- scope multiline array trailing comment alignment to the array contents instead of inheriting the parent key-value width
- scope multiline inline table trailing comment alignment to the inline table contents with the same local behavior
- update formatter tests to cover local alignment behavior and the adjusted parent-line expectations

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked

Fixes #1922
