### PR TITLE
fix(lsp): complete literal keys in tables

### DIFF
--- a/crates/tombi-extension/src/completion/completion_edit.rs
+++ b/crates/tombi-extension/src/completion/completion_edit.rs
@@ -376,7 +376,7 @@ impl CompletionEdit {
                     new_text: "".to_string(),
                 }]),
             }),
-            Some(CompletionHint::Comma { .. }) => Some(Self {
+            Some(CompletionHint::Comma { .. }) | None => Some(Self {
                 text_edit: CompletionTextEdit::Edit(TextEdit {
                     new_text: format!("{key_name} = {value_label}"),
                     range: key_range,
@@ -384,7 +384,7 @@ impl CompletionEdit {
                 insert_text_format: None,
                 additional_text_edits: None,
             }),
-            Some(CompletionHint::InTableHeader) | None => None,
+            Some(CompletionHint::InTableHeader) => None,
         }
     }
 

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -277,6 +277,23 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn cargo_dependencies_serde_table_bare_key(
+                r#"
+                [dependencies.serde]
+                work█
+                "#,
+                Select("workspace = true"),
+                SchemaPath(cargo_schema_path()),
+            ) -> Ok(
+                r#"
+                [dependencies.serde]
+                workspace = true
+                "#
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn cargo_dependencies_serde_dot_optional(
                 r#"
                 [dependencies]


### PR DESCRIPTION
## Summary

- Generate `key = literal` completion edits when a schema literal key completion has no `CompletionHint`.
- Keep table-header completions disabled, while allowing normal table bodies such as `[dependencies.serde]`.
- Add a Cargo regression test for completing `workspace = true` inside `[dependencies.serde]`.

## Verification

- `cargo fmt --all`
- `cargo test -p tombi-lsp --test test_completion_edit cargo_dependencies_serde_table_bare_key -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
