### PR TITLE
ci: pin OSV scanner workflow to existing action ref

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@b56b5191101d5f27d4787d5583d8d01e9518a7af" # v2.4.0
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2" # v2.3.8
     with:
       scan-args: |-
         --include-git-root


### PR DESCRIPTION
## Summary
- replace the OSV Scanner reusable workflow ref with an existing google/osv-scanner-action v2.3.8 commit
- keep the restored OSV workflow on main/schedule/manual events so the default-branch code scanning configuration can refresh

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/osv-scanner.yml
- /tmp/osv-scanner-v2.3.8-darwin-arm64 --include-git-root -r ./
- git diff --check origin/main..HEAD