### PR TITLE
Stabilize diagnostic collection names

### DIFF
--- a/crates/tombi-lsp/src/handler/initialize.rs
+++ b/crates/tombi-lsp/src/handler/initialize.rs
@@ -171,6 +171,7 @@ pub fn server_capabilities(
         ),
         diagnostic_provider: if backend_capabilities.diagnostic_mode == DiagnosticMode::Pull {
             Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
+                identifier: Some("tombi".to_string()),
                 inter_file_dependencies: false,
                 workspace_diagnostics: true,
                 ..Default::default()

--- a/editors/vscode/src/options/client-options.ts
+++ b/editors/vscode/src/options/client-options.ts
@@ -9,6 +9,7 @@ export function clientOptions(
   workspaceFolder?: vscode.WorkspaceFolder,
 ): languageclient.LanguageClientOptions {
   const options = {
+    diagnosticCollectionName: "tombi",
     documentSelector: SUPPORT_TOML_LANGUAGES.flatMap((language) => [
       { scheme: "file", language },
       { scheme: "untitled", language },


### PR DESCRIPTION
## Summary
- set the VS Code extension diagnostic collection name to `tombi`
- set the LSP pull diagnostic provider identifier to `tombi`
- reduce anonymous/generated diagnostic collection names for normal Tombi diagnostics

## Verification
- `cargo fmt --all`
- `pnpm --dir editors/vscode typecheck`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo nextest run --workspace --locked --no-fail-fast` (2116 passed; nextest reported 1 leaky test, no failures)
