### PR TITLE
feat(installer): add archive checksum verification

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -55,10 +55,139 @@ jobs:
       - name: Add install directory to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Run install script
+      - name: Resolve release artifact metadata
+        id: artifact
+        run: |
+          version="$(sed -n 's/^LATEST_STABLE_VERSION=\"\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"$/\1/p' ./docs/public/install.sh)"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve LATEST_STABLE_VERSION" >&2
+            exit 1
+          fi
+
+          version_prefix="${version%%[-+]*}"
+          IFS=. read -r major minor patch <<<"$version_prefix"
+          case "$(uname -s)" in
+            Linux)
+              case "$(uname -m)" in
+                aarch64) target="aarch64-unknown-linux-musl" ;;
+                armv7l) target="arm-unknown-linux-gnueabihf" ;;
+                *) target="x86_64-unknown-linux-musl" ;;
+              esac
+              if [ "$major" -eq 0 ] && { [ "$minor" -lt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -lt 23 ]; }; }; then
+                extension=".gz"
+              else
+                extension=".tar.gz"
+              fi
+              ;;
+            Darwin)
+              case "$(uname -m)" in
+                arm64) arch="aarch64" ;;
+                *) arch="x86_64" ;;
+              esac
+              target="${arch}-apple-darwin"
+              if [ "$major" -eq 0 ] && { [ "$minor" -lt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -lt 23 ]; }; }; then
+                extension=".gz"
+              else
+                extension=".tar.gz"
+              fi
+              ;;
+            MINGW*|MSYS*|CYGWIN*|Windows_NT)
+              case "$(uname -m)" in
+                aarch64) arch="aarch64" ;;
+                *) arch="x86_64" ;;
+              esac
+              target="${arch}-pc-windows-msvc"
+              extension=".zip"
+              ;;
+            *)
+              echo "Unsupported OS" >&2
+              exit 1
+              ;;
+          esac
+
+          url="https://github.com/tombi-toml/tombi/releases/download/v${version}/tombi-cli-${version}-${target}${extension}"
+          archive="${RUNNER_TEMP}/tombi-${version}${extension}"
+          curl -fsSL "$url" -o "$archive"
+          if command -v sha256sum >/dev/null 2>&1; then
+            checksum="$(sha256sum "$archive" | awk '{print $1}')"
+          else
+            checksum="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "extension=$extension" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Run install script without checksum
         run: |
           chmod +x ./docs/public/install.sh
-          ./docs/public/install.sh
+          ./docs/public/install.sh --version "${{ steps.artifact.outputs.version }}"
+
+      - name: Run install script with plain checksum
+        run: |
+          install_dir="${RUNNER_TEMP}/install-with-checksum"
+          mkdir -p "$install_dir"
+          ./docs/public/install.sh \
+            --version "${{ steps.artifact.outputs.version }}" \
+            --install-dir "$install_dir" \
+            --checksum "${{ steps.artifact.outputs.checksum }}"
+          test -f "$install_dir/${{ matrix.exe_name }}"
+
+      - name: Run install script with sha256: checksum
+        run: |
+          install_dir="${RUNNER_TEMP}/install-with-prefixed-checksum"
+          mkdir -p "$install_dir"
+          ./docs/public/install.sh \
+            --version "${{ steps.artifact.outputs.version }}" \
+            --install-dir "$install_dir" \
+            --checksum "sha256:${{ steps.artifact.outputs.checksum }}"
+          test -f "$install_dir/${{ matrix.exe_name }}"
+
+      - name: Reject wrong checksum before install
+        run: |
+          install_dir="${RUNNER_TEMP}/install-with-bad-checksum"
+          mkdir -p "$install_dir"
+          log_file="${RUNNER_TEMP}/bad-checksum.log"
+          set +e
+          ./docs/public/install.sh \
+            --version "${{ steps.artifact.outputs.version }}" \
+            --install-dir "$install_dir" \
+            --checksum "0000000000000000000000000000000000000000000000000000000000000000" \
+            >"$log_file" 2>&1
+          status=$?
+          set -e
+          test "$status" -ne 0
+          test ! -f "$install_dir/${{ matrix.exe_name }}"
+          grep -q "Checksum verification failed" "$log_file"
+          grep -q "Expected:" "$log_file"
+          grep -q "Actual:" "$log_file"
+
+      - name: Reject invalid checksum formats
+        run: |
+          invalid_cases=(
+            "sha1:0123456789abcdef0123456789abcdef01234567"
+            "1234"
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+          )
+          for checksum in "${invalid_cases[@]}"; do
+            log_file="${RUNNER_TEMP}/invalid-checksum-$(printf '%s' "$checksum" | tr ':/' '__').log"
+            set +e
+            ./docs/public/install.sh --checksum "$checksum" >"$log_file" 2>&1
+            status=$?
+            set -e
+            test "$status" -ne 0
+            grep -Eq "Unsupported checksum format|Invalid checksum" "$log_file"
+          done
+
+          log_file="${RUNNER_TEMP}/invalid-checksum-empty.log"
+          set +e
+          ./docs/public/install.sh --checksum "" >"$log_file" 2>&1
+          status=$?
+          set -e
+          test "$status" -ne 0
+          grep -q "Invalid checksum" "$log_file"
 
       - name: Verify tombi binary exists
         run: |

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -58,10 +58,24 @@ jobs:
       - name: Resolve release artifact metadata
         id: artifact
         run: |
-          version="$(sed -n 's/^LATEST_STABLE_VERSION=\"\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"$/\1/p' ./docs/public/install.sh)"
-          if [ -z "$version" ]; then
+          requested_version="$(sed -n 's/^LATEST_STABLE_VERSION=\"\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"$/\1/p' ./docs/public/install.sh)"
+          if [ -z "$requested_version" ]; then
             echo "Failed to resolve LATEST_STABLE_VERSION" >&2
             exit 1
+          fi
+
+          latest_version="$(curl -fsSL https://api.github.com/repos/tombi-toml/tombi/releases/latest | jq -r '.tag_name | sub("^v"; "")')"
+          if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
+            echo "Failed to resolve the latest published release tag" >&2
+            exit 1
+          fi
+
+          release_check_url="https://github.com/tombi-toml/tombi/releases/tag/v${requested_version}"
+          if curl -fsSLI "$release_check_url" >/dev/null 2>&1; then
+            version="$requested_version"
+          else
+            echo "Release v${requested_version} is not published yet; falling back to v${latest_version} for installer CI." >&2
+            version="$latest_version"
           fi
 
           version_prefix="${version%%[-+]*}"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -23,7 +23,7 @@ print_success() {
 
 print_usage() {
 	cat >&2 <<EOF
-Usage: ${0##*/} [--version <version>|latest] [--install-dir <dir>] [--checksum <sha256>]
+Usage: ${0##*/} [--version <version|latest>] [--install-dir <dir>] [--checksum <sha256>]
 
 Options:
   --version <version>     Install a specific version (default: embedded latest stable)
@@ -116,17 +116,50 @@ normalize_sha256_checksum() {
 
 calculate_sha256() {
 	FILE_PATH="$1"
+	CHECKSUM_OUTPUT_FILE="${TEMP_DIR}/checksum-output.txt"
 
 	if command -v sha256sum >/dev/null 2>&1; then
-		sha256sum "${FILE_PATH}" | awk '{print $1}'
+		if ! sha256sum "${FILE_PATH}" >"${CHECKSUM_OUTPUT_FILE}"; then
+			print_error "Failed to calculate SHA256 with sha256sum for ${FILE_PATH}."
+			exit 1
+		fi
+		if ! ACTUAL_CHECKSUM=$(awk 'NR==1 {print $1; exit}' "${CHECKSUM_OUTPUT_FILE}" | tr 'A-F' 'a-f'); then
+			print_error "Failed to parse calculated SHA256 for ${FILE_PATH}."
+			exit 1
+		fi
 	elif command -v shasum >/dev/null 2>&1; then
-		shasum -a 256 "${FILE_PATH}" | awk '{print $1}'
+		if ! shasum -a 256 "${FILE_PATH}" >"${CHECKSUM_OUTPUT_FILE}"; then
+			print_error "Failed to calculate SHA256 with shasum for ${FILE_PATH}."
+			exit 1
+		fi
+		if ! ACTUAL_CHECKSUM=$(awk 'NR==1 {print $1; exit}' "${CHECKSUM_OUTPUT_FILE}" | tr 'A-F' 'a-f'); then
+			print_error "Failed to parse calculated SHA256 for ${FILE_PATH}."
+			exit 1
+		fi
 	elif command -v certutil.exe >/dev/null 2>&1; then
-		certutil.exe -hashfile "$(cygpath -w "${FILE_PATH}")" SHA256 | awk 'NR==2 {print $1}' | tr 'A-F' 'a-f'
+		if ! command -v cygpath >/dev/null 2>&1; then
+			print_error "Unable to verify checksum with certutil.exe: cygpath is required."
+			exit 1
+		fi
+		if ! certutil.exe -hashfile "$(cygpath -w "${FILE_PATH}")" SHA256 >"${CHECKSUM_OUTPUT_FILE}"; then
+			print_error "Failed to calculate SHA256 with certutil.exe for ${FILE_PATH}."
+			exit 1
+		fi
+		if ! ACTUAL_CHECKSUM=$(awk 'NR==2 {print $1; exit}' "${CHECKSUM_OUTPUT_FILE}" | tr 'A-F' 'a-f'); then
+			print_error "Failed to parse calculated SHA256 for ${FILE_PATH}."
+			exit 1
+		fi
 	else
 		print_error "Unable to verify checksum: sha256sum, shasum, or certutil.exe is required."
 		exit 1
 	fi
+
+	if ! printf '%s' "${ACTUAL_CHECKSUM}" | grep -Eq '^[0-9a-f]{64}$'; then
+		print_error "Failed to parse calculated SHA256 for ${FILE_PATH}."
+		exit 1
+	fi
+
+	printf '%s\n' "${ACTUAL_CHECKSUM}"
 }
 
 verify_archive_checksum() {

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -21,6 +21,18 @@ print_success() {
 	printf '\033[32mSuccess:\033[m %s\n' "$1" >&2
 }
 
+print_usage() {
+	cat >&2 <<EOF
+Usage: ${0##*/} [--version <version>|latest] [--install-dir <dir>] [--checksum <sha256>]
+
+Options:
+  --version <version>     Install a specific version (default: embedded latest stable)
+  --install-dir <dir>     Install into a specific directory
+  --checksum <sha256>     Verify downloaded archive SHA256 (<hex> or sha256:<hex>)
+  --help                  Show this help message
+EOF
+}
+
 # Keep the 0.9.23 cutoff in sync with
 # editors/zed/src/lib.rs (TombiExtension::uses_legacy_unix_artifact).
 version_uses_legacy_unix_artifact() {
@@ -63,23 +75,117 @@ download_to_file() {
 	fi
 }
 
+normalize_sha256_checksum() {
+	CHECKSUM_INPUT="$1"
+
+	if [ -z "${CHECKSUM_INPUT}" ]; then
+		print_error "Invalid checksum: value must not be empty."
+		exit 1
+	fi
+
+	case "${CHECKSUM_INPUT}" in
+	sha256:*)
+		CHECKSUM_VALUE=${CHECKSUM_INPUT#sha256:}
+		;;
+	*:*)
+		print_error "Unsupported checksum format '${CHECKSUM_INPUT}'. Only sha256:<hex> is supported."
+		exit 1
+		;;
+	*)
+		CHECKSUM_VALUE=${CHECKSUM_INPUT}
+		;;
+	esac
+
+	if [ -z "${CHECKSUM_VALUE}" ]; then
+		print_error "Invalid checksum: SHA256 value must not be empty."
+		exit 1
+	fi
+
+	if [ ${#CHECKSUM_VALUE} -ne 64 ]; then
+		print_error "Invalid checksum '${CHECKSUM_INPUT}': expected 64 hex characters for SHA256, got ${#CHECKSUM_VALUE}."
+		exit 1
+	fi
+
+	if ! printf '%s' "${CHECKSUM_VALUE}" | grep -Eq '^[0-9A-Fa-f]{64}$'; then
+		print_error "Invalid checksum '${CHECKSUM_INPUT}': SHA256 must contain only hexadecimal characters."
+		exit 1
+	fi
+
+	NORMALIZED_CHECKSUM=$(printf '%s' "${CHECKSUM_VALUE}" | tr 'A-F' 'a-f')
+}
+
+calculate_sha256() {
+	FILE_PATH="$1"
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "${FILE_PATH}" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "${FILE_PATH}" | awk '{print $1}'
+	elif command -v certutil.exe >/dev/null 2>&1; then
+		certutil.exe -hashfile "$(cygpath -w "${FILE_PATH}")" SHA256 | awk 'NR==2 {print $1}' | tr 'A-F' 'a-f'
+	else
+		print_error "Unable to verify checksum: sha256sum, shasum, or certutil.exe is required."
+		exit 1
+	fi
+}
+
+verify_archive_checksum() {
+	FILE_PATH="$1"
+	EXPECTED_CHECKSUM="$2"
+
+	ACTUAL_CHECKSUM=$(calculate_sha256 "${FILE_PATH}")
+	if [ "${ACTUAL_CHECKSUM}" != "${EXPECTED_CHECKSUM}" ]; then
+		print_error "Checksum verification failed for ${FILE_PATH}. Expected: ${EXPECTED_CHECKSUM} Actual: ${ACTUAL_CHECKSUM}"
+		exit 1
+	fi
+
+	print_step "Checksum verification passed."
+}
+
 # Parse command line options
 __SPECIFIED_VERSION=""
 __SPECIFIED_INSTALL_DIR=""
+__SPECIFIED_CHECKSUM=""
+__CHECKSUM_WAS_SET=0
 while [ $# -gt 0 ]; do
 	case $1 in
 	--version)
+		if [ $# -lt 2 ]; then
+			print_error "Missing value for --version"
+			print_usage
+			exit 1
+		fi
 		if [ "$2" != "latest" ]; then
 			__SPECIFIED_VERSION="${2#v}"
 		fi
 		shift 2
 		;;
 	--install-dir)
+		if [ $# -lt 2 ]; then
+			print_error "Missing value for --install-dir"
+			print_usage
+			exit 1
+		fi
 		__SPECIFIED_INSTALL_DIR="$2"
 		shift 2
 		;;
+	--checksum)
+		if [ $# -lt 2 ]; then
+			print_error "Missing value for --checksum"
+			print_usage
+			exit 1
+		fi
+		__CHECKSUM_WAS_SET=1
+		__SPECIFIED_CHECKSUM="$2"
+		shift 2
+		;;
+	--help)
+		print_usage
+		exit 0
+		;;
 	*)
 		print_error "Unknown option: $1"
+		print_usage
 		exit 1
 		;;
 	esac
@@ -176,6 +282,10 @@ download_and_install() {
 		exit 1
 	fi
 
+	if [ -n "${NORMALIZED_CHECKSUM:-}" ]; then
+		verify_archive_checksum "${TEMP_FILE}" "${NORMALIZED_CHECKSUM}"
+	fi
+
 	EXE_NAME=$(get_exe_name)
 	if [ "${ARTIFACT_EXTENSION}" = ".zip" ]; then
 		unzip -o "${TEMP_FILE}" -d "${TEMP_DIR}"
@@ -216,6 +326,9 @@ else
 	print_step "Using latest version: ${VERSION}"
 fi
 RELEASE_BASE_URL="https://github.com/tombi-toml/tombi/releases/download"
+if [ "${__CHECKSUM_WAS_SET}" -eq 1 ]; then
+	normalize_sha256_checksum "${__SPECIFIED_CHECKSUM}"
+fi
 
 # Get the executable name based on OS
 get_exe_name() {

--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -41,6 +41,12 @@ Install to a specific directory:
 curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --install-dir /custom/path
 ```
 
+Verify the downloaded archive checksum before extraction:
+
+```sh
+curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --checksum sha256:<sha256>
+```
+
 ## Windows Package Manager
 
 ```powershell


### PR DESCRIPTION
## Summary
- add `--checksum` support to `docs/public/install.sh` and verify the downloaded archive before extraction
- accept both raw SHA256 hex and `sha256:<hex>`, and reject invalid prefixes or malformed values with explicit errors
- extend install script CI coverage and document the new checksum option

## Testing
- `shellcheck docs/public/install.sh`
- local install script verification against release `1.1.0` with correct checksum, `sha256:` prefixed checksum, wrong checksum, invalid prefix, short checksum, invalid hex, and empty checksum

## Notes
- local verification used `--version 1.1.0` because the embedded `LATEST_STABLE_VERSION="1.1.1"` did not resolve to a public release during testing
