### PR TITLE
ci: validate winget manifest leaf directory

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -64,4 +64,5 @@ runs:
         if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
           throw "winget command is not available; cannot validate manifest."
         }
-        winget validate --manifest $manifestDir
+        $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
+        winget validate --manifest $manifestVersionDir


### PR DESCRIPTION
## Summary
- pass the generated winget version manifest directory to `winget validate`
- keep uploading the full generated manifest tree as the workflow artifact

## CI failure
Fixes `validate-winget-manifest` in https://github.com/tombi-toml/tombi/actions/runs/28352639463/job/83988464016.

The previous run got past `wingetcreate update` and the injected `InvocationParameter` check, then failed at the explicit `winget validate --manifest $manifestDir` step:

```text
Manifest validation failed.
Msg:[Subdirectory not supported in manifest path]
```

`$manifestDir` points at the parent output directory, while `winget validate` expects the leaf version directory that contains the generated manifest YAML files.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/generate-winget-manifest/action.yml"); puts "yaml ok"'`
- `ruby -e 'path = "D:/a/tombi/tombi/winget-manifests/manifests/t/tombi-toml/tombi/1.1.6/tombi-toml.tombi.installer.yaml"; dir = File.dirname(path); abort "bad" unless dir.end_with?("/1.1.6"); puts dir'`
- `actionlint .github/workflows/release_cli_vscode.yml`

`winget` is not available in this local environment, so the Windows runner path is covered by the next GitHub Actions run.
