### PR TITLE
ci: use trusted publishing for PyPI release

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -237,27 +237,32 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [linux, musllinux, windows, macos, sdist]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tombi
     permissions:
-      # Use to sign the release artifacts
+      # Use to authenticate to PyPI and sign the release artifacts
       id-token: write
-      # Used to upload release artifacts
-      contents: write
+      # Used to read workflow context during attestation generation
+      contents: read
       # Used to generate artifact attestation
       attestations: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: tombi-py-wheels-*
+          path: dist
+          merge-multiple: true
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
-          subject-path: "tombi-py-wheels-*/*"
+          subject-path: "dist/*"
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          command: upload
-          args: --non-interactive --skip-existing tombi-py-wheels-*/*
+          packages-dir: dist/
+          skip-existing: true
 
   delete-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -237,7 +237,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [linux, musllinux, windows, macos, sdist]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: pypi
       url: https://pypi.org/p/tombi


### PR DESCRIPTION
## Summary
- switch the PyPI publish job from API-token upload to GitHub OIDC trusted publishing
- scope the `pypi` environment to the tag-only publish job and reduce job permissions
- download built artifacts into `dist/` for attestation and `gh-action-pypi-publish`

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_pypi.yml"); puts "ok"'
- git diff --check -- .github/workflows/release_pypi.yml