### PR TITLE
feat: include target in CLI version output

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -62,7 +62,17 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Resolve release artifact metadata
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
+          github_api_curl() {
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$@"
+          }
+
           requested_version="$(grep -E '^LATEST_STABLE_VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"$' ./docs/public/install.sh)"
           requested_version="${requested_version#LATEST_STABLE_VERSION=\"}"
           requested_version="${requested_version%\"}"
@@ -71,7 +81,7 @@ jobs:
             exit 1
           fi
 
-          latest_version="$(curl -fsSL https://api.github.com/repos/tombi-toml/tombi/releases/latest | jq -r '.tag_name | sub("^v"; "")')"
+          latest_version="$(github_api_curl https://api.github.com/repos/tombi-toml/tombi/releases/latest | jq -r '.tag_name | sub("^v"; "")')"
           if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
             echo "Failed to resolve the latest published release tag" >&2
             exit 1
@@ -127,7 +137,7 @@ jobs:
           esac
 
           asset_name="tombi-cli-${version}-${target}${extension}"
-          release_json="$(curl -fsSL "https://api.github.com/repos/tombi-toml/tombi/releases/tags/v${version}")"
+          release_json="$(github_api_curl "https://api.github.com/repos/tombi-toml/tombi/releases/tags/v${version}")"
           url="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .browser_download_url' | head -n 1)"
           checksum="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' | head -n 1)"
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -402,7 +402,10 @@ main() {
 	fi
 
 	if "${EXE_NAME}" --version >/dev/null 2>&1; then
-		INSTALLED_VERSION=$("${EXE_NAME}" --version 2>&1 | head -n 1 | sed -E 's/tombi //; s/^v//' || echo "unknown")
+		INSTALLED_VERSION=$("${EXE_NAME}" --version 2>&1 | head -n 1 | sed -nE 's/^tombi v?([0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?).*/\1/p')
+		if [ -z "$INSTALLED_VERSION" ]; then
+			INSTALLED_VERSION="unknown"
+		fi
 		if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
 			print_error "Installed version mismatch: expected ${VERSION}, but got ${INSTALLED_VERSION}"
 			exit 1

--- a/editors/vscode/src/lsp/server.test.ts
+++ b/editors/vscode/src/lsp/server.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseTombiVersionOutput } from "./server";
+
+describe("parseTombiVersionOutput", () => {
+  it("keeps the plain semver from legacy version output", () => {
+    expect(parseTombiVersionOutput("tombi 1.1.5\n")).toBe("1.1.5");
+  });
+
+  it("drops target information from version output before semver comparisons", () => {
+    expect(
+      parseTombiVersionOutput("tombi 1.1.5 (aarch64-apple-darwin)\n"),
+    ).toBe("1.1.5");
+  });
+
+  it("keeps prerelease suffixes such as the development version", () => {
+    expect(
+      parseTombiVersionOutput("tombi 0.0.0-dev (aarch64-apple-darwin)\n"),
+    ).toBe("0.0.0-dev");
+  });
+});

--- a/editors/vscode/src/lsp/server.ts
+++ b/editors/vscode/src/lsp/server.ts
@@ -20,10 +20,7 @@ export class Server {
           ]).stdout.setEncoding("utf-8"),
         );
 
-        const prefix = LANGUAGE_SERVER_NAME;
-        version = version
-          .slice(version.startsWith(prefix) ? prefix.length : 0)
-          .trim();
+        version = parseTombiVersionOutput(version);
       } catch {
         version = "<unknown>";
       }
@@ -35,4 +32,12 @@ export class Server {
 
     return this.version;
   }
+}
+
+export function parseTombiVersionOutput(output: string): string {
+  const version = output
+    .trim()
+    .match(/^tombi\s+v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)/)?.[1];
+
+  return version ?? output.trim();
 }

--- a/rust/tombi-cli/build.rs
+++ b/rust/tombi-cli/build.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 fn main() {
+    let target = std::env::var("TARGET").expect("TARGET should be set by Cargo");
     let re = tombi_regex::Regex::new(r"^v\d+\.\d+\.\d+$").unwrap();
 
     // Try to get version from git tag
@@ -23,5 +24,6 @@ fn main() {
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
 
     println!("cargo:rustc-env=__TOMBI_VERSION={git_version}");
+    println!("cargo:rustc-env=__TOMBI_TARGET_TRIPLE={target}");
     println!("cargo:rerun-if-changed=.git/HEAD");
 }

--- a/rust/tombi-cli/src/app.rs
+++ b/rust/tombi-cli/src/app.rs
@@ -10,7 +10,7 @@ use clap::{
 #[command(
     name="tombi",
     about = app_about(),
-    version = env!("__TOMBI_VERSION").trim_start_matches('v'),
+    version = app_version(),
     styles=app_styles(),
     disable_help_subcommand(true),
 )]
@@ -84,6 +84,14 @@ fn app_about() -> String {
 
     format!(
         "{title_style}                          {title} {title_style:#}{desc_style}: TOML Toolkit                          {desc_style:#}"
+    )
+}
+
+fn app_version() -> String {
+    format!(
+        "{} ({})",
+        env!("__TOMBI_VERSION").trim_start_matches('v'),
+        env!("__TOMBI_TARGET_TRIPLE"),
     )
 }
 


### PR DESCRIPTION
## Summary
- include the Cargo target triple in `tombi --version` output
- keep install.sh and VS Code extension semver parsing compatible with the new output
- add VS Code parser tests for legacy, target-suffixed, and dev version outputs

## Verification
- cargo fmt --all
- cargo check -p tombi-cli
- cargo run -p tombi-cli -- --version
- pnpm install
- pnpm --filter tombi test
- pnpm --filter tombi typecheck
- pnpm --filter tombi lint:check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked

## Cross-repo impact check
- checked tombi-toml/setup-tombi usage of `tombi --version`; setup-tombi only logs direct binary output and its CI uses substring matching
- checked tombi-toml/tombi-pre-commit; no `--version` output parsing found
- checked tombi-toml/toml-tools-benchmark; version verification remains substring based and accepts the target-suffixed output
