### PR TITLE
fix(vscode): color TOML dates as constants

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -171,16 +171,16 @@
             "constant.language.boolean.toml"
           ],
           "offsetDateTime": [
-            "constant.regexp.datetime.offset.toml"
+            "constant.other.datetime.offset.toml"
           ],
           "localDateTime": [
-            "constant.regexp.datetime.local.toml"
+            "constant.other.datetime.local.toml"
           ],
           "localDate": [
-            "constant.regexp.date.local.toml"
+            "constant.other.date.local.toml"
           ],
           "localTime": [
-            "constant.regexp.time.local.toml"
+            "constant.other.time.local.toml"
           ],
           "comment": [
             "comment.line.number-sign.toml"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -171,16 +171,16 @@
             "constant.language.boolean.toml"
           ],
           "offsetDateTime": [
-            "constant.other.datetime.offset.toml"
+            "constant.regexp.datetime.offset.toml"
           ],
           "localDateTime": [
-            "constant.other.datetime.local.toml"
+            "constant.regexp.datetime.local.toml"
           ],
           "localDate": [
-            "constant.other.date.local.toml"
+            "constant.regexp.date.local.toml"
           ],
           "localTime": [
-            "constant.other.time.local.toml"
+            "constant.regexp.time.local.toml"
           ],
           "comment": [
             "comment.line.number-sign.toml"

--- a/editors/vscode/syntaxes/toml.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.tmLanguage.json
@@ -265,19 +265,19 @@
           "end": "'"
         },
         {
-          "name": "constant.regexp.datetime.offset.toml",
+          "name": "constant.regexp constant.other.datetime.offset.toml",
           "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
         },
         {
-          "name": "constant.regexp.datetime.local.toml",
+          "name": "constant.regexp constant.other.datetime.local.toml",
           "match": "(\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)"
         },
         {
-          "name": "constant.regexp.date.local.toml",
+          "name": "constant.regexp constant.other.date.local.toml",
           "match": "\\d{4}\\-\\d{2}\\-\\d{2}"
         },
         {
-          "name": "constant.regexp.time.local.toml",
+          "name": "constant.regexp constant.other.time.local.toml",
           "match": "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
         },
         {

--- a/editors/vscode/syntaxes/toml.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.tmLanguage.json
@@ -265,19 +265,19 @@
           "end": "'"
         },
         {
-          "name": "constant.other.datetime.offset.toml",
+          "name": "constant.regexp.datetime.offset.toml",
           "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
         },
         {
-          "name": "constant.other.datetime.local.toml",
+          "name": "constant.regexp.datetime.local.toml",
           "match": "(\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)"
         },
         {
-          "name": "constant.other.date.local.toml",
+          "name": "constant.regexp.date.local.toml",
           "match": "\\d{4}\\-\\d{2}\\-\\d{2}"
         },
         {
-          "name": "constant.other.time.local.toml",
+          "name": "constant.regexp.time.local.toml",
           "match": "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
         },
         {

--- a/editors/vscode/syntaxes/toml.tmLanguage.json
+++ b/editors/vscode/syntaxes/toml.tmLanguage.json
@@ -265,19 +265,19 @@
           "end": "'"
         },
         {
-          "name": "string.regexp constant.other.datetime.offset.toml",
+          "name": "constant.other.datetime.offset.toml",
           "match": "(?<!\\w)(\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[\\+\\-]\\d{2}:\\d{2}))(?!\\w)"
         },
         {
-          "name": "string.regexp constant.other.datetime.local.toml",
+          "name": "constant.other.datetime.local.toml",
           "match": "(\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)"
         },
         {
-          "name": "string.regexp constant.other.date.local.toml",
+          "name": "constant.other.date.local.toml",
           "match": "\\d{4}\\-\\d{2}\\-\\d{2}"
         },
         {
-          "name": "string.regexp constant.other.time.local.toml",
+          "name": "constant.other.time.local.toml",
           "match": "\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?"
         },
         {


### PR DESCRIPTION
## Summary

- update TOML date/time TextMate scopes in the VS Code syntax grammar
- stop tagging date/time literals as `string.regexp` so themes can color them as constants

## Verification

- `jq empty editors/vscode/syntaxes/toml.tmLanguage.json`
- `git diff --check`
- `pnpm -C editors/vscode run build`
- `pnpm -C editors/vscode run format:check`
- `pnpm -C editors/vscode run lint:check`
- `pnpm -C editors/vscode run typecheck`
- `pnpm -C editors/vscode run test`

## Release surface

- affects the VS Code extension syntax grammar
- `editors/vscode/**` is included in `ci_vscode_extensions.yml` and `release_cli_vscode.yml` relevant-change paths
