### PR TITLE
fix(ci): include LICENSE in python sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "maturin"
 [tool.maturin]
 bindings = "bin"
 include = [
+  { format = "sdist", path = "LICENSE" },
   { format = "sdist", path = "www.schemastore.org/**/*.json" },
   { format = "sdist", path = "www.tombi.dev/**/*.json" },
 ]


### PR DESCRIPTION
## Summary
- include the repo root LICENSE in maturin sdist inputs
- fix PyPI release failure caused by missing LICENSE in the source tarball

## Verification
- uv run maturin sdist -m rust/tombi-cli/Cargo.toml -o .context/ci-investigation
- tar -tzf .context/ci-investigation/tombi-0.0.0.dev0.tar.gz | rg "(^|/)LICENSE$"
- cargo check -p tombi-cli