### PR TITLE
fix(ci): pass snapcraft matrix platform to build

### DIFF
--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -67,6 +67,8 @@ jobs:
 
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
+        with:
+          snapcraft-args: --platform ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary
- pass the release_snap matrix platform through to snapcore/action-build
- ensure each snapcraft matrix job builds the requested platform instead of always producing the default amd64 snap

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_snap.yml"); puts "yaml ok"'