### PR TITLE
fix(lsp): clear diagnostics after document close if workspace-diagnostics is disabled

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -424,7 +424,7 @@ impl tower_lsp::LanguageServer for Backend {
         &self,
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>, tower_lsp::jsonrpc::Error> {
-        let text_document_uri = params.text_document.uri.clone().into();
+        let text_document_uri: tombi_uri::Uri = params.text_document.uri.clone().into();
         let line_index = {
             let Ok(document_sources) = self.document_sources.try_read() else {
                 return Ok(None);

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -2,7 +2,7 @@ use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType};
 
 use crate::{
     backend::Backend,
-    workspace_config::{WorkspaceConfig, get_workspace_configs},
+    workspace_config::{WorkspaceConfig, get_workspace_configs, is_workspace_target},
     workspace_diagnostic::upsert_document_source,
 };
 
@@ -90,18 +90,4 @@ pub async fn handle_did_change_watched_files(
     if should_refresh_pull_diagnostics {
         backend.refresh_pull_diagnostics().await;
     }
-}
-
-fn is_workspace_target(
-    text_document_uri: &tombi_uri::Uri,
-    workspace_configs: &[WorkspaceConfig],
-    home_dir: Option<&std::path::Path>,
-) -> bool {
-    let Ok(text_document_path) = tombi_uri::Uri::to_file_path(text_document_uri) else {
-        return false;
-    };
-
-    workspace_configs
-        .iter()
-        .any(|workspace_config| workspace_config.is_workspace_target(&text_document_path, home_dir))
 }

--- a/crates/tombi-lsp/src/handler/did_close.rs
+++ b/crates/tombi-lsp/src/handler/did_close.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 
-use crate::Backend;
+use crate::{Backend, config_manager::ConfigSchemaStore};
 
 pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentParams) {
     log::info!("handle_did_close");
@@ -8,7 +8,7 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
 
     let DidCloseTextDocumentParams { text_document } = params;
 
-    let text_document_uri = text_document.uri.into();
+    let text_document_uri: tombi_uri::Uri = text_document.uri.clone().into();
 
     {
         let mut document_sources = backend.document_sources.write().await;
@@ -23,4 +23,23 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
         .write()
         .await
         .close(&text_document_uri);
+
+    let ConfigSchemaStore { config, .. } = backend
+        .config_manager
+        .config_schema_store_for_uri(&text_document_uri)
+        .await;
+
+    if !config
+        .lsp
+        .as_ref()
+        .and_then(|server| server.workspace_diagnostic.as_ref())
+        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
+        .unwrap_or_default()
+        .value()
+    {
+        backend
+            .client
+            .publish_diagnostics(text_document.uri, Vec::new(), None)
+            .await;
+    }
 }

--- a/crates/tombi-lsp/src/workspace_config.rs
+++ b/crates/tombi-lsp/src/workspace_config.rs
@@ -86,3 +86,17 @@ pub async fn get_workspace_configs(backend: &Backend) -> Option<Vec<WorkspaceCon
 
     Some(configs)
 }
+
+pub fn is_workspace_target(
+    text_document_uri: &tombi_uri::Uri,
+    workspace_configs: &[WorkspaceConfig],
+    home_dir: Option<&std::path::Path>,
+) -> bool {
+    let Ok(text_document_path) = tombi_uri::Uri::to_file_path(text_document_uri) else {
+        return false;
+    };
+
+    workspace_configs
+        .iter()
+        .any(|workspace_config| workspace_config.is_workspace_target(&text_document_path, home_dir))
+}


### PR DESCRIPTION
## Summary

- Clear diagnostics on `didClose` when workspace diagnostics are disabled for the file.
- Move workspace-target matching into `workspace_config` so watched-file handling can reuse the same helper.

Fixes #1996

## Validation

- `cargo fmt --all`
- `cargo check -p tombi-lsp --locked`
- `cargo test -p tombi-lsp --locked`
- `cargo check -p tombi-lsp --locked` after merging `origin/main`
