### PR TITLE
Deprecate legacy document-link feature toggles

### DIFF
--- a/crates/tombi-config/src/extensions/cargo/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/cargo/lsp/document_link.rs
@@ -27,9 +27,10 @@ toggle_features! {
         ))
     )]
     pub struct CargoDocumentLinkFeatureTree {
-        /// # Cargo.toml document link feature
+        /// # Deprecated Cargo.toml document link feature
         ///
-        /// Whether document links are created for `Cargo.toml` references.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub cargo_toml: Option<ToggleFeatureDefaultFalse>,
 
         /// # crates.io document link feature
@@ -37,19 +38,22 @@ toggle_features! {
         /// Whether document links are created for crates.io package references.
         pub crates_io: Option<ToggleFeatureDefaultTrue>,
 
-        /// # Git document link feature
+        /// # Deprecated Git document link feature
         ///
-        /// Whether document links are created for Git references.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub git: Option<ToggleFeatureDefaultFalse>,
 
-        /// # Path document link feature
+        /// # Deprecated path document link feature
         ///
-        /// Whether document links are created for filesystem paths.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub path: Option<ToggleFeatureDefaultFalse>,
 
-        /// # Workspace document link feature
+        /// # Deprecated workspace document link feature
         ///
-        /// Whether document links are created for `workspace = true` references.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub workspace: Option<ToggleFeatureDefaultFalse>,
     }
 }

--- a/crates/tombi-config/src/extensions/pyproject/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/pyproject/lsp/document_link.rs
@@ -27,9 +27,10 @@ toggle_features! {
         ))
     )]
     pub struct PyprojectDocumentLinkFeatureTree {
-        /// # pyproject.toml document link feature
+        /// # Deprecated pyproject.toml document link feature
         ///
-        /// Whether document links are created for `pyproject.toml` references.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub pyproject_toml: Option<ToggleFeatureDefaultFalse>,
 
         /// # PyPI document link feature

--- a/crates/tombi-config/src/extensions/tombi/lsp/document_link.rs
+++ b/crates/tombi-config/src/extensions/tombi/lsp/document_link.rs
@@ -24,9 +24,10 @@ toggle_features! {
         ))
     )]
     pub struct TombiDocumentLinkFeatureTree {
-        /// # Path document link feature
+        /// # Deprecated path document link feature
         ///
-        /// Whether document links are created for filesystem paths.
+        /// Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.
+        #[cfg_attr(feature = "jsonschema", schemars(extend("deprecated" = true)))]
         pub path: Option<ToggleFeatureDefaultFalse>,
     }
 }

--- a/crates/tombi-linter/tests/integration/tombi_schema.rs
+++ b/crates/tombi-linter/tests/integration/tombi_schema.rs
@@ -174,7 +174,7 @@ test_lint! {
     fn test_tombi_schema_extensions_lsp_feature_tree(
         r#"
         [extensions]
-        "tombi-toml/tombi" = { lsp.document-link.path.enabled = false, lsp.hover.enabled = false }
+        "tombi-toml/tombi" = { lsp.hover.enabled = false }
         "tombi-toml/cargo" = { lsp.hover.default-features.enabled = false, lsp.hover.feature-dependencies.enabled = false, lsp.hover.dependency-detail.enabled = false }
         "tombi-toml/pyproject" = { lsp.hover.dependency-detail.enabled = false }
         "#,

--- a/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-all-enabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-all-enabled/tombi.toml
@@ -1,0 +1,2 @@
+[extensions]
+"tombi-toml/tombi" = { lsp.document-link.path.enabled = true }

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -8,6 +8,12 @@ fn cargo_document_link_all_enabled_config_path() -> std::path::PathBuf {
     )
 }
 
+fn tombi_document_link_all_enabled_config_path() -> std::path::PathBuf {
+    project_root_path().join(
+        "crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-all-enabled/tombi.toml",
+    )
+}
+
 mod document_link_tests {
     use super::*;
 
@@ -860,6 +866,7 @@ mod document_link_tests {
                 catalog = { path = "https://www.schemastore.org/api/json/catalog.json" }
                 "#,
                 SourcePath(project_root_path().join("tombi.toml")),
+                ConfigPath(tombi_document_link_all_enabled_config_path()),
             ) -> Ok(Some(vec![
                 {
                     url: "https://www.schemastore.org/api/json/catalog.json",
@@ -877,6 +884,7 @@ mod document_link_tests {
                 catalog = { paths = ["https://www.schemastore.org/api/json/catalog.json"] }
                 "#,
                 SourcePath(project_root_path().join("tombi.toml")),
+                ConfigPath(tombi_document_link_all_enabled_config_path()),
             ) -> Ok(Some(vec![
                 {
                     url: "https://www.schemastore.org/api/json/catalog.json",
@@ -894,6 +902,7 @@ mod document_link_tests {
                 catalog = { paths = ["schemas/type-test.schema.json"] }
                 "#,
                 SourcePath(project_root_path().join("tombi.toml")),
+                ConfigPath(tombi_document_link_all_enabled_config_path()),
             ) -> Ok(Some(vec![
                 {
                     path: project_root_path().join("schemas/type-test.schema.json"),
@@ -941,6 +950,7 @@ mod document_link_tests {
                 path = "www.schemastore.org/tombi.json"
                 "#,
                 SourcePath(project_root_path().join("tombi.toml")),
+                ConfigPath(tombi_document_link_all_enabled_config_path()),
             ) -> Ok(Some(vec![
                 {
                     path: project_root_path().join("www.schemastore.org/tombi.json"),
@@ -958,6 +968,7 @@ mod document_link_tests {
                 path = "https://www.schemastore.org/cargo-make.json"
                 "#,
                 SourcePath(project_root_path().join("tombi.toml")),
+                ConfigPath(tombi_document_link_all_enabled_config_path()),
             ) -> Ok(Some(vec![
                 {
                     url: "https://www.schemastore.org/cargo-make.json",

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -299,10 +299,7 @@ tables-out-of-order = "error"
       path.enabled = true,
     },
     document-link = {
-      cargo-toml.enabled = true,
       crates-io.enabled = true,
-      git.enabled = true,
-      path.enabled = true,
     },
     goto-declaration = {
       dependency.enabled = true,
@@ -338,7 +335,6 @@ tables-out-of-order = "error"
     },
     document-link = {
       pypi-org.enabled = true,
-      pyproject-toml.enabled = true,
     },
     goto-declaration = {
       dependency.enabled = true,
@@ -362,9 +358,6 @@ tables-out-of-order = "error"
 "tombi-toml/tombi" = {
   lsp = {
     completion = {
-      path.enabled = true,
-    },
-    document-link = {
       path.enabled = true,
     },
     goto-definition = {
@@ -1230,7 +1223,6 @@ If an extension or feature is omitted, it is enabled by default.
 [extensions]
 "tombi-toml/cargo" = { lsp.completion.path.enabled = false }
 "tombi-toml/pyproject" = { lsp.document-link.pypi-org.enabled = false }
-"tombi-toml/tombi" = { lsp.document-link.path.enabled = false }
 ```
 
 Available extension IDs:
@@ -1483,54 +1475,6 @@ See [Cargo Extension > Document Links](/docs/extensions/tombi-extension-cargo#do
 ### extensions."tombi-toml/cargo".lsp.document-link.enabled
 
 Enable or disable all Cargo document links.
-
-- Type: `Boolean`
-- Default: `true`
-
-### extensions."tombi-toml/cargo".lsp.document-link.cargo-toml
-
-Configure document links to `Cargo.toml` files.
-These links jump to member manifests or workspace manifests referenced from the current file.
-
-See [Cargo Extension > Document Links](/docs/extensions/tombi-extension-cargo#document-links).
-
-- Type: `Table`
-
-### extensions."tombi-toml/cargo".lsp.document-link.cargo-toml.enabled
-
-Enable or disable document links to `Cargo.toml` files.
-
-- Type: `Boolean`
-- Default: `true`
-
-### extensions."tombi-toml/cargo".lsp.document-link.git
-
-Configure document links to Git repositories referenced from Cargo manifests.
-These links open repository URLs referenced by Cargo dependency tables.
-
-See [Cargo Extension > Document Links](/docs/extensions/tombi-extension-cargo#document-links).
-
-- Type: `Table`
-
-### extensions."tombi-toml/cargo".lsp.document-link.git.enabled
-
-Enable or disable document links to Git repositories referenced from Cargo manifests.
-
-- Type: `Boolean`
-- Default: `true`
-
-### extensions."tombi-toml/cargo".lsp.document-link.path
-
-Configure document links to local paths referenced from Cargo manifests.
-These links open local files or directories referenced by Cargo manifest fields.
-
-See [Cargo Extension > Document Links](/docs/extensions/tombi-extension-cargo#document-links).
-
-- Type: `Table`
-
-### extensions."tombi-toml/cargo".lsp.document-link.path.enabled
-
-Enable or disable document links to local paths referenced from Cargo manifests.
 
 - Type: `Boolean`
 - Default: `true`
@@ -1999,22 +1943,6 @@ Enable or disable all `pyproject.toml` document links.
 - Type: `Boolean`
 - Default: `true`
 
-### extensions."tombi-toml/pyproject".lsp.document-link.pyproject-toml
-
-Configure document links to `pyproject.toml` files.
-These links open member manifests and workspace manifests discovered from uv metadata.
-
-See [Pyproject Extension > Document Links](/docs/extensions/tombi-extension-pyproject#document-links).
-
-- Type: `Table`
-
-### extensions."tombi-toml/pyproject".lsp.document-link.pyproject-toml.enabled
-
-Enable or disable document links to `pyproject.toml` files.
-
-- Type: `Boolean`
-- Default: `true`
-
 ### extensions."tombi-toml/pyproject".lsp.document-link.pypi-org
 
 Configure document links to PyPI pages referenced from `pyproject.toml`.
@@ -2243,20 +2171,6 @@ Configure Tombi configuration document links.
 ### extensions."tombi-toml/tombi".lsp.document-link.enabled
 
 Enable or disable all Tombi configuration document links.
-
-- Type: `Boolean`
-- Default: `true`
-
-### extensions."tombi-toml/tombi".lsp.document-link.path
-
-Configure document links to paths referenced from Tombi configuration files.
-This opens local paths referenced from `tombi.toml`.
-
-- Type: `Table`
-
-### extensions."tombi-toml/tombi".lsp.document-link.path.enabled
-
-Enable or disable document links to paths referenced from Tombi configuration files.
 
 - Type: `Boolean`
 - Default: `true`

--- a/tombi.toml
+++ b/tombi.toml
@@ -129,9 +129,6 @@ overrides = [
     completion = {
       path.enabled = true,
     },
-    document-link = {
-      path.enabled = true,
-    },
     goto-definition = {
       path.enabled = true,
     },

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -1942,8 +1942,8 @@
       "type": "object",
       "properties": {
         "cargo-toml": {
-          "title": "Cargo.toml document link feature",
-          "description": "Whether document links are created for `Cargo.toml` references.",
+          "title": "Deprecated Cargo.toml document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -1951,7 +1951,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         },
         "crates-io": {
           "title": "crates.io document link feature",
@@ -1966,8 +1967,8 @@
           ]
         },
         "git": {
-          "title": "Git document link feature",
-          "description": "Whether document links are created for Git references.",
+          "title": "Deprecated Git document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -1975,11 +1976,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         },
         "path": {
-          "title": "Path document link feature",
-          "description": "Whether document links are created for filesystem paths.",
+          "title": "Deprecated path document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -1987,11 +1989,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         },
         "workspace": {
-          "title": "Workspace document link feature",
-          "description": "Whether document links are created for `workspace = true` references.",
+          "title": "Deprecated workspace document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -1999,7 +2002,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         }
       },
       "additionalProperties": false,
@@ -2509,8 +2513,8 @@
       "type": "object",
       "properties": {
         "pyproject-toml": {
-          "title": "pyproject.toml document link feature",
-          "description": "Whether document links are created for `pyproject.toml` references.",
+          "title": "Deprecated pyproject.toml document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -2518,7 +2522,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         },
         "pypi-org": {
           "title": "PyPI document link feature",
@@ -2870,8 +2875,8 @@
       "type": "object",
       "properties": {
         "path": {
-          "title": "Path document link feature",
-          "description": "Whether document links are created for filesystem paths.",
+          "title": "Deprecated path document link feature",
+          "description": "Deprecated. This setting is accepted for backward compatibility and will be removed in a future release.",
           "anyOf": [
             {
               "$ref": "#/definitions/ToggleFeatureDefaultFalse"
@@ -2879,7 +2884,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "deprecated": true
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- mark legacy document-link feature toggles as deprecated in the config schema
- remove deprecated document-link toggle entries from the configuration docs and repo config
- add explicit LSP fixture coverage for deprecated Tombi document-link path behavior

## Verification
- cargo xtask codegen jsonschema
- cargo fmt --all
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked
- cargo shear
- pnpm -C docs lint:check
- git diff --check

Note: `pnpm -C docs build` was not completed locally because docs dependencies are not installed (`tsx: command not found`).