### PR TITLE
Remove blank issue setting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-blank_issues_enabled: false
 contact_links:
   - name: JSON Schema addition
     url: https://github.com/SchemaStore/schemastore/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-  - name: JSON Schema addition
+  - name: 📚 JSON Schema addition
     url: https://github.com/SchemaStore/schemastore/issues/new/choose
     about: Request the target project to generate or maintain its JSON Schema first, then ask SchemaStore to register it. Do not open a Tombi issue only to add a third-party project schema.
-  - name: Discussions
+  - name: 💬 Discussions
     url: https://github.com/tombi-toml/tombi/discussions
     about: Ask questions, share ideas, or discuss behavior before opening an issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-  - name: 📚 JSON Schema addition
+  - name: 🛤️ JSON Schema addition
     url: https://github.com/SchemaStore/schemastore/issues/new/choose
     about: Request the target project to generate or maintain its JSON Schema first, then ask SchemaStore to register it. Do not open a Tombi issue only to add a third-party project schema.
-  - name: 💬 Discussions
+  - name: 👥 Discussions
     url: https://github.com/tombi-toml/tombi/discussions
     about: Ask questions, share ideas, or discuss behavior before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
-name: Feature Request
+name: ✨ Feature Request
 description: Suggest an improvement or new feature for Tombi.
-title: "Feature Request: "
+title: "✨ Feature Request: "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,6 +1,6 @@
-name: Issue
+name: 🐛 Issue
 description: Report a bug or unexpected behavior in Tombi.
-title: "Issue: "
+title: "🐛 Issue: "
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- Remove the `blank_issues_enabled` setting from the issue template chooser config
- Keep the JSON Schema addition and Discussions contact links

## Verification
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/*.yml