### PR TITLE
feat(validator): support ajv-errors-style errorMessage for not schema violations

### DIFF
--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -28,6 +28,8 @@ mod json_schema_test_suite;
 mod min_max_contains_test_schema;
 #[path = "integration/non_schema.rs"]
 mod non_schema;
+#[path = "integration/not_error_message_test_schema.rs"]
+mod not_error_message_test_schema;
 #[path = "integration/other_schema.rs"]
 mod other_schema;
 #[path = "integration/prefix_items_test_schema.rs"]

--- a/crates/tombi-linter/tests/integration/not_error_message_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/not_error_message_test_schema.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use tombi_linter::test_lint;
+use tombi_test_lib::project_root_path;
+
+fn schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("not-error-message-test.schema.json")
+}
+
+test_lint! {
+    #[test]
+    fn test_not_schema_match_with_custom_error_message(
+        r#"
+        with_message = "forbidden"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::NotSchemaMatch {
+            message: "This value is forbidden.".to_string(),
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_not_schema_match_without_custom_error_message(
+        r#"
+        without_message = "forbidden"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::NotSchemaMatch {
+            message: "\"not\" schema is matched".to_string(),
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_not_schema_match_valid_value(
+        r#"
+        with_message = "allowed"
+        without_message = "allowed"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}

--- a/crates/tombi-linter/tests/integration/not_error_message_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/not_error_message_test_schema.rs
@@ -17,9 +17,9 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Err([
-        tombi_validator::DiagnosticKind::NotSchemaMatch {
-            message: "This value is forbidden.".to_string(),
-        },
+        tombi_validator::DiagnosticKind::NotSchemaMatchWithMessage(
+            "This value is forbidden.".to_string(),
+        ),
     ])
 }
 
@@ -31,9 +31,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Err([
-        tombi_validator::DiagnosticKind::NotSchemaMatch {
-            message: "\"not\" schema is matched".to_string(),
-        },
+        tombi_validator::DiagnosticKind::NotSchemaMatch,
     ])
 }
 

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -740,6 +740,7 @@ mod completion_labels {
                 "issue-1895-rustfmt-like.schema.json",
                 "lsp-consistency-test.schema.json",
                 "min-max-contains-test.schema.json",
+                "not-error-message-test.schema.json",
                 "one-of-hover-discriminator-test.schema.json",
                 "partial-taskipy.schema.json",
                 "prefix-items-test.schema.json",

--- a/crates/tombi-schema-store/src/schema/not_schema.rs
+++ b/crates/tombi-schema-store/src/schema/not_schema.rs
@@ -5,10 +5,15 @@ use crate::{AnchorCollector, DynamicAnchorCollector, SchemaItem, schema_item_fro
 #[derive(Debug, Clone)]
 pub struct NotSchema {
     pub schema: SchemaItem,
-    pub error_message: Option<String>,
+    error_message: Option<String>,
 }
 
 impl NotSchema {
+    #[inline]
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+
     #[inline]
     pub fn new(
         object: &tombi_json::ObjectNode,

--- a/crates/tombi-schema-store/src/schema/not_schema.rs
+++ b/crates/tombi-schema-store/src/schema/not_schema.rs
@@ -1,10 +1,11 @@
-use tombi_x_keyword::StringFormat;
+use tombi_x_keyword::{StringFormat, X_NOT_ERROR_MESSAGE};
 
 use crate::{AnchorCollector, DynamicAnchorCollector, SchemaItem, schema_item_from_schema_value};
 
 #[derive(Debug, Clone)]
 pub struct NotSchema {
     pub schema: SchemaItem,
+    pub error_message: Option<String>,
 }
 
 impl NotSchema {
@@ -27,6 +28,11 @@ impl NotSchema {
                     dynamic_anchor_collector,
                 )
             })
-            .map(|schema| Self { schema })
+            .map(|schema| Self {
+                schema,
+                error_message: object
+                    .get(X_NOT_ERROR_MESSAGE)
+                    .and_then(|value| value.as_str().map(str::to_string)),
+            })
     }
 }

--- a/crates/tombi-schema-store/src/schema/not_schema.rs
+++ b/crates/tombi-schema-store/src/schema/not_schema.rs
@@ -1,4 +1,4 @@
-use tombi_x_keyword::{StringFormat, X_NOT_ERROR_MESSAGE};
+use tombi_x_keyword::{ERROR_MESSAGE, StringFormat};
 
 use crate::{AnchorCollector, DynamicAnchorCollector, SchemaItem, schema_item_from_schema_value};
 
@@ -36,7 +36,9 @@ impl NotSchema {
             .map(|schema| Self {
                 schema,
                 error_message: object
-                    .get(X_NOT_ERROR_MESSAGE)
+                    .get(ERROR_MESSAGE)
+                    .and_then(|value| value.as_object())
+                    .and_then(|error_messages| error_messages.get("not"))
                     .and_then(|value| value.as_str().map(str::to_string)),
             })
     }

--- a/crates/tombi-validator/src/diagnostic.rs
+++ b/crates/tombi-validator/src/diagnostic.rs
@@ -151,8 +151,11 @@ pub enum DiagnosticKind {
     #[error("The schema matches no values")]
     Nothing,
 
-    #[error("{message}")]
-    NotSchemaMatch { message: String },
+    #[error("\"not\" schema is matched")]
+    NotSchemaMatch,
+
+    #[error("{0}")]
+    NotSchemaMatchWithMessage(String),
 
     #[error("When \"{dependent_key}\" is present, \"{required_key}\" is required")]
     TableDependencyRequired {
@@ -213,7 +216,9 @@ impl DiagnosticKind {
             DiagnosticKind::OneOfMultipleMatch { .. } => "one-of-multiple-match",
             DiagnosticKind::OneOfNoMatch { .. } => "one-of-no-match",
             DiagnosticKind::Nothing => "nothing",
-            DiagnosticKind::NotSchemaMatch { .. } => "not-schema-match",
+            DiagnosticKind::NotSchemaMatch | DiagnosticKind::NotSchemaMatchWithMessage(_) => {
+                "not-schema-match"
+            }
             DiagnosticKind::KeyEmpty => "key-empty",
             DiagnosticKind::TableDependencyRequired { .. } => "table-dependency-required",
         }

--- a/crates/tombi-validator/src/diagnostic.rs
+++ b/crates/tombi-validator/src/diagnostic.rs
@@ -151,8 +151,8 @@ pub enum DiagnosticKind {
     #[error("The schema matches no values")]
     Nothing,
 
-    #[error("\"not\" schema is matched")]
-    NotSchemaMatch,
+    #[error("{message}")]
+    NotSchemaMatch { message: String },
 
     #[error("When \"{dependent_key}\" is present, \"{required_key}\" is required")]
     TableDependencyRequired {
@@ -213,7 +213,7 @@ impl DiagnosticKind {
             DiagnosticKind::OneOfMultipleMatch { .. } => "one-of-multiple-match",
             DiagnosticKind::OneOfNoMatch { .. } => "one-of-no-match",
             DiagnosticKind::Nothing => "nothing",
-            DiagnosticKind::NotSchemaMatch => "not-schema-match",
+            DiagnosticKind::NotSchemaMatch { .. } => "not-schema-match",
             DiagnosticKind::KeyEmpty => "key-empty",
             DiagnosticKind::TableDependencyRequired { .. } => "table-dependency-required",
         }

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -5,6 +5,8 @@ use tombi_severity_level::SeverityLevelDefaultError;
 
 use crate::{Validate, validate::handle_unused_noqa};
 
+const DEFAULT_NOT_SCHEMA_MATCH_MESSAGE: &str = "\"not\" schema is matched";
+
 pub async fn validate_not<'a, T>(
     value: &T,
     accessors: &[tombi_schema_store::Accessor],
@@ -33,9 +35,13 @@ where
             .await
             .is_ok()
     {
+        let message = not_schema
+            .error_message
+            .clone()
+            .unwrap_or_else(|| DEFAULT_NOT_SCHEMA_MATCH_MESSAGE.to_string());
         let mut diagnostics = Vec::with_capacity(1);
         crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::NotSchemaMatch),
+            kind: Box::new(crate::DiagnosticKind::NotSchemaMatch { message }),
             range: value.range(),
         }
         .push_diagnostic_with_level(

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -5,8 +5,6 @@ use tombi_severity_level::SeverityLevelDefaultError;
 
 use crate::{Validate, validate::handle_unused_noqa};
 
-const DEFAULT_NOT_SCHEMA_MATCH_MESSAGE: &str = "\"not\" schema is matched";
-
 pub async fn validate_not<'a, T>(
     value: &T,
     accessors: &[tombi_schema_store::Accessor],
@@ -35,13 +33,13 @@ where
             .await
             .is_ok()
     {
-        let message = not_schema
-            .error_message
-            .clone()
-            .unwrap_or_else(|| DEFAULT_NOT_SCHEMA_MATCH_MESSAGE.to_string());
+        let kind = match not_schema.error_message() {
+            Some(message) => crate::DiagnosticKind::NotSchemaMatchWithMessage(message.to_string()),
+            None => crate::DiagnosticKind::NotSchemaMatch,
+        };
         let mut diagnostics = Vec::with_capacity(1);
         crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::NotSchemaMatch { message }),
+            kind: Box::new(kind),
             range: value.range(),
         }
         .push_diagnostic_with_level(

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -6,6 +6,7 @@ pub const X_TOMBI_ARRAY_VALUES_ORDER_BY: &str = "x-tombi-array-values-order-by";
 pub const X_TOMBI_TABLE_KEYS_ORDER: &str = "x-tombi-table-keys-order";
 pub const X_TOMBI_STRING_FORMATS: &str = "x-tombi-string-formats";
 pub const X_TOMBI_ADDITIONAL_KEY_LABEL: &str = "x-tombi-additional-key-label";
+pub const X_NOT_ERROR_MESSAGE: &str = "x-not-error-message";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/tombi-x-keyword/src/lib.rs
+++ b/crates/tombi-x-keyword/src/lib.rs
@@ -6,7 +6,7 @@ pub const X_TOMBI_ARRAY_VALUES_ORDER_BY: &str = "x-tombi-array-values-order-by";
 pub const X_TOMBI_TABLE_KEYS_ORDER: &str = "x-tombi-table-keys-order";
 pub const X_TOMBI_STRING_FORMATS: &str = "x-tombi-string-formats";
 pub const X_TOMBI_ADDITIONAL_KEY_LABEL: &str = "x-tombi-additional-key-label";
-pub const X_NOT_ERROR_MESSAGE: &str = "x-not-error-message";
+pub const ERROR_MESSAGE: &str = "errorMessage";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/schemas/not-error-message-test.schema.json
+++ b/schemas/not-error-message-test.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "NotErrorMessageTest",
+  "type": "object",
+  "properties": {
+    "with_message": {
+      "type": "string",
+      "not": {
+        "const": "forbidden"
+      },
+      "x-not-error-message": "This value is forbidden."
+    },
+    "without_message": {
+      "type": "string",
+      "not": {
+        "const": "forbidden"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/not-error-message-test.schema.json
+++ b/schemas/not-error-message-test.schema.json
@@ -8,7 +8,9 @@
       "not": {
         "const": "forbidden"
       },
-      "x-not-error-message": "This value is forbidden."
+      "errorMessage": {
+        "not": "This value is forbidden."
+      }
     },
     "without_message": {
       "type": "string",


### PR DESCRIPTION
## Summary
- Parse ajv-errors-style `errorMessage` from JSON Schema objects that define a `not` constraint, reading the message from the `not` key (e.g. `"errorMessage": { "not": "..." }`)
- Show the custom message in `not-schema-match` diagnostics when provided, otherwise keep the default message
- Add integration tests covering custom message, default message, and valid values

## Test plan
- [x] `cargo clippy -p tombi-schema-store -p tombi-validator -p tombi-linter -p tombi-x-keyword --locked -- -D warnings`
- [x] `cargo nextest run -p tombi-linter not_error_message_test_schema --locked --no-fail-fast`


Made with [Cursor](https://cursor.com)
