### PR TITLE
refactor(dist): infer CLI-only illumos builds

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: ./.github/actions/set-version
 
       - name: Run xtask dist
-        run: cargo xtask dist --cli-only
+        run: cargo xtask dist
 
       - name: Verify tombi-cli artifact
         run: |

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -217,7 +217,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: ./.github/actions/set-version
       - name: Run xtask dist
-        run: cargo xtask dist --cli-only
+        run: cargo xtask dist
         env:
           RUST_BACKTRACE: "1"
       - name: Upload tombi-cli artifacts

--- a/xtask/src/app.rs
+++ b/xtask/src/app.rs
@@ -42,9 +42,7 @@ pub fn run(args: impl Into<Args>) -> Result<(), anyhow::Error> {
         command::XTaskCommand::TomlTest(args) => {
             command::toml_test::run(&xshell::Shell::new().unwrap(), verbosity, args)?
         }
-        command::XTaskCommand::Dist(args) => {
-            command::dist::run(&xshell::Shell::new().unwrap(), args)?
-        }
+        command::XTaskCommand::Dist => command::dist::run(&xshell::Shell::new().unwrap())?,
     }
     Ok(())
 }

--- a/xtask/src/command.rs
+++ b/xtask/src/command.rs
@@ -20,5 +20,5 @@ pub enum XTaskCommand {
     TomlTest(toml_test::Args),
 
     /// Prepare the distribution.
-    Dist(dist::Args),
+    Dist,
 }

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -13,17 +13,10 @@ use zip::{DateTime, ZipWriter, write::FileOptions};
 use super::set_version::DEV_VERSION;
 use crate::utils::project_root_path;
 
-#[derive(clap::Args, Debug)]
-pub struct Args {
-    /// Build and package only the CLI tarball, skipping the VS Code extension.
-    #[arg(long)]
-    pub cli_only: bool,
-}
-
-pub fn run(sh: &Shell, args: Args) -> Result<(), anyhow::Error> {
+pub fn run(sh: &Shell) -> Result<(), anyhow::Error> {
     let project_root = project_root_path();
     let target = Target::get(&project_root);
-    let vscode_target = resolve_vscode_target(args.cli_only);
+    let vscode_target = resolve_vscode_target(&target.target_name);
     let dist = project_root.join("dist");
 
     println!("Target: {target:#?}");
@@ -206,8 +199,8 @@ impl VscodeTarget {
         let vscode_target_name = match std::env::var("VSCODE_TARGET") {
             Ok(target) if !target.is_empty() => target,
             Ok(_) => panic!(
-                "VSCODE_TARGET is set but empty. Pass in --cli-only to \
-                 skip the VS Code extension, or set VSCODE_TARGET to a vsce target."
+                "VSCODE_TARGET is set but empty. Unset it to use the host default, \
+                 or set it to a vsce target."
             ),
             _ => {
                 if cfg!(target_os = "linux") {
@@ -231,8 +224,8 @@ impl VscodeTarget {
     }
 }
 
-fn resolve_vscode_target(cli_only: bool) -> Option<VscodeTarget> {
-    (!cli_only).then(VscodeTarget::get)
+fn resolve_vscode_target(target_name: &str) -> Option<VscodeTarget> {
+    (!target_name.ends_with("-illumos")).then(VscodeTarget::get)
 }
 
 fn tar_gz(src_path: &Path, root_dir: &str, dest_path: &Path) -> anyhow::Result<()> {
@@ -309,12 +302,15 @@ mod tests {
     }
 
     #[test]
-    fn empty_vscode_target_only_panics_when_vscode_dist_is_requested() {
-        let _guard = pushenv("VSCODE_TARGET", "");
+    fn illumos_target_skips_vscode_dist() {
+        assert!(resolve_vscode_target("x86_64-unknown-illumos").is_none());
+    }
 
-        assert!(resolve_vscode_target(true).is_none());
+    #[test]
+    fn empty_vscode_target_panics_for_supported_targets() {
+        let _vscode = pushenv("VSCODE_TARGET", "");
 
-        let panic = std::panic::catch_unwind(|| resolve_vscode_target(false))
+        let panic = std::panic::catch_unwind(|| resolve_vscode_target("x86_64-unknown-linux-gnu"))
             .expect_err("resolving the VS Code target with empty VSCODE_TARGET panicked");
         let message = panic
             .downcast_ref::<&str>()

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -21,6 +21,12 @@ pub fn run(sh: &Shell) -> Result<(), anyhow::Error> {
 
     println!("Target: {target:#?}");
     println!("VSCode target: {vscode_target:#?}");
+    if vscode_target.is_none() {
+        println!(
+            "Skipping VS Code extension packaging for illumos target: {}",
+            target.target_name
+        );
+    }
 
     sh.remove_path(&dist)?;
     sh.create_dir(&dist)?;


### PR DESCRIPTION
## Summary

- skip VS Code packaging automatically when `TOMBI_TARGET` is an illumos target
- remove the illumos-only `--cli-only` argument from `cargo xtask dist`
- run the illumos CI and release jobs with the standard argument-free dist command

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'SC2086' .github/workflows/release_cli_vscode.yml .github/workflows/ci_install_script.yml`
