### PR TITLE
ci: ignore winget manifest validation warnings

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -65,4 +65,4 @@ runs:
           throw "winget command is not available; cannot validate manifest."
         }
         $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
-        winget validate --manifest $manifestVersionDir
+        winget validate --manifest $manifestVersionDir --ignore-warnings


### PR DESCRIPTION
## Summary
- pass `--ignore-warnings` to the explicit `winget validate` dry-run
- keep real validation failures fatal while avoiding CI failure on schema header warnings emitted for wingetcreate-generated manifests

## CI failure
Fixes `validate-winget-manifest` in https://github.com/tombi-toml/tombi/actions/runs/28353886247/job/83992373669.

The run now reaches the explicit `winget validate` step and reports:

```text
Manifest validation succeeded with warnings.
Manifest Warning: The schema header URL does not match the expected pattern.
```

The command exits non-zero after warnings, so the workflow still fails even though validation succeeds. Microsoft documents `--nowarn,--ignore-warnings` for `winget validate`, so this dry-run uses that option for warning-only validation output.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/generate-winget-manifest/action.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/release_cli_vscode.yml`

`winget` is not available in this local environment, so the Windows runner path is covered by the next GitHub Actions run.
