### PR TITLE
ci: submit winget manifest leaf directory

### DIFF
--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -597,5 +597,11 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           WINGETCREATE_PATH: ${{ steps.wingetcreate.outputs.path }}
         run: |
-          $manifestDir = Join-Path $PWD "winget-manifests"
-          & $env:WINGETCREATE_PATH submit $manifestDir -t $env:WINGET_TOKEN
+          $manifestRoot = Join-Path $PWD "winget-manifests"
+          $installerManifest = Get-ChildItem -Path $manifestRoot -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
+          if (-not $installerManifest) {
+            throw "winget installer manifest was not downloaded."
+          }
+
+          $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
+          & $env:WINGETCREATE_PATH submit $manifestVersionDir -t $env:WINGET_TOKEN


### PR DESCRIPTION
## Summary
- resolve the downloaded Winget installer manifest before submission
- pass its leaf version directory to wingetcreate submit
- fail with a clear error when the manifest artifact is missing

## Cause
The release workflow passed the artifact root to wingetcreate submit. The artifact contains nested manifests under manifests/t/tombi-toml/tombi/<version>, and wingetcreate rejects subdirectories in the submitted manifest path.

Fixes the publish-winget failure in https://github.com/tombi-toml/tombi/actions/runs/29594219501/job/87937317458.

## Verification
- cargo fmt --all -- --check
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release_cli_vscode.yml
- git diff --check
- confirmed leaf-directory resolution against the failing run artifact