### PR TITLE
ci: harden winget manifest invocation check

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -53,7 +53,11 @@ runs:
           Set-Content -Path $installerManifest.FullName -Value $content -NoNewline
         }
 
-        if ($content -notmatch "(?m)^\s+InvocationParameter: --version$") {
+        $content = Get-Content $installerManifest.FullName -Raw
+        $hasInvocationParameter = $content -split "\r?\n" | Where-Object {
+          $_ -match "^\s+InvocationParameter: --version\s*$"
+        }
+        if (-not $hasInvocationParameter) {
           throw "winget installer manifest does not contain InvocationParameter: --version."
         }
 


### PR DESCRIPTION
## Summary
- harden the winget manifest `InvocationParameter: --version` check against CRLF line endings
- re-read the generated installer manifest before validating the injected metadata

## CI failure
- Fixes `validate-winget-manifest` in https://github.com/tombi-toml/tombi/actions/runs/28351344499/job/83984691343

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/generate-winget-manifest/action.yml"); puts "yaml ok"'`
- `ruby -e 'content = "  InvocationParameter: --version\r\nManifestType: installer\r\n"; has = content.split(/\r?\n/).any? { |line| line.match?(/^\s+InvocationParameter: --version\s*$/) }; abort "missing" unless has; puts "line check ok"'`
- `actionlint .github/workflows/release_cli_vscode.yml`

`pwsh` and `winget` are not available in this local environment, so the Windows runner path is covered by the next GitHub Actions run.
