### PR TITLE
fix(lint): avoid false unused deprecated directive

### DIFF
--- a/crates/tombi-linter/tests/integration/tombi_schema.rs
+++ b/crates/tombi-linter/tests/integration/tombi_schema.rs
@@ -184,6 +184,25 @@ test_lint! {
 
 test_lint! {
     #[test]
+    fn test_tombi_schema_deprecated_key_disabled_does_not_report_unused_noqa_on_value(
+        r#"
+        [extensions]
+        "tombi-toml/tombi" = {
+          lsp = {
+            document-link = {
+              # tombi: lint.rules.deprecated.disabled = true
+              path = { enabled = true }
+            },
+            goto-definition.path.enabled = true,
+          }
+        }
+        "#,
+        SchemaPath(tombi_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
     fn test_tombi_schema_lint_rules_deprecated(
         r#"
         [[schemas]]

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -748,7 +748,7 @@ async fn validate_table(
         }
     }
 
-    if total_diagnostics.is_empty() {
+    if total_diagnostics.is_empty() && table_schema.deprecation.is_some() {
         handle_deprecated(
             &mut total_diagnostics,
             table_schema.deprecation.as_ref(),


### PR DESCRIPTION
## Summary

- Avoid reporting `unused-noqa` for `deprecated.disabled` when the current table schema is not itself deprecated.
- Add regression coverage for suppressing deprecated `extensions."tombi-toml/tombi".lsp.document-link.path`.

## Test

- `cargo fmt --all`
- `cargo test -p tombi-linter --test integration tombi_schema::test_tombi_schema_deprecated_key_disabled_does_not_report_unused_noqa_on_value -- --nocapture`
- `cargo test -p tombi-validator`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
