### PR TITLE
ci: check Biome schema version

### DIFF
--- a/.github/workflows/ci_vscode_extensions.yml
+++ b/.github/workflows/ci_vscode_extensions.yml
@@ -57,7 +57,6 @@ jobs:
           node-version-file: '.node-version'
           cache: 'pnpm'
       - run: pnpm install
-        working-directory: ./editors/vscode
       - name: Check Biome schema version
         run: |
           node <<'NODE'

--- a/.github/workflows/ci_vscode_extensions.yml
+++ b/.github/workflows/ci_vscode_extensions.yml
@@ -56,7 +56,32 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
-      - run: pnpm install && pnpm run build
+      - run: pnpm install
+        working-directory: ./editors/vscode
+      - name: Check Biome schema version
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const config = JSON.parse(fs.readFileSync("biome.json", "utf8"));
+          const schema = config.$schema ?? "";
+          const match = schema.match(/^https:\/\/biomejs\.dev\/schemas\/([^/]+)\/schema\.json$/);
+          if (!match) {
+            console.error(`Invalid Biome schema URL: ${schema}`);
+            process.exit(1);
+          }
+
+          const biomePackage = JSON.parse(
+            fs.readFileSync("node_modules/@biomejs/biome/package.json", "utf8"),
+          );
+          if (match[1] !== biomePackage.version) {
+            console.error(
+              `Biome schema version mismatch: biome.json uses ${match[1]}, but @biomejs/biome is ${biomePackage.version}`,
+            );
+            process.exit(1);
+          }
+          NODE
+      - run: pnpm run build
         working-directory: ./editors/vscode
       - run: pnpm run format:check
         working-directory: ./editors/vscode


### PR DESCRIPTION
## Summary
- add a CI check that compares `biome.json` `$schema` with the installed `@biomejs/biome` package version
- split the VS Code extension workflow install/build step so the schema check runs immediately after install

## Tests
- inline Node.js schema check
- `pnpm -C editors/vscode run build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci_vscode_extensions.yml"); puts "yaml ok"'`\n- `git diff --check`