### PR TITLE
ci: use shared release environment

### DIFF
--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -152,6 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: tombi-release
     permissions:

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -152,6 +152,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    environment:
+      name: tombi-release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -240,7 +240,7 @@ jobs:
     needs: [linux, musllinux, windows, macos, sdist]
     if: startsWith(github.ref, 'refs/tags/')
     environment:
-      name: pypi
+      name: tombi-release
       url: https://pypi.org/p/tombi
     permissions:
       # Use to authenticate to PyPI and sign the release artifacts


### PR DESCRIPTION
## Summary
- add the shared `tombi-release` environment gate to npm publishing
- switch the PyPI publishing environment from `pypi` to `tombi-release`

## Verification
- `ruby -e 'require "yaml"; %w[.github/workflows/release_npm.yml .github/workflows/release_pypi.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `git diff --check`\n\n## Notes\n- The GitHub environment and npm/PyPI trusted publisher settings must be updated to use `tombi-release` before the next release publish.