### PR TITLE
fix(validator): report schema resolution errors

### DIFF
--- a/crates/tombi-extension/src/completion.rs
+++ b/crates/tombi-extension/src/completion.rs
@@ -512,7 +512,7 @@ impl FromLsp<CompletionContent> for tower_lsp::lsp_types::CompletionItem {
     ) -> tower_lsp::lsp_types::CompletionItem {
         const SECTION_SEPARATOR: &str = "-----";
 
-        let sorted_text = format!("{}_{}", source.priority.as_prefix(), &source.label);
+        let sorted_text = format!("{}_{}", source.priority.as_prefix(), source.label);
 
         let mut schema_text = None;
         if let Some(schema_uri) = &source.schema_uri {

--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -38,6 +38,8 @@ mod prefix_items_test_schema;
 mod recursive_anchor_ref_test_schema;
 #[path = "integration/recursive_defs_any_of_test_schema.rs"]
 mod recursive_defs_any_of_test_schema;
+#[path = "integration/schema_resolution_error.rs"]
+mod schema_resolution_error;
 #[path = "integration/string_format_test_schema.rs"]
 mod string_format_test_schema;
 #[path = "integration/table_const_enum_test_schema.rs"]

--- a/crates/tombi-linter/tests/integration/schema_resolution_error.rs
+++ b/crates/tombi-linter/tests/integration/schema_resolution_error.rs
@@ -1,0 +1,241 @@
+use tombi_diagnostic::Level;
+use tombi_linter::test_lint;
+
+fn schema_path() -> std::path::PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("schemas")
+        .join("schema-resolution-error-test.schema.json")
+}
+
+test_lint! {
+    #[test]
+    fn test_property_schema_resolution_error(
+        r#"
+        direct = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_all_of_schema_resolution_error(
+        r#"
+        all-of-error = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_any_of_schema_resolution_error(
+        r#"
+        any-of-error = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_one_of_schema_resolution_error(
+        r#"
+        one-of-error = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_if_schema_resolution_error(
+        r#"
+        if-error = {}
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_then_schema_resolution_error(
+        r#"
+        then-error = {}
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_else_schema_resolution_error(
+        r#"
+        else-error = {}
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_items_schema_resolution_error(
+        r#"
+        items-error = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_prefix_items_schema_resolution_error(
+        r#"
+        prefix-items-error = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_overflow_items_schema_resolution_error(
+        r#"
+        overflow-items-error = [1, 2]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_overflow_items_schema_not_applied(
+        r#"
+        overflow-items-error = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_contains_schema_resolution_error(
+        r#"
+        contains-error = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_unevaluated_items_schema_resolution_error(
+        r#"
+        unevaluated-items-error = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_pattern_property_schema_resolution_error(
+        r#"
+        [pattern-properties-error]
+        pat-key = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_additional_property_schema_resolution_error(
+        r#"
+        [additional-properties-error]
+        extra = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_unevaluated_property_schema_resolution_error(
+        r#"
+        [unevaluated-properties-error]
+        extra = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR },
+        { code: "table-strict-additional-keys", level: Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_property_names_schema_resolution_error(
+        r#"
+        [property-names-error]
+        key = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_dependency_schema_resolution_error(
+        r#"
+        [dependencies-error]
+        trigger = "x"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_dependent_schema_resolution_error(
+        r#"
+        [dependent-schemas-error]
+        trigger = "x"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "invalid-json-pointer", level: Level::ERROR }
+    ])
+}

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -248,7 +248,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                             {
                                                 log::trace!(
                                                     "property_schema = {:?}",
-                                                    &current_schema.value_schema
+                                                    current_schema.value_schema
                                                 );
 
                                                 let Some(mut contents) =
@@ -311,7 +311,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                         if pattern.is_match(accessor_str) {
                                             log::trace!(
                                                 "pattern_property_schema = {:?}",
-                                                &current_schema.value_schema
+                                                current_schema.value_schema
                                             );
                                             if let Ok(Some(current_schema)) = table_schema
                                                 .resolve_pattern_property_schema(

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -42,8 +42,8 @@ pub use not_schema::NotSchema;
 pub use offset_date_time_schema::OffsetDateTimeSchema;
 pub use one_of_schema::OneOfSchema;
 pub use referable_schema::{
-    CurrentSchema, Referable, is_online_url, resolve_and_collect_schemas, resolve_json_pointer,
-    resolve_schema_item,
+    CurrentSchema, Referable, is_online_url, resolve_and_collect_schemas,
+    resolve_and_collect_schemas_with_errors, resolve_json_pointer, resolve_schema_item,
 };
 pub use schema_context::{ResolvedFormatOrder, SchemaContext};
 pub use schema_cycle_guard::{SchemaCycleGuard, SchemaVisits};

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -692,11 +692,6 @@ fn is_plain_name_fragment(fragment: &str) -> bool {
     !fragment.is_empty() && !fragment.contains('/')
 }
 
-/// Two-path schema collection: tries a read lock first for already-resolved schemas,
-/// resolves refs on cloned entries, and writes back only newly-resolved entries.
-///
-/// Returns `None` when schema traversal is re-entrant (cycle guard) or when
-/// an initial read lock cannot be acquired due to concurrent mutation.
 pub async fn resolve_and_collect_schemas(
     schemas: &super::ReferableValueSchemas,
     schema_uri: Cow<'_, SchemaUri>,
@@ -705,6 +700,37 @@ pub async fn resolve_and_collect_schemas(
     schema_visits: &crate::SchemaVisits,
     accessors: &[crate::Accessor],
 ) -> Option<Vec<CurrentSchema<'static>>> {
+    let (collected, errors) = resolve_and_collect_schemas_with_errors(
+        schemas,
+        schema_uri,
+        definitions,
+        schema_store,
+        schema_visits,
+        accessors,
+    )
+    .await?;
+
+    for err in errors {
+        log::warn!("{err}");
+    }
+
+    Some(collected)
+}
+
+/// Two-path schema collection: tries a read lock first for already-resolved schemas,
+/// resolves refs on cloned entries, and writes back only newly-resolved entries.
+///
+/// Returns the successfully resolved schemas together with any resolution errors.
+/// Returns `None` when schema traversal is re-entrant (cycle guard) or when
+/// an initial read lock cannot be acquired due to concurrent mutation.
+pub async fn resolve_and_collect_schemas_with_errors(
+    schemas: &super::ReferableValueSchemas,
+    schema_uri: Cow<'_, SchemaUri>,
+    definitions: Cow<'_, SchemaDefinitions>,
+    schema_store: &crate::SchemaStore,
+    schema_visits: &crate::SchemaVisits,
+    accessors: &[crate::Accessor],
+) -> Option<(Vec<CurrentSchema<'static>>, Vec<crate::Error>)> {
     let Some(_cycle_guard) = schema_visits.get_cycle_guard(schemas) else {
         log::debug!(
             "detected composite schema cycle while collecting schemas: schema_uri={schema_uri} accessors={accessors} reason=reentrant_schema_traversal",
@@ -749,6 +775,7 @@ pub async fn resolve_and_collect_schemas(
     // Build output from read result and avoid cloning the whole referable vector.
     if let Some(resolved_schemas) = resolved_schemas {
         let mut collected = Vec::with_capacity(resolved_schemas.len());
+        let mut errors = Vec::new();
         let default_schema_uri = schema_uri.as_ref().clone();
         let default_definitions = definitions.clone().into_owned();
 
@@ -765,7 +792,7 @@ pub async fn resolve_and_collect_schemas(
                         ),
                         Ok(None) => (default_schema_uri.clone(), default_definitions.clone()),
                         Err(err) => {
-                            log::warn!("{err}");
+                            errors.push(err);
                             continue;
                         }
                     }
@@ -780,11 +807,12 @@ pub async fn resolve_and_collect_schemas(
             });
         }
 
-        return Some(collected);
+        return Some((collected, errors));
     }
 
     // Slow path: unresolved refs exist. Resolve on cloned entries and cache back.
     let mut collected = Vec::with_capacity(schema_entries.len());
+    let mut errors = Vec::new();
     let mut resolved_indices = Vec::new();
     for (index, referable_schema) in schema_entries.iter_mut().enumerate() {
         let was_ref = referable_schema.is_ref();
@@ -795,7 +823,7 @@ pub async fn resolve_and_collect_schemas(
             Ok(Some(current_schema)) => collected.push(current_schema.into_owned()),
             Ok(None) => {}
             Err(err) => {
-                log::warn!("{err}");
+                errors.push(err);
             }
         }
 
@@ -812,7 +840,7 @@ pub async fn resolve_and_collect_schemas(
                 schema_uri = schema_uri.as_ref(),
                 accessors = crate::Accessors::from(accessors.to_vec())
             );
-            return Some(collected);
+            return Some((collected, errors));
         };
 
         for index in resolved_indices {
@@ -826,7 +854,7 @@ pub async fn resolve_and_collect_schemas(
         }
     }
 
-    Some(collected)
+    Some((collected, errors))
 }
 
 /// Resolve a schema item without holding its write lock across await points.

--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -33,18 +33,23 @@ where
         let mut total_score = 0;
         let mut evaluated_locations = crate::EvaluatedLocations::new();
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
-            &all_of_schema.schemas,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            schema_context.store,
-            &schema_context.schema_visits,
-            accessors,
-        )
-        .await
+        let Some((resolved_schemas, resolution_errors)) =
+            tombi_schema_store::resolve_and_collect_schemas_with_errors(
+                &all_of_schema.schemas,
+                current_schema.schema_uri.clone(),
+                current_schema.definitions.clone(),
+                schema_context.store,
+                &schema_context.schema_visits,
+                accessors,
+            )
+            .await
         else {
             return Ok(crate::EvaluatedLocations::new());
         };
+
+        total_diagnostics.extend(resolution_errors.into_iter().map(|err| {
+            tombi_diagnostic::Diagnostic::new_error(err.to_string(), err.code(), value.range())
+        }));
 
         for resolved_schema in &resolved_schemas {
             match value

--- a/crates/tombi-validator/src/validate/any_of.rs
+++ b/crates/tombi-validator/src/validate/any_of.rs
@@ -66,15 +66,16 @@ where
             }
         }
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
-            &any_of_schema.schemas,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            schema_context.store,
-            &schema_context.schema_visits,
-            accessors,
-        )
-        .await
+        let Some((resolved_schemas, resolution_errors)) =
+            tombi_schema_store::resolve_and_collect_schemas_with_errors(
+                &any_of_schema.schemas,
+                current_schema.schema_uri.clone(),
+                current_schema.definitions.clone(),
+                schema_context.store,
+                &schema_context.schema_visits,
+                accessors,
+            )
+            .await
         else {
             if total_diagnostics.is_empty() {
                 return Ok(base_evaluated_locations);
@@ -86,6 +87,10 @@ where
                 });
             }
         };
+
+        total_diagnostics.extend(resolution_errors.into_iter().map(|err| {
+            tombi_diagnostic::Diagnostic::new_error(err.to_string(), err.code(), value.range())
+        }));
 
         let mut total_error = crate::Error::new();
         let mut matched = false;

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -150,34 +150,39 @@ async fn validate_array(
     }
 
     if let Some(prefix_items) = &array_schema.prefix_items {
-        // Resolve the overflow schema once before the loop
-        let overflow_schema =
-            if let Some(additional_items_schema) = &array_schema.additional_items_schema {
-                tombi_schema_store::resolve_schema_item(
-                    additional_items_schema,
-                    current_schema.schema_uri.clone(),
-                    current_schema.definitions.clone(),
-                    schema_context.store,
-                )
-                .await
-                .inspect_err(|err| log::warn!("{err}"))
-                .ok()
-                .flatten()
-            } else if let Some(items) = &array_schema.items {
-                // 2020-12: items acts as additionalItems when prefixItems is present
-                tombi_schema_store::resolve_schema_item(
-                    items,
-                    current_schema.schema_uri.clone(),
-                    current_schema.definitions.clone(),
-                    schema_context.store,
-                )
-                .await
-                .inspect_err(|err| log::warn!("{err}"))
-                .ok()
-                .flatten()
-            } else {
-                None
-            };
+        // Resolve the overflow schema once before the loop.
+        // 2020-12: items acts as additionalItems when prefixItems is present.
+        let overflow_schema = if array_value.values().len() > prefix_items.len() {
+            match array_schema
+                .additional_items_schema
+                .as_ref()
+                .or(array_schema.items.as_ref())
+            {
+                Some(overflow_item) => {
+                    match tombi_schema_store::resolve_schema_item(
+                        overflow_item,
+                        current_schema.schema_uri.clone(),
+                        current_schema.definitions.clone(),
+                        schema_context.store,
+                    )
+                    .await
+                    {
+                        Ok(overflow_schema) => overflow_schema,
+                        Err(err) => {
+                            total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                                err.to_string(),
+                                err.code(),
+                                array_value.range(),
+                            ));
+                            None
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
 
         // Tuple validation: validate each element against its positional schema
         for (index, value) in array_value.values().iter().enumerate() {
@@ -189,19 +194,30 @@ async fn validate_array(
 
             if index < prefix_items.len() {
                 evaluated[index] = true;
-                if let Ok(Some(item_schema)) = tombi_schema_store::resolve_schema_item(
+                match tombi_schema_store::resolve_schema_item(
                     &prefix_items[index],
                     current_schema.schema_uri.clone(),
                     current_schema.definitions.clone(),
                     schema_context.store,
                 )
                 .await
-                .inspect_err(|err| log::warn!("{err}"))
-                    && let Err(crate::Error { diagnostics, .. }) = value
-                        .validate(&new_accessors, Some(&item_schema), schema_context)
-                        .await
                 {
-                    total_diagnostics.extend(diagnostics);
+                    Ok(Some(item_schema)) => {
+                        if let Err(crate::Error { diagnostics, .. }) = value
+                            .validate(&new_accessors, Some(&item_schema), schema_context)
+                            .await
+                        {
+                            total_diagnostics.extend(diagnostics);
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                            err.to_string(),
+                            err.code(),
+                            value.range(),
+                        ));
+                    }
                 }
             } else if let Some(overflow) = &overflow_schema {
                 evaluated[index] = true;
@@ -229,43 +245,65 @@ async fn validate_array(
         }
     } else if let Some(items) = &array_schema.items {
         // Single schema for all items
-        if let Ok(Some(current_schema)) = tombi_schema_store::resolve_schema_item(
+        match tombi_schema_store::resolve_schema_item(
             items,
             current_schema.schema_uri.clone(),
             current_schema.definitions.clone(),
             schema_context.store,
         )
         .await
-        .inspect_err(|err| log::warn!("{err}"))
         {
-            for (index, value) in array_value.values().iter().enumerate() {
-                evaluated[index] = true;
-                let new_accessors = accessors
-                    .iter()
-                    .cloned()
-                    .chain(std::iter::once(tombi_schema_store::Accessor::Index(index)))
-                    .collect_vec();
+            Ok(Some(current_schema)) => {
+                for (index, value) in array_value.values().iter().enumerate() {
+                    evaluated[index] = true;
+                    let new_accessors = accessors
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::once(tombi_schema_store::Accessor::Index(index)))
+                        .collect_vec();
 
-                if let Err(crate::Error { diagnostics, .. }) = value
-                    .validate(&new_accessors, Some(&current_schema), schema_context)
-                    .await
-                {
-                    total_diagnostics.extend(diagnostics);
+                    if let Err(crate::Error { diagnostics, .. }) = value
+                        .validate(&new_accessors, Some(&current_schema), schema_context)
+                        .await
+                    {
+                        total_diagnostics.extend(diagnostics);
+                    }
                 }
+            }
+            Ok(None) => {}
+            Err(err) => {
+                total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                    err.to_string(),
+                    err.code(),
+                    array_value.range(),
+                ));
             }
         }
     }
 
-    if let Some(contains) = &array_schema.contains
-        && let Ok(Some(contains_schema)) = tombi_schema_store::resolve_schema_item(
+    let contains_schema = match &array_schema.contains {
+        Some(contains) => match tombi_schema_store::resolve_schema_item(
             contains,
             current_schema.schema_uri.clone(),
             current_schema.definitions.clone(),
             schema_context.store,
         )
         .await
-        .inspect_err(|err| log::warn!("{err}"))
-    {
+        {
+            Ok(contains_schema) => contains_schema,
+            Err(err) => {
+                total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                    err.to_string(),
+                    err.code(),
+                    array_value.range(),
+                ));
+                None
+            }
+        },
+        None => None,
+    };
+
+    if let Some(contains_schema) = contains_schema {
         let min_contains = array_schema.min_contains.unwrap_or(1);
         let max_contains = array_schema.max_contains;
         let needs_full_count = max_contains.is_some() || has_unevaluated_items;
@@ -342,16 +380,24 @@ async fn validate_array(
     // Run unevaluatedItems after all applicators that can mark items as evaluated.
     if has_unevaluated_items {
         let unevaluated_schema = if let Some(schema_item) = &array_schema.unevaluated_items_schema {
-            tombi_schema_store::resolve_schema_item(
+            match tombi_schema_store::resolve_schema_item(
                 schema_item,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
                 schema_context.store,
             )
             .await
-            .inspect_err(|err| log::warn!("{err}"))
-            .ok()
-            .flatten()
+            {
+                Ok(unevaluated_schema) => unevaluated_schema,
+                Err(err) => {
+                    total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        array_value.range(),
+                    ));
+                    None
+                }
+            }
         } else {
             None
         };

--- a/crates/tombi-validator/src/validate/if_then_else.rs
+++ b/crates/tombi-validator/src/validate/if_then_else.rs
@@ -32,57 +32,90 @@ where
         };
 
     // Resolve and validate the `if` schema
-    let if_result = if let Ok(Some(if_current_schema)) = tombi_schema_store::resolve_schema_item(
+    let if_result = match tombi_schema_store::resolve_schema_item(
         &if_then_else_schema.if_schema,
         current_schema.schema_uri.clone(),
         current_schema.definitions.clone(),
         schema_context.store,
     )
     .await
-    .inspect_err(|err| log::warn!("{err}"))
     {
-        value
-            .validate(accessors, Some(&if_current_schema), schema_context)
-            .await
-    } else {
-        return Ok(crate::EvaluatedLocations::new());
+        Ok(Some(if_current_schema)) => {
+            value
+                .validate(accessors, Some(&if_current_schema), schema_context)
+                .await
+        }
+        Ok(None) => return Ok(crate::EvaluatedLocations::new()),
+        Err(err) => {
+            return Err(vec![tombi_diagnostic::Diagnostic::new_error(
+                err.to_string(),
+                err.code(),
+                value.range(),
+            )]
+            .into());
+        }
     };
 
     // Per JSON Schema spec: branching is based on assertion result.
     if is_assertion_success(&if_result) {
         // `if` matched → apply `then` schema if present
-        if let Some(then_schema) = &if_then_else_schema.then_schema
-            && let Ok(Some(then_current_schema)) = tombi_schema_store::resolve_schema_item(
+        if let Some(then_schema) = &if_then_else_schema.then_schema {
+            match tombi_schema_store::resolve_schema_item(
                 then_schema,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
                 schema_context.store,
             )
             .await
-            .inspect_err(|err| log::warn!("{err}"))
-        {
-            let branch_result = value
-                .validate(accessors, Some(&then_current_schema), schema_context)
-                .await;
-            return merge_if_result(branch_result, if_result);
+            {
+                Ok(Some(then_current_schema)) => {
+                    let branch_result = value
+                        .validate(accessors, Some(&then_current_schema), schema_context)
+                        .await;
+                    return merge_if_result(branch_result, if_result);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    return merge_if_result(
+                        Err(vec![tombi_diagnostic::Diagnostic::new_error(
+                            err.to_string(),
+                            err.code(),
+                            value.range(),
+                        )]
+                        .into()),
+                        if_result,
+                    );
+                }
+            }
         }
 
         return merge_if_result(Ok(crate::EvaluatedLocations::new()), if_result);
     } else {
         // `if` did not match → apply `else` schema if present
-        if let Some(else_schema) = &if_then_else_schema.else_schema
-            && let Ok(Some(else_current_schema)) = tombi_schema_store::resolve_schema_item(
+        if let Some(else_schema) = &if_then_else_schema.else_schema {
+            match tombi_schema_store::resolve_schema_item(
                 else_schema,
                 Cow::Borrowed(current_schema.schema_uri.as_ref()),
                 Cow::Borrowed(current_schema.definitions.as_ref()),
                 schema_context.store,
             )
             .await
-            .inspect_err(|err| log::warn!("{err}"))
-        {
-            return value
-                .validate(accessors, Some(&else_current_schema), schema_context)
-                .await;
+            {
+                Ok(Some(else_current_schema)) => {
+                    return value
+                        .validate(accessors, Some(&else_current_schema), schema_context)
+                        .await;
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(vec![tombi_diagnostic::Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        value.range(),
+                    )]
+                    .into());
+                }
+            }
         }
     }
 

--- a/crates/tombi-validator/src/validate/one_of.rs
+++ b/crates/tombi-validator/src/validate/one_of.rs
@@ -66,15 +66,16 @@ where
 
         let mut valid_count = 0;
 
-        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
-            &one_of_schema.schemas,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            schema_context.store,
-            &schema_context.schema_visits,
-            accessors,
-        )
-        .await
+        let Some((resolved_schemas, resolution_errors)) =
+            tombi_schema_store::resolve_and_collect_schemas_with_errors(
+                &one_of_schema.schemas,
+                current_schema.schema_uri.clone(),
+                current_schema.definitions.clone(),
+                schema_context.store,
+                &schema_context.schema_visits,
+                accessors,
+            )
+            .await
         else {
             if total_diagnostics.is_empty() {
                 return Ok(base_evaluated_locations);
@@ -86,16 +87,23 @@ where
                 });
             }
         };
+        let has_resolution_errors = !resolution_errors.is_empty();
+        total_diagnostics.extend(resolution_errors.into_iter().map(|err| {
+            tombi_diagnostic::Diagnostic::new_error(err.to_string(), err.code(), value.range())
+        }));
+
         let total_count = resolved_schemas.len();
         if total_count == 0 {
-            crate::Diagnostic {
-                kind: Box::new(crate::DiagnosticKind::OneOfNoMatch { total_count }),
-                range: value.range(),
+            if !has_resolution_errors {
+                crate::Diagnostic {
+                    kind: Box::new(crate::DiagnosticKind::OneOfNoMatch { total_count }),
+                    range: value.range(),
+                }
+                .push_diagnostic_with_level(
+                    SeverityLevelDefaultError::default(),
+                    &mut total_diagnostics,
+                );
             }
-            .push_diagnostic_with_level(
-                SeverityLevelDefaultError::default(),
-                &mut total_diagnostics,
-            );
             return Err(crate::Error {
                 score: crate::error::TYPE_MATCHED_SCORE,
                 diagnostics: total_diagnostics,

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -178,7 +178,7 @@ async fn validate_table(
         {
             matched_key = true;
 
-            if let Ok(Some(current_schema)) = table_schema
+            match table_schema
                 .resolve_property_schema(
                     &schema_accessor,
                     current_schema.schema_uri.clone(),
@@ -186,17 +186,33 @@ async fn validate_table(
                     schema_context.store,
                 )
                 .await
-                .inspect_err(|err| log::warn!("{err}"))
-                && let Err(crate::Error {
-                    mut diagnostics, ..
-                }) = value
-                    .validate(&new_accessors, Some(&current_schema), schema_context)
-                    .await
             {
-                convert_deprecated_diagnostics_range(&current_schema, value, key, &mut diagnostics)
-                    .await;
+                Ok(Some(current_schema)) => {
+                    if let Err(crate::Error {
+                        mut diagnostics, ..
+                    }) = value
+                        .validate(&new_accessors, Some(&current_schema), schema_context)
+                        .await
+                    {
+                        convert_deprecated_diagnostics_range(
+                            &current_schema,
+                            value,
+                            key,
+                            &mut diagnostics,
+                        )
+                        .await;
 
-                total_diagnostics.extend(diagnostics);
+                        total_diagnostics.extend(diagnostics);
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        key.range() + value.range(),
+                    ));
+                }
             }
         }
 
@@ -214,7 +230,7 @@ async fn validate_table(
                 };
                 if pattern.is_match(accessor_raw_text) {
                     matched_key = true;
-                    if let Ok(Some(current_schema)) = table_schema
+                    match table_schema
                         .resolve_pattern_property_schema(
                             &pattern_key,
                             current_schema.schema_uri.clone(),
@@ -222,22 +238,33 @@ async fn validate_table(
                             schema_context.store,
                         )
                         .await
-                        .inspect_err(|err| log::warn!("{err}"))
-                        && let Err(crate::Error {
-                            mut diagnostics, ..
-                        }) = value
-                            .validate(&new_accessors, Some(&current_schema), schema_context)
-                            .await
                     {
-                        convert_deprecated_diagnostics_range(
-                            &current_schema,
-                            value,
-                            key,
-                            &mut diagnostics,
-                        )
-                        .await;
+                        Ok(Some(current_schema)) => {
+                            if let Err(crate::Error {
+                                mut diagnostics, ..
+                            }) = value
+                                .validate(&new_accessors, Some(&current_schema), schema_context)
+                                .await
+                            {
+                                convert_deprecated_diagnostics_range(
+                                    &current_schema,
+                                    value,
+                                    key,
+                                    &mut diagnostics,
+                                )
+                                .await;
 
-                        total_diagnostics.extend(diagnostics);
+                                total_diagnostics.extend(diagnostics);
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                                err.to_string(),
+                                err.code(),
+                                key.range() + value.range(),
+                            ));
+                        }
                     }
                 }
             }
@@ -284,34 +311,45 @@ async fn validate_table(
             let mut validated_by_additional_schema = false;
             if let Some((_, referable_additional_property_schema)) =
                 &table_schema.additional_property_schema
-                && let Ok(Some(current_schema)) = tombi_schema_store::resolve_schema_item(
+            {
+                match tombi_schema_store::resolve_schema_item(
                     referable_additional_property_schema,
                     current_schema.schema_uri.clone(),
                     current_schema.definitions.clone(),
                     schema_context.store,
                 )
                 .await
-                .inspect_err(|err| log::warn!("{err}"))
-            {
-                let deprecation = current_schema.value_schema.deprecation().await;
-                handle_deprecated_value(
-                    &mut total_diagnostics,
-                    deprecation.as_ref(),
-                    &new_accessors,
-                    value,
-                    Some(&current_schema),
-                    schema_context,
-                    table_value.comment_directives(),
-                    table_rules.as_ref().map(|rules| &rules.common),
-                );
-
-                if let Err(crate::Error { diagnostics, .. }) = value
-                    .validate(&new_accessors, Some(&current_schema), schema_context)
-                    .await
                 {
-                    total_diagnostics.extend(diagnostics);
+                    Ok(Some(current_schema)) => {
+                        let deprecation = current_schema.value_schema.deprecation().await;
+                        handle_deprecated_value(
+                            &mut total_diagnostics,
+                            deprecation.as_ref(),
+                            &new_accessors,
+                            value,
+                            Some(&current_schema),
+                            schema_context,
+                            table_value.comment_directives(),
+                            table_rules.as_ref().map(|rules| &rules.common),
+                        );
+
+                        if let Err(crate::Error { diagnostics, .. }) = value
+                            .validate(&new_accessors, Some(&current_schema), schema_context)
+                            .await
+                        {
+                            total_diagnostics.extend(diagnostics);
+                        }
+                        validated_by_additional_schema = true;
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                            err.to_string(),
+                            err.code(),
+                            key.range() + value.range(),
+                        ));
+                    }
                 }
-                validated_by_additional_schema = true;
             }
 
             // `additionalProperties` contributes to evaluated properties only when the keyword exists.
@@ -322,23 +360,33 @@ async fn validate_table(
                 && !validated_by_additional_schema
                 && !evaluated_by_additional_default
             {
-                if let Some(schema_item) = &table_schema.unevaluated_property_schema
-                    && let Ok(Some(unevaluated_schema)) = tombi_schema_store::resolve_schema_item(
+                if let Some(schema_item) = &table_schema.unevaluated_property_schema {
+                    match tombi_schema_store::resolve_schema_item(
                         schema_item,
                         current_schema.schema_uri.clone(),
                         current_schema.definitions.clone(),
                         schema_context.store,
                     )
                     .await
-                    .inspect_err(|err| log::warn!("{err}"))
-                {
-                    if let Err(crate::Error { diagnostics, .. }) = value
-                        .validate(&new_accessors, Some(&unevaluated_schema), schema_context)
-                        .await
                     {
-                        total_diagnostics.extend(diagnostics);
+                        Ok(Some(unevaluated_schema)) => {
+                            if let Err(crate::Error { diagnostics, .. }) = value
+                                .validate(&new_accessors, Some(&unevaluated_schema), schema_context)
+                                .await
+                            {
+                                total_diagnostics.extend(diagnostics);
+                            }
+                            continue;
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                                err.to_string(),
+                                err.code(),
+                                key.range() + value.range(),
+                            ));
+                        }
                     }
-                    continue;
                 }
 
                 if table_schema.unevaluated_properties == Some(false) {
@@ -545,37 +593,46 @@ async fn validate_table(
                     }
                 }
                 tombi_schema_store::Dependency::Schema(schema_item) => {
-                    if let Ok(Some(dep_schema)) = tombi_schema_store::resolve_schema_item(
+                    match tombi_schema_store::resolve_schema_item(
                         schema_item,
                         current_schema.schema_uri.clone(),
                         current_schema.definitions.clone(),
                         schema_context.store,
                     )
                     .await
-                    .inspect_err(|err| log::warn!("{err}"))
                     {
-                        // A dependency schema is an additional constraint layered on top of
-                        // the parent table schema. Running strict mode here against the
-                        // partial dependency schema causes false-positive additional key
-                        // diagnostics for valid keys defined by the parent schema.
-                        let dependency_schema_context = tombi_schema_store::SchemaContext {
-                            toml_version: schema_context.toml_version,
-                            root_schema: schema_context.root_schema,
-                            sub_schema_uri_map: schema_context.sub_schema_uri_map,
-                            deprecated_lint_level: schema_context.deprecated_lint_level,
-                            schema_format_rules: schema_context.schema_format_rules,
-                            schema_lint_rules: schema_context.schema_lint_rules,
-                            schema_overrides: schema_context.schema_overrides,
-                            schema_visits: schema_context.schema_visits.clone(),
-                            store: schema_context.store,
-                            strict: Some(false),
-                        };
+                        Ok(Some(dep_schema)) => {
+                            // A dependency schema is an additional constraint layered on top of
+                            // the parent table schema. Running strict mode here against the
+                            // partial dependency schema causes false-positive additional key
+                            // diagnostics for valid keys defined by the parent schema.
+                            let dependency_schema_context = tombi_schema_store::SchemaContext {
+                                toml_version: schema_context.toml_version,
+                                root_schema: schema_context.root_schema,
+                                sub_schema_uri_map: schema_context.sub_schema_uri_map,
+                                deprecated_lint_level: schema_context.deprecated_lint_level,
+                                schema_format_rules: schema_context.schema_format_rules,
+                                schema_lint_rules: schema_context.schema_lint_rules,
+                                schema_overrides: schema_context.schema_overrides,
+                                schema_visits: schema_context.schema_visits.clone(),
+                                store: schema_context.store,
+                                strict: Some(false),
+                            };
 
-                        if let Err(crate::Error { diagnostics, .. }) = table_value
-                            .validate(accessors, Some(&dep_schema), &dependency_schema_context)
-                            .await
-                        {
-                            total_diagnostics.extend(diagnostics);
+                            if let Err(crate::Error { diagnostics, .. }) = table_value
+                                .validate(accessors, Some(&dep_schema), &dependency_schema_context)
+                                .await
+                            {
+                                total_diagnostics.extend(diagnostics);
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                                err.to_string(),
+                                err.code(),
+                                table_value.range(),
+                            ));
                         }
                     }
                 }
@@ -613,34 +670,43 @@ async fn validate_table(
                 continue;
             }
 
-            if let Ok(Some(dep_schema)) = tombi_schema_store::resolve_schema_item(
+            match tombi_schema_store::resolve_schema_item(
                 schema_item,
                 current_schema.schema_uri.clone(),
                 current_schema.definitions.clone(),
                 schema_context.store,
             )
             .await
-            .inspect_err(|err| log::warn!("{err}"))
             {
-                // See the rationale in the `Dependency::Schema` branch above.
-                let dependency_schema_context = tombi_schema_store::SchemaContext {
-                    toml_version: schema_context.toml_version,
-                    root_schema: schema_context.root_schema,
-                    sub_schema_uri_map: schema_context.sub_schema_uri_map,
-                    deprecated_lint_level: schema_context.deprecated_lint_level,
-                    schema_format_rules: schema_context.schema_format_rules,
-                    schema_lint_rules: schema_context.schema_lint_rules,
-                    schema_overrides: schema_context.schema_overrides,
-                    schema_visits: schema_context.schema_visits.clone(),
-                    store: schema_context.store,
-                    strict: Some(false),
-                };
+                Ok(Some(dep_schema)) => {
+                    // See the rationale in the `Dependency::Schema` branch above.
+                    let dependency_schema_context = tombi_schema_store::SchemaContext {
+                        toml_version: schema_context.toml_version,
+                        root_schema: schema_context.root_schema,
+                        sub_schema_uri_map: schema_context.sub_schema_uri_map,
+                        deprecated_lint_level: schema_context.deprecated_lint_level,
+                        schema_format_rules: schema_context.schema_format_rules,
+                        schema_lint_rules: schema_context.schema_lint_rules,
+                        schema_overrides: schema_context.schema_overrides,
+                        schema_visits: schema_context.schema_visits.clone(),
+                        store: schema_context.store,
+                        strict: Some(false),
+                    };
 
-                if let Err(crate::Error { diagnostics, .. }) = table_value
-                    .validate(accessors, Some(&dep_schema), &dependency_schema_context)
-                    .await
-                {
-                    total_diagnostics.extend(diagnostics);
+                    if let Err(crate::Error { diagnostics, .. }) = table_value
+                        .validate(accessors, Some(&dep_schema), &dependency_schema_context)
+                        .await
+                    {
+                        total_diagnostics.extend(diagnostics);
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        table_value.range(),
+                    ));
                 }
             }
         }
@@ -716,35 +782,40 @@ async fn validate_table(
         }
     }
 
-    if let Some(property_name_schema) = &table_schema.property_names
-        && let Ok(Some(property_name_current_schema)) = tombi_schema_store::resolve_schema_item(
-            property_name_schema,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            schema_context.store,
-        )
-        .await
-        .inspect_err(|err| log::warn!("{err}"))
-    {
-        for key in table_value.keys() {
-            if let Err(crate::Error { diagnostics, .. }) = key
-                .validate(
-                    accessors,
-                    Some(&property_name_current_schema),
-                    schema_context,
-                )
-                .await
+    let property_name_current_schema =
+        if let Some(property_name_schema) = &table_schema.property_names {
+            match tombi_schema_store::resolve_schema_item(
+                property_name_schema,
+                current_schema.schema_uri.clone(),
+                current_schema.definitions.clone(),
+                schema_context.store,
+            )
+            .await
             {
-                total_diagnostics.extend(diagnostics);
+                Ok(property_name_current_schema) => property_name_current_schema,
+                Err(err) => {
+                    total_diagnostics.push(tombi_diagnostic::Diagnostic::new_error(
+                        err.to_string(),
+                        err.code(),
+                        table_value.range(),
+                    ));
+                    None
+                }
             }
-        }
-    } else {
-        for key in table_value.keys() {
-            if let Err(crate::Error { diagnostics, .. }) =
-                key.validate(accessors, None, schema_context).await
-            {
-                total_diagnostics.extend(diagnostics);
-            }
+        } else {
+            None
+        };
+
+    for key in table_value.keys() {
+        if let Err(crate::Error { diagnostics, .. }) = key
+            .validate(
+                accessors,
+                property_name_current_schema.as_ref(),
+                schema_context,
+            )
+            .await
+        {
+            total_diagnostics.extend(diagnostics);
         }
     }
 

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -115,9 +115,9 @@ pub fn load_with_path_and_level(
                 current_dir.join(TOMBI_TOML_FILENAME),
                 current_dir.join(".config").join(TOMBI_TOML_FILENAME),
             ] {
-                log::trace!("Checking config file at {:?}", &config_path);
+                log::trace!("Checking config file at {:?}", config_path);
                 if config_path.is_file() {
-                    log::debug!("Project config found at {:?}", &config_path);
+                    log::debug!("Project config found at {:?}", config_path);
 
                     let Some(config) = try_from_path(&config_path)? else {
                         unreachable!(
@@ -131,7 +131,7 @@ pub fn load_with_path_and_level(
             }
 
             let pyproject_toml_path = current_dir.join(PYPROJECT_TOML_FILENAME);
-            log::trace!("Checking pyproject.toml file at {:?}", &pyproject_toml_path);
+            log::trace!("Checking pyproject.toml file at {:?}", pyproject_toml_path);
             if pyproject_toml_path.exists() {
                 log::debug!(
                     "\"{}\" found at {:?}",
@@ -144,12 +144,12 @@ pub fn load_with_path_and_level(
                         return Ok((config, Some(pyproject_toml_path), ConfigLevel::Project));
                     }
                     Ok(None) => {
-                        log::debug!("No [tool.tombi] found in {:?}", &pyproject_toml_path);
+                        log::debug!("No [tool.tombi] found in {:?}", pyproject_toml_path);
                     }
                     Err(error) => {
                         log::debug!(
                             "Failed to parse pyproject.toml file for config at {:?}: {}",
-                            &pyproject_toml_path,
+                            pyproject_toml_path,
                             error
                         );
                     }
@@ -164,7 +164,7 @@ pub fn load_with_path_and_level(
 
     if let Some((user_config_path, config_level)) = get_user_or_system_tombi_config_path_and_level()
     {
-        log::debug!("{CONFIG_TOML_FILENAME} found at {:?}", &user_config_path);
+        log::debug!("{CONFIG_TOML_FILENAME} found at {:?}", user_config_path);
         let Some(config) = try_from_path(&user_config_path)? else {
             unreachable!("{CONFIG_TOML_FILENAME} should always be parsed successfully.");
         };

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -190,7 +190,7 @@ where
                 for file in files {
                     match file {
                         FileSearchEntry::Found(source_path) => {
-                            log::debug!("Formatting... {:?}", &source_path);
+                            log::debug!("Formatting... {:?}", source_path);
 
                             // Get format options with override support
                             let Some(format_options) = tombi_glob::get_format_options(

--- a/schemas/schema-resolution-error-test.schema.json
+++ b/schemas/schema-resolution-error-test.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "direct": {
+      "$ref": "#/$defs/missing"
+    },
+    "all-of-error": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/missing"
+        }
+      ]
+    },
+    "any-of-error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/missing"
+        }
+      ]
+    },
+    "one-of-error": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/missing"
+        }
+      ]
+    },
+    "if-error": {
+      "type": "object",
+      "if": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "then-error": {
+      "type": "object",
+      "if": {
+        "type": "object"
+      },
+      "then": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "else-error": {
+      "type": "object",
+      "if": {
+        "type": "string"
+      },
+      "else": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "items-error": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "prefix-items-error": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/missing"
+        }
+      ]
+    },
+    "overflow-items-error": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "integer"
+        }
+      ],
+      "items": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "contains-error": {
+      "type": "array",
+      "contains": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "unevaluated-items-error": {
+      "type": "array",
+      "unevaluatedItems": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "pattern-properties-error": {
+      "type": "object",
+      "patternProperties": {
+        "^pat": {
+          "$ref": "#/$defs/missing"
+        }
+      }
+    },
+    "additional-properties-error": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "unevaluated-properties-error": {
+      "type": "object",
+      "unevaluatedProperties": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "property-names-error": {
+      "type": "object",
+      "additionalProperties": true,
+      "propertyNames": {
+        "$ref": "#/$defs/missing"
+      }
+    },
+    "dependencies-error": {
+      "type": "object",
+      "properties": {
+        "trigger": {
+          "type": "string"
+        }
+      },
+      "dependencies": {
+        "trigger": {
+          "$ref": "#/$defs/missing"
+        }
+      }
+    },
+    "dependent-schemas-error": {
+      "type": "object",
+      "properties": {
+        "trigger": {
+          "type": "string"
+        }
+      },
+      "dependentSchemas": {
+        "trigger": {
+          "$ref": "#/$defs/missing"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- surface schema reference resolution failures as validator diagnostics across object, array, and conditional applicators
- preserve composite schema resolution errors while continuing to evaluate successfully resolved branches
- resolve tuple overflow schemas only when overflow items are present
- add declarative linter integration coverage for invalid schema references
- remove redundant formatting borrows reported by Rust 1.97 clippy

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast
- cargo test --workspace --doc --locked