### PR TITLE
Fix anyOf hover enum leakage

### DIFF
--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -97,7 +97,7 @@ where
                     {
                         Ok(_) => true,
                         Err(tombi_validator::Error { diagnostics, .. }) => {
-                            diagnostics.iter().all(is_allowed_branch_diagnostic)
+                            diagnostics.iter().all(Diagnostic::is_warning)
                         }
                     };
 
@@ -176,10 +176,6 @@ where
         Some(HoverContent::Value(hover_value_content))
     }
     .boxed()
-}
-
-fn is_allowed_branch_diagnostic(diagnostic: &Diagnostic) -> bool {
-    diagnostic.is_warning() || matches!(diagnostic.code(), "enum" | "const")
 }
 
 impl GetHoverContent for tombi_schema_store::AnyOfSchema {

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -55,15 +55,6 @@ where
         .await?;
 
         for resolved_schema in &resolved_schemas {
-            if let Some(values) = resolved_schema
-                .value_schema
-                .as_ref()
-                .get_enum(schema_uri, definitions, schema_context)
-                .await
-            {
-                enum_values.extend(values);
-            }
-
             value_type_set.insert(resolved_schema.value_schema.value_type().await);
         }
 
@@ -100,17 +91,31 @@ where
                         hover_value_content.value_type = value_type.clone();
                     }
 
-                    match value
+                    let is_applicable_branch = match value
                         .validate(accessors, Some(resolved_schema), schema_context)
                         .await
                     {
-                        Ok(_) => valid_hover_value_contents.push(hover_value_content.clone()),
-                        Err(tombi_validator::Error { diagnostics, .. })
-                            if diagnostics.iter().all(Diagnostic::is_warning) =>
-                        {
-                            valid_hover_value_contents.push(hover_value_content.clone());
+                        Ok(_) => true,
+                        Err(tombi_validator::Error { diagnostics, .. }) => {
+                            diagnostics.iter().all(is_allowed_branch_diagnostic)
                         }
-                        _ => {}
+                    };
+
+                    if is_applicable_branch {
+                        valid_hover_value_contents.push(hover_value_content.clone());
+
+                        if let Some(values) = resolved_schema
+                            .value_schema
+                            .as_ref()
+                            .get_enum(
+                                &resolved_schema.schema_uri,
+                                &resolved_schema.definitions,
+                                schema_context,
+                            )
+                            .await
+                        {
+                            enum_values.extend(values);
+                        }
                     }
 
                     any_hover_value_contents.push(hover_value_content);
@@ -171,6 +176,10 @@ where
         Some(HoverContent::Value(hover_value_content))
     }
     .boxed()
+}
+
+fn is_allowed_branch_diagnostic(diagnostic: &Diagnostic) -> bool {
+    diagnostic.is_warning() || matches!(diagnostic.code(), "enum" | "const")
 }
 
 impl GetHoverContent for tombi_schema_store::AnyOfSchema {

--- a/crates/tombi-lsp/tests/fixtures/any-of-table-property-enum.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/any-of-table-property-enum.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "format": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FeatureToggle"
+        },
+        {
+          "$ref": "#/definitions/FormatOptions"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "FeatureToggle": {
+      "type": "string",
+      "enum": ["on", "off"]
+    },
+    "FormatOptions": {
+      "type": "object",
+      "properties": {
+        "indent-style": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IndentStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IndentStyle": {
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "space"
+        },
+        {
+          "type": "string",
+          "const": "tab"
+        }
+      ]
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -29,6 +29,11 @@ fn array_values_order_one_of_schema_path() -> PathBuf {
         .join("crates/tombi-lsp/tests/fixtures/array-values-order-one-of.schema.json")
 }
 
+fn any_of_table_property_enum_schema_path() -> PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("crates/tombi-lsp/tests/fixtures/any-of-table-property-enum.schema.json")
+}
+
 fn exact_index_hover_test_schema_path() -> PathBuf {
     tombi_test_lib::project_root_path().join("schemas/exact-index-hover-test.schema.json")
 }
@@ -909,6 +914,40 @@ mod hover_keys_value {
                 "Keys": "repos[0].hooks[0].id",
                 "Value": "String",
                 "Default": "\"builtin-hook\""
+            });
+        );
+    }
+
+    mod any_of_schema {
+        use super::*;
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_hover_uses_enum_from_matching_table_property_branch(
+                r#"
+                [format]
+                indent-style = "█space"
+                "#,
+                SchemaPath(any_of_table_property_enum_schema_path()),
+            ) -> Ok({
+                "Keys": "format.indent-style",
+                "Value": "String?",
+                "Enum": ["\"space\"", "\"tab\""]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_hover_keeps_matching_table_property_enum_while_editing_invalid_value(
+                r#"
+                [format]
+                indent-style = "█spac"
+                "#,
+                SchemaPath(any_of_table_property_enum_schema_path()),
+            ) -> Ok({
+                "Keys": "format.indent-style",
+                "Value": "String?",
+                "Enum": ["\"space\"", "\"tab\""]
             });
         );
     }


### PR DESCRIPTION
## Summary

- Scope `anyOf` hover enum collection to branches that validate for the current accessor/value.
- Prevent parent union enum values such as `"on"`/`"off"` from leaking into nested property hover content.
- Add a regression fixture for `format = FeatureToggle | FormatOptions` and `format.indent-style = "space"`.

## Tests

- `cargo fmt --all --check`
- `cargo test -p tombi-lsp --test test_hover`
- `cargo nextest run`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo nextest run --workspace --locked --no-fail-fast`
