### PR TITLE
Add release asset attestations

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -216,6 +216,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -241,7 +243,12 @@ jobs:
         id: find_cli_assets
         shell: bash
         run: |
-          echo "ASSETS=$(find tombi-cli-artifacts tombi-vscode-artifacts -type f | tr '\n' ' ')" >> "$GITHUB_ENV"
+          echo "ASSETS=$(find tombi-cli-artifacts tombi-vscode-artifacts -type f | sort | tr '\n' ' ')" >> "$GITHUB_ENV"
+          {
+            echo "release_assets<<EOF"
+            find tombi-cli-artifacts tombi-vscode-artifacts -type f | sort
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check ASSETS
         run: |
@@ -251,6 +258,12 @@ jobs:
             exit 1
           fi
           echo "ASSETS found successfully."
+
+      - name: Generate artifact attestation
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        if: startsWith(github.ref, 'refs/tags/') && needs.check-release-notes.outputs.exists == 'false'
+        with:
+          subject-path: ${{ steps.find_cli_assets.outputs.release_assets }}
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -258,7 +258,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: "dist/*"
       - name: Publish to PyPI


### PR DESCRIPTION
## Summary

- add GitHub artifact attestations for CLI and VSCode release assets before creating a GitHub Release
- update the PyPI artifact attestation step from actions/attest-build-provenance@v1 to actions/attest@v4.1.1

Closes #1992

## Tests

- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/release_cli_vscode.yml .github/workflows/release_pypi.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release_cli_vscode.yml .github/workflows/release_pypi.yml
