### PR TITLE
Use GitHub App token for dependent release dispatches

### DIFF
--- a/.github/actions/dispatch-versioned-release/action.yml
+++ b/.github/actions/dispatch-versioned-release/action.yml
@@ -1,0 +1,157 @@
+name: Dispatch versioned release
+description: Dispatch a release workflow in another repository and wait for completion.
+
+inputs:
+  client-id:
+    description: GitHub App client ID.
+    required: true
+  private-key:
+    description: GitHub App private key.
+    required: true
+  owner:
+    description: Repository owner.
+    required: true
+  repository:
+    description: Repository name to dispatch.
+    required: true
+  tag:
+    description: Release tag to pass as the version input.
+    required: true
+  workflow:
+    description: Workflow file name to dispatch.
+    required: false
+    default: release.yml
+  ref:
+    description: Branch name or refs/heads/<branch> to dispatch the workflow on.
+    required: false
+    default: main
+  max-attempts:
+    description: Number of polling attempts.
+    required: false
+    default: "60"
+  poll-interval-ms:
+    description: Delay between polling attempts in milliseconds.
+    required: false
+    default: "10000"
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        client-id: ${{ inputs.client-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: |
+          ${{ inputs.repository }}
+        permission-actions: write
+        permission-contents: read
+
+    - name: Dispatch release workflow
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      with:
+        github-token: ${{ steps.app-token.outputs.token }}
+        script: |
+          const owner = "${{ inputs.owner }}";
+          const repo = "${{ inputs.repository }}";
+          const tag = "${{ inputs.tag }}";
+          const workflow = "${{ inputs.workflow }}";
+          const ref = "${{ inputs.ref }}";
+          const branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+          const maxAttempts = Number("${{ inputs.max-attempts }}");
+          const pollIntervalMs = Number("${{ inputs.poll-interval-ms }}");
+
+          if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+            core.setFailed(`max-attempts must be a positive integer: ${maxAttempts}`);
+            return;
+          }
+
+          if (!Number.isInteger(pollIntervalMs) || pollIntervalMs < 1) {
+            core.setFailed(`poll-interval-ms must be a positive integer: ${pollIntervalMs}`);
+            return;
+          }
+
+          try {
+            await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `tags/${tag}`,
+            });
+            core.info(`${repo} already has tag ${tag}. Skipping release dispatch.`);
+            return;
+          } catch (error) {
+            if (error.status !== 404) {
+              throw error;
+            }
+          }
+
+          const dispatchedAfter = new Date(Date.now() - 5000).toISOString();
+          await github.rest.actions.createWorkflowDispatch({
+            owner,
+            repo,
+            workflow_id: workflow,
+            ref: branch,
+            inputs: {
+              version: tag,
+            },
+          });
+
+          core.info(`Triggered ${repo} ${workflow} on ${branch}.`);
+
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          let workflowRun;
+
+          for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: workflow,
+              branch,
+              event: "workflow_dispatch",
+              per_page: 10,
+            });
+
+            workflowRun = data.workflow_runs.find(
+              (run) => run.created_at >= dispatchedAfter,
+            );
+
+            if (workflowRun) {
+              core.info(
+                `Found ${repo} release run ${workflowRun.id} with status ${workflowRun.status}.`,
+              );
+              if (workflowRun.status === "completed") {
+                break;
+              }
+            } else {
+              core.info(`Waiting for ${repo} release run to appear.`);
+            }
+
+            if (attempt === maxAttempts) {
+              core.setFailed(`Timed out waiting for ${repo} release workflow to complete.`);
+              return;
+            }
+
+            await sleep(pollIntervalMs);
+          }
+
+          if (!workflowRun) {
+            core.setFailed(`${repo} release workflow run was not found.`);
+            return;
+          }
+
+          if (workflowRun.conclusion !== "success") {
+            core.setFailed(
+              `${repo} release workflow concluded with ${workflowRun.conclusion}.`,
+            );
+            return;
+          }
+
+          const { data: tagRef } = await github.rest.git.getRef({
+            owner,
+            repo,
+            ref: `tags/${tag}`,
+          });
+
+          core.info(`${repo} release workflow completed and created ${repo}@${tag} (${tagRef.object.sha}).`);

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -45,6 +45,7 @@ jobs:
           head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           paths: |
             .cargo/**
+            .github/actions/dispatch-versioned-release/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
             .node-version
@@ -425,112 +426,20 @@ jobs:
             echo "stable_tag=" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Create GitHub App token for setup-tombi
-        id: app-token
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: steps.stable-version.outputs.stable_tag != ''
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          persist-credentials: false
+
+      - name: Trigger setup-tombi release workflow
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: ./.github/actions/dispatch-versioned-release
         with:
           client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: |
-            setup-tombi
-          permission-contents: write
-          permission-actions: write
-
-      - name: Trigger setup-tombi release workflow
-        if: steps.stable-version.outputs.stable_tag != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = "setup-tombi";
-            const tag = "${{ steps.stable-version.outputs.stable_tag }}";
-
-            try {
-              await github.rest.git.getRef({
-                owner,
-                repo,
-                ref: `tags/${tag}`,
-              });
-              core.info(`setup-tombi already has tag ${tag}. Skipping release dispatch.`);
-              return;
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-            }
-
-            const dispatchedAfter = new Date().toISOString();
-            await github.rest.actions.createWorkflowDispatch({
-              owner,
-              repo,
-              workflow_id: "release.yml",
-              ref: "main",
-              inputs: {
-                version: tag,
-              },
-            });
-
-            core.info("Triggered setup-tombi release.yml on main.");
-
-            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-            const maxAttempts = 60;
-            let workflowRun;
-
-            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: "release.yml",
-                branch: "main",
-                event: "workflow_dispatch",
-                per_page: 10,
-              });
-
-              workflowRun = data.workflow_runs.find(
-                (run) => run.created_at >= dispatchedAfter,
-              );
-
-              if (workflowRun) {
-                core.info(
-                  `Found setup-tombi release run ${workflowRun.id} with status ${workflowRun.status}.`,
-                );
-                if (workflowRun.status === "completed") {
-                  break;
-                }
-              } else {
-                core.info("Waiting for setup-tombi release run to appear.");
-              }
-
-              if (attempt === maxAttempts) {
-                core.setFailed("Timed out waiting for setup-tombi release workflow to complete.");
-                return;
-              }
-
-              await sleep(10000);
-            }
-
-            if (!workflowRun) {
-              core.setFailed("setup-tombi release workflow run was not found.");
-              return;
-            }
-
-            if (workflowRun.conclusion !== "success") {
-              core.setFailed(
-                `setup-tombi release workflow concluded with ${workflowRun.conclusion}.`,
-              );
-              return;
-            }
-
-            const { data: tagRef } = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: `tags/${tag}`,
-            });
-
-            core.info(`setup-tombi release workflow completed and created ${repo}@${tag} (${tagRef.object.sha}).`);
+          repository: setup-tombi
+          tag: ${{ steps.stable-version.outputs.stable_tag }}
 
   publish-winget:
     needs: [release-notes]

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -37,6 +37,7 @@ jobs:
           head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           paths: |
             .cargo/**
+            .github/actions/dispatch-versioned-release/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
             .python-version
@@ -280,15 +281,35 @@ jobs:
     name: Notify pre-commit mirror
     runs-on: ubuntu-latest
     needs: [release-python]
+    permissions:
+      contents: read
     steps:
-      - name: "Update pre-commit mirror"
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - name: Detect stable release tag
+        id: stable-version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "stable_tag=${REF_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Skipping tombi-pre-commit update for non-stable tag: ${REF_NAME}"
+            echo "stable_tag=" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: steps.stable-version.outputs.stable_tag != ''
         with:
-          github-token: ${{ secrets.TOMBI_PRE_COMMIT_PAT }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: 'tombi-pre-commit',
-              workflow_id: 'main.yml',
-              ref: 'main',
-            })
+          persist-credentials: false
+
+      - name: "Update pre-commit mirror"
+        if: steps.stable-version.outputs.stable_tag != ''
+        uses: ./.github/actions/dispatch-versioned-release
+        with:
+          client-id: ${{ secrets.VERSION_UPDATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERSION_UPDATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repository: tombi-pre-commit
+          workflow: release.yml
+          tag: ${{ steps.stable-version.outputs.stable_tag }}


### PR DESCRIPTION
## Summary

- add a shared `dispatch-versioned-release` composite action for dependent release workflow dispatches
- switch `release_pypi.yml` from `TOMBI_PRE_COMMIT_PAT` to the existing `VERSION_UPDATE_APP` credentials
- reuse the shared dispatch/polling action from `release_cli_vscode.yml` for `setup-tombi`
- include the shared action in release relevant-changes filters

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "OK #{p}" }' .github/actions/dispatch-versioned-release/action.yml .github/workflows/release_cli_vscode.yml .github/workflows/release_pypi.yml`
- `git diff --check`

## Follow-up GitHub settings

- add `tombi-pre-commit` to the `VERSION_UPDATE_APP` repository access
- grant the app `Actions: write` and `Contents: read` for `tombi-pre-commit`
- remove the `TOMBI_PRE_COMMIT_PAT` repo secret after the migration is deployed
