### PR TITLE
fix(lsp): avoid cloning document URIs

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -424,12 +424,12 @@ impl tower_lsp::LanguageServer for Backend {
         &self,
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>, tower_lsp::jsonrpc::Error> {
-        let text_document_uri: tombi_uri::Uri = params.text_document.uri.clone().into();
+        let text_document_uri = params.text_document.uri.as_ref();
         let line_index = {
             let Ok(document_sources) = self.document_sources.try_read() else {
                 return Ok(None);
             };
-            let Some(document_source) = document_sources.get(&text_document_uri) else {
+            let Some(document_source) = document_sources.get(text_document_uri) else {
                 return Ok(None);
             };
             document_source.line_index_arc()

--- a/crates/tombi-lsp/src/handler/did_close.rs
+++ b/crates/tombi-lsp/src/handler/did_close.rs
@@ -8,12 +8,12 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
 
     let DidCloseTextDocumentParams { text_document } = params;
 
-    let text_document_uri: tombi_uri::Uri = text_document.uri.clone().into();
+    let text_document_uri = text_document.uri.as_ref();
 
     {
         let mut document_sources = backend.document_sources.write().await;
 
-        if let Some(document) = document_sources.get_mut(&text_document_uri) {
+        if let Some(document) = document_sources.get_mut(text_document_uri) {
             document.version = None;
         }
     }
@@ -22,11 +22,11 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
         .workspace_diagnostics_cache
         .write()
         .await
-        .close(&text_document_uri);
+        .close(text_document_uri);
 
     let ConfigSchemaStore { config, .. } = backend
         .config_manager
-        .config_schema_store_for_uri(&text_document_uri)
+        .config_schema_store_for_uri(text_document_uri)
         .await;
 
     if !config

--- a/crates/tombi-uri/src/lib.rs
+++ b/crates/tombi-uri/src/lib.rs
@@ -26,6 +26,7 @@ macro_rules! comment_directive_schemastore_hostname {
     };
 }
 
+#[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Uri(url::Url);
 
@@ -64,6 +65,12 @@ impl From<Uri> for url::Url {
 impl AsRef<url::Url> for Uri {
     fn as_ref(&self) -> &url::Url {
         &self.0
+    }
+}
+
+impl AsRef<Uri> for url::Url {
+    fn as_ref(&self) -> &Uri {
+        unsafe { std::mem::transmute(self) }
     }
 }
 


### PR DESCRIPTION
## Summary
- add borrowed `url::Url` to `tombi_uri::Uri` access
- avoid cloning LSP document URIs in inlay hint and did-close paths

## Tests
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo nextest run --workspace --locked --no-fail-fast`
