### PR TITLE
fix(lsp): avoid stale diagnostics after changes

### DIFF
--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -14,10 +14,30 @@ pub async fn get_diagnostics_result(
     backend: &Backend,
     text_document_uri: &tombi_uri::Uri,
 ) -> Option<DiagnosticsResult> {
-    {
-        let workspace_diagnostics_cache = backend.workspace_diagnostics_cache.read().await;
-        if let Some(diagnostics_result) = workspace_diagnostics_cache.get(text_document_uri) {
-            return Some(diagnostics_result.clone());
+    if let Some(diagnostics_result) = {
+        backend
+            .workspace_diagnostics_cache
+            .read()
+            .await
+            .get(text_document_uri)
+            .cloned()
+    } {
+        // Reuse the cached result only when it was computed for the document
+        // version the editor is currently showing. `did_change` updates the
+        // document version and clears the cache in separate critical sections,
+        // and messages are processed concurrently, so a pull-diagnostics request
+        // can otherwise observe a cache entry left over from the previous version
+        // and report stale (false positive / false negative) diagnostics until
+        // the next edit.
+        let current_version = backend
+            .document_sources
+            .read()
+            .await
+            .get(text_document_uri)
+            .and_then(|document_source| document_source.version);
+
+        if diagnostics_result.version == current_version {
+            return Some(diagnostics_result);
         }
     }
 

--- a/crates/tombi-lsp/src/handler/did_change.rs
+++ b/crates/tombi-lsp/src/handler/did_change.rs
@@ -12,21 +12,25 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
     } = params;
 
     let text_document_uri = text_document.uri.into();
-    let mut latest_content_change = None;
+    let mut latest_text = None;
 
     for content_change in content_changes {
         if let Some(range) = content_change.range {
             log::warn!("Range change is not supported: {:?}", range);
         } else {
-            let toml_version = backend
-                .text_document_toml_version(&text_document_uri, &content_change.text)
-                .await;
-
-            latest_content_change = Some((content_change.text, toml_version));
+            latest_text = Some(content_change.text);
         }
     }
 
-    let need_publish_diagnostics = {
+    // Apply the edit and bump the document version up front, without awaiting in
+    // between, so that concurrently-processed requests (most importantly pull
+    // diagnostics) observe the new content immediately instead of a stale
+    // snapshot. Resolving the TOML version touches the schema store (async), which
+    // would otherwise yield before the document is updated and let a pull compute
+    // diagnostics against the previous version. The TOML version is reused from the
+    // previous parse here and refined below only if the edit actually changed it
+    // (e.g. an edited `#:schema` directive).
+    let (need_publish_diagnostics, previous_toml_version) = {
         let mut document_sources = backend.document_sources.write().await;
         let Some(document) = document_sources.get_mut(&text_document_uri) else {
             return;
@@ -35,13 +39,14 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
         let need_publish_diagnostics = document
             .version
             .is_none_or(|version| version < text_document.version);
+        let previous_toml_version = document.toml_version;
 
-        if let Some((text, toml_version)) = latest_content_change {
-            document.set_text(text, toml_version);
+        if let Some(text) = latest_text.as_ref() {
+            document.set_text(text, previous_toml_version);
         }
         document.version = Some(text_document.version);
 
-        need_publish_diagnostics
+        (need_publish_diagnostics, previous_toml_version)
     };
 
     backend
@@ -49,6 +54,33 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
         .write()
         .await
         .clear(&text_document_uri);
+
+    // Refine the TOML version if this edit changed it, and re-apply only when the
+    // document has not been superseded by a newer change in the meantime.
+    if let Some(text) = latest_text.as_ref() {
+        let toml_version = backend
+            .text_document_toml_version(&text_document_uri, text)
+            .await;
+
+        if toml_version != previous_toml_version {
+            {
+                let mut document_sources = backend.document_sources.write().await;
+                let Some(document) = document_sources.get_mut(&text_document_uri) else {
+                    return;
+                };
+                if document.version != Some(text_document.version) {
+                    return;
+                }
+                document.set_text(text, toml_version);
+            }
+
+            backend
+                .workspace_diagnostics_cache
+                .write()
+                .await
+                .clear(&text_document_uri);
+        }
+    }
 
     if need_publish_diagnostics {
         // Publish diagnostics for the changed document

--- a/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/schema.json
+++ b/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
+  "title": "Test Schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/test.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/test.toml
@@ -1,0 +1,2 @@
+#:schema schema.json
+id = "Test1"

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -183,6 +183,53 @@ mod diagnostic {
             ) -> Ok([]);
         );
     }
+
+    /// Test for issue #1953: stale pull diagnostics after didChange
+    /// https://github.com/tombi-toml/tombi/issues/1953
+    mod issue_1953_stale_pull_diagnostics {
+        use tombi_test_lib::project_root_path;
+
+        use super::*;
+        use std::path::PathBuf;
+
+        fn fixture_path() -> PathBuf {
+            project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics")
+        }
+
+        fn valid_text() -> String {
+            "#:schema schema.json\nid = \"Test1\"\n".to_string()
+        }
+
+        fn invalid_text() -> String {
+            "#:schema schema.json\nidx = \"Test1\"\n".to_string()
+        }
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn pull_diagnostics_clear_stale_error_after_fixing_key(
+                SourcePath(fixture_path().join("test.toml")),
+                SourceText(valid_text()),
+                LspDiagnosticMode(tombi_lsp::backend::DiagnosticMode::Pull),
+                SourceChanges(vec![(1, invalid_text()), (2, valid_text())]),
+            ) -> Ok([]);
+        );
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn pull_diagnostics_report_latest_error_after_reintroducing_key(
+                SourcePath(fixture_path().join("test.toml")),
+                SourceText(valid_text()),
+                LspDiagnosticMode(tombi_lsp::backend::DiagnosticMode::Pull),
+                SourceChanges(vec![(1, invalid_text()), (2, valid_text()), (3, invalid_text())]),
+            ) -> Ok([
+                Diagnostic {
+                    message: "\"idx\" is not allowed",
+                    range: ((1, 0), (1, 13)),
+                }
+            ]);
+        );
+    }
 }
 
 // Unified test macro
@@ -208,13 +255,13 @@ macro_rules! test_diagnostic {
         use tombi_lsp::Backend;
         use tower_lsp::{
             lsp_types::{
-                Url, DidOpenTextDocumentParams,
-                TextDocumentItem, DocumentDiagnosticParams,
-                TextDocumentIdentifier, WorkDoneProgressParams,
+                DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentDiagnosticParams,
+                TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Url,
+                VersionedTextDocumentIdentifier, WorkDoneProgressParams,
             },
             LspService,
         };
-        use tombi_lsp::handler::{handle_did_open, handle_diagnostic};
+        use tombi_lsp::handler::{handle_diagnostic, handle_did_change, handle_did_open};
 
         tombi_test_lib::init_log();
 
@@ -223,6 +270,7 @@ macro_rules! test_diagnostic {
         struct TestArgs {
             source_file_path: Option<std::path::PathBuf>,
             source_text: Option<String>,
+            source_changes: Vec<(i32, String)>,
             schema_file_path: Option<std::path::PathBuf>,
             config_file_path: Option<std::path::PathBuf>,
             diagnostic_mode: Option<tombi_lsp::backend::DiagnosticMode>,
@@ -527,6 +575,7 @@ macro_rules! test_diagnostic_file {
         struct TestArgs {
             source_file_path: Option<std::path::PathBuf>,
             source_text: Option<String>,
+            source_changes: Vec<(i32, String)>,
             schema_file_path: Option<std::path::PathBuf>,
             config_file_path: Option<std::path::PathBuf>,
             diagnostic_mode: Option<tombi_lsp::backend::DiagnosticMode>,
@@ -553,6 +602,15 @@ macro_rules! test_diagnostic_file {
         impl ApplyTestArg for SourceText {
             fn apply(self, config: &mut TestArgs) {
                 config.source_text = Some(self.0);
+            }
+        }
+
+        #[allow(unused)]
+        struct SourceChanges(Vec<(i32, String)>);
+
+        impl ApplyTestArg for SourceChanges {
+            fn apply(self, config: &mut TestArgs) {
+                config.source_changes = self.0;
             }
         }
 
@@ -673,6 +731,24 @@ macro_rules! test_diagnostic_file {
             },
         )
         .await;
+
+        for (version, text) in config.source_changes {
+            tombi_lsp::handler::handle_did_change(
+                backend,
+                tower_lsp::lsp_types::DidChangeTextDocumentParams {
+                    text_document: tower_lsp::lsp_types::VersionedTextDocumentIdentifier {
+                        uri: toml_file_url.clone(),
+                        version,
+                    },
+                    content_changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
+                        range: None,
+                        range_length: None,
+                        text,
+                    }],
+                },
+            )
+            .await;
+        }
 
         // Get diagnostics
         let diagnostic_result = handle_diagnostic(


### PR DESCRIPTION
## Summary
- update document text/version before async TOML-version resolution in didChange
- ignore cached pull diagnostics when their version no longer matches the current document
- refresh TOML version after the edit only if the document has not been superseded

Fixes #1953

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked