### PR TITLE
fix(validator): report not schema resolution errors

### DIFF
--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -28,6 +28,8 @@ mod json_schema_test_suite;
 mod min_max_contains_test_schema;
 #[path = "integration/non_schema.rs"]
 mod non_schema;
+#[path = "integration/not_schema.rs"]
+mod not_schema;
 #[path = "integration/other_schema.rs"]
 mod other_schema;
 #[path = "integration/prefix_items_test_schema.rs"]

--- a/crates/tombi-linter/tests/integration/not_schema.rs
+++ b/crates/tombi-linter/tests/integration/not_schema.rs
@@ -1,0 +1,23 @@
+use tombi_linter::test_lint;
+use tombi_schema_store::SchemaUri;
+
+fn schema_path() -> std::path::PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("schemas")
+        .join("not-schema-test.schema.json")
+}
+
+test_lint! {
+    #[test]
+    fn test_unresolved_ref_reports_error(
+        r#"
+        value = "foo"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_schema_store::Error::InvalidJsonPointer {
+            pointer: "#/$defs/missing".to_string(),
+            schema_uri: SchemaUri::from_file_path(schema_path()).unwrap(),
+        }
+    ])
+}

--- a/crates/tombi-linter/tests/integration/not_schema.rs
+++ b/crates/tombi-linter/tests/integration/not_schema.rs
@@ -1,5 +1,5 @@
+use tombi_diagnostic::Level;
 use tombi_linter::test_lint;
-use tombi_schema_store::SchemaUri;
 
 fn schema_path() -> std::path::PathBuf {
     tombi_test_lib::project_root_path()
@@ -9,15 +9,46 @@ fn schema_path() -> std::path::PathBuf {
 
 test_lint! {
     #[test]
-    fn test_unresolved_ref_reports_error(
+    fn test_invalid_ref_reports_error_diagnostic(
         r#"
         value = "foo"
         "#,
         SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_inline_not_rejects_matching_value(
+        r#"
+        inline = "foo"
+        "#,
+        SchemaPath(schema_path()),
     ) -> Err([
-        tombi_schema_store::Error::InvalidJsonPointer {
-            pointer: "#/$defs/missing".to_string(),
-            schema_uri: SchemaUri::from_file_path(schema_path()).unwrap(),
-        }
+        tombi_validator::DiagnosticKind::NotSchemaMatch
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_inline_not_accepts_non_matching_value(
+        r#"
+        inline = "bar"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_inline_not_treats_warning_only_result_as_match(
+        r#"
+        warning = "foo"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::NotSchemaMatch
     ])
 }

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -740,6 +740,7 @@ mod completion_labels {
                 "issue-1895-rustfmt-like.schema.json",
                 "lsp-consistency-test.schema.json",
                 "min-max-contains-test.schema.json",
+                "not-schema-test.schema.json",
                 "one-of-hover-discriminator-test.schema.json",
                 "partial-taskipy.schema.json",
                 "prefix-items-test.schema.json",

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -17,7 +17,7 @@ pub async fn validate_not<'a, T>(
 where
     T: Validate + ValueImpl + Sync + Send,
 {
-    if let Ok(Some(current_schema)) = not_schema
+    let matches_not_schema = match not_schema
         .schema
         .write()
         .await
@@ -27,12 +27,23 @@ where
             schema_context.store,
         )
         .await
-        .inspect_err(|err| log::warn!("{err}"))
-        && value
+    {
+        Ok(Some(current_schema)) => value
             .validate(accessors, Some(&current_schema), schema_context)
             .await
-            .is_ok()
-    {
+            .is_ok(),
+        Ok(None) => false,
+        Err(err) => {
+            return Err(vec![tombi_diagnostic::Diagnostic::new_error(
+                err.to_string(),
+                err.code(),
+                value.range(),
+            )]
+            .into());
+        }
+    };
+
+    if matches_not_schema {
         let mut diagnostics = Vec::with_capacity(1);
         crate::Diagnostic {
             kind: Box::new(crate::DiagnosticKind::NotSchemaMatch),

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -3,7 +3,10 @@ use tombi_document_tree::ValueImpl;
 use tombi_schema_store::{CurrentSchema, SchemaContext};
 use tombi_severity_level::SeverityLevelDefaultError;
 
-use crate::{Validate, validate::handle_unused_noqa};
+use crate::{
+    Validate,
+    validate::{handle_unused_noqa, is_assertion_success},
+};
 
 pub async fn validate_not<'a, T>(
     value: &T,
@@ -17,21 +20,19 @@ pub async fn validate_not<'a, T>(
 where
     T: Validate + ValueImpl + Sync + Send,
 {
-    let matches_not_schema = match not_schema
-        .schema
-        .write()
-        .await
-        .resolve(
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            schema_context.store,
-        )
-        .await
+    let matches_not_schema = match tombi_schema_store::resolve_schema_item(
+        &not_schema.schema,
+        current_schema.schema_uri.clone(),
+        current_schema.definitions.clone(),
+        schema_context.store,
+    )
+    .await
     {
-        Ok(Some(current_schema)) => value
-            .validate(accessors, Some(&current_schema), schema_context)
-            .await
-            .is_ok(),
+        Ok(Some(current_schema)) => is_assertion_success(
+            &value
+                .validate(accessors, Some(&current_schema), schema_context)
+                .await,
+        ),
         Ok(None) => false,
         Err(err) => {
             return Err(vec![tombi_diagnostic::Diagnostic::new_error(

--- a/schemas/not-schema-test.schema.json
+++ b/schemas/not-schema-test.schema.json
@@ -7,6 +7,18 @@
       "not": {
         "$ref": "#/$defs/missing"
       }
+    },
+    "inline": {
+      "type": "string",
+      "not": {
+        "pattern": "^foo$"
+      }
+    },
+    "warning": {
+      "type": "string",
+      "not": {
+        "deprecated": true
+      }
     }
   }
 }

--- a/schemas/not-schema-test.schema.json
+++ b/schemas/not-schema-test.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "value": {
+      "type": "string",
+      "not": {
+        "$ref": "#/$defs/missing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add regression coverage for an invalid `$ref` used directly as a `not` subschema
- surface direct `not` subschema resolution errors as lint diagnostics
- resolve the schema item without holding its write lock across validation
- use assertion semantics for warning-only subschema results
- verify normal inline `not` match and non-match behavior

## Bug case

Given this schema:

```json
{
  "type": "object",
  "properties": {
    "value": {
      "type": "string",
      "not": {
        "$ref": "#/$defs/missing"
      }
    }
  }
}
```

and this TOML document:

```toml
value = "foo"
```

the `$ref` cannot resolve because `#/$defs/missing` does not exist. Resolving the schema item assigned to `not` returns `Err(InvalidJsonPointer)`.

Previously, `validate_not` used `if let Ok(Some(...))` around resolution. The error was only logged, did not match the `Ok(Some(...))` pattern, and execution fell through to a successful validation result. As a result, every value passed lint even though this `not` subschema could not be evaluated. This was a fail-open reference-resolution bug, not a general problem with inline `not` constraints.

The new implementation matches the direct `not` schema-item resolution result explicitly. A resolution `Err` becomes a user-facing diagnostic with the original error code and message, so this case now fails lint with an `invalid-json-pointer` error. Resolved schemas continue through normal assertion evaluation, including treating warning-only results as assertion success.

`Ok(None)` keeps the existing unresolved/offline behavior.

## Scope

This change covers errors returned while resolving the schema item directly assigned to `not`. It does not reclassify resolution errors produced later while evaluating deeper descendant or composite schemas; that requires validator-wide separation between assertion failures and schema-evaluation failures.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tombi-validator`
- `cargo test -p tombi-validator` (20 passed)
- `cargo test -p tombi-linter --test integration not_schema::` (4 passed)
- `cargo test -p tombi-linter --test integration` (284 passed)
- `cargo clippy -p tombi-linter --test integration -- -D warnings`

The regression test and implementation fix are kept in separate commits. Follow-up review fixes add diagnostic metadata assertions and coverage for resolved inline `not` behavior.
