### PR TITLE
chore: bump biome $schema to match pinned CLI 2.3.8

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
     "includes": [


### PR DESCRIPTION
## What and why

The repo pins `@biomejs/biome` to **2.3.8** (`package.json` `^2.3.8`, resolved to `2.3.8` in `pnpm-lock.yaml`), but `biome.json` still declares the **2.2.4** `$schema`. Running the pinned CLI on a clean checkout surfaces the drift:

```
$ npx @biomejs/biome@2.3.8 check biome.json
biome.json:1:15 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  i The configuration schema version does not match the CLI version 2.3.8
  i   Expected:  2.3.8
      Found:     2.2.4
  i Run the command biome migrate to migrate the configuration file.
```

This is the exact notice `biome migrate` is designed to clear, and it shows up for anyone running `pnpm lint` / `pnpm format` locally.

## Changes

- Bump the `$schema` URL from `2.2.4` to `2.3.8` — **only** the schema line changes (`+1/-1`). This is exactly what `biome migrate` emits; no rules, formatting, or ignore semantics are touched.

## Validation

Generated with Biome's own migration (not hand-edited):

```
$ npx @biomejs/biome@2.3.8 migrate --write
  - biome.json: configuration successfully migrated.

# after:
$ npx @biomejs/biome@2.3.8 check biome.json   # schema-mismatch notice is gone
```
