### PR TITLE
Use std assert_matches macro in tests

### DIFF
--- a/crates/tombi-glob/src/walk_dir.rs
+++ b/crates/tombi-glob/src/walk_dir.rs
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_error_handling() {
         let result = find_rust_files("/nonexistent/path");
-        assert!(matches!(result, Err(crate::Error::RootPathNotFound { .. })));
+        std::assert_matches!(result, Err(crate::Error::RootPathNotFound { .. }));
     }
 
     #[tokio::test]

--- a/crates/tombi-schema-store/src/schema/document_schema.rs
+++ b/crates/tombi-schema-store/src/schema/document_schema.rs
@@ -374,10 +374,7 @@ mod tests {
         let schema_value = tombi_json::ValueNode::from_str("true").expect("valid");
         let uri = tombi_uri::SchemaUri::from_str("https://example.com/s.json").expect("valid uri");
         let doc = DocumentSchema::new(schema_value, uri);
-        assert!(matches!(
-            doc.value_schema.as_deref(),
-            Some(ValueSchema::Anything(_))
-        ));
+        std::assert_matches!(doc.value_schema.as_deref(), Some(ValueSchema::Anything(_)));
     }
 
     #[test]
@@ -385,10 +382,7 @@ mod tests {
         let schema_value = tombi_json::ValueNode::from_str("false").expect("valid");
         let uri = tombi_uri::SchemaUri::from_str("https://example.com/s.json").expect("valid uri");
         let doc = DocumentSchema::new(schema_value, uri);
-        assert!(matches!(
-            doc.value_schema.as_deref(),
-            Some(ValueSchema::Nothing(_))
-        ));
+        std::assert_matches!(doc.value_schema.as_deref(), Some(ValueSchema::Nothing(_)));
     }
 
     #[test]

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -996,7 +996,7 @@ mod test {
         assert!(result.is_ok());
         if let Ok(Some(schema)) = result {
             // The schema should be resolved correctly
-            assert!(matches!(schema, ValueSchema::String(_)));
+            std::assert_matches!(schema, ValueSchema::String(_));
         }
 
         // Test case 2: Multiple percent-encoded characters
@@ -1015,7 +1015,7 @@ mod test {
         );
         assert!(result.is_ok());
         if let Ok(Some(schema)) = result {
-            assert!(matches!(schema, ValueSchema::String(_)));
+            std::assert_matches!(schema, ValueSchema::String(_));
         }
 
         // Test case 3: Invalid percent encoding should be preserved
@@ -1064,7 +1064,7 @@ mod test {
         );
         assert!(result.is_ok());
         if let Ok(Some(schema)) = result {
-            assert!(matches!(schema, ValueSchema::String(_)));
+            std::assert_matches!(schema, ValueSchema::String(_));
         }
 
         let result = resolve_json_pointer(
@@ -1075,7 +1075,7 @@ mod test {
         );
         assert!(result.is_ok());
         if let Ok(Some(schema)) = result {
-            assert!(matches!(schema, ValueSchema::String(_)));
+            std::assert_matches!(schema, ValueSchema::String(_));
         }
     }
 
@@ -1092,7 +1092,7 @@ mod test {
         };
 
         let value_type = referable.value_type().await;
-        assert!(matches!(value_type, crate::ValueType::AnyOf(types) if types.is_empty()));
+        std::assert_matches!(value_type, crate::ValueType::AnyOf(types) if types.is_empty());
     }
 
     #[tokio::test]
@@ -1130,13 +1130,13 @@ mod test {
             let defs = definitions.read().await;
             defs.get("#/$defs/useDynamic").cloned().unwrap()
         };
-        assert!(matches!(
+        std::assert_matches!(
             referable,
             Referable::Ref {
                 kind: super::ReferenceKind::DynamicRef,
                 ..
             }
-        ));
+        );
 
         let resolved = referable
             .resolve(
@@ -1147,10 +1147,10 @@ mod test {
             .await
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             resolved.map(|s| s.value_schema),
             Some(schema) if matches!(&*schema, ValueSchema::String(_))
-        ));
+        );
         let _ = std::fs::remove_file(schema_path);
     }
 
@@ -1189,13 +1189,13 @@ mod test {
             let defs = definitions.read().await;
             defs.get("#/$defs/useRecursive").cloned().unwrap()
         };
-        assert!(matches!(
+        std::assert_matches!(
             referable,
             Referable::Ref {
                 kind: super::ReferenceKind::RecursiveRef,
                 ..
             }
-        ));
+        );
 
         let resolved = referable
             .resolve(
@@ -1206,10 +1206,10 @@ mod test {
             .await
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             resolved.map(|s| s.value_schema),
             Some(schema) if matches!(&*schema, ValueSchema::String(_))
-        ));
+        );
         let _ = std::fs::remove_file(schema_path);
     }
 
@@ -1274,10 +1274,10 @@ mod test {
             .await
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             resolved.map(|s| s.value_schema),
             Some(schema) if matches!(&*schema, ValueSchema::String(_))
-        ));
+        );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
@@ -1288,7 +1288,7 @@ mod test {
         assert_eq!(local, Some((None, "#rootDyn".to_string())));
 
         let remote = parse_dynamic_anchor_reference("https://example.com/schema.json#rootDyn");
-        assert!(matches!(remote, Some((Some(_), anchor)) if anchor == "#rootDyn"));
+        std::assert_matches!(remote, Some((Some(_), anchor)) if anchor == "#rootDyn");
 
         assert!(parse_dynamic_anchor_reference("#/defs/x").is_none());
     }

--- a/crates/tombi-schema-store/src/schema/value_schema.rs
+++ b/crates/tombi-schema-store/src/schema/value_schema.rs
@@ -1228,7 +1228,7 @@ mod tests {
             r#"{ "const": "dynamic" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
 
         let Some(ValueSchema::String(s)) = schema else {
             panic!("schema is not a String schema");
@@ -1242,7 +1242,7 @@ mod tests {
             r#"{ "const": true }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Boolean(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Boolean(_)));
 
         let Some(ValueSchema::Boolean(b)) = schema else {
             panic!("schema is not a Boolean schema");
@@ -1256,7 +1256,7 @@ mod tests {
             r#"{ "const": 42 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Integer(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Integer(_)));
 
         let Some(ValueSchema::Integer(i)) = schema else {
             panic!("schema is not an Integer schema");
@@ -1271,7 +1271,7 @@ mod tests {
             r#"{ "const": 3.14 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
 
         if let Some(ValueSchema::Float(f)) = schema {
             assert_eq!(f.const_value, Some(3.14));
@@ -1284,7 +1284,7 @@ mod tests {
             r#"{ "const": null }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Null)));
+        std::assert_matches!(schema, Some(ValueSchema::Null));
     }
 
     #[tokio::test]
@@ -1299,21 +1299,21 @@ mod tests {
             }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::AnyOf(_))));
+        std::assert_matches!(schema, Some(ValueSchema::AnyOf(_)));
 
         let Some(ValueSchema::AnyOf(any_of)) = schema else {
             panic!("schema is not an AnyOf schema");
         };
 
         let schemas = any_of.schemas.read().await;
-        assert!(matches!(
+        std::assert_matches!(
             schemas.first().unwrap().value_type().await,
             ValueType::Integer
-        ));
-        assert!(matches!(
+        );
+        std::assert_matches!(
             schemas.get(1).unwrap().value_type().await,
             ValueType::String
-        ));
+        );
     }
 
     #[tokio::test]
@@ -1367,7 +1367,7 @@ mod tests {
             r#"{ "const": [1, 2, 3] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1376,7 +1376,7 @@ mod tests {
             r#"{ "const": [] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1385,7 +1385,7 @@ mod tests {
             r#"{ "const": {"key": "value"} }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1394,7 +1394,7 @@ mod tests {
             r#"{ "const": {} }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1403,7 +1403,7 @@ mod tests {
             r#"{ "const": [[1, 2], [3, 4]] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1435,7 +1435,7 @@ mod tests {
             r#"{ "contentMediaType": "application/json" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
     }
 
     #[test]
@@ -1444,7 +1444,7 @@ mod tests {
             r#"{ "const": {"nested": {"key": "value"}} }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     fn parse_schema_with_formats(json: &str, formats: &[StringFormat]) -> Option<ValueSchema> {
@@ -1468,7 +1468,7 @@ mod tests {
             Some(crate::JsonSchemaDialect::Draft07),
         );
         // Should create LocalDateSchema, not StringSchema
-        assert!(matches!(schema, Some(ValueSchema::LocalDate(_))));
+        std::assert_matches!(schema, Some(ValueSchema::LocalDate(_)));
     }
 
     #[test]
@@ -1477,7 +1477,7 @@ mod tests {
             r#"{ "const": "2024-01-10T12:00:00Z", "format": "date-time" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::OffsetDateTime(_))));
+        std::assert_matches!(schema, Some(ValueSchema::OffsetDateTime(_)));
     }
 
     #[test]
@@ -1487,7 +1487,7 @@ mod tests {
             r#"{ "const": "test@example.com", "format": "email" }"#,
             &[StringFormat::Email],
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
 
         if let Some(ValueSchema::String(s)) = schema {
             assert_eq!(s.format, Some(StringFormat::Email));
@@ -1501,7 +1501,7 @@ mod tests {
             r#"{ "enum": [1, 2, 3] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Integer(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Integer(_)));
     }
 
     #[test]
@@ -1511,7 +1511,7 @@ mod tests {
             r#"{ "enum": [1.5, 2.5, 3.5] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1525,7 +1525,7 @@ mod tests {
             Some(crate::JsonSchemaDialect::Draft07),
         );
         // After removing integer, only number remains, so FloatSchema should be created
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[tokio::test]
@@ -1542,14 +1542,14 @@ mod tests {
             panic!("schema is not a OneOf schema");
         };
         let schemars = one_of.schemas.read().await;
-        assert!(matches!(
+        std::assert_matches!(
             schemars.first().unwrap().value_type().await,
             ValueType::Float
-        ));
-        assert!(matches!(
+        );
+        std::assert_matches!(
             schemars.get(1).unwrap().value_type().await,
             ValueType::String
-        ));
+        );
     }
 
     // --- Tests for type inference from type-specific keywords ---
@@ -1560,7 +1560,7 @@ mod tests {
             r#"{ "minLength": 1 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
     }
 
     #[test]
@@ -1569,7 +1569,7 @@ mod tests {
             r#"{ "maxLength": 100 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
     }
 
     #[test]
@@ -1578,7 +1578,7 @@ mod tests {
             r#"{ "pattern": "^[a-z]+$" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
     }
 
     #[test]
@@ -1587,7 +1587,7 @@ mod tests {
             r#"{ "format": "date" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::LocalDate(_))));
+        std::assert_matches!(schema, Some(ValueSchema::LocalDate(_)));
     }
 
     #[test]
@@ -1596,7 +1596,7 @@ mod tests {
             r#"{ "format": "date-time" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::OffsetDateTime(_))));
+        std::assert_matches!(schema, Some(ValueSchema::OffsetDateTime(_)));
     }
 
     #[test]
@@ -1605,7 +1605,7 @@ mod tests {
             r#"{ "minimum": 0 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1614,7 +1614,7 @@ mod tests {
             r#"{ "maximum": 100 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1623,7 +1623,7 @@ mod tests {
             r#"{ "exclusiveMinimum": 0 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1632,7 +1632,7 @@ mod tests {
             r#"{ "exclusiveMaximum": 100 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1641,7 +1641,7 @@ mod tests {
             r#"{ "multipleOf": 5 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
     }
 
     #[test]
@@ -1650,7 +1650,7 @@ mod tests {
             r#"{ "items": { "type": "string" } }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1659,7 +1659,7 @@ mod tests {
             r#"{ "minItems": 1 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1668,7 +1668,7 @@ mod tests {
             r#"{ "maxItems": 10 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1677,7 +1677,7 @@ mod tests {
             r#"{ "uniqueItems": true }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Array(_)));
     }
 
     #[test]
@@ -1686,7 +1686,7 @@ mod tests {
             r#"{ "prefixItems": [ { "type": "string" } ] }"#,
             Some(crate::JsonSchemaDialect::Draft2020_12),
         );
-        assert!(matches!(schema_2020, Some(ValueSchema::Array(_))));
+        std::assert_matches!(schema_2020, Some(ValueSchema::Array(_)));
 
         let schema_07 = parse_schema_with_dialect(
             r#"{ "prefixItems": [ { "type": "string" } ] }"#,
@@ -1701,7 +1701,7 @@ mod tests {
             r#"{ "properties": { "name": { "type": "string" } } }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1710,7 +1710,7 @@ mod tests {
             r#"{ "required": ["name"] }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1719,7 +1719,7 @@ mod tests {
             r#"{ "additionalProperties": false }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1728,7 +1728,7 @@ mod tests {
             r#"{ "minProperties": 1 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1737,7 +1737,7 @@ mod tests {
             r#"{ "maxProperties": 10 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1746,7 +1746,7 @@ mod tests {
             r#"{ "propertyNames": { "pattern": "^[a-z]+$" } }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Table(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
     }
 
     #[test]
@@ -1755,7 +1755,7 @@ mod tests {
             r#"{ "minLength": 1, "maxLength": 50, "title": "Name", "description": "A name" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::String(_))));
+        std::assert_matches!(schema, Some(ValueSchema::String(_)));
         if let Some(ValueSchema::String(s)) = schema {
             assert_eq!(s.min_length, Some(1));
             assert_eq!(s.max_length, Some(50));
@@ -1770,7 +1770,7 @@ mod tests {
             r#"{ "minimum": 0, "maximum": 100 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Float(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Float(_)));
         if let Some(ValueSchema::Float(f)) = schema {
             assert_eq!(f.minimum, Some(0.0));
             assert_eq!(f.maximum, Some(100.0));
@@ -1785,7 +1785,7 @@ mod tests {
             r#"{ "title": "Something", "description": "A thing" }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Anything(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Anything(_)));
     }
 
     #[test]
@@ -1798,7 +1798,7 @@ mod tests {
             }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Anything(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Anything(_)));
     }
 
     #[test]
@@ -1826,6 +1826,6 @@ mod tests {
             r#"{ "type": "integer", "minimum": 0 }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        assert!(matches!(schema, Some(ValueSchema::Integer(_))));
+        std::assert_matches!(schema, Some(ValueSchema::Integer(_)));
     }
 }

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -1435,10 +1435,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             document_schema.value_schema.as_deref(),
             Some(ValueSchema::Anything(_))
-        ));
+        );
 
         let _ = std::fs::remove_file(schema_path);
     }
@@ -1480,10 +1480,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             document_schema.value_schema.as_deref(),
             Some(ValueSchema::String(_))
-        ));
+        );
 
         let _ = std::fs::remove_file(schema_path);
     }
@@ -1509,10 +1509,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             document_schema.value_schema.as_deref(),
             Some(ValueSchema::String(_))
-        ));
+        );
 
         std::fs::write(&schema_path, r#"{"type":"integer"}"#).unwrap();
         bump_modified(&schema_path);
@@ -1523,10 +1523,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert!(matches!(
+        std::assert_matches!(
             document_schema.value_schema.as_deref(),
             Some(ValueSchema::Integer(_))
-        ));
+        );
 
         let _ = std::fs::remove_file(schema_path);
     }

--- a/extensions/tombi-extension-cargo/src/lib.rs
+++ b/extensions/tombi-extension-cargo/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) use workspace::{
     workspace_dependency_usage_locations,
 };
 
+#[derive(Debug)]
 pub(crate) enum CargoNavigationFeature {
     Dependency,
     Member,
@@ -91,7 +92,7 @@ mod tests {
     fn classify_workspace_members_as_member_feature() {
         let feature = classify_cargo_navigation_feature(&[key("workspace"), key("members")]);
 
-        assert!(matches!(feature, CargoNavigationFeature::Member));
+        std::assert_matches!(feature, CargoNavigationFeature::Member);
     }
 
     #[test]
@@ -99,6 +100,6 @@ mod tests {
         let feature =
             classify_cargo_navigation_feature(&[key("workspace"), key("dependencies"), key("foo")]);
 
-        assert!(matches!(feature, CargoNavigationFeature::Dependency));
+        std::assert_matches!(feature, CargoNavigationFeature::Dependency);
     }
 }

--- a/extensions/tombi-extension-pyproject/src/hover.rs
+++ b/extensions/tombi-extension-pyproject/src/hover.rs
@@ -263,9 +263,6 @@ mod tests {
             Requirement::<VerbatimUrl>::from_str("demo @ https://example.com/demo-0.1.0.tar.gz")
                 .unwrap();
 
-        assert!(matches!(
-            requirement.version_or_url,
-            Some(VersionOrUrl::Url(_))
-        ));
+        std::assert_matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_)));
     }
 }


### PR DESCRIPTION
## Summary
- replace test `assert!(matches!(...))` calls with `std::assert_matches!(...)`
- derive `Debug` for `CargoNavigationFeature` so `std::assert_matches!` can render assertion failures
- leave `debug_assert!(matches!(...))` sites unchanged

## Verification
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
