### PR TITLE
Align multiline delimiter comments with trailing comment width

### DIFF
--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -89,13 +89,14 @@ fn format_multiline_array(
 
     f.write_indent()?;
     write!(f, "[")?;
-
     if let Some(trailing_comment) = array.bracket_start_trailing_comment() {
+        if let Some(trailing_comment_alignment_width) = trailing_comment_alignment_width {
+            write_trailing_comment_alignment_space(f, *trailing_comment_alignment_width)?;
+        }
         trailing_comment.format(f)?;
     }
 
     write!(f, "{}", f.line_ending())?;
-
     f.inc_indent();
 
     let groups = array

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -98,6 +98,9 @@ fn format_multiline_inline_table(
     write!(f, "{{")?;
 
     if let Some(trailing_comment) = table.brace_start_trailing_comment() {
+        if let Some(trailing_comment_alignment_width) = trailing_comment_alignment_width {
+            write_trailing_comment_alignment_space(f, *trailing_comment_alignment_width)?;
+        }
         trailing_comment.format(f)?;
     }
 

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -1719,6 +1719,76 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_trailing_comment_alignment_true_uses_local_groups_for_array_and_inline_table(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+
+                [root]  # table
+                short = 1  # table group 1
+                very.long.long.long.key = 2  # table group 1
+
+                items = [  # array
+                  "A",  # array group 1
+                  "BB",  # array group 1
+
+                  "CCC",  # array group 2
+                  "DDDD",  # array group 2
+                ]  # array end
+
+                config = {  # inline table
+                  x = 1,  # inline group 1
+                  long_key = [  # inline nested array
+                    1,  # nested array group 1
+                    22,  # nested array group 1
+                  ],  # inline group 1
+
+                  nested = {  # inline group 2
+                    a = "x",  # nested inline group 2
+                    bb = "y",  # nested inline group 2
+                  },  # inline group 2
+                }  # inline table
+                "#,
+                TomlVersion::V1_1_0,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        trailing_comment_alignment: Some(true),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+
+                [root]  # table
+                short = 1                    # table group 1
+                very.long.long.long.key = 2  # table group 1
+
+                items = [  # array
+                  "A",     # array group 1
+                  "BB",    # array group 1
+
+                  "CCC",   # array group 2
+                  "DDDD",  # array group 2
+                ]          # array end
+
+                config = {      # inline table
+                  x = 1,        # inline group 1
+                  long_key = [  # inline nested array
+                    1,          # nested array group 1
+                    22,         # nested array group 1
+                  ],            # inline group 1
+
+                  nested = {    # inline group 2
+                    a = "x",    # nested inline group 2
+                    bb = "y",   # nested inline group 2
+                  },            # inline group 2
+                }               # inline table
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_trailing_comment_alignment_and_indent_table_key_value_pairs_true_in_inline_table(
                 r#"
                 [table]


### PR DESCRIPTION
## Summary
- reuse existing trailing comment alignment width for multiline array opening lines
- reuse existing trailing comment alignment width for multiline inline table opening lines
- add a regression test covering grouped comments across tables, arrays, and inline tables

Closes #1922

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked
