### PR TITLE
fix(cargo-hover): show feature dependency metadata in hover

### DIFF
--- a/crates/tombi-config/src/extensions/cargo.rs
+++ b/crates/tombi-config/src/extensions/cargo.rs
@@ -95,12 +95,49 @@ mod tests {
     }
 
     #[test]
+    fn cargo_hover_feature_tree_deserializes_feature_dependencies_key() {
+        let features: super::CargoHoverFeatureTree = serde_json::from_value(serde_json::json!({
+            "feature-dependencies": {
+                "enabled": false
+            }
+        }))
+        .expect("feature-dependencies should deserialize");
+
+        assert_eq!(
+            features.feature_dependencies,
+            Some(ToggleFeatureDefaultTrue {
+                enabled: Some(false.into()),
+            })
+        );
+    }
+
+    #[test]
+    fn cargo_hover_feature_tree_serializes_feature_dependencies_key() {
+        let value = serde_json::to_value(super::CargoHoverFeatureTree {
+            dependency_detail: None,
+            default_features: None,
+            feature_dependencies: Some(ToggleFeatureDefaultTrue {
+                enabled: Some(false.into()),
+            }),
+        })
+        .expect("feature-dependencies should serialize");
+
+        assert_eq!(
+            value.get("feature-dependencies"),
+            Some(&serde_json::json!({
+                "enabled": false
+            }))
+        );
+    }
+
+    #[test]
     fn cargo_hover_feature_tree_serializes_default_features_key() {
         let value = serde_json::to_value(super::CargoHoverFeatureTree {
             dependency_detail: None,
             default_features: Some(ToggleFeatureDefaultTrue {
                 enabled: Some(false.into()),
             }),
+            feature_dependencies: None,
         })
         .expect("default-features should serialize");
 

--- a/crates/tombi-config/src/extensions/cargo/lsp/hover.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/hover.rs
@@ -39,5 +39,10 @@ toggle_features! {
         ///
         /// Whether hover shows default Cargo dependency features.
         pub default_features: Option<ToggleFeatureDefaultTrue>,
+
+        /// # Feature dependencies hover feature
+        ///
+        /// Whether hover shows dependencies of the selected Cargo feature.
+        pub feature_dependencies: Option<ToggleFeatureDefaultTrue>,
     }
 }

--- a/crates/tombi-linter/tests/integration/tombi_schema.rs
+++ b/crates/tombi-linter/tests/integration/tombi_schema.rs
@@ -175,7 +175,7 @@ test_lint! {
         r#"
         [extensions]
         "tombi-toml/tombi" = { lsp.document-link.path.enabled = false, lsp.hover.enabled = false }
-        "tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.dependency-detail.enabled = false }
+        "tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.feature-dependencies.enabled = false, lsp.hover.dependency-detail.enabled = false }
         "tombi-toml/pyproject" = { lsp.hover.dependency-detail.enabled = false }
         "#,
         SchemaPath(tombi_schema_path()),

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -126,6 +126,14 @@ pub async fn handle_hover(
             .map(|default_features| default_features.enabled())
             .unwrap_or_default()
             .value();
+        let cargo_feature_dependencies_hover_enabled = config
+            .cargo_extension_features()
+            .and_then(|features| features.lsp())
+            .and_then(|lsp| lsp.hover())
+            .and_then(|hover| hover.feature_dependencies())
+            .map(|feature_dependencies| feature_dependencies.enabled())
+            .unwrap_or_default()
+            .value();
         let pyproject_dependency_detail_hover_enabled = config
             .pyproject_extension_features()
             .and_then(|features| features.lsp())
@@ -151,7 +159,8 @@ pub async fn handle_hover(
         let extension_hover = match extension_hover {
             some @ Some(_) => some,
             None if cargo_dependency_detail_hover_enabled
-                || cargo_default_features_hover_enabled =>
+                || cargo_default_features_hover_enabled
+                || cargo_feature_dependencies_hover_enabled =>
             {
                 tombi_extension_cargo::hover(
                     &text_document_uri,
@@ -162,6 +171,7 @@ pub async fn handle_hover(
                     offline,
                     cache_options,
                     cargo_dependency_detail_hover_enabled,
+                    cargo_feature_dependencies_hover_enabled,
                     cargo_default_features_hover_enabled,
                 )
                 .await?

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/Cargo.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = ["member"]
+
+[workspace.dependencies]
+member = { path = "member" }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/tombi.toml
@@ -1,0 +1,8 @@
+[extensions]
+"tombi-toml/cargo" = {
+  lsp.hover = {
+    default-features.enabled = true,
+    feature-dependencies.enabled = false,
+    dependency-detail.enabled = true,
+  }
+}

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -465,7 +465,7 @@ mod hover_keys_value {
                 "Keys": "dependencies.local-path-crate.features",
                 "Value": "Array?",
                 "Description": Some(
-                    "List of features to activate in the dependency.\n\nDefault Features:\n  - extras"
+                    "List of features to activate in the dependency.\n\nDefault Features:\n  - `extras`"
                 ),
             });
         );
@@ -503,7 +503,7 @@ mod hover_keys_value {
                 "Keys": "dependencies.serde.features[0]",
                 "Value": "String",
                 "Description": Some(
-                    "List of features to activate in the dependency.\n\nDefault Features:\n  - std"
+                    "List of features to activate in the dependency.\n\nFeature Dependencies:\n  - `serde_derive`\n\nDefault Features:\n  - `std`"
                 ),
             });
         );

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -542,7 +542,49 @@ mod hover_keys_value {
             ) -> Ok({
                 "Keys": "dependencies.serde.features[0]",
                 "Value": "String",
-                "Description": Some("List of features to activate in the dependency."),
+                "Description": Some(
+                    "List of features to activate in the dependency.\n\nFeature Dependencies:\n  - `serde_derive`"
+                ),
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn cargo_registry_dependency_feature_item_skips_feature_dependencies_when_disabled_by_extensions(
+                r#"
+                [dependencies]
+                serde = { version = "=1.0.228", features = ["derive█"] }
+                "#,
+                SourcePath(tombi_test_lib::project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/Cargo.toml"
+                )),
+                UseTestCacheHome,
+                tombi_lsp::backend::Options {
+                    offline: Some(true),
+                    no_cache: Some(false),
+                },
+                SchemaPath(cargo_schema_path()),
+                CachedRemoteJson {
+                    url: "https://crates.io/api/v1/crates/serde/1.0.228",
+                    body: r#"{
+                        "version": {
+                            "num": "1.0.228",
+                            "features": {
+                                "alloc": [],
+                                "default": ["std"],
+                                "derive": ["serde_derive"],
+                                "rc": [],
+                                "std": ["serde_core/std"]
+                            }
+                        }
+                    }"#,
+                },
+            ) -> Ok({
+                "Keys": "dependencies.serde.features[0]",
+                "Value": "String",
+                "Description": Some(
+                    "List of features to activate in the dependency.\n\nDefault Features:\n  - `std`"
+                ),
             });
         );
 

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -316,6 +316,8 @@ tables-out-of-order = "error"
     },
     hover = {
       dependency-detail.enabled = true,
+      feature-dependencies.enabled = true,
+      default-features.enabled = true,
     },
     inlay-hint = {
       default-features.enabled = true,
@@ -350,6 +352,7 @@ tables-out-of-order = "error"
     },
     hover = {
       dependency-detail.enabled = true,
+      feature-dependencies.enabled = true,
     },
     inlay-hint = {
       dependency-version.enabled = true,
@@ -1669,6 +1672,21 @@ See [Cargo Extension > Hover](/docs/extensions/tombi-extension-cargo#hover).
 ### extensions."tombi-toml/cargo".lsp.hover.dependency-detail.enabled
 
 Enable or disable dependency detail hover for Cargo dependencies.
+
+- Type: `Boolean`
+- Default: `true`
+
+### extensions."tombi-toml/cargo".lsp.hover.feature-dependencies
+
+Configure feature dependency hover for Cargo dependencies.
+
+See [Cargo Extension > Hover](/docs/extensions/tombi-extension-cargo#hover).
+
+- Type: `Table`
+
+### extensions."tombi-toml/cargo".lsp.hover.feature-dependencies.enabled
+
+Enable or disable feature dependency hover for Cargo dependencies.
 
 - Type: `Boolean`
 - Default: `true`

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -127,6 +127,7 @@ async fn collect_prefetch_urls(
     let lsp = features.and_then(|features| features.lsp());
     let (
         dependency_detail_hover_enabled,
+        feature_dependencies_hover_enabled,
         default_features_hover_enabled,
         dependency_version_completion_enabled,
         dependency_feature_completion_enabled,
@@ -142,6 +143,11 @@ async fn collect_prefetch_urls(
                     hover
                         .dependency_detail()
                         .map(|dependency_detail| dependency_detail.enabled())
+                }),
+                hover.as_ref().and_then(|hover| {
+                    hover
+                        .feature_dependencies()
+                        .map(|feature_dependencies| feature_dependencies.enabled())
                 }),
                 hover.as_ref().and_then(|hover| {
                     hover
@@ -169,6 +175,9 @@ async fn collect_prefetch_urls(
         .unwrap_or_default();
 
     let warm_hover = dependency_detail_hover_enabled.unwrap_or_default().value();
+    let warm_feature_dependencies_hover = feature_dependencies_hover_enabled
+        .unwrap_or_default()
+        .value();
     let warm_default_features_hover = default_features_hover_enabled.unwrap_or_default().value();
     let warm_versions = dependency_version_completion_enabled
         .unwrap_or_default()
@@ -184,6 +193,7 @@ async fn collect_prefetch_urls(
         .value();
 
     if !warm_hover
+        && !warm_feature_dependencies_hover
         && !warm_default_features_hover
         && !warm_versions
         && !warm_feature_details
@@ -194,7 +204,11 @@ async fn collect_prefetch_urls(
 
     let workspace_path = get_workspace_cargo_toml_path(document_tree);
     let cargo_lock_fut = async {
-        if warm_feature_details || warm_default_features_hover || prioritize_inlay_hint {
+        if warm_feature_details
+            || warm_feature_dependencies_hover
+            || warm_default_features_hover
+            || prioritize_inlay_hint
+        {
             load_cached_cargo_lock(cargo_toml_path, toml_version).await
         } else {
             None
@@ -499,6 +513,7 @@ mod tests {
                 hover: Some(CargoHoverFeatures::Features(CargoHoverFeatureTree {
                     dependency_detail: Some(disabled_toggle()),
                     default_features: None,
+                    feature_dependencies: Some(disabled_toggle()),
                 })),
                 ..Default::default()
             })),

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -1,9 +1,11 @@
 use std::path::Path;
 
+use itertools::Itertools;
 use tombi_config::TomlVersion;
 use tombi_document_tree::{Value, dig_accessors, dig_keys};
 use tombi_extension::fetch_cached_remote_json;
 use tombi_extension::{HoverMetadata, HoverTextChange, append_latest_version};
+use tombi_hashmap::HashMap;
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
@@ -159,6 +161,12 @@ enum DependencyHoverTarget {
     Version,
 }
 
+#[derive(Debug, Default)]
+struct DependencyFeatureMetadata {
+    feature_dependencies_map: Option<HashMap<String, Vec<String>>>,
+    default_features: Option<Vec<String>>,
+}
+
 async fn feature_key_hover_metadata(
     document_tree: &tombi_document_tree::DocumentTree,
     accessors: &[Accessor],
@@ -288,7 +296,8 @@ async fn dependency_features_hover_metadata(
         return Ok(None);
     };
 
-    let Some(default_features) = dependency_default_features(
+    let feature_name = hovered_dependency_feature_name(document_tree, accessors);
+    let dependency_feature_metadata = try_get_dependency_feature_metadata(
         document_tree,
         dependency_key,
         dependency_value,
@@ -297,16 +306,21 @@ async fn dependency_features_hover_metadata(
         offline,
         cache_options,
     )
-    .await?
-    else {
-        return Ok(None);
-    };
+    .await?;
 
-    Ok(Some(HoverMetadata {
+    Ok(format_dependency_features_hover_tooltip(
+        dependency_feature_metadata.as_ref().and_then(|metadata| {
+            feature_name
+                .as_deref()
+                .and_then(|name| metadata.feature_dependencies(name))
+        }),
+        dependency_feature_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.default_features()),
+    )
+    .map(|description| HoverMetadata {
         title: None,
-        description: Some(HoverTextChange::Append(format_default_features_tooltip(
-            &default_features,
-        ))),
+        description: Some(HoverTextChange::Append(description)),
     }))
 }
 
@@ -345,7 +359,7 @@ fn dependency_features_parent_accessors(accessors: &[Accessor]) -> Option<&[Acce
     None
 }
 
-async fn dependency_default_features(
+async fn try_get_dependency_feature_metadata(
     document_tree: &tombi_document_tree::DocumentTree,
     dependency_key: &str,
     dependency_value: &Value,
@@ -353,7 +367,7 @@ async fn dependency_default_features(
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
-) -> Result<Option<Vec<String>>, tower_lsp::jsonrpc::Error> {
+) -> Result<Option<DependencyFeatureMetadata>, tower_lsp::jsonrpc::Error> {
     let Value::Table(table) = dependency_value else {
         return Ok(None);
     };
@@ -364,7 +378,7 @@ async fn dependency_default_features(
         else {
             return Ok(None);
         };
-        return Ok(package_default_features(&dependency_document_tree));
+        return Ok(get_dependency_feature_metadata(&dependency_document_tree));
     }
 
     if table.contains_key("git") || table.contains_key("registry") {
@@ -372,7 +386,7 @@ async fn dependency_default_features(
     }
 
     if let Some(Value::String(version)) = table.get("version") {
-        return registry_dependency_default_features(
+        return registry_dependency_feature_metadata(
             dependency_package_name(dependency_key, dependency_value),
             version.value(),
             cargo_toml_path,
@@ -407,10 +421,6 @@ async fn dependency_default_features(
         return Ok(None);
     };
 
-    if dependency_table_default_features_disabled(workspace_dependency_table) {
-        return Ok(None);
-    }
-
     if let Some(Value::String(path)) = workspace_dependency_table.get("path") {
         let Some((_, _, dependency_document_tree)) = find_cargo_toml(
             &workspace_cargo_toml_path,
@@ -419,7 +429,7 @@ async fn dependency_default_features(
         ) else {
             return Ok(None);
         };
-        return Ok(package_default_features(&dependency_document_tree));
+        return Ok(get_dependency_feature_metadata(&dependency_document_tree));
     }
 
     if workspace_dependency_table.contains_key("git")
@@ -432,7 +442,7 @@ async fn dependency_default_features(
         return Ok(None);
     };
 
-    registry_dependency_default_features(
+    registry_dependency_feature_metadata(
         dependency_package_name(dependency_key, workspace_dependency_value),
         version.value(),
         cargo_toml_path,
@@ -443,14 +453,31 @@ async fn dependency_default_features(
     .await
 }
 
-async fn registry_dependency_default_features(
+fn hovered_dependency_feature_name(
+    document_tree: &tombi_document_tree::DocumentTree,
+    accessors: &[Accessor],
+) -> Option<String> {
+    if !matches!(
+        accessors,
+        [.., Accessor::Key(features), Accessor::Index(_)] if features == "features"
+    ) {
+        return None;
+    }
+
+    match dig_accessors(document_tree, accessors) {
+        Some((_, Value::String(feature))) => Some(feature.value().to_string()),
+        _ => None,
+    }
+}
+
+async fn registry_dependency_feature_metadata(
     crate_name: &str,
     version_requirement: &str,
     cargo_toml_path: &Path,
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
-) -> Result<Option<Vec<String>>, tower_lsp::jsonrpc::Error> {
+) -> Result<Option<DependencyFeatureMetadata>, tower_lsp::jsonrpc::Error> {
     let Some(version) = (if let Some(version) = exact_crates_io_version(version_requirement) {
         Some(version)
     } else {
@@ -462,14 +489,22 @@ async fn registry_dependency_default_features(
     };
 
     let url = format!("https://crates.io/api/v1/crates/{crate_name}/{version}");
-    let Some(mut resp) =
+    let Some(resp) =
         fetch_cached_remote_json::<CratesIoVersionDetailResponse>(&url, offline, cache_options)
             .await
     else {
         return Ok(None);
     };
 
-    Ok(resp.version.features.remove("default"))
+    let mut features = resp.version.features;
+    let default_features = features
+        .remove("default")
+        .filter(|features| !features.is_empty());
+
+    Ok(Some(DependencyFeatureMetadata {
+        feature_dependencies_map: Some(features),
+        default_features,
+    }))
 }
 
 fn dependency_table_default_features_disabled(table: &tombi_document_tree::Table) -> bool {
@@ -489,31 +524,92 @@ fn format_default_features_tooltip(default_features: &[String]) -> String {
         "Default Features:\n{}",
         default_features
             .iter()
-            .map(|feature| format!("  - {feature}"))
-            .collect::<Vec<_>>()
+            .map(|feature| format!("  - `{feature}`"))
             .join("\n")
     )
 }
 
-fn package_default_features(
+fn format_feature_dependencies_tooltip(feature_dependencies: &[String]) -> String {
+    format!(
+        "Feature Dependencies:\n{}",
+        feature_dependencies
+            .iter()
+            .map(|feature| format!("  - `{feature}`"))
+            .join("\n")
+    )
+}
+
+fn format_dependency_features_hover_tooltip(
+    feature_dependencies: Option<&[String]>,
+    default_features: Option<&[String]>,
+) -> Option<String> {
+    match (feature_dependencies, default_features) {
+        (Some(feature_dependencies), Some(default_features))
+            if !feature_dependencies.is_empty() =>
+        {
+            Some(format!(
+                "{}\n\n{}",
+                format_feature_dependencies_tooltip(feature_dependencies),
+                format_default_features_tooltip(default_features),
+            ))
+        }
+        (Some(feature_dependencies), _) if !feature_dependencies.is_empty() => {
+            Some(format_feature_dependencies_tooltip(feature_dependencies))
+        }
+        (_, Some(default_features)) if !default_features.is_empty() => {
+            Some(format_default_features_tooltip(default_features))
+        }
+        _ => None,
+    }
+}
+
+fn get_dependency_feature_metadata(
     dependency_document_tree: &tombi_document_tree::DocumentTree,
-) -> Option<Vec<String>> {
-    let (_, Value::Array(default_features)) =
-        dig_keys(dependency_document_tree, &["features", "default"])?
-    else {
+) -> Option<DependencyFeatureMetadata> {
+    let (_, Value::Table(features)) = dig_keys(dependency_document_tree, &["features"])? else {
         return None;
     };
 
-    let default_features = default_features
-        .values()
-        .iter()
-        .filter_map(|value| match value {
-            Value::String(feature) => Some(feature.value().to_string()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+    let mut feature_dependencies_map = HashMap::default();
+    for (feature_key, value) in features.key_values() {
+        let Value::Array(feature_values) = value else {
+            continue;
+        };
+        let feature_dependencies = feature_values
+            .values()
+            .iter()
+            .filter_map(|value| match value {
+                Value::String(feature) => Some(feature.value().to_string()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        feature_dependencies_map.insert(feature_key.value.to_string(), feature_dependencies);
+    }
 
-    (!default_features.is_empty()).then_some(default_features)
+    let default_features = feature_dependencies_map
+        .remove("default")
+        .filter(|default_features| !default_features.is_empty());
+
+    Some(DependencyFeatureMetadata {
+        feature_dependencies_map: Some(feature_dependencies_map),
+        default_features,
+    })
+}
+
+impl DependencyFeatureMetadata {
+    fn feature_dependencies(&self, feature_name: &str) -> Option<&[String]> {
+        self.feature_dependencies_map
+            .as_ref()?
+            .get(feature_name)
+            .map(Vec::as_slice)
+            .filter(|features| !features.is_empty())
+    }
+
+    fn default_features(&self) -> Option<&[String]> {
+        self.default_features
+            .as_deref()
+            .filter(|features| !features.is_empty())
+    }
 }
 
 fn get_dependency_accessors(accessors: &[Accessor]) -> Option<&[Accessor]> {
@@ -834,7 +930,22 @@ mod tests {
     fn format_default_features_tooltip_renders_sorted_feature_list() {
         assert_eq!(
             format_default_features_tooltip(&["bbb".to_string(), "aaa".to_string()]),
-            "Default Features:\n  - aaa\n  - bbb"
+            "Default Features:\n  - `aaa`\n  - `bbb`"
+        );
+    }
+
+    #[test]
+    fn format_dependency_features_hover_tooltip_places_feature_dependencies_before_default_features()
+     {
+        assert_eq!(
+            format_dependency_features_hover_tooltip(
+                Some(&["serde_derive".to_string()]),
+                Some(&["std".to_string()]),
+            ),
+            Some(
+                "Feature Dependencies:\n  - `serde_derive`\n\nDefault Features:\n  - `std`"
+                    .to_string()
+            )
         );
     }
 }

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -27,6 +27,7 @@ pub async fn hover(
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
     dependency_detail_hover_enabled: bool,
+    feature_dependencies_hover_enabled: bool,
     default_features_hover_enabled: bool,
 ) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
     if !text_document_uri.path().ends_with("Cargo.toml") {
@@ -50,7 +51,7 @@ pub async fn hover(
         return Ok(Some(metadata));
     }
 
-    if default_features_hover_enabled
+    if (feature_dependencies_hover_enabled || default_features_hover_enabled)
         && let Some(metadata) = dependency_features_hover_metadata(
             document_tree,
             accessors,
@@ -59,6 +60,8 @@ pub async fn hover(
             toml_version,
             offline,
             cache_options,
+            feature_dependencies_hover_enabled,
+            default_features_hover_enabled,
         )
         .await?
     {
@@ -274,7 +277,13 @@ async fn dependency_features_hover_metadata(
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
+    feature_dependencies_hover_enabled: bool,
+    default_features_hover_enabled: bool,
 ) -> Result<Option<HoverMetadata>, tower_lsp::jsonrpc::Error> {
+    if !feature_dependencies_hover_enabled && !default_features_hover_enabled {
+        return Ok(None);
+    }
+
     let Some(dependency_accessors) = dependency_features_parent_accessors(accessors) else {
         return Ok(None);
     };
@@ -309,14 +318,22 @@ async fn dependency_features_hover_metadata(
     .await?;
 
     Ok(format_dependency_features_hover_tooltip(
-        dependency_feature_metadata.as_ref().and_then(|metadata| {
-            feature_name
-                .as_deref()
-                .and_then(|name| metadata.feature_dependencies(name))
-        }),
-        dependency_feature_metadata
-            .as_ref()
-            .and_then(|metadata| metadata.default_features()),
+        if feature_dependencies_hover_enabled {
+            dependency_feature_metadata.as_ref().and_then(|metadata| {
+                feature_name
+                    .as_deref()
+                    .and_then(|name| metadata.feature_dependencies(name))
+            })
+        } else {
+            None
+        },
+        if default_features_hover_enabled {
+            dependency_feature_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.default_features())
+        } else {
+            None
+        },
     )
     .map(|description| HoverMetadata {
         title: None,
@@ -923,6 +940,8 @@ mod tests {
                 TomlVersion::V1_0_0,
                 true,
                 None,
+                true,
+                true,
             )
             .await
             .unwrap(),

--- a/extensions/tombi-extension-cargo/src/hover.rs
+++ b/extensions/tombi-extension-cargo/src/hover.rs
@@ -421,6 +421,10 @@ async fn try_get_dependency_feature_metadata(
         return Ok(None);
     };
 
+    if dependency_table_default_features_disabled(workspace_dependency_table) {
+        return Ok(None);
+    }
+
     if let Some(Value::String(path)) = workspace_dependency_table.get("path") {
         let Some((_, _, dependency_document_tree)) = find_cargo_toml(
             &workspace_cargo_toml_path,

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -2172,6 +2172,18 @@
               "type": "null"
             }
           ]
+        },
+        "feature-dependencies": {
+          "title": "Feature dependencies hover feature",
+          "description": "Whether hover shows dependencies of the selected Cargo feature.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ToggleFeatureDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- show feature dependency metadata when hovering dependency feature items in Cargo manifests
- keep default feature lists in the tooltip and render both sections with code formatting
- update hover tests to cover feature dependencies before default features

## Validation
- cargo fmt --all --check
- cargo test -p tombi-extension-cargo
- cargo test -p tombi-lsp --test test_hover
- cargo clippy --workspace --all-targets --locked -- -D warnings