### PR TITLE
docs(install): remove sha256 prefix from checksum example

### DIFF
--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -44,7 +44,7 @@ curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --install-di
 Verify the downloaded archive checksum before extraction:
 
 ```sh
-curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --checksum sha256:<sha256>
+curl -fsSL https://tombi-toml.github.io/tombi/install.sh | sh -s -- --checksum <sha256>
 ```
 
 ## Windows Package Manager


### PR DESCRIPTION
## Summary
- remove the `sha256:` prefix from the checksum example in the installation docs
- keep the shell example aligned with the expected `--checksum <sha256>` usage

## Testing
- not run (docs-only change)