### PR TITLE
fix(ci): allow snapcraft cross-build platforms on amd64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,7 +10,9 @@ confinement: classic
 platforms:
   amd64:
   arm64:
+    build-on: [amd64]
   armhf:
+    build-on: [amd64]
 
 parts:
   tombi:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,6 +9,7 @@ grade: stable
 confinement: classic
 platforms:
   amd64:
+    build-on: [amd64, arm64]
   arm64:
     build-on: [amd64, arm64]
   armhf:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,9 +10,9 @@ confinement: classic
 platforms:
   amd64:
   arm64:
-    build-on: [amd64]
+    build-on: [amd64, arm64]
   armhf:
-    build-on: [amd64]
+    build-on: [amd64, arm64]
 
 parts:
   tombi:


### PR DESCRIPTION
## Summary
- pass the snap release matrix platform to snapcraft so each matrix job targets the intended architecture
- allow the arm64 and armhf snapcraft platforms to build on the amd64 GitHub Actions runner
- fix the post-merge Release Snap package failure from run 27182774217

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_snap.yml"); YAML.load_file("snapcraft.yaml"); puts "yaml ok"'