### PR TITLE
fix(vscode): make executable settings machine-scoped

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -219,14 +219,14 @@
             "string",
             "null"
           ],
-          "scope": "resource",
+          "scope": "machine",
           "default": null,
           "pattern": "^.*tombi(\\.exe)?$"
         },
         "tombi.args": {
           "description": "Arguments to `tombi` command.",
           "type": "array",
-          "scope": "resource",
+          "scope": "machine",
           "default": null,
           "items": {
             "type": "string",
@@ -236,7 +236,7 @@
         "tombi.env": {
           "description": "Environment variables to pass to `tombi` command.",
           "type": "object",
-          "scope": "resource",
+          "scope": "machine",
           "default": null,
           "patternProperties": {
             "^.+$": {


### PR DESCRIPTION
## Summary
- address tombi/security/advisories
- mark `tombi.path`, `tombi.args`, and `tombi.env` as machine-scoped VS Code settings
- prevent workspace `.vscode/settings.json` from overriding executable launch controls

## Validation
- `pnpm -C editors/vscode format:check`
- `pnpm -C editors/vscode lint:check`
- `pnpm -C editors/vscode typecheck`
- `pnpm -C editors/vscode test`
- `pnpm -C editors/vscode build`
- `git diff --check`
