### PR TITLE
Fix nested anyOf hover enum selection

### DIFF
--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -102,20 +102,28 @@ where
                     };
 
                     if is_applicable_branch {
-                        valid_hover_value_contents.push(hover_value_content.clone());
-
-                        if let Some(values) = resolved_schema
-                            .value_schema
+                        if let Some(values) = hover_value_content
+                            .constraints
                             .as_ref()
-                            .get_enum(
-                                &resolved_schema.schema_uri,
-                                &resolved_schema.definitions,
-                                schema_context,
-                            )
-                            .await
+                            .and_then(|constraints| constraints.r#enum.as_ref())
                         {
-                            enum_values.extend(values);
+                            enum_values.extend(values.clone());
+                        } else if hover_value_content.accessors.as_ref() == accessors {
+                            if let Some(values) = resolved_schema
+                                .value_schema
+                                .as_ref()
+                                .get_enum(
+                                    &resolved_schema.schema_uri,
+                                    &resolved_schema.definitions,
+                                    schema_context,
+                                )
+                                .await
+                            {
+                                enum_values.extend(values);
+                            }
                         }
+
+                        valid_hover_value_contents.push(hover_value_content.clone());
                     }
 
                     any_hover_value_contents.push(hover_value_content);

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -107,7 +107,7 @@ where
                             .as_ref()
                             .and_then(|constraints| constraints.r#enum.as_ref())
                         {
-                            enum_values.extend(values.clone());
+                            enum_values.extend(values.iter().cloned());
                         } else if hover_value_content.accessors.as_ref() == accessors {
                             if let Some(values) = resolved_schema
                                 .value_schema

--- a/crates/tombi-lsp/tests/fixtures/any-of-table-property-enum.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/any-of-table-property-enum.schema.json
@@ -11,6 +11,16 @@
           "$ref": "#/definitions/FormatOptions"
         }
       ]
+    },
+    "check": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TypeCheckOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,
@@ -34,6 +44,54 @@
         }
       },
       "additionalProperties": false
+    },
+    "TypeCheckOptions": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FeatureToggle"
+        },
+        {
+          "$ref": "#/definitions/TypeCheckOptionsTable"
+        }
+      ]
+    },
+    "TypeCheckOptionsTable": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CheckRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CheckRules": {
+      "type": "object",
+      "properties": {
+        "unknown-table": {
+          "description": "Report references to tables that are not defined across loaded SQL files. Default is error.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "error"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RuleLevel": {
+      "type": "string",
+      "enum": ["off", "warn", "error"]
     },
     "IndentStyle": {
       "oneOf": [

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -950,6 +950,23 @@ mod hover_keys_value {
                 "Enum": ["\"space\"", "\"tab\""]
             });
         );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn nested_any_of_hover_uses_enum_from_deep_matching_table_property_branch(
+                r#"
+                [check]
+                [check.rules]
+                unknown-table = "█error"
+                "#,
+                SchemaPath(any_of_table_property_enum_schema_path()),
+            ) -> Ok({
+                "Keys": "check.rules.unknown-table",
+                "Value": "String?",
+                "Enum": ["\"off\"", "\"warn\"", "\"error\""],
+                "Default": "\"error\""
+            });
+        );
     }
 
     mod adjacent_applicators_schema {


### PR DESCRIPTION
## Summary
- prefer enum constraints from the matching hover branch for nested anyOf hover values
- only fall back to resolved schema enum lookup when the hover content accessors match the requested accessors
- add a nested anyOf table-property fixture and hover regression test

## Verification
- cargo fmt --all --check
- cargo test -p tombi-lsp --test test_hover nested_any_of_hover_uses_enum_from_deep_matching_table_property_branch --locked
- cargo test -p tombi-lsp --test test_hover --locked