### PR TITLE
fix(pyproject): keep declarations out of references

### DIFF
--- a/crates/tombi-lsp/tests/test_references.rs
+++ b/crates/tombi-lsp/tests/test_references.rs
@@ -488,7 +488,7 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
-            async fn project_dependencies_workspace_usage_locations(
+            async fn project_dependencies_without_workspace_root_usage_return_no_references(
                 r#"
                 [project]
                 name = "app1"
@@ -498,9 +498,7 @@ mod references_tests {
                 ]
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
-            ) -> Ok([
-                pyproject_workspace_fixtures_path().join("pyproject.toml"),
-            ]);
+            ) -> Ok([]);
         );
 
         test_references!(
@@ -523,7 +521,30 @@ mod references_tests {
 
         test_references!(
             #[tokio::test]
-            async fn pyproject_references_use_references_setting_not_goto_definition(
+            async fn workspace_dependency_string_lists_member_usages(
+                r#"
+                [project]
+                name = "workspace"
+                version = "0.1.0"
+                dependencies = ["pydantic>=2.10█"]
+
+                [tool.uv.workspace]
+                members = [
+                    "members/app1",
+                    "members/app2",
+                    "members/app3",
+                ]
+                "#,
+                SourcePath(pyproject_workspace_fixtures_path().join("pyproject.toml")),
+            ) -> Ok([
+                pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml"),
+                pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml"),
+            ]);
+        );
+
+        test_references!(
+            #[tokio::test]
+            async fn include_declaration_adds_workspace_dependency_declaration_for_member_dependency(
                 r#"
                 [project]
                 name = "app1"
@@ -533,9 +554,33 @@ mod references_tests {
                 ]
                 "#,
                 SourcePath(pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml")),
-                ConfigPath(fixture_config_path("pyproject-references-only-enabled")),
+                IncludeDeclaration(true),
             ) -> Ok([
                 pyproject_workspace_fixtures_path().join("pyproject.toml"),
+            ]);
+        );
+
+        test_references!(
+            #[tokio::test]
+            async fn pyproject_references_use_references_setting_not_goto_definition(
+                r#"
+                [project]
+                name = "workspace"
+                version = "0.1.0"
+                dependencies = ["pydantic>=2.10█"]
+
+                [tool.uv.workspace]
+                members = [
+                    "members/app1",
+                    "members/app2",
+                    "members/app3",
+                ]
+                "#,
+                SourcePath(pyproject_workspace_fixtures_path().join("pyproject.toml")),
+                ConfigPath(fixture_config_path("pyproject-references-only-enabled")),
+            ) -> Ok([
+                pyproject_workspace_fixtures_path().join("members/app1/pyproject.toml"),
+                pyproject_workspace_fixtures_path().join("members/app2/pyproject.toml"),
             ]);
         );
 

--- a/extensions/tombi-extension-pyproject/src/references.rs
+++ b/extensions/tombi-extension-pyproject/src/references.rs
@@ -3,10 +3,10 @@ use tombi_document_tree::{Value, dig_accessors, dig_keys};
 use tombi_schema_store::{Accessor, matches_accessors};
 
 use crate::{
-    collect_workspace_project_dependency_definitions, extract_exclude_patterns,
-    extract_member_patterns, find_pyproject_toml_paths, find_workspace_pyproject_toml,
-    get_workspace_member_dependency_definitions, is_dependency_name_accessors,
-    is_project_name_accessors, load_pyproject_toml_document_tree, parse_requirement,
+    extract_exclude_patterns, extract_member_patterns, find_pyproject_toml_paths,
+    find_workspace_pyproject_toml, get_workspace_member_dependency_definitions,
+    is_dependency_name_accessors, is_project_name_accessors, load_pyproject_toml_document_tree,
+    parse_requirement,
 };
 
 pub async fn references(
@@ -51,14 +51,6 @@ pub async fn references(
         let package_name = requirement.name.as_ref();
 
         let mut locations = Vec::new();
-        if requirement.version_or_url.is_none() {
-            locations.extend(collect_workspace_project_dependency_definitions(
-                package_name,
-                &pyproject_toml_path,
-                toml_version,
-            ));
-        }
-
         if tombi_document_tree::dig_keys(document_tree, &["tool", "uv", "workspace"]).is_some() {
             locations.extend(get_workspace_member_dependency_definitions(
                 document_tree,


### PR DESCRIPTION
## Summary
- keep pyproject references focused on usage locations only
- stop returning workspace-root declarations for member dependency references
- add regression coverage for workspace dependency references and includeDeclaration behavior

## Testing
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked