### PR TITLE
feat(dist): add x86_64-unknown-illumos binary distribution

### DIFF
--- a/.github/scripts/install-cross.sh
+++ b/.github/scripts/install-cross.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Download a pinned cross-rs release, verify its SHA256 checksum, and add it to PATH.
+set -euo pipefail
+
+CROSS_VERSION="${CROSS_VERSION:-0.2.5}"
+CROSS_SHA256="${CROSS_SHA256:-642375d1bcf3bd88272c32ba90e999f3d983050adf45e66bd2d3887e8e838bad}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+url="https://github.com/cross-rs/cross/releases/download/v${CROSS_VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz"
+curl -fsSL "${url}" -o "${work_dir}/cross.tar.gz"
+echo "${CROSS_SHA256}  ${work_dir}/cross.tar.gz" | sha256sum --check || {
+	echo "::error::cross v${CROSS_VERSION} tarball failed sha256 verification (expected ${CROSS_SHA256})"
+	exit 1
+}
+
+install_dir="${HOME}/.cross-bin"
+mkdir -p "${install_dir}"
+tar -xzf "${work_dir}/cross.tar.gz" -C "${install_dir}" cross cross-util
+echo "${install_dir}" >>"${GITHUB_PATH}"

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
+      illumos: ${{ steps.filter-illumos.outputs.relevant }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -34,6 +35,153 @@ jobs:
             .github/workflows/release_cli_vscode.yml
             .github/actions/relevant-changes/**
             .github/workflows/ci_install_script.yml
+      - id: filter-illumos
+        uses: ./.github/actions/relevant-changes
+        with:
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          paths: |
+            .cargo/**
+            Cargo.toml
+            Cargo.lock
+            rust-toolchain.toml
+            crates/**
+            extensions/**
+            rust/**
+            xtask/**
+            schemas/**
+            www.schemastore.org/**
+            www.schemastore.tombi/**
+            tombi.toml
+            type-test.toml
+            docs/public/install.sh
+            .github/scripts/install-cross.sh
+            .github/actions/relevant-changes/**
+            .github/actions/set-version/**
+            .github/workflows/ci_install_script.yml
+            .github/workflows/release_cli_vscode.yml
+
+  build-cli-illumos:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.illumos == 'true'
+    name: Build CLI (x86_64-unknown-illumos)
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      TOMBI_TARGET: x86_64-unknown-illumos
+      TOMBI_DIST_CARGO: cross
+      CARGO_PROFILE_RELEASE_LTO: "fat"
+      # Don't strip illumos binaries because stripping on a different platform
+      # breaks illumos observability tooling such as pstack. See
+      # https://github.com/oxidecomputer/helios/issues/147.
+      CARGO_PROFILE_RELEASE_STRIP: "none"
+      RUST_BACKTRACE: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update stable
+
+      - name: Install cross
+        run: .github/scripts/install-cross.sh
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: ./.github/actions/set-version
+
+      - name: Run xtask dist
+        run: cargo xtask dist --cli-only
+
+      - name: Verify tombi-cli artifact
+        run: |
+          artifact="dist/tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}.tar.gz"
+          archive_root="tombi-cli-${TOMBI_VERSION}-${TOMBI_TARGET}"
+          expected_path="${archive_root}/tombi"
+
+          test -f "${artifact}"
+          test "$(tar -tzf "${artifact}")" = "${expected_path}"
+
+          extract_dir="${RUNNER_TEMP}/tombi-cli-illumos"
+          mkdir -p "${extract_dir}"
+          tar -xzf "${artifact}" -C "${extract_dir}"
+          test -x "${extract_dir}/${expected_path}"
+
+      - name: Verify tombi CLI is an unstripped illumos ELF
+        run: |
+          binary="target/${TOMBI_TARGET}/release/tombi"
+          file_output="$(file "${binary}")"
+          printf '%s\n' "${file_output}"
+
+          case "${file_output}" in
+          *"ELF 64-bit LSB executable"*"interpreter /lib/amd64/ld.so.1"*) ;;
+          *)
+            echo "illumos CLI binary is not a Solaris-ABI ELF executable" >&2
+            exit 1
+            ;;
+          esac
+
+          case "${file_output}" in
+          *", not stripped")
+            ;;
+          *)
+            echo "illumos CLI binary was stripped; stripping is explicitly disabled for illumos" >&2
+            exit 1
+            ;;
+          esac
+
+      - name: Upload tombi-cli artifact for smoke test
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tombi-cli-x86_64-unknown-illumos-smoke
+          path: dist/tombi-cli-*-x86_64-unknown-illumos.tar.gz
+
+  smoke-test-cli-illumos:
+    needs: build-cli-illumos
+    name: Smoke test CLI on OmniOS (x86_64-unknown-illumos)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: tombi-cli-x86_64-unknown-illumos-smoke
+          path: dist
+
+      # Test that the CLI runs on OmniOS (an illumos distro).
+      - name: Run tombi CLI and install.sh on OmniOS
+        uses: vmactions/omnios-vm@7f2be0b927aad1a78498c8aeeac4c4ce1fabd322 # v1.3.3
+        with:
+          release: r151058
+          usesh: true
+          mem: 4096
+          run: |
+            # Download the CLI artifact and ensure it runs.
+            set -ex
+            uname -a
+            mkdir -p smoke
+            gunzip -c dist/tombi-cli-*-x86_64-unknown-illumos.tar.gz > smoke/tombi-cli.tar
+            (cd smoke && tar -xf tombi-cli.tar)
+            bin="$(find smoke -name tombi -type f)"
+            "$bin" --version
+            printf 'title = "smoke"\nvalue   =    1\n' > smoke/smoke.toml
+            "$bin" format --offline smoke/smoke.toml
+            cat smoke/smoke.toml
+            "$bin" lint --offline smoke/smoke.toml
+
+            # Test that the install script works.
+            mkdir -p smoke/install-dir
+            # TODO: This is going to fail until the first illumos release -- remove the
+            # `|| true` once available.
+            sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1 || true
+            cat smoke/install.log
+            grep "Detected system: x86_64-unknown-illumos" smoke/install.log
 
   test-install-script:
     needs: detect-changes

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -109,10 +109,6 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             vscode_target: darwin-arm64
-          - os: ubuntu-24.04
-            target: x86_64-unknown-illumos
-            vscode_target: ""
-            use_cross: true
       fail-fast: false
     env:
       TOMBI_TARGET: ${{ matrix.target }}
@@ -123,21 +119,15 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        run: rustup update --no-self-update stable
-      - name: Add Rust target
-        if: ${{ !matrix.use_cross }}
-        run: rustup target add ${{ matrix.target }}
-      - name: Install cross
-        if: ${{ matrix.use_cross }}
-        run: .github/scripts/install-cross.sh
+        run: |
+          rustup update --no-self-update stable
+          rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        if: matrix.vscode_target != ''
         with:
           run_install: false
 
       - name: Install Node.js
-        if: matrix.vscode_target != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
@@ -152,23 +142,16 @@ jobs:
         run: sudo apt-get install gcc-arm-linux-gnueabihf
 
       - run: pnpm install && pnpm run build
-        if: matrix.vscode_target != ''
         working-directory: ./editors/vscode
 
       - run: which pnpm
-        if: matrix.vscode_target != ''
 
       - uses: ./.github/actions/set-version
 
       - name: Run xtask dist
-        run: cargo xtask dist ${{ !matrix.vscode_target && '--cli-only' || '' }}
+        run: cargo xtask dist
         env:
           RUST_BACKTRACE: "1"
-          TOMBI_DIST_CARGO: ${{ matrix.use_cross && 'cross' || 'cargo' }}
-          # Don't strip illumos binaries because stripping on a different platform
-          # breaks illumos observability tooling such as pstack. See
-          # https://github.com/oxidecomputer/helios/issues/147.
-          CARGO_PROFILE_RELEASE_STRIP: ${{ matrix.target == 'x86_64-unknown-illumos' && 'none' || 'symbols' }}
 
       # FIXME: pnpm cannot exec `cargo xtask dist` on windows.
       #        See https://github.com/matklad/xshell/issues/82
@@ -179,12 +162,12 @@ jobs:
 
       - name: Publish VSCode Extension
         run: npx vsce publish --no-dependencies --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/') && matrix.vscode_target != ''
+        if: startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
 
       - name: Publish OpenVSX Extension
         run: npx ovsx publish --no-dependencies --pat ${{ secrets.OPEN_VSX_ACCESS_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/') && matrix.vscode_target != ''
+        if: startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
         timeout-minutes: 5
 
@@ -204,10 +187,44 @@ jobs:
 
       - name: Upload tombi-vscode artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: matrix.vscode_target != ''
         with:
           name: tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
           path: dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
+
+  release-cli-illumos:
+    name: dist (x86_64-unknown-illumos)
+    runs-on: ubuntu-24.04
+    needs: [delete-old-dev-artifacts]
+    defaults:
+      run:
+        shell: bash
+    env:
+      TOMBI_TARGET: x86_64-unknown-illumos
+      TOMBI_DIST_CARGO: cross
+      GITHUB_REF: ${{ (github.ref) }}
+      # Don't strip illumos binaries because stripping on a different platform
+      # breaks illumos observability tooling such as pstack. See
+      # https://github.com/oxidecomputer/helios/issues/147.
+      CARGO_PROFILE_RELEASE_STRIP: "none"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update stable
+      - name: Install cross
+        run: .github/scripts/install-cross.sh
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/set-version
+      - name: Run xtask dist
+        run: cargo xtask dist --cli-only
+        env:
+          RUST_BACKTRACE: "1"
+      - name: Upload tombi-cli artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
 
   check-release-notes:
     needs: detect-changes
@@ -231,7 +248,7 @@ jobs:
           fi
 
   release-notes:
-    needs: [release-cli-and-vscode, check-release-notes]
+    needs: [release-cli-and-vscode, release-cli-illumos, check-release-notes]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -49,6 +49,7 @@ jobs:
             .github/actions/dispatch-versioned-release/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
+            .github/scripts/install-cross.sh
             .node-version
             .npmrc
             Cargo.toml
@@ -108,6 +109,10 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             vscode_target: darwin-arm64
+          - os: ubuntu-24.04
+            target: x86_64-unknown-illumos
+            vscode_target: ""
+            use_cross: true
       fail-fast: false
     env:
       TOMBI_TARGET: ${{ matrix.target }}
@@ -118,15 +123,21 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update stable
-          rustup target add ${{ matrix.target }}
+        run: rustup update --no-self-update stable
+      - name: Add Rust target
+        if: ${{ !matrix.use_cross }}
+        run: rustup target add ${{ matrix.target }}
+      - name: Install cross
+        if: ${{ matrix.use_cross }}
+        run: .github/scripts/install-cross.sh
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: matrix.vscode_target != ''
         with:
           run_install: false
 
       - name: Install Node.js
+        if: matrix.vscode_target != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
@@ -141,16 +152,23 @@ jobs:
         run: sudo apt-get install gcc-arm-linux-gnueabihf
 
       - run: pnpm install && pnpm run build
+        if: matrix.vscode_target != ''
         working-directory: ./editors/vscode
 
       - run: which pnpm
+        if: matrix.vscode_target != ''
 
       - uses: ./.github/actions/set-version
 
-      - name: Rub xtask dist
-        run: cargo xtask dist
+      - name: Run xtask dist
+        run: cargo xtask dist ${{ !matrix.vscode_target && '--cli-only' || '' }}
         env:
           RUST_BACKTRACE: "1"
+          TOMBI_DIST_CARGO: ${{ matrix.use_cross && 'cross' || 'cargo' }}
+          # Don't strip illumos binaries because stripping on a different platform
+          # breaks illumos observability tooling such as pstack. See
+          # https://github.com/oxidecomputer/helios/issues/147.
+          CARGO_PROFILE_RELEASE_STRIP: ${{ matrix.target == 'x86_64-unknown-illumos' && 'none' || 'symbols' }}
 
       # FIXME: pnpm cannot exec `cargo xtask dist` on windows.
       #        See https://github.com/matklad/xshell/issues/82
@@ -161,12 +179,12 @@ jobs:
 
       - name: Publish VSCode Extension
         run: npx vsce publish --no-dependencies --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.vscode_target != ''
         working-directory: ./editors/vscode
 
       - name: Publish OpenVSX Extension
         run: npx ovsx publish --no-dependencies --pat ${{ secrets.OPEN_VSX_ACCESS_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.vscode_target != ''
         working-directory: ./editors/vscode
         timeout-minutes: 5
 
@@ -186,6 +204,7 @@ jobs:
 
       - name: Upload tombi-vscode artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.vscode_target != ''
         with:
           name: tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
           path: dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix

--- a/.github/workflows/release_npm.yml
+++ b/.github/workflows/release_npm.yml
@@ -40,6 +40,7 @@ jobs:
             .cargo/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
+            .github/scripts/install-cross.sh
             Cargo.toml
             Cargo.lock
             rust-toolchain.toml
@@ -85,6 +86,10 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             vscode_target: darwin-arm64
+          - os: ubuntu-24.04
+            target: x86_64-unknown-illumos
+            vscode_target: sunos-x64
+            use_cross: true
       fail-fast: false
     name: Package ${{ matrix.vscode_target }}
     runs-on: ${{ matrix.os }}
@@ -100,7 +105,12 @@ jobs:
           node-version-file: ".node-version"
 
       - name: Install Rust toolchain
+        if: ${{ !matrix.use_cross }}
         run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross
+        if: ${{ matrix.use_cross }}
+        run: .github/scripts/install-cross.sh
 
       - name: Install arm64 toolchain
         if: matrix.vscode_target == 'linux-arm64' || matrix.vscode_target == 'linux-arm64-musl'
@@ -123,7 +133,12 @@ jobs:
 
       # Build the CLI binary
       - name: Build binaries
-        run: cargo build -p tombi-cli --release --target ${{ matrix.target }}
+        run: ${{ matrix.use_cross && 'cross' || 'cargo' }} build -p tombi-cli --release --target ${{ matrix.target }}
+        env:
+          # Don't strip illumos binaries because stripping on a different platform
+          # breaks illumos observability tooling such as pstack. See
+          # https://github.com/oxidecomputer/helios/issues/147.
+          CARGO_PROFILE_RELEASE_STRIP: ${{ matrix.target == 'x86_64-unknown-illumos' && 'none' || 'symbols' }}
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - run: ls target

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -261,6 +261,30 @@ detect_os_arch() {
 		fi
 		TARGET="${ARCH}-${OS}"
 		;;
+	SunOS)
+		# SunOS can mean either illumos or Oracle Solaris. tombi only ships
+		# prebuilt binaries for illumos.
+		OS_FLAVOR="$(uname -o 2>/dev/null || echo unknown)"
+		if [ "${OS_FLAVOR}" != "illumos" ]; then
+			print_error "Unsupported operating system: ${OS} (${OS_FLAVOR})."
+			print_error "tombi provides prebuilt binaries for illumos only, not Oracle Solaris."
+			print_error "On illumos, ensure 'uname -o' reports 'illumos'; otherwise build from source: https://github.com/tombi-toml/tombi"
+			exit 1
+		fi
+		case "${ARCH}" in
+		i86pc | x86_64)
+			ARCH="x86_64"
+			;;
+		*)
+			print_error "Unsupported architecture '${ARCH}' on illumos."
+			print_error "tombi provides an illumos binary for x86_64 (i86pc) only."
+			print_error "Build tombi from source for this architecture: https://github.com/tombi-toml/tombi"
+			exit 1
+			;;
+		esac
+		OS="unknown-illumos"
+		TARGET="${ARCH}-${OS}"
+		;;
 	*)
 		print_error "Unsupported OS: ${OS}"
 		exit 1

--- a/typescript/@tombi-toml/cli-sunos-x64/package.json
+++ b/typescript/@tombi-toml/cli-sunos-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tombi-toml/cli-sunos-x64",
+  "version": "0.0.0-dev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tombi-toml/tombi.git",
+    "directory": "typescript/@tombi-toml/cli-sunos-x64"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "homepage": "https://tombi-toml.github.io/tombi/",
+  "os": [
+    "sunos"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/typescript/@tombi-toml/tombi/bin/tombi
+++ b/typescript/@tombi-toml/tombi/bin/tombi
@@ -34,6 +34,12 @@ const PLATFORMS = {
     x64: "@tombi-toml/cli-linux-x64-musl/tombi",
     arm64: "@tombi-toml/cli-linux-arm64-musl/tombi",
   },
+  // "sunos" matches both Oracle Solaris and illumos, but we only publish
+  // binaries on illumos, not on Solaris. There doesn't appear to be a way to
+  // distinguish between the two over here.
+  sunos: {
+    x64: "@tombi-toml/cli-sunos-x64/tombi",
+  },
 };
 
 const binPath =

--- a/typescript/@tombi-toml/tombi/package.json
+++ b/typescript/@tombi-toml/tombi/package.json
@@ -43,6 +43,7 @@
     "@tombi-toml/cli-linux-x64": "0.0.0-dev",
     "@tombi-toml/cli-linux-arm64": "0.0.0-dev",
     "@tombi-toml/cli-linux-x64-musl": "0.0.0-dev",
-    "@tombi-toml/cli-linux-arm64-musl": "0.0.0-dev"
+    "@tombi-toml/cli-linux-arm64-musl": "0.0.0-dev",
+    "@tombi-toml/cli-sunos-x64": "0.0.0-dev"
   }
 }

--- a/typescript/@tombi-toml/tombi/scripts/generate-packages.mjs
+++ b/typescript/@tombi-toml/tombi/scripts/generate-packages.mjs
@@ -77,12 +77,10 @@ function writeManifest(packagePath) {
 		fs.readFileSync(manifestPath).toString("utf-8"),
 	);
 
-	const nativePackages = PLATFORMS.flatMap((platform) =>
-		ARCHITECTURES.map((arch) => [
-			`@tombi-toml/${getName(platform, arch)}`,
-			rootManifest.version,
-		]),
-	);
+	const nativePackages = TARGETS.map(([platform, arch]) => [
+		`@tombi-toml/${getName(platform, arch)}`,
+		rootManifest.version,
+	]);
 
 	manifestData.version = rootManifest.version;
 	manifestData.optionalDependencies = Object.fromEntries(nativePackages);
@@ -95,10 +93,21 @@ function writeManifest(packagePath) {
 const PLATFORMS = ["win32-%s", "darwin-%s", "linux-%s", "linux-%s-musl"];
 const ARCHITECTURES = ["x64", "arm64"];
 
-for (const platform of PLATFORMS) {
-	for (const arch of ARCHITECTURES) {
-		copyBinaryToNativePackage(platform, arch);
-	}
+// We only publish x86_64 binaries for illumos. aarch64-unknown-illumos is a
+// Tier 3 Rust target, but Rust (as of 1.97) doesn't have a prebuilt std for it
+// so it cannot be built or distributed today. It is therefore excluded from the
+// symmetric PLATFORMS x ARCHITECTURES matrix above.
+const EXTRA_TARGETS = [["sunos-%s", "x64"]];
+
+const TARGETS = [
+	...PLATFORMS.flatMap((platform) =>
+		ARCHITECTURES.map((arch) => [platform, arch]),
+	),
+	...EXTRA_TARGETS,
+];
+
+for (const [platform, arch] of TARGETS) {
+	copyBinaryToNativePackage(platform, arch);
 }
 
 writeManifest("tombi");

--- a/xtask/src/app.rs
+++ b/xtask/src/app.rs
@@ -42,7 +42,9 @@ pub fn run(args: impl Into<Args>) -> Result<(), anyhow::Error> {
         command::XTaskCommand::TomlTest(args) => {
             command::toml_test::run(&xshell::Shell::new().unwrap(), verbosity, args)?
         }
-        command::XTaskCommand::Dist => command::dist::run(&xshell::Shell::new().unwrap())?,
+        command::XTaskCommand::Dist(args) => {
+            command::dist::run(&xshell::Shell::new().unwrap(), args)?
+        }
     }
     Ok(())
 }

--- a/xtask/src/command.rs
+++ b/xtask/src/command.rs
@@ -20,5 +20,5 @@ pub enum XTaskCommand {
     TomlTest(toml_test::Args),
 
     /// Prepare the distribution.
-    Dist,
+    Dist(dist::Args),
 }

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -13,18 +13,29 @@ use zip::{DateTime, ZipWriter, write::FileOptions};
 use super::set_version::DEV_VERSION;
 use crate::utils::project_root_path;
 
-pub fn run(sh: &Shell) -> Result<(), anyhow::Error> {
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// Build and package only the CLI tarball, skipping the VS Code extension.
+    #[arg(long)]
+    pub cli_only: bool,
+}
+
+pub fn run(sh: &Shell, args: Args) -> Result<(), anyhow::Error> {
     let project_root = project_root_path();
     let target = Target::get(&project_root);
+    let vscode_target = resolve_vscode_target(args.cli_only);
     let dist = project_root.join("dist");
 
     println!("Target: {target:#?}");
+    println!("VSCode target: {vscode_target:#?}");
 
     sh.remove_path(&dist)?;
     sh.create_dir(&dist)?;
 
     dist_server(sh, &target)?;
-    dist_client(sh, &target)?;
+    if let Some(vscode_target) = &vscode_target {
+        dist_client(sh, &target, vscode_target)?;
+    }
 
     Ok(())
 }
@@ -38,14 +49,17 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
         }
     }
 
-    let manifest_path = project_root_path()
-        .join("rust")
-        .join("tombi-cli")
-        .join("Cargo.toml");
+    // Setting TOMBI_DIST_CARGO=cross allows for cross-compilation to other platforms.
+    let cargo = std::env::var("TOMBI_DIST_CARGO").unwrap_or_else(|_| "cargo".to_owned());
 
+    let _dir = sh.push_dir(project_root_path());
     xshell::cmd!(
         sh,
-        "cargo build --locked --manifest-path {manifest_path} --bin tombi --target {target_name} --release"
+        // cross mounts the workspace at /project in its container, so deriving
+        // a manifest path from `project_root_path()` and passing it in as
+        // `--manifest-path` is not going to work. Select the tombi-cli crate by
+        // name instead, which should work in all cases.
+        "{cargo} build --locked -p tombi-cli --bin tombi --target {target_name} --release"
     )
     .run()?;
 
@@ -67,11 +81,19 @@ fn dist_server(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn dist_client(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
-    dist_editor_vscode(sh, target)
+fn dist_client(
+    sh: &Shell,
+    target: &Target,
+    vscode_target: &VscodeTarget,
+) -> Result<(), anyhow::Error> {
+    dist_editor_vscode(sh, target, vscode_target)
 }
 
-fn dist_editor_vscode(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> {
+fn dist_editor_vscode(
+    sh: &Shell,
+    target: &Target,
+    vscode_target: &VscodeTarget,
+) -> Result<(), anyhow::Error> {
     let vscode_path = project_root_path().join("editors").join("vscode");
     let bundle_path = vscode_path.join("server");
     sh.remove_path(&bundle_path)?;
@@ -94,8 +116,8 @@ fn dist_editor_vscode(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> 
         sh.copy_file(symbols_path, &bundle_path)?;
     }
 
-    let vscode_target = &target.vscode_target_name;
-    let vscode_artifact_name = &target.vscode_artifact_name;
+    let vscode_target_name = &vscode_target.vscode_target_name;
+    let vscode_artifact_name = &vscode_target.vscode_artifact_name;
 
     let _d = sh.push_dir(vscode_path);
 
@@ -104,7 +126,7 @@ fn dist_editor_vscode(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> 
     if !cfg!(target_os = "windows") {
         xshell::cmd!(
             sh,
-            "pnpm exec vsce package --no-dependencies -o ../../dist/{vscode_artifact_name} --target {vscode_target}"
+            "pnpm exec vsce package --no-dependencies -o ../../dist/{vscode_artifact_name} --target {vscode_target_name}"
         )
         .run()?;
     }
@@ -112,16 +134,18 @@ fn dist_editor_vscode(sh: &Shell, target: &Target) -> Result<(), anyhow::Error> 
     Ok(())
 }
 
+fn dist_version() -> String {
+    std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| DEV_VERSION.to_owned())
+}
+
 #[derive(Debug)]
 struct Target {
     target_name: String,
-    vscode_target_name: String,
     exe_name: String,
     server_path: PathBuf,
     symbols_path: Option<PathBuf>,
     cli_artifact_dir_name: String,
     cli_artifact_name: String,
-    vscode_artifact_name: String,
 }
 
 impl Target {
@@ -140,21 +164,7 @@ impl Target {
                 }
             }
         };
-        let vscode_target_name = match std::env::var("VSCODE_TARGET") {
-            Ok(target) => target,
-            _ => {
-                if cfg!(target_os = "linux") {
-                    "linux-x64".to_owned()
-                } else if cfg!(target_os = "windows") {
-                    "win32-x64".to_owned()
-                } else if cfg!(target_os = "macos") {
-                    "darwin-arm64".to_owned()
-                } else {
-                    panic!("Unsupported OS, maybe try setting VSCODE_TARGET")
-                }
-            }
-        };
-        let version = std::env::var("CARGO_PKG_VERSION").unwrap_or(DEV_VERSION.to_owned());
+        let version = dist_version();
 
         let out_path = project_root
             .join("target")
@@ -173,19 +183,56 @@ impl Target {
         let server_path = out_path.join(&exe_name);
         let cli_artifact_dir_name = format!("tombi-cli-{version}-{target_name}");
         let cli_artifact_name = format!("{cli_artifact_dir_name}{cli_artifact_suffix}");
-        let vscode_artifact_name = format!("tombi-vscode-{version}-{vscode_target_name}.vsix");
 
         Self {
             target_name,
-            vscode_target_name,
             exe_name,
             server_path,
             symbols_path,
             cli_artifact_dir_name,
             cli_artifact_name,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VscodeTarget {
+    vscode_target_name: String,
+    vscode_artifact_name: String,
+}
+
+impl VscodeTarget {
+    fn get() -> Self {
+        let vscode_target_name = match std::env::var("VSCODE_TARGET") {
+            Ok(target) if !target.is_empty() => target,
+            Ok(_) => panic!(
+                "VSCODE_TARGET is set but empty. Pass in --cli-only to \
+                 skip the VS Code extension, or set VSCODE_TARGET to a vsce target."
+            ),
+            _ => {
+                if cfg!(target_os = "linux") {
+                    "linux-x64".to_owned()
+                } else if cfg!(target_os = "windows") {
+                    "win32-x64".to_owned()
+                } else if cfg!(target_os = "macos") {
+                    "darwin-arm64".to_owned()
+                } else {
+                    panic!("Unsupported OS, maybe try setting VSCODE_TARGET")
+                }
+            }
+        };
+        let version = dist_version();
+        let vscode_artifact_name = format!("tombi-vscode-{version}-{vscode_target_name}.vsix");
+
+        Self {
+            vscode_target_name,
             vscode_artifact_name,
         }
     }
+}
+
+fn resolve_vscode_target(cli_only: bool) -> Option<VscodeTarget> {
+    (!cli_only).then(VscodeTarget::get)
 }
 
 fn tar_gz(src_path: &Path, root_dir: &str, dest_path: &Path) -> anyhow::Result<()> {
@@ -242,20 +289,37 @@ fn zip(src_path: &Path, symbols_path: Option<&PathBuf>, dest_path: &Path) -> any
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::glue::pushenv;
 
     #[test]
     fn unix_targets_always_use_tar_gz() {
-        unsafe {
-            std::env::set_var("TOMBI_TARGET", "aarch64-apple-darwin");
-        }
+        let _darwin = pushenv("TOMBI_TARGET", "aarch64-apple-darwin");
         let target = Target::get(Path::new("."));
         assert_eq!(
             target.cli_artifact_name,
             format!("tombi-cli-{DEV_VERSION}-aarch64-apple-darwin.tar.gz")
         );
 
-        unsafe {
-            std::env::remove_var("TOMBI_TARGET");
-        }
+        let _illumos = pushenv("TOMBI_TARGET", "x86_64-unknown-illumos");
+        let target = Target::get(Path::new("."));
+        assert_eq!(
+            target.cli_artifact_name,
+            format!("tombi-cli-{DEV_VERSION}-x86_64-unknown-illumos.tar.gz")
+        );
+    }
+
+    #[test]
+    fn empty_vscode_target_only_panics_when_vscode_dist_is_requested() {
+        let _guard = pushenv("VSCODE_TARGET", "");
+
+        assert!(resolve_vscode_target(true).is_none());
+
+        let panic = std::panic::catch_unwind(|| resolve_vscode_target(false))
+            .expect_err("resolving the VS Code target with empty VSCODE_TARGET panicked");
+        let message = panic
+            .downcast_ref::<&str>()
+            .copied()
+            .expect("panic payload was a str literal");
+        assert!(message.contains("VSCODE_TARGET is set but empty"));
     }
 }


### PR DESCRIPTION
Part of https://github.com/tombi-toml/tombi/issues/2006.

Building on https://github.com/tombi-toml/tombi/pull/2008, add release binaries (built via cross) and npm. VS Code doesn't support illumos so add a way to skip VS Code as well.

I decided to disable stripping since it breaks observability tooling, as documented in https://github.com/oxidecomputer/helios/issues/147.

TODO:

- [ ] Might also be worth adding illumos CI using the vmactions VM -- libc recently added it in https://github.com/rust-lang/libc/pull/5237.