### PR TITLE
Improve formatting edit debug log

### DIFF
--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -114,7 +114,7 @@ pub async fn handle_formatting(
             if document_text.as_ref() != formatted {
                 let edits =
                     compute_text_edits(document_text.as_ref(), &formatted, line_index.as_ref());
-                log::debug!("{:?}", edits);
+                log::debug!("edits: {:?}", edits);
                 if let Ok(mut document_sources) = backend.document_sources.try_write()
                     && let Some(document_source) = document_sources.get_mut(&text_document_uri)
                     && document_source.text() == document_text.as_ref()


### PR DESCRIPTION
## Summary
- Add an `edits:` label to the formatting debug log so TextEdit output is easier to identify in server logs.

## Verification
- cargo fmt --all --check
- cargo check -p tombi-lsp --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked

## Rebase verification
- cargo fmt --all --check
- cargo check -p tombi-lsp --locked
- git diff --check origin/main...HEAD
