### PR TITLE
docs: explain selective auto-sort re-enable

### DIFF
--- a/docs/src/routes/docs/formatter/auto-sorting.mdx
+++ b/docs/src/routes/docs/formatter/auto-sorting.mdx
@@ -26,7 +26,7 @@ format.rules.table-keys-order.enabled = false
 ```
 
 If you want to keep automatic sorting only for specific keys after disabling it globally,
-use [`schemas[*].overrides[*]`](/docs/configuration#schemasoverrides) to re-enable sorting for those targets.
+use [`schemas[*].overrides[*]`](/docs/configuration#schemas-overrides) to re-enable sorting for those targets.
 
 For example, the following configuration disables sorting for `Cargo.toml` as a whole,
 but keeps schema-based key sorting only under `[dependencies]`, `[dev-dependencies]`, and `[build-dependencies]`.

--- a/docs/src/routes/docs/formatter/auto-sorting.mdx
+++ b/docs/src/routes/docs/formatter/auto-sorting.mdx
@@ -25,6 +25,26 @@ format.rules.array-values-order.enabled = false
 format.rules.table-keys-order.enabled = false
 ```
 
+If you want to keep automatic sorting only for specific keys after disabling it globally,
+use [`schemas[*].overrides[*]`](/docs/configuration#schemasoverrides) to re-enable sorting for those targets.
+
+For example, the following configuration disables sorting for `Cargo.toml` as a whole,
+but keeps schema-based key sorting only under `[dependencies]`, `[dev-dependencies]`, and `[build-dependencies]`.
+
+```toml
+[[schemas]]
+path = "tombi://www.schemastore.org/cargo.json"
+include = ["Cargo.toml"]
+format.rules.array-values-order.enabled = false
+format.rules.table-keys-order.enabled = false
+
+[[schemas.overrides]]
+targets = ["dependencies", "dev-dependencies", "build-dependencies"]
+format.rules = {
+  table-keys-order = "schema"
+}
+```
+
 ## How to Specify Auto Sorting Methods
 
 Tombi does not perform automatic sorting unless a sorting method is specified.
@@ -49,7 +69,7 @@ This is probably the method you'll benefit from the most.
 
 When schemas automatically retrieved from the [JSON Schema Store](https://www.schemastore.org) contain the following keys, automatic sorting is performed according to that schema:
 
-- [x-tombi-table-keys-order](/docs/json-schema#x-tombi-table-keys-order) 
+- [x-tombi-table-keys-order](/docs/json-schema#x-tombi-table-keys-order)
 - [x-tombi-array-values-order](/docs/json-schema#x-tombi-array-values-order)
 - [x-tombi-array-values-order-by](/docs/json-schema#x-tombi-array-values-order-by)
 


### PR DESCRIPTION
## Summary
- document how to re-enable schema-based key sorting for specific sections after disabling auto sorting globally
- add a Cargo.toml example using `schemas.overrides`
- remove trailing whitespace in the schema keys list

## Testing
- not run (Biome ignores this MDX path in both repo root and docs workspace configs)