### PR TITLE
ci: pin npm release tooling versions

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -170,11 +170,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          # npm trusted publishing requires Node 22.14.0+.
+          node-version: 22.14.0
           registry-url: "https://registry.npmjs.org"
 
-      - name: Update npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Install pinned npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.1
 
       - name: Generate npm package
         run: node typescript/@tombi-toml/tombi/scripts/generate-packages.mjs

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -170,12 +170,9 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          # npm trusted publishing requires Node 22.14.0+.
-          node-version: 22.14.0
+          # Node 24 includes a compatible npm for trusted publishing.
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
-
-      - name: Install pinned npm for OIDC trusted publishing
-        run: npm install -g npm@11.5.1
 
       - name: Generate npm package
         run: node typescript/@tombi-toml/tombi/scripts/generate-packages.mjs


### PR DESCRIPTION
## Summary
- replace the mutable `npm install -g npm@latest` step in `release_npm.yml`
- pin the npm CLI used for trusted publishing to `npm@11.5.1`
- raise the release job Node runtime to `22.14.0` to satisfy npm trusted publishing requirements

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_npm.yml"); puts "ok"'`
- `git diff --check -- .github/workflows/release_npm.yml`
