### PR TITLE
fix(lsp): merge allOf table key completions

### DIFF
--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -740,6 +740,24 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                 ));
                             }
 
+                            // `allOf` schemas always apply alongside the direct
+                            // properties, so their key completions must be merged in
+                            // even when direct properties already produced candidates.
+                            if let Some(all_of_schema) = table_schema.all_of.as_deref() {
+                                let completion_items = super::all_of::find_all_of_completion_items(
+                                    self,
+                                    position,
+                                    keys,
+                                    accessors,
+                                    all_of_schema,
+                                    current_schema,
+                                    schema_context,
+                                    completion_hint,
+                                )
+                                .await;
+                                completion_contents.extend(completion_items);
+                            }
+
                             if completion_contents.is_empty() {
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref() {
                                     let completion_items =
@@ -775,26 +793,9 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                         return completion_items;
                                     }
                                 }
-                                if let Some(all_of_schema) = table_schema.all_of.as_deref() {
-                                    let completion_items =
-                                        super::all_of::find_all_of_completion_items(
-                                            self,
-                                            position,
-                                            keys,
-                                            accessors,
-                                            all_of_schema,
-                                            current_schema,
-                                            schema_context,
-                                            completion_hint,
-                                        )
-                                        .await;
-                                    if !completion_items.is_empty() {
-                                        return completion_items;
-                                    }
-                                }
                             }
                         }
-                        completion_contents
+                        crate::completion::dedup_completion_contents(completion_contents)
                     }
                     ValueSchema::OneOf(one_of_schema) => {
                         find_one_of_completion_items(

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -743,6 +743,13 @@ impl FindCompletionContents for tombi_document_tree::Table {
                             // `allOf` schemas always apply alongside the direct
                             // properties, so their key completions must be merged in
                             // even when direct properties already produced candidates.
+                            //
+                            // `oneOf`/`anyOf` are intentionally NOT merged here: their
+                            // branches are alternatives, and a key that is `required` in
+                            // only one branch would otherwise be promoted to a global
+                            // `required` key (mis-ordering it ahead of unconditionally
+                            // required keys, e.g. pyproject's `version`/`dynamic` vs
+                            // `name`). They are evaluated as a fallback only.
                             if let Some(all_of_schema) = table_schema.all_of.as_deref() {
                                 let completion_items = super::all_of::find_all_of_completion_items(
                                     self,

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -1094,6 +1094,17 @@ mod completion_labels {
                 SchemaPath(adjacent_applicators_test_schema_path()),
             ) -> Ok(["true"]);
         }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_all_of_table_merges_properties_and_all_of_keys(
+                r#"
+                [object_all]
+                █
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok(["bar", "baz", "foo"]);
+        }
     }
 
     mod consistency_schema {

--- a/schemas/adjacent-applicators-test.schema.json
+++ b/schemas/adjacent-applicators-test.schema.json
@@ -115,7 +115,8 @@
         {
           "required": ["bar"],
           "properties": {
-            "bar": { "type": "string" }
+            "bar": { "type": "string" },
+            "baz": { "type": "boolean" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

- merge adjacent `allOf` table key completions with direct property completions
- deduplicate merged completion contents before returning them
- add a completion-label regression for table keys from both `properties` and `allOf`

## Tests

- `cargo fmt --all --check`
- `cargo test -p tombi-lsp --test test_completion_labels adjacent_all_of_table_merges_properties_and_all_of_keys -- --nocapture`
- `cargo check -p tombi-lsp --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
