### PR TITLE
Add illumos CLI release artifacts

### DIFF
--- a/.github/actions/build-cli-illumos/action.yml
+++ b/.github/actions/build-cli-illumos/action.yml
@@ -22,4 +22,7 @@ runs:
       shell: bash
       run: cargo xtask dist
       env:
+        TOMBI_TARGET: x86_64-unknown-illumos
+        TOMBI_DIST_BUILD_TOOL: cross
+        TOMBI_DIST_CLI_ONLY: "1"
         RUST_BACKTRACE: "1"

--- a/.github/actions/build-cli-illumos/action.yml
+++ b/.github/actions/build-cli-illumos/action.yml
@@ -25,4 +25,26 @@ runs:
         TOMBI_TARGET: x86_64-unknown-illumos
         TOMBI_DIST_BUILD_TOOL: cross
         TOMBI_DIST_CLI_ONLY: "1"
+        CARGO_PROFILE_RELEASE_LTO: "fat"
+        CARGO_PROFILE_RELEASE_STRIP: "symbols"
+        # cross mounts the host Rust toolchain at /rust. rust-objcopy needs the
+        # matching libLLVM from this directory when Cargo strips the binary.
+        LD_LIBRARY_PATH: /rust/lib
         RUST_BACKTRACE: "1"
+
+    - name: Verify tombi CLI is stripped
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        binary="target/x86_64-unknown-illumos/release/tombi"
+        file_output="$(file "${binary}")"
+        printf '%s\n' "${file_output}"
+
+        case "${file_output}" in
+          *", stripped") ;;
+          *)
+            echo "illumos CLI binary is not stripped" >&2
+            exit 1
+            ;;
+        esac

--- a/.github/actions/build-cli-illumos/action.yml
+++ b/.github/actions/build-cli-illumos/action.yml
@@ -1,0 +1,25 @@
+name: Build illumos CLI
+description: Build the x86_64 illumos CLI release artifact with cross.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      shell: bash
+      run: |
+        rustup update --no-self-update stable
+        rustup target add x86_64-unknown-illumos
+
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+    - name: Install cross
+      shell: bash
+      run: cargo install cross --version 0.2.5 --locked
+
+    - uses: ./.github/actions/set-version
+
+    - name: Run xtask dist
+      shell: bash
+      run: cargo xtask dist
+      env:
+        RUST_BACKTRACE: "1"

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
+      illumos: ${{ steps.filter-illumos.outputs.relevant }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -31,9 +32,68 @@ jobs:
           paths: |
             docs/public/install.sh
             xtask/src/command/dist.rs
+            .github/actions/build-cli-illumos/**
             .github/workflows/release_cli_vscode.yml
             .github/actions/relevant-changes/**
             .github/workflows/ci_install_script.yml
+      - id: filter-illumos
+        uses: ./.github/actions/relevant-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          paths: |
+            .cargo/**
+            Cargo.toml
+            Cargo.lock
+            rust-toolchain.toml
+            crates/**
+            extensions/**
+            rust/**
+            xtask/**
+            schemas/**
+            www.schemastore.org/**
+            www.schemastore.tombi/**
+            tombi.toml
+            type-test.toml
+            .github/actions/build-cli-illumos/**
+            .github/actions/relevant-changes/**
+            .github/actions/set-version/**
+            .github/workflows/ci_install_script.yml
+            .github/workflows/release_cli_vscode.yml
+
+  build-cli-illumos:
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.illumos == 'true'
+    name: Build CLI (x86_64-unknown-illumos)
+    runs-on: ubuntu-24.04
+    env:
+      TOMBI_TARGET: x86_64-unknown-illumos
+      TOMBI_DIST_BUILD_TOOL: cross
+      TOMBI_DIST_CLI_ONLY: "1"
+      GITHUB_REF: ${{ github.ref }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/build-cli-illumos
+
+      - name: Verify tombi-cli artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact="dist/tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}.tar.gz"
+          archive_root="tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}"
+          expected_path="${archive_root}/tombi"
+
+          test -f "${artifact}"
+          test "$(tar -tzf "${artifact}")" = "${expected_path}"
+
+          extract_dir="${RUNNER_TEMP}/tombi-cli-illumos"
+          mkdir -p "${extract_dir}"
+          tar -xzf "${artifact}" -C "${extract_dir}"
+          test -x "${extract_dir}/${expected_path}"
 
   test-install-script:
     needs: detect-changes

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -45,6 +45,7 @@ jobs:
             .cargo/**
             Cargo.toml
             Cargo.lock
+            Cross.toml
             rust-toolchain.toml
             crates/**
             extensions/**
@@ -201,21 +202,6 @@ jobs:
                 *) arch="x86_64" ;;
               esac
               target="${arch}-apple-darwin"
-              if [ "$major" -eq 0 ] && { [ "$minor" -lt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -lt 23 ]; }; }; then
-                extension=".gz"
-              else
-                extension=".tar.gz"
-              fi
-              ;;
-            SunOS)
-              case "$(uname -m)" in
-                x86_64|amd64|i86pc) arch="x86_64" ;;
-                *)
-                  echo "Unsupported illumos architecture" >&2
-                  exit 1
-                  ;;
-              esac
-              target="${arch}-unknown-illumos"
               if [ "$major" -eq 0 ] && { [ "$minor" -lt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -lt 23 ]; }; }; then
                 extension=".gz"
               else

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -68,9 +68,10 @@ jobs:
     name: Build CLI (x86_64-unknown-illumos)
     runs-on: ubuntu-24.04
     env:
+      # The build tool (cross) and cli-only flag are fixed by the
+      # build-cli-illumos action; TOMBI_TARGET is kept here because the
+      # artifact verification step below references it.
       TOMBI_TARGET: x86_64-unknown-illumos
-      TOMBI_DIST_BUILD_TOOL: cross
-      TOMBI_DIST_CLI_ONLY: "1"
       GITHUB_REF: ${{ github.ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -134,6 +135,7 @@ jobs:
           case "$1" in
             -s) echo "SunOS" ;;
             -m) echo "i86pc" ;;
+            -o) echo "illumos" ;;
             *) echo "SunOS" ;;
           esac
           SHIM

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -61,6 +61,31 @@ jobs:
       - name: Add install directory to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      # GitHub does not offer illumos runners, so exercise install.sh's SunOS
+      # branch by shimming `uname` (i86pc is what real illumos reports for x86_64).
+      - name: Verify illumos target detection (simulated)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          shim_dir="${RUNNER_TEMP}/uname-shim"
+          mkdir -p "$shim_dir"
+          cat > "$shim_dir/uname" <<'SHIM'
+          #!/bin/sh
+          case "$1" in
+            -s) echo "SunOS" ;;
+            -m) echo "i86pc" ;;
+            *) echo "SunOS" ;;
+          esac
+          SHIM
+          chmod +x "$shim_dir/uname"
+          # Download of the not-yet-published illumos asset is expected to fail;
+          # only the target detection printed before the download is asserted.
+          output="$(PATH="$shim_dir:$PATH" ./docs/public/install.sh --version 1.2.0 2>&1 || true)"
+          printf '%s\n' "$output"
+          if ! printf '%s\n' "$output" | grep -q "Detected system: x86_64-unknown-illumos"; then
+            echo "install.sh did not resolve the illumos target for simulated SunOS" >&2
+            exit 1
+          fi
+
       - name: Resolve release artifact metadata
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -122,6 +122,21 @@ jobs:
                 extension=".tar.gz"
               fi
               ;;
+            SunOS)
+              case "$(uname -m)" in
+                x86_64|amd64|i86pc) arch="x86_64" ;;
+                *)
+                  echo "Unsupported illumos architecture" >&2
+                  exit 1
+                  ;;
+              esac
+              target="${arch}-unknown-illumos"
+              if [ "$major" -eq 0 ] && { [ "$minor" -lt 9 ] || { [ "$minor" -eq 9 ] && [ "$patch" -lt 23 ]; }; }; then
+                extension=".gz"
+              else
+                extension=".tar.gz"
+              fi
+              ;;
             MINGW*|MSYS*|CYGWIN*|Windows_NT)
               case "$(uname -m)" in
                 aarch64) arch="aarch64" ;;

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -197,9 +197,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [delete-old-dev-artifacts]
     env:
-      TOMBI_TARGET: x86_64-unknown-illumos
-      TOMBI_DIST_BUILD_TOOL: cross
-      TOMBI_DIST_CLI_ONLY: "1"
+      # TOMBI_TARGET / TOMBI_DIST_BUILD_TOOL / TOMBI_DIST_CLI_ONLY are fixed by
+      # the build-cli-illumos action; only GITHUB_REF (consumed by set-version)
+      # is job-specific here.
       GITHUB_REF: ${{ (github.ref) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -47,6 +47,7 @@ jobs:
           paths: |
             .cargo/**
             .github/actions/dispatch-versioned-release/**
+            .github/actions/build-cli-illumos/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
             .node-version
@@ -203,18 +204,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update stable
-          rustup target add x86_64-unknown-illumos
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install cross
-        run: cargo install cross --version 0.2.5 --locked
-      - uses: ./.github/actions/set-version
-      - name: Rub xtask dist
-        run: cargo xtask dist
-        env:
-          RUST_BACKTRACE: "1"
+      - uses: ./.github/actions/build-cli-illumos
       - name: Upload tombi-cli artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -190,6 +190,37 @@ jobs:
           name: tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
           path: dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
 
+  release-cli-illumos:
+    name: dist (x86_64-unknown-illumos)
+    runs-on: ubuntu-24.04
+    needs: [delete-old-dev-artifacts]
+    env:
+      TOMBI_TARGET: x86_64-unknown-illumos
+      TOMBI_DIST_BUILD_TOOL: cross
+      TOMBI_DIST_CLI_ONLY: "1"
+      GITHUB_REF: ${{ (github.ref) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup update --no-self-update stable
+          rustup target add x86_64-unknown-illumos
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cross
+        run: cargo install cross --version 0.2.5 --locked
+      - uses: ./.github/actions/set-version
+      - name: Rub xtask dist
+        run: cargo xtask dist
+        env:
+          RUST_BACKTRACE: "1"
+      - name: Upload tombi-cli artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-x86_64-unknown-illumos.tar.gz
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-x86_64-unknown-illumos.tar.gz
+
   check-release-notes:
     needs: detect-changes
     if: needs.detect-changes.outputs.relevant == 'true'
@@ -212,7 +243,7 @@ jobs:
           fi
 
   release-notes:
-    needs: [release-cli-and-vscode, check-release-notes]
+    needs: [release-cli-and-vscode, release-cli-illumos, check-release-notes]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -54,6 +54,7 @@ jobs:
             .npmrc
             Cargo.toml
             Cargo.lock
+            Cross.toml
             rust-toolchain.toml
             package.json
             pnpm-lock.yaml

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+# cross runs the build inside a container that does not inherit host env vars by
+# default. Forward the release profile knobs set by the release workflow so the
+# cross-built CLI matches the artifacts produced by the native `cargo` targets.
+[build.env]
+passthrough = [
+    "CARGO_PROFILE_RELEASE_LTO",
+    "CARGO_PROFILE_RELEASE_STRIP",
+    "RUST_BACKTRACE",
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 # cross runs the build inside a container that does not inherit host env vars by
-# default. Forward the release profile knobs set by the release workflow so the
+# default. Forward the release profile knobs set by the build action so the
 # cross-built CLI matches the artifacts produced by the native `cargo` targets.
 [build.env]
 passthrough = [
@@ -7,3 +7,8 @@ passthrough = [
     "CARGO_PROFILE_RELEASE_STRIP",
     "RUST_BACKTRACE",
 ]
+
+# LD_LIBRARY_PATH lets rust-objcopy load libLLVM from the toolchain mounted at
+# /rust when Cargo strips the illumos binary.
+[target.x86_64-unknown-illumos.env]
+passthrough = ["LD_LIBRARY_PATH"]

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -253,6 +253,14 @@ detect_os_arch() {
 		TARGET="${ARCH}-${OS}"
 		;;
 	SunOS)
+		# `uname -s` reports SunOS on both illumos and Oracle Solaris, but the
+		# release artifacts are illumos-only. Reject Solaris instead of handing
+		# it an ABI-incompatible binary. `uname -o` is unavailable on some
+		# systems, so only reject when it explicitly reports Solaris.
+		if [ "$(uname -o 2>/dev/null || echo)" = "Solaris" ]; then
+			print_error "Oracle Solaris is not supported; release builds target illumos only."
+			exit 1
+		fi
 		OS="unknown-illumos"
 		case "${ARCH}" in
 		x86_64 | amd64 | i86pc)

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -252,6 +252,19 @@ detect_os_arch() {
 		fi
 		TARGET="${ARCH}-${OS}"
 		;;
+	SunOS)
+		OS="unknown-illumos"
+		case "${ARCH}" in
+		x86_64 | amd64 | i86pc)
+			ARCH="x86_64"
+			;;
+		*)
+			print_error "Unsupported illumos architecture: ${ARCH}"
+			exit 1
+			;;
+		esac
+		TARGET="${ARCH}-${OS}"
+		;;
 	MINGW* | MSYS* | CYGWIN* | Windows_NT)
 		OS="pc-windows-msvc"
 		if [ "${ARCH}" = "aarch64" ]; then

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -24,7 +24,9 @@ pub fn run(sh: &Shell) -> Result<(), anyhow::Error> {
     sh.create_dir(&dist)?;
 
     dist_server(sh, &target)?;
-    dist_client(sh, &target)?;
+    if !target.cli_only {
+        dist_client(sh, &target)?;
+    }
 
     Ok(())
 }
@@ -43,11 +45,21 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
         .join("tombi-cli")
         .join("Cargo.toml");
 
-    xshell::cmd!(
-        sh,
-        "cargo build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
-    )
-    .run()?;
+    match std::env::var("TOMBI_DIST_BUILD_TOOL").as_deref() {
+        Ok("cross") => xshell::cmd!(
+            sh,
+            "cross build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
+        )
+        .run()?,
+        Ok("cargo") | Err(_) => xshell::cmd!(
+            sh,
+            "cargo build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
+        )
+        .run()?,
+        Ok(build_tool) => {
+            anyhow::bail!("Unsupported TOMBI_DIST_BUILD_TOOL: {build_tool}");
+        }
+    }
 
     let dist = project_root_path().join("dist");
     if target_name.contains("-windows-") {
@@ -122,6 +134,7 @@ struct Target {
     cli_artifact_dir_name: String,
     cli_artifact_name: String,
     vscode_artifact_name: String,
+    cli_only: bool,
 }
 
 impl Target {
@@ -174,6 +187,7 @@ impl Target {
         let cli_artifact_dir_name = format!("tombi-cli-{version}-{target_name}");
         let cli_artifact_name = format!("{cli_artifact_dir_name}{cli_artifact_suffix}");
         let vscode_artifact_name = format!("tombi-vscode-{version}-{vscode_target_name}.vsix");
+        let cli_only = std::env::var("TOMBI_DIST_CLI_ONLY").is_ok_and(|value| value == "1");
 
         Self {
             target_name,
@@ -184,6 +198,7 @@ impl Target {
             cli_artifact_dir_name,
             cli_artifact_name,
             vscode_artifact_name,
+            cli_only,
         }
     }
 }
@@ -242,9 +257,14 @@ fn zip(src_path: &Path, symbols_path: Option<&PathBuf>, dest_path: &Path) -> any
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn unix_targets_always_use_tar_gz() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
         unsafe {
             std::env::set_var("TOMBI_TARGET", "aarch64-apple-darwin");
         }
@@ -256,6 +276,31 @@ mod tests {
 
         unsafe {
             std::env::remove_var("TOMBI_TARGET");
+        }
+    }
+
+    #[test]
+    fn cli_only_targets_still_use_target_named_artifacts() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        unsafe {
+            std::env::set_var("TOMBI_TARGET", "x86_64-unknown-illumos");
+            std::env::set_var("VSCODE_TARGET", "unused");
+            std::env::set_var("TOMBI_DIST_CLI_ONLY", "1");
+        }
+
+        let target = Target::get(Path::new("."));
+
+        assert!(target.cli_only);
+        assert_eq!(
+            target.cli_artifact_name,
+            format!("tombi-cli-{DEV_VERSION}-x86_64-unknown-illumos.tar.gz")
+        );
+
+        unsafe {
+            std::env::remove_var("TOMBI_TARGET");
+            std::env::remove_var("VSCODE_TARGET");
+            std::env::remove_var("TOMBI_DIST_CLI_ONLY");
         }
     }
 }

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -46,11 +46,18 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
         .join("Cargo.toml");
 
     match std::env::var("TOMBI_DIST_BUILD_TOOL").as_deref() {
-        Ok("cross") => xshell::cmd!(
-            sh,
-            "cross build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
-        )
-        .run()?,
+        Ok("cross") => {
+            // cross builds inside a container that mounts the workspace root, so
+            // host absolute paths do not exist there. Run from the project root
+            // and select the crate by package name instead of an absolute
+            // `--manifest-path`.
+            let _dir = sh.push_dir(project_root_path());
+            xshell::cmd!(
+                sh,
+                "cross build --locked -p tombi-cli --bin tombi --target {target_name} --release"
+            )
+            .run()?
+        }
         Ok("cargo") | Err(_) => xshell::cmd!(
             sh,
             "cargo build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"


### PR DESCRIPTION
## Summary

- Add a dedicated release job for the `x86_64-unknown-illumos` CLI artifact.
- Allow `cargo xtask dist` to build CLI-only targets and use `cross` when requested.
- Teach the install script and installer CI metadata resolver to map SunOS/x86_64 to `x86_64-unknown-illumos`.

Closes #2006

## Validation

- `cargo fmt --all --check`
- `.context/bin/actionlint -ignore 'SC2086' .github/workflows/release_cli_vscode.yml .github/workflows/ci_install_script.yml`
- `sh -n docs/public/install.sh && git diff --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo nextest run --workspace --locked --no-fail-fast`
