### PR TITLE
Fix Windows release CRT linkage

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -25,7 +25,7 @@ env:
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
   CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
   CARGO_PROFILE_RELEASE_LTO: "fat"
-  RUSTFLAGS: "-C strip=symbols"
+  CARGO_PROFILE_RELEASE_STRIP: "symbols"
 
 jobs:
   detect-changes:

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -16,7 +16,7 @@ env:
   CC_arm_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-  RUSTFLAGS: "-C strip=symbols"
+  CARGO_PROFILE_RELEASE_STRIP: "symbols"
   GITHUB_REF: ${{ (github.ref) }}
 
 jobs:


### PR DESCRIPTION
## Summary
- replace release workflow `RUSTFLAGS=-C strip=symbols` with `CARGO_PROFILE_RELEASE_STRIP=symbols`
- preserve the Windows MSVC `+crt-static` rustflags from `.cargo/config.toml`
- apply the same fix to the npm release workflow so Windows binaries are built consistently

## Context
The winget validation for tombi 1.1.5 failed with `STATUS_DLL_NOT_FOUND`. The published Windows CLI binary imports `VCRUNTIME140.dll` and UCRT DLLs even though the repository config intends static CRT linkage for MSVC targets.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release_cli_vscode.yml .github/workflows/release_npm.yml`
- `git diff --check`
- confirmed no workflow-level `RUSTFLAGS` remain and `.cargo/config.toml` still provides `+crt-static`
