### PR TITLE
Send CLI diagnostics to stderr

### DIFF
--- a/crates/tombi-diagnostic/src/printer/pretty.rs
+++ b/crates/tombi-diagnostic/src/printer/pretty.rs
@@ -37,10 +37,10 @@ impl Print<Pretty> for Diagnostic {
             (Style::new(), Style::new(), Style::new())
         };
 
-        println!(": {}", message_style.paint(self.message()));
+        eprintln!(": {}", message_style.paint(self.message()));
 
         if let Some(source_file) = self.source_file() {
-            println!(
+            eprintln!(
                 "    {} {}",
                 at_style.paint("at"),
                 link_style.paint(format!(
@@ -51,7 +51,7 @@ impl Print<Pretty> for Diagnostic {
                 )),
             );
         } else {
-            println!(
+            eprintln!(
                 "    {}",
                 at_style.paint(format!(
                     "at line {} column {}",

--- a/crates/tombi-diagnostic/src/printer/simple.rs
+++ b/crates/tombi-diagnostic/src/printer/simple.rs
@@ -23,7 +23,7 @@ impl Print<Simple> for Level {
             Style::new()
         };
 
-        print!("{}", level_style.paint(self.as_padded_str()));
+        eprint!("{}", level_style.paint(self.as_padded_str()));
     }
 }
 
@@ -36,6 +36,6 @@ impl Print<Simple> for Diagnostic {
         };
 
         self.level().print(printer);
-        println!(": {}", message_style.paint(self.message()));
+        eprintln!(": {}", message_style.paint(self.message()));
     }
 }

--- a/rust/tombi-cli/src/error.rs
+++ b/rust/tombi-cli/src/error.rs
@@ -84,6 +84,6 @@ impl Print<Simple> for Error {
         };
 
         Level::ERROR.print(printer);
-        println!(": {}", message_style.paint(self.to_string()));
+        eprintln!(": {}", message_style.paint(self.to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- send diagnostic printer output to stderr instead of stdout
- send CLI error printer output to stderr as well
- keep stdout available for command payloads such as formatted TOML, shell completions, and future machine-readable output

## Breaking Changes
- Human-readable diagnostics and CLI errors from `tombi lint` and `tombi format --check` now go to stderr instead of stdout.

## Notes
- This PR intentionally does not change `tombi format --diff`; diff stdout behavior will be handled separately.

## Tests
- `cargo fmt --all`
- `cargo check -p tombi-cli -p tombi-diagnostic`