### PR TITLE
Update test fixtures for cargo hover feature and stale pull diagnostics

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-hover-feature-dependencies-disabled/tombi.toml
@@ -2,7 +2,7 @@
 "tombi-toml/cargo" = {
   lsp.hover = {
     default-features.enabled = true,
-    feature-dependencies.enabled = false,
     dependency-detail.enabled = true,
+    feature-dependencies.enabled = false,
   }
 }

--- a/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/test.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-1953-stale-pull-diagnostics/test.toml
@@ -1,2 +1,3 @@
 #:schema schema.json
+
 id = "Test1"


### PR DESCRIPTION
* Adjusted `tombi.toml` to ensure `feature-dependencies.enabled` is set to false.
* Added a blank line in `test.toml` for improved readability and consistency.