### PR TITLE
docs: document TOMBI_NO_COLOR

### DIFF
--- a/docs/src/routes/docs/environment-variables.mdx
+++ b/docs/src/routes/docs/environment-variables.mdx
@@ -20,6 +20,15 @@ When set, Tombi will not fetch schemas from remote sources and will only use cac
 - Type: `true | false`
 - Default: `false`
 
+## TOMBI_NO_COLOR
+
+Disable ANSI color output from Tombi CLI diagnostics.
+
+When set to a non-empty value, Tombi will not emit ANSI color sequences in CLI diagnostics. If `TOMBI_NO_COLOR` is not set, Tombi will fall back to `NO_COLOR` if available.
+
+- Type: `String`
+- Default: unset
+
 ## TOMBI_NO_CACHE
 
 Disable cache usage and fetch the latest data from remote sources.


### PR DESCRIPTION
## Summary
- Document the `TOMBI_NO_COLOR` environment variable on the environment variables page
- Note that Tombi falls back to `NO_COLOR` when `TOMBI_NO_COLOR` is unset

## Verification
- `git diff --check`
- `pnpm -C docs lint:check`
- `pnpm -C docs build`

## Notes
- `pnpm -C docs format:check` currently reports existing generated `docs/.output` and `docs/.vinxi` formatting differences; those paths are gitignored and not part of this PR.
- Direct `biome format/lint src/routes/docs/environment-variables.mdx` processes 0 files because MDX is ignored by the current Biome config.
