### PR TITLE
Apply quote style to string keys

### DIFF
--- a/crates/tombi-formatter/src/format.rs
+++ b/crates/tombi-formatter/src/format.rs
@@ -6,17 +6,44 @@ mod root;
 mod table;
 mod value;
 
+use std::borrow::Cow;
 use std::fmt::Write;
 
 use itertools::Itertools;
 use tombi_ast::{AstChildren, AstNode};
-use tombi_config::TomlVersion;
+use tombi_config::{StringQuoteStyle, TomlVersion};
 use tombi_syntax::SyntaxKind::{LINE_BREAK, WHITESPACE};
 
 use crate::types::AlignmentWidth;
 
 pub trait Format {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error>;
+}
+
+/// Re-quote `text` to use `quote` as its delimiter, swapping the surrounding quotes.
+///
+/// Leaves `text` untouched when the new delimiter or an escape would alter the content.
+// TODO: Only supports simple conditions, so it needs to be changed to behavior closer to black
+fn requote_string(text: &str, quote: char) -> Cow<'_, str> {
+    if text.contains('\\') || text.contains(quote) {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(format!("{quote}{}{quote}", &text[1..text.len() - 1]))
+    }
+}
+
+fn format_basic_string_quote_style(text: &str, quote_style: StringQuoteStyle) -> Cow<'_, str> {
+    match quote_style {
+        StringQuoteStyle::Double | StringQuoteStyle::Preserve => Cow::Borrowed(text),
+        StringQuoteStyle::Single => requote_string(text, '\''),
+    }
+}
+
+fn format_literal_string_quote_style(text: &str, quote_style: StringQuoteStyle) -> Cow<'_, str> {
+    match quote_style {
+        StringQuoteStyle::Single | StringQuoteStyle::Preserve => Cow::Borrowed(text),
+        StringQuoteStyle::Double => requote_string(text, '"'),
+    }
 }
 
 fn write_trailing_comment_alignment_space(

--- a/crates/tombi-formatter/src/format/array_of_table.rs
+++ b/crates/tombi-formatter/src/format/array_of_table.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use itertools::Itertools;
 use tombi_ast::DanglingCommentGroupOr;
 
-use crate::{Format, format::filter_map_unique_keys};
+use crate::{Format, format::filter_map_unique_keys, types::WithAlignmentHint};
 
 impl Format for tombi_ast::ArrayOfTable {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
@@ -22,7 +22,9 @@ impl Format for tombi_ast::ArrayOfTable {
         self.header_leading_comments().collect_vec().format(f)?;
 
         f.write_indent()?;
-        write!(f, "[[{header}]]")?;
+        write!(f, "[[")?;
+        WithAlignmentHint::new(&header).format(f)?;
+        write!(f, "]]")?;
 
         if let Some(comment) = self.header_trailing_comment() {
             comment.format(f)?;

--- a/crates/tombi-formatter/src/format/key.rs
+++ b/crates/tombi-formatter/src/format/key.rs
@@ -5,6 +5,7 @@ use tombi_ast::AstNode;
 
 use crate::{
     Format,
+    format::{format_basic_string_quote_style, format_literal_string_quote_style},
     types::{AlignmentWidth, WithAlignmentHint},
 };
 
@@ -13,8 +14,19 @@ impl Format for WithAlignmentHint<&tombi_ast::Keys> {
         let keys = self.value;
         let mut keys_string = keys
             .keys()
-            .map(|key| key.syntax().text().to_string())
-            .collect_vec()
+            .map(|key| match key {
+                tombi_ast::Key::BareKey(it) => it.syntax().text().to_string(),
+                tombi_ast::Key::BasicString(it) => format_basic_string_quote_style(
+                    it.token().unwrap().text(),
+                    f.string_quote_style(),
+                )
+                .into_owned(),
+                tombi_ast::Key::LiteralString(it) => format_literal_string_quote_style(
+                    it.token().unwrap().text(),
+                    f.string_quote_style(),
+                )
+                .into_owned(),
+            })
             .join(".");
 
         if let Some(keys_alignment_width) = self.equal_alignment_width {

--- a/crates/tombi-formatter/src/format/table.rs
+++ b/crates/tombi-formatter/src/format/table.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use itertools::Itertools;
 use tombi_ast::DanglingCommentGroupOr;
 
-use crate::{Format, format::filter_map_unique_keys};
+use crate::{Format, format::filter_map_unique_keys, types::WithAlignmentHint};
 
 impl Format for tombi_ast::Table {
     fn format(&self, f: &mut crate::Formatter) -> Result<(), std::fmt::Error> {
@@ -22,7 +22,9 @@ impl Format for tombi_ast::Table {
         self.header_leading_comments().collect_vec().format(f)?;
 
         f.write_indent()?;
-        write!(f, "[{header}]")?;
+        write!(f, "[")?;
+        WithAlignmentHint::new(&header).format(f)?;
+        write!(f, "]")?;
 
         if let Some(trailing_comment) = self.header_trailing_comment() {
             trailing_comment.format(f)?;

--- a/crates/tombi-formatter/src/format/value/string.rs
+++ b/crates/tombi-formatter/src/format/value/string.rs
@@ -2,11 +2,13 @@ use itertools::Itertools;
 use std::fmt::Write;
 
 use tombi_ast::AstNode;
-use tombi_config::StringQuoteStyle;
 
 use super::LiteralNode;
 use crate::{
-    format::{Format, write_trailing_comment_alignment_space},
+    format::{
+        Format, format_basic_string_quote_style, format_literal_string_quote_style,
+        write_trailing_comment_alignment_space,
+    },
     types::WithAlignmentHint,
 };
 
@@ -23,18 +25,8 @@ impl Format for WithAlignmentHint<&tombi_ast::BasicString> {
         value.leading_comments().collect_vec().format(f)?;
 
         f.write_indent()?;
-        let text = value.token().unwrap().text().to_owned();
-        let text = match f.string_quote_style() {
-            StringQuoteStyle::Double | StringQuoteStyle::Preserve => text,
-            StringQuoteStyle::Single => {
-                // TODO: Only supports simple conditions, so it needs to be changed to behavior closer to black
-                if text.contains("\\") || text.contains("'") {
-                    text
-                } else {
-                    format!("'{}'", &text[1..text.len() - 1])
-                }
-            }
-        };
+        let token = value.token().unwrap();
+        let text = format_basic_string_quote_style(token.text(), f.string_quote_style());
         write!(f, "{text}")?;
 
         if let Some(comment) = value.trailing_comment() {
@@ -60,18 +52,8 @@ impl Format for WithAlignmentHint<&tombi_ast::LiteralString> {
         value.leading_comments().collect_vec().format(f)?;
 
         f.write_indent()?;
-        let text = value.token().unwrap().text().to_owned();
-        let text = match f.string_quote_style() {
-            StringQuoteStyle::Single | StringQuoteStyle::Preserve => text,
-            StringQuoteStyle::Double => {
-                // TODO: Only supports simple conditions, so it needs to be changed to behavior closer to black
-                if text.contains("\\") || text.contains("\"") {
-                    text
-                } else {
-                    format!("\"{}\"", &text[1..text.len() - 1])
-                }
-            }
-        };
+        let token = value.token().unwrap();
+        let text = format_literal_string_quote_style(token.text(), f.string_quote_style());
         write!(f, "{text}")?;
 
         if let Some(comment) = value.trailing_comment() {

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -1455,6 +1455,37 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_string_key_quote_style_double(
+                r#"
+                'key' = 'value'
+
+                [dependencies.'unicase']
+                name = 'unicase'
+
+                [[dependencies.'array']]
+                name = 'array'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                "key" = "value"
+
+                [dependencies."unicase"]
+                name = "unicase"
+
+                [[dependencies."array"]]
+                name = "array"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_string_quote_style_single(
                 r#"
                 key = "value"
@@ -1474,6 +1505,58 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_string_key_quote_style_single(
+                r#"
+                "key" = "value"
+
+                [dependencies."unicase"]
+                name = "unicase"
+
+                [[dependencies."array"]]
+                name = "array"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Single),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                'key' = 'value'
+
+                [dependencies.'unicase']
+                name = 'unicase'
+
+                [[dependencies.'array']]
+                name = 'array'
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_string_key_quote_style_single_preserves_unsafe_basic_keys(
+                r#"
+                "key'" = "value"
+                "key\n" = "escaped"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Single),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                "key'" = 'value'
+                "key\n" = 'escaped'
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_string_quote_style_preserve(
                 r#"
                 key = "value"
@@ -1487,6 +1570,92 @@ mod format_options {
             ) -> Ok(
                 r#"
                 key = "value"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_string_key_quote_style_double_preserves_unsafe_literal_keys(
+                r#"
+                'key"' = 'value'
+                'key\n' = 'escaped'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                'key"' = "value"
+                'key\n' = "escaped"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_string_key_quote_style_preserve(
+                r#"
+                "key" = 'value'
+
+                [dependencies.'unicase']
+                name = "unicase"
+
+                [[dependencies."array"]]
+                name = 'array'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Preserve),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(source)
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_string_key_quote_style_double_with_equals_sign_alignment(
+                r#"
+                'key' = 'value'
+                'longer' = 'value2'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        key_value_equals_sign_alignment: Some(true),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                "key"    = "value"
+                "longer" = "value2"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_string_key_quote_style_single_with_equals_sign_alignment(
+                r#"
+                "key" = "value"
+                "longer" = "value2"
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Single),
+                        key_value_equals_sign_alignment: Some(true),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                'key'    = 'value'
+                'longer' = 'value2'
                 "#
             )
         }

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -108,8 +108,8 @@ where
                             .and_then(|constraints| constraints.r#enum.as_ref())
                         {
                             enum_values.extend(values.iter().cloned());
-                        } else if hover_value_content.accessors.as_ref() == accessors {
-                            if let Some(values) = resolved_schema
+                        } else if hover_value_content.accessors.as_ref() == accessors
+                            && let Some(values) = resolved_schema
                                 .value_schema
                                 .as_ref()
                                 .get_enum(
@@ -118,9 +118,8 @@ where
                                     schema_context,
                                 )
                                 .await
-                            {
-                                enum_values.extend(values);
-                            }
+                        {
+                            enum_values.extend(values);
                         }
 
                         valid_hover_value_contents.push(hover_value_content.clone());


### PR DESCRIPTION
## Summary

- Apply `string_quote_style` to quoted keys in key-values, table headers, and array-of-table headers.
- Reuse the existing simple string re-quoting behavior for both values and keys.
- Add formatter option coverage for double, single, preserve, and equals-sign alignment cases.
- Address a current Clippy `collapsible_if` warning in `tombi-lsp`.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
  - Result: 2107 passed, 1 failed (`tombi-extension remote_cache::tests::warms_missing_cache`)
  - Follow-up: `cargo nextest run -p tombi-extension remote_cache::tests::warms_missing_cache --locked` passed
- `cargo test --workspace --doc --locked`
