### PR TITLE
fix(glob): remove unused profile import

### DIFF
--- a/crates/tombi-glob/src/bin/profile.rs
+++ b/crates/tombi-glob/src/bin/profile.rs
@@ -1,6 +1,5 @@
 use std::{env, path::PathBuf, time::Instant};
 
-use tombi_config::FilesOptions;
 use tombi_glob::{FileSearchEntry, search_pattern_matched_paths};
 
 #[tokio::main]


### PR DESCRIPTION
## Summary

- remove the unused `FilesOptions` import from the `tombi-glob` profile binary
- keep workspace Clippy clean with warnings denied

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`