### PR TITLE
ci: validate winget manifest before submission

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -1,0 +1,64 @@
+name: Generate winget manifest
+description: Generate the tombi winget manifest with wingetcreate, inject InstallationMetadata, and validate it.
+
+inputs:
+  release-tag:
+    description: GitHub release tag that hosts the installer assets (e.g. v1.2.3).
+    required: true
+  version:
+    description: Stable version number without the leading v (e.g. 1.2.3).
+    required: true
+  wingetcreate-path:
+    description: Path to a verified wingetcreate.exe (see the setup-wingetcreate action).
+    required: true
+  output-dir:
+    description: Directory the generated manifest is written into.
+    required: false
+    default: winget-manifests
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      env:
+        REF_NAME: ${{ inputs.release-tag }}
+        VERSION: ${{ inputs.version }}
+        WINGETCREATE_PATH: ${{ inputs.wingetcreate-path }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        $x64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+        $arm64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-aarch64-pc-windows-msvc.zip"
+
+        $manifestDir = Join-Path $PWD $env:OUTPUT_DIR
+        & $env:WINGETCREATE_PATH update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --out $manifestDir
+
+        $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
+        if (-not $installerManifest) {
+          throw "winget installer manifest was not generated."
+        }
+
+        # wingetcreate does not emit InstallationMetadata, so inject it manually.
+        # The -notmatch guard keeps this idempotent if a future version starts emitting it.
+        $content = Get-Content $installerManifest.FullName -Raw
+        if ($content -notmatch "(?m)^InstallationMetadata:") {
+          $installationMetadata = @(
+            "InstallationMetadata:"
+            "  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource'"
+            "  Files:"
+            "  - RelativeFilePath: tombi.exe"
+            "    FileType: launch"
+            "    InvocationParameter: --version"
+          ) -join "`r`n"
+          $content = $content -replace "(?m)^ManifestType:", "$installationMetadata`r`nManifestType:"
+          Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
+        }
+
+        if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
+          throw "winget installer manifest does not contain InvocationParameter: --version."
+        }
+
+        if (Get-Command winget -ErrorAction SilentlyContinue) {
+          winget validate --manifest $manifestDir
+        } else {
+          Write-Warning "winget command is not available; skipped local winget validate."
+        }

--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -57,8 +57,7 @@ runs:
           throw "winget installer manifest does not contain InvocationParameter: --version."
         }
 
-        if (Get-Command winget -ErrorAction SilentlyContinue) {
-          winget validate --manifest $manifestDir
-        } else {
-          Write-Warning "winget command is not available; skipped local winget validate."
+        if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+          throw "winget command is not available; cannot validate manifest."
         }
+        winget validate --manifest $manifestDir

--- a/.github/actions/setup-wingetcreate/action.yml
+++ b/.github/actions/setup-wingetcreate/action.yml
@@ -1,0 +1,36 @@
+name: Setup wingetcreate
+description: Download wingetcreate.exe and verify it against its published SHA256 checksum.
+
+inputs:
+  version:
+    description: wingetcreate release version without the leading v.
+    required: false
+    default: 1.12.8.0
+
+outputs:
+  path:
+    description: Absolute path to the verified wingetcreate.exe.
+    value: ${{ steps.download.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - id: download
+      shell: pwsh
+      env:
+        WINGETCREATE_VERSION: ${{ inputs.version }}
+      run: |
+        $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+        $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
+        $wingetCreatePath = Join-Path $PWD "wingetcreate.exe"
+
+        Invoke-WebRequest $wingetCreateUrl -OutFile $wingetCreatePath
+        Invoke-WebRequest $wingetCreateChecksumUrl -OutFile "$wingetCreatePath.sha256.txt"
+
+        $expectedHash = (Get-Content "$wingetCreatePath.sha256.txt" -Raw).Trim().ToUpperInvariant()
+        $actualHash = (Get-FileHash $wingetCreatePath -Algorithm SHA256).Hash.ToUpperInvariant()
+        if ($actualHash -ne $expectedHash) {
+          throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
+        }
+
+        "path=$wingetCreatePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -539,6 +539,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+    outputs:
+      stable_version: ${{ steps.stable-version.outputs.stable_version }}
     steps:
       - name: Detect stable release tag
         id: stable-version
@@ -617,7 +619,7 @@ jobs:
 
   publish-winget:
     needs: [validate-winget-release-manifest]
-    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
+    if: needs.validate-winget-release-manifest.outputs.stable_version != ''
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -204,10 +204,10 @@ jobs:
           set -e
           if gh release view "${{ github.ref_name }}" --json body -q ".body" | grep -q .; then
             echo "Release notes exist for tag ${{ github.ref_name }}"
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "No release notes found for tag ${{ github.ref_name }}"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
   release-notes:
@@ -240,7 +240,7 @@ jobs:
         id: find_cli_assets
         shell: bash
         run: |
-          echo "ASSETS=$(find tombi-cli-artifacts tombi-vscode-artifacts -type f | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "ASSETS=$(find tombi-cli-artifacts tombi-vscode-artifacts -type f | tr '\n' ' ')" >> "$GITHUB_ENV"
 
       - name: Check ASSETS
         run: |
@@ -441,7 +441,99 @@ jobs:
           repository: setup-tombi
           tag: ${{ steps.stable-version.outputs.stable_tag }}
 
-  publish-winget:
+  validate-winget-manifest:
+    if: "!startsWith(github.ref, 'refs/tags/v')"
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve winget validation release
+        id: winget-release
+        shell: pwsh
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
+            "release_tag=$env:REF_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            $headers = @{
+              "Accept" = "application/vnd.github+json"
+              "Authorization" = "Bearer $env:GITHUB_TOKEN"
+              "X-GitHub-Api-Version" = "2022-11-28"
+            }
+            $latestRelease = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/tombi-toml/tombi/releases/latest"
+            if ($latestRelease.tag_name -notmatch '^v(\d+\.\d+\.\d+)$') {
+              throw "Latest release tag is not a stable version: $($latestRelease.tag_name)"
+            }
+
+            Write-Host "Using latest stable release $($latestRelease.tag_name) for winget dry-run validation."
+            "release_tag=$($latestRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Generate and validate winget manifest
+        shell: pwsh
+        env:
+          REF_NAME: ${{ steps.winget-release.outputs.release_tag }}
+          VERSION: ${{ steps.winget-release.outputs.stable_version }}
+          WINGETCREATE_VERSION: 1.12.8.0
+        run: |
+          $x64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
+          $arm64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-aarch64-pc-windows-msvc.zip"
+          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
+
+          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
+          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
+
+          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
+          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
+          }
+
+          $manifestDir = Join-Path $PWD "winget-manifests"
+          .\wingetcreate.exe update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --out $manifestDir
+
+          $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
+          if (-not $installerManifest) {
+            throw "winget installer manifest was not generated."
+          }
+
+          $content = Get-Content $installerManifest.FullName -Raw
+          if ($content -notmatch "(?m)^InstallationMetadata:") {
+            $installationMetadata = @(
+              "InstallationMetadata:"
+              "  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource'"
+              "  Files:"
+              "  - RelativeFilePath: tombi.exe"
+              "    FileType: launch"
+              "    InvocationParameter: --version"
+            ) -join "`r`n"
+            $content = $content -replace "(?m)^ManifestType:", "$installationMetadata`r`nManifestType:"
+            Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
+          }
+
+          $content = Get-Content $installerManifest.FullName -Raw
+          if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
+            throw "winget installer manifest does not contain InvocationParameter: --version."
+          }
+
+          if (Get-Command winget -ErrorAction SilentlyContinue) {
+            winget validate --manifest $manifestDir
+          } else {
+            Write-Warning "winget command is not available; skipped local winget validate."
+          }
+
+      - name: Upload winget manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: winget-manifests
+          path: winget-manifests
+
+  validate-winget-release-manifest:
     needs: [release-notes]
     if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
     runs-on: windows-latest
@@ -461,20 +553,14 @@ jobs:
             "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
-      - name: Submit winget manifest update
+      - name: Generate and validate winget manifest
         if: steps.stable-version.outputs.stable_version != ''
         shell: pwsh
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
           VERSION: ${{ steps.stable-version.outputs.stable_version }}
           WINGETCREATE_VERSION: 1.12.8.0
         run: |
-          if (-not $env:WINGET_TOKEN) {
-            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
-            exit 0
-          }
-
           $x64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
           $arm64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-aarch64-pc-windows-msvc.zip"
           $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
@@ -489,4 +575,81 @@ jobs:
             throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
           }
 
-          .\wingetcreate.exe update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION -t $env:WINGET_TOKEN --submit
+          $manifestDir = Join-Path $PWD "winget-manifests"
+          .\wingetcreate.exe update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --out $manifestDir
+
+          $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
+          if (-not $installerManifest) {
+            throw "winget installer manifest was not generated."
+          }
+
+          $content = Get-Content $installerManifest.FullName -Raw
+          if ($content -notmatch "(?m)^InstallationMetadata:") {
+            $installationMetadata = @(
+              "InstallationMetadata:"
+              "  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource'"
+              "  Files:"
+              "  - RelativeFilePath: tombi.exe"
+              "    FileType: launch"
+              "    InvocationParameter: --version"
+            ) -join "`r`n"
+            $content = $content -replace "(?m)^ManifestType:", "$installationMetadata`r`nManifestType:"
+            Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
+          }
+
+          $content = Get-Content $installerManifest.FullName -Raw
+          if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
+            throw "winget installer manifest does not contain InvocationParameter: --version."
+          }
+
+          if (Get-Command winget -ErrorAction SilentlyContinue) {
+            winget validate --manifest $manifestDir
+          } else {
+            Write-Warning "winget command is not available; skipped local winget validate."
+          }
+
+      - name: Upload winget manifest
+        if: steps.stable-version.outputs.stable_version != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: winget-manifests
+          path: winget-manifests
+
+  publish-winget:
+    needs: [validate-winget-release-manifest]
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download winget manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: winget-manifests
+          path: winget-manifests
+
+      - name: Submit winget manifest update
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          WINGETCREATE_VERSION: 1.12.8.0
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
+            exit 0
+          }
+
+          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
+
+          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
+          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
+
+          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
+          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
+          }
+
+          $manifestDir = Join-Path $PWD "winget-manifests"
+          .\wingetcreate.exe submit $manifestDir -t $env:WINGET_TOKEN

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -26,6 +26,7 @@ env:
   CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
   CARGO_PROFILE_RELEASE_LTO: "fat"
   CARGO_PROFILE_RELEASE_STRIP: "symbols"
+  WINGETCREATE_VERSION: 1.12.8.0
 
 jobs:
   detect-changes:
@@ -447,6 +448,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Resolve winget validation release
         id: winget-release
         shell: pwsh
@@ -473,59 +478,18 @@ jobs:
             "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
+      - name: Setup wingetcreate
+        id: wingetcreate
+        uses: ./.github/actions/setup-wingetcreate
+        with:
+          version: ${{ env.WINGETCREATE_VERSION }}
+
       - name: Generate and validate winget manifest
-        shell: pwsh
-        env:
-          REF_NAME: ${{ steps.winget-release.outputs.release_tag }}
-          VERSION: ${{ steps.winget-release.outputs.stable_version }}
-          WINGETCREATE_VERSION: 1.12.8.0
-        run: |
-          $x64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
-          $arm64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-aarch64-pc-windows-msvc.zip"
-          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
-          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
-
-          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
-          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
-
-          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
-          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
-          if ($actualHash -ne $expectedHash) {
-            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
-          }
-
-          $manifestDir = Join-Path $PWD "winget-manifests"
-          .\wingetcreate.exe update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --out $manifestDir
-
-          $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
-          if (-not $installerManifest) {
-            throw "winget installer manifest was not generated."
-          }
-
-          $content = Get-Content $installerManifest.FullName -Raw
-          if ($content -notmatch "(?m)^InstallationMetadata:") {
-            $installationMetadata = @(
-              "InstallationMetadata:"
-              "  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource'"
-              "  Files:"
-              "  - RelativeFilePath: tombi.exe"
-              "    FileType: launch"
-              "    InvocationParameter: --version"
-            ) -join "`r`n"
-            $content = $content -replace "(?m)^ManifestType:", "$installationMetadata`r`nManifestType:"
-            Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
-          }
-
-          $content = Get-Content $installerManifest.FullName -Raw
-          if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
-            throw "winget installer manifest does not contain InvocationParameter: --version."
-          }
-
-          if (Get-Command winget -ErrorAction SilentlyContinue) {
-            winget validate --manifest $manifestDir
-          } else {
-            Write-Warning "winget command is not available; skipped local winget validate."
-          }
+        uses: ./.github/actions/generate-winget-manifest
+        with:
+          release-tag: ${{ steps.winget-release.outputs.release_tag }}
+          version: ${{ steps.winget-release.outputs.stable_version }}
+          wingetcreate-path: ${{ steps.wingetcreate.outputs.path }}
 
       - name: Upload winget manifest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -542,6 +506,10 @@ jobs:
     outputs:
       stable_version: ${{ steps.stable-version.outputs.stable_version }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Detect stable release tag
         id: stable-version
         shell: pwsh
@@ -555,60 +523,20 @@ jobs:
             "stable_version=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
+      - name: Setup wingetcreate
+        id: wingetcreate
+        if: steps.stable-version.outputs.stable_version != ''
+        uses: ./.github/actions/setup-wingetcreate
+        with:
+          version: ${{ env.WINGETCREATE_VERSION }}
+
       - name: Generate and validate winget manifest
         if: steps.stable-version.outputs.stable_version != ''
-        shell: pwsh
-        env:
-          REF_NAME: ${{ github.ref_name }}
-          VERSION: ${{ steps.stable-version.outputs.stable_version }}
-          WINGETCREATE_VERSION: 1.12.8.0
-        run: |
-          $x64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-x86_64-pc-windows-msvc.zip"
-          $arm64InstallerUrl = "https://github.com/tombi-toml/tombi/releases/download/$env:REF_NAME/tombi-cli-$env:VERSION-aarch64-pc-windows-msvc.zip"
-          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
-          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
-
-          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
-          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
-
-          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
-          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
-          if ($actualHash -ne $expectedHash) {
-            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
-          }
-
-          $manifestDir = Join-Path $PWD "winget-manifests"
-          .\wingetcreate.exe update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --out $manifestDir
-
-          $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
-          if (-not $installerManifest) {
-            throw "winget installer manifest was not generated."
-          }
-
-          $content = Get-Content $installerManifest.FullName -Raw
-          if ($content -notmatch "(?m)^InstallationMetadata:") {
-            $installationMetadata = @(
-              "InstallationMetadata:"
-              "  DefaultInstallLocation: '%LOCALAPPDATA%\Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource'"
-              "  Files:"
-              "  - RelativeFilePath: tombi.exe"
-              "    FileType: launch"
-              "    InvocationParameter: --version"
-            ) -join "`r`n"
-            $content = $content -replace "(?m)^ManifestType:", "$installationMetadata`r`nManifestType:"
-            Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
-          }
-
-          $content = Get-Content $installerManifest.FullName -Raw
-          if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
-            throw "winget installer manifest does not contain InvocationParameter: --version."
-          }
-
-          if (Get-Command winget -ErrorAction SilentlyContinue) {
-            winget validate --manifest $manifestDir
-          } else {
-            Write-Warning "winget command is not available; skipped local winget validate."
-          }
+        uses: ./.github/actions/generate-winget-manifest
+        with:
+          release-tag: ${{ github.ref_name }}
+          version: ${{ steps.stable-version.outputs.stable_version }}
+          wingetcreate-path: ${{ steps.wingetcreate.outputs.path }}
 
       - name: Upload winget manifest
         if: steps.stable-version.outputs.stable_version != ''
@@ -624,34 +552,43 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check winget token
+        id: token
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
+            "configured=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "configured=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
       - name: Download winget manifest
+        if: steps.token.outputs.configured == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: winget-manifests
           path: winget-manifests
 
+      - name: Setup wingetcreate
+        id: wingetcreate
+        if: steps.token.outputs.configured == 'true'
+        uses: ./.github/actions/setup-wingetcreate
+        with:
+          version: ${{ env.WINGETCREATE_VERSION }}
+
       - name: Submit winget manifest update
+        if: steps.token.outputs.configured == 'true'
         shell: pwsh
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-          WINGETCREATE_VERSION: 1.12.8.0
+          WINGETCREATE_PATH: ${{ steps.wingetcreate.outputs.path }}
         run: |
-          if (-not $env:WINGET_TOKEN) {
-            Write-Host "WINGET_TOKEN is not configured; skipping winget manifest submission."
-            exit 0
-          }
-
-          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
-          $wingetCreateChecksumUrl = "$wingetCreateUrl.txt"
-
-          Invoke-WebRequest $wingetCreateUrl -OutFile wingetcreate.exe
-          Invoke-WebRequest $wingetCreateChecksumUrl -OutFile wingetcreate.exe.sha256.txt
-
-          $expectedHash = (Get-Content wingetcreate.exe.sha256.txt -Raw).Trim().ToUpperInvariant()
-          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToUpperInvariant()
-          if ($actualHash -ne $expectedHash) {
-            throw "wingetcreate.exe checksum mismatch. Expected $expectedHash but got $actualHash."
-          }
-
           $manifestDir = Join-Path $PWD "winget-manifests"
-          .\wingetcreate.exe submit $manifestDir -t $env:WINGET_TOKEN
+          & $env:WINGETCREATE_PATH submit $manifestDir -t $env:WINGET_TOKEN

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -456,27 +456,21 @@ jobs:
         id: winget-release
         shell: pwsh
         env:
-          REF_NAME: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if ($env:REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
-            "release_tag=$env:REF_NAME" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          } else {
-            $headers = @{
-              "Accept" = "application/vnd.github+json"
-              "Authorization" = "Bearer $env:GITHUB_TOKEN"
-              "X-GitHub-Api-Version" = "2022-11-28"
-            }
-            $latestRelease = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/tombi-toml/tombi/releases/latest"
-            if ($latestRelease.tag_name -notmatch '^v(\d+\.\d+\.\d+)$') {
-              throw "Latest release tag is not a stable version: $($latestRelease.tag_name)"
-            }
-
-            Write-Host "Using latest stable release $($latestRelease.tag_name) for winget dry-run validation."
-            "release_tag=$($latestRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $headers = @{
+            "Accept" = "application/vnd.github+json"
+            "Authorization" = "Bearer $env:GITHUB_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
           }
+          $latestRelease = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/tombi-toml/tombi/releases/latest"
+          if ($latestRelease.tag_name -notmatch '^v(\d+\.\d+\.\d+)$') {
+            throw "Latest release tag is not a stable version: $($latestRelease.tag_name)"
+          }
+
+          Write-Host "Using latest stable release $($latestRelease.tag_name) for winget dry-run validation."
+          "release_tag=$($latestRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Setup wingetcreate
         id: wingetcreate
@@ -499,7 +493,7 @@ jobs:
 
   validate-winget-release-manifest:
     needs: [release-notes]
-    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     permissions:
       contents: read
@@ -547,7 +541,7 @@ jobs:
 
   publish-winget:
     needs: [validate-winget-release-manifest]
-    if: needs.validate-winget-release-manifest.outputs.stable_version != ''
+    if: needs.validate-winget-release-manifest.outputs.stable_version != '' && (github.event_name != 'workflow_dispatch' || inputs.skip_winget != true)
     runs-on: windows-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- split winget manifest generation/validation from the final submission step
- add dry-run winget manifest validation for non-release refs using the latest stable release assets
- add release-tag validation that injects `InvocationParameter: --version`, uploads the validated manifest, and only then submits it
- quote existing GitHub output/env file writes so actionlint passes the workflow

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_cli_vscode.yml"); puts "yaml ok"'`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release_cli_vscode.yml`
