### PR TITLE
fix(ci): quote install workflow step name

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -149,7 +149,7 @@ jobs:
             --checksum "${{ steps.artifact.outputs.checksum }}"
           test -f "$install_dir/${{ matrix.exe_name }}"
 
-      - name: Run install script with sha256: checksum
+      - name: "Run install script with sha256: checksum"
         run: |
           install_dir="${RUNNER_TEMP}/install-with-prefixed-checksum"
           mkdir -p "$install_dir"

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Resolve release artifact metadata
         id: artifact
         run: |
-          requested_version="$(awk -F'\"' '/^LATEST_STABLE_VERSION=\"[0-9]+\\.[0-9]+\\.[0-9]+\"$/ { print $2; exit }' ./docs/public/install.sh)"
+          requested_version="$(grep -E '^LATEST_STABLE_VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"$' ./docs/public/install.sh | cut -d'\"' -f2)"
           if [ -z "$requested_version" ]; then
             echo "Failed to resolve LATEST_STABLE_VERSION" >&2
             exit 1

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -56,7 +56,6 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Resolve release artifact metadata
-        id: artifact
         run: |
           requested_version="$(grep -E '^LATEST_STABLE_VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"$' ./docs/public/install.sh)"
           requested_version="${requested_version#LATEST_STABLE_VERSION=\"}"
@@ -121,54 +120,72 @@ jobs:
               ;;
           esac
 
-          url="https://github.com/tombi-toml/tombi/releases/download/v${version}/tombi-cli-${version}-${target}${extension}"
-          archive="${RUNNER_TEMP}/tombi-${version}${extension}"
-          curl -fsSL "$url" -o "$archive"
-          if command -v sha256sum >/dev/null 2>&1; then
-            checksum="$(sha256sum "$archive" | awk '{print $1}')"
-          else
-            checksum="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          asset_name="tombi-cli-${version}-${target}${extension}"
+          release_json="$(curl -fsSL "https://api.github.com/repos/tombi-toml/tombi/releases/tags/v${version}")"
+          url="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .browser_download_url' | head -n 1)"
+          checksum="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' | head -n 1)"
+
+          if [ -z "$url" ] || [ "$url" = "null" ]; then
+            echo "Failed to resolve release asset URL for ${asset_name}" >&2
+            exit 1
+          fi
+          if [ -z "$checksum" ] || [ "$checksum" = "null" ]; then
+            echo "Failed to resolve release asset digest for ${asset_name}" >&2
+            exit 1
           fi
 
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "target=$target" >> "$GITHUB_OUTPUT"
-          echo "extension=$extension" >> "$GITHUB_OUTPUT"
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+          checksum="${checksum#sha256:}"
+          if ! printf '%s' "$checksum" | grep -Eq '^[0-9a-f]{64}$'; then
+            echo "Invalid release asset digest for ${asset_name}: ${checksum}" >&2
+            exit 1
+          fi
+
+          metadata_file="${RUNNER_TEMP}/install-metadata.env"
+          {
+            printf 'version=%s\n' "$version"
+            printf 'target=%s\n' "$target"
+            printf 'extension=%s\n' "$extension"
+            printf 'url=%s\n' "$url"
+            printf 'checksum=%s\n' "$checksum"
+          } > "$metadata_file"
 
       - name: Run install script without checksum
         run: |
+          . "${RUNNER_TEMP}/install-metadata.env"
           chmod +x ./docs/public/install.sh
-          ./docs/public/install.sh --version "${{ steps.artifact.outputs.version }}"
+          ./docs/public/install.sh --version "$version"
 
       - name: Run install script with plain checksum
         run: |
+          . "${RUNNER_TEMP}/install-metadata.env"
           install_dir="${RUNNER_TEMP}/install-with-checksum"
           mkdir -p "$install_dir"
           ./docs/public/install.sh \
-            --version "${{ steps.artifact.outputs.version }}" \
+            --version "$version" \
             --install-dir "$install_dir" \
-            --checksum "${{ steps.artifact.outputs.checksum }}"
+            --checksum "$checksum"
           test -f "$install_dir/${{ matrix.exe_name }}"
 
       - name: "Run install script with sha256: checksum"
         run: |
+          . "${RUNNER_TEMP}/install-metadata.env"
           install_dir="${RUNNER_TEMP}/install-with-prefixed-checksum"
           mkdir -p "$install_dir"
           ./docs/public/install.sh \
-            --version "${{ steps.artifact.outputs.version }}" \
+            --version "$version" \
             --install-dir "$install_dir" \
-            --checksum "sha256:${{ steps.artifact.outputs.checksum }}"
+            --checksum "sha256:${checksum}"
           test -f "$install_dir/${{ matrix.exe_name }}"
 
       - name: Reject wrong checksum before install
         run: |
+          . "${RUNNER_TEMP}/install-metadata.env"
           install_dir="${RUNNER_TEMP}/install-with-bad-checksum"
           mkdir -p "$install_dir"
           log_file="${RUNNER_TEMP}/bad-checksum.log"
           set +e
           ./docs/public/install.sh \
-            --version "${{ steps.artifact.outputs.version }}" \
+            --version "$version" \
             --install-dir "$install_dir" \
             --checksum "0000000000000000000000000000000000000000000000000000000000000000" \
             >"$log_file" 2>&1

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Resolve release artifact metadata
         id: artifact
         run: |
-          requested_version="$(grep -E '^LATEST_STABLE_VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"$' ./docs/public/install.sh | cut -d'\"' -f2)"
+          requested_version="$(grep -E '^LATEST_STABLE_VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"$' ./docs/public/install.sh)"
+          requested_version="${requested_version#LATEST_STABLE_VERSION=\"}"
+          requested_version="${requested_version%\"}"
           if [ -z "$requested_version" ]; then
             echo "Failed to resolve LATEST_STABLE_VERSION" >&2
             exit 1

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Resolve release artifact metadata
         id: artifact
         run: |
-          requested_version="$(sed -n 's/^LATEST_STABLE_VERSION=\"\([0-9]\+\.[0-9]\+\.[0-9]\+\)\"$/\1/p' ./docs/public/install.sh)"
+          requested_version="$(awk -F'\"' '/^LATEST_STABLE_VERSION=\"[0-9]+\\.[0-9]+\\.[0-9]+\"$/ { print $2; exit }' ./docs/public/install.sh)"
           if [ -z "$requested_version" ]; then
             echo "Failed to resolve LATEST_STABLE_VERSION" >&2
             exit 1


### PR DESCRIPTION
## Summary
- quote the install workflow step name containing `sha256: checksum`
- fix GitHub Actions workflow parsing so `ci_install_script.yml` can instantiate jobs again

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci_install_script.yml"); puts "yaml ok"'