### PR TITLE
test(lsp): silence deprecated fixture warnings

### DIFF
--- a/crates/tombi-lsp/tests/fixtures/dot-config-project-root/.config/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/dot-config-project-root/.config/tombi.toml
@@ -9,6 +9,11 @@ include = ["product.toml"]
 
 [extensions]
 "tombi-toml/tombi" = {
-  lsp.document-link.path.enabled = true,
-  lsp.goto-definition.path.enabled = true,
+  lsp = {
+    document-link = {
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = true },
+    },
+    goto-definition.path.enabled = true,
+  },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-all-enabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-all-enabled/tombi.toml
@@ -1,10 +1,14 @@
 [extensions]
 "tombi-toml/cargo" = {
   lsp.document-link = {
-    cargo-toml.enabled = true,
+    # tombi: lint.rules.deprecated.disabled = true
+    cargo-toml = { enabled = true },
     crates-io.enabled = true,
-    git.enabled = true,
-    path.enabled = true,
-    workspace.enabled = true,
+    # tombi: lint.rules.deprecated.disabled = true
+    git = { enabled = true },
+    # tombi: lint.rules.deprecated.disabled = true
+    path = { enabled = true },
+    # tombi: lint.rules.deprecated.disabled = true
+    workspace = { enabled = true },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled-bin/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled-bin/tombi.toml
@@ -2,8 +2,10 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = false,
-      path.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = false },
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = true },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-cargo-toml-disabled/tombi.toml
@@ -2,10 +2,14 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = false,
-      git.enabled = true,
-      path.enabled = true,
-      workspace.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = false },
+      # tombi: lint.rules.deprecated.disabled = true
+      git = { enabled = true },
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = true },
+      # tombi: lint.rules.deprecated.disabled = true
+      workspace = { enabled = true },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-crates-io-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-crates-io-disabled/tombi.toml
@@ -2,9 +2,11 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = true },
       crates-io.enabled = false,
-      path.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = true },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-git-disabled/tombi.toml
@@ -2,8 +2,10 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = true,
-      git.enabled = false,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = true },
+      # tombi: lint.rules.deprecated.disabled = true
+      git = { enabled = false },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-path-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-path-disabled/tombi.toml
@@ -1,2 +1,7 @@
 [extensions]
-"tombi-toml/cargo" = { lsp.document-link.path.enabled = false }
+"tombi-toml/cargo" = {
+  lsp.document-link = {
+    # tombi: lint.rules.deprecated.disabled = true
+    path = { enabled = false },
+  },
+}

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-disabled/tombi.toml
@@ -2,9 +2,12 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = true,
-      path.enabled = false,
-      workspace.enabled = false,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = true },
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = false },
+      # tombi: lint.rules.deprecated.disabled = true
+      workspace = { enabled = false },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/cargo-document-link-workspace-local-cargo-toml-disabled/tombi.toml
@@ -2,9 +2,12 @@
 "tombi-toml/cargo" = {
   lsp = {
     document-link = {
-      cargo-toml.enabled = false,
-      path.enabled = false,
-      workspace.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      cargo-toml = { enabled = false },
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = false },
+      # tombi: lint.rules.deprecated.disabled = true
+      workspace = { enabled = true },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pypi-disabled/tombi.toml
@@ -3,7 +3,8 @@
   lsp = {
     document-link = {
       pypi-org.enabled = false,
-      pyproject-toml.enabled = true,
+      # tombi: lint.rules.deprecated.disabled = true
+      pyproject-toml = { enabled = true },
     },
   },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pyproject-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/pyproject-document-link-pyproject-disabled/tombi.toml
@@ -1,2 +1,7 @@
 [extensions]
-"tombi-toml/pyproject" = { lsp.document-link.pyproject-toml.enabled = false }
+"tombi-toml/pyproject" = {
+  lsp.document-link = {
+    # tombi: lint.rules.deprecated.disabled = true
+    pyproject-toml = { enabled = false },
+  },
+}

--- a/crates/tombi-lsp/tests/fixtures/extensions/tombi-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/tombi-disabled/tombi.toml
@@ -1,5 +1,10 @@
 [extensions]
 "tombi-toml/tombi" = {
-  lsp.document-link.path.enabled = false,
-  lsp.goto-definition.path.enabled = false,
+  lsp = {
+    document-link = {
+      # tombi: lint.rules.deprecated.disabled = true
+      path = { enabled = false },
+    },
+    goto-definition.path.enabled = false,
+  },
 }

--- a/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-all-enabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/extensions/tombi-document-link-all-enabled/tombi.toml
@@ -1,2 +1,7 @@
 [extensions]
-"tombi-toml/tombi" = { lsp.document-link.path.enabled = true }
+"tombi-toml/tombi" = {
+  lsp.document-link = {
+    # tombi: lint.rules.deprecated.disabled = true
+    path = { enabled = true },
+  },
+}


### PR DESCRIPTION
## Summary

- suppress deprecated diagnostics only where LSP fixtures intentionally exercise legacy document-link feature toggles
- expand dotted feature keys into equivalent inline tables so each directive targets the deprecated parent key
- preserve the existing backward-compatibility test behavior while keeping repository lint output clean

## Validation

- `cargo fmt --all`
- `cargo tombi lint`
- `cargo test -p tombi-lsp --test test_document_link`
- `cargo nextest run`
- `git diff --check`