### PR TITLE
chore: update package lock files for SunOS package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,8 @@ importers:
 
   typescript/@tombi-toml/cli-linux-x64-musl: {}
 
+  typescript/@tombi-toml/cli-sunos-x64: {}
+
   typescript/@tombi-toml/cli-win32-arm64: {}
 
   typescript/@tombi-toml/cli-win32-x64: {}
@@ -203,6 +205,9 @@ importers:
         specifier: 0.0.0-dev
         version: 0.0.0-dev
       '@tombi-toml/cli-linux-x64-musl':
+        specifier: 0.0.0-dev
+        version: 0.0.0-dev
+      '@tombi-toml/cli-sunos-x64':
         specifier: 0.0.0-dev
         version: 0.0.0-dev
       '@tombi-toml/cli-win32-arm64':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1279,6 +1279,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@tombi-toml/cli-sunos-x64@0.0.0-dev':
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [sunos]
+
   '@tombi-toml/cli-win32-arm64@0.0.0-dev':
     resolution: {integrity: sha512-d0Fr4C40WFZUFeUOT4xcVqQNwko+F+WEvTGfsw9OOhxA1RwNq/pZ2/H0wL9NM8cmNIq00jhoDklDaPNzTWglFQ==}
     engines: {node: '>=14.0.0'}
@@ -5901,6 +5906,9 @@ snapshots:
     optional: true
 
   '@tombi-toml/cli-linux-x64@0.0.0-dev':
+    optional: true
+
+  '@tombi-toml/cli-sunos-x64@0.0.0-dev':
     optional: true
 
   '@tombi-toml/cli-win32-arm64@0.0.0-dev':

--- a/typescript/@tombi-toml/tombi/package-lock.json
+++ b/typescript/@tombi-toml/tombi/package-lock.json
@@ -21,6 +21,7 @@
         "@tombi-toml/cli-linux-arm64-musl": "0.0.0-dev",
         "@tombi-toml/cli-linux-x64": "0.0.0-dev",
         "@tombi-toml/cli-linux-x64-musl": "0.0.0-dev",
+        "@tombi-toml/cli-sunos-x64": "0.0.0-dev",
         "@tombi-toml/cli-win32-arm64": "0.0.0-dev",
         "@tombi-toml/cli-win32-x64": "0.0.0-dev"
       }
@@ -120,6 +121,9 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tombi-toml/cli-sunos-x64": {
+      "optional": true
     },
     "node_modules/@tombi-toml/cli-win32-arm64": {
       "version": "0.0.0-dev",


### PR DESCRIPTION
## Summary

- update `pnpm-lock.yaml` for the SunOS CLI workspace and optional dependency added in #2014
- update the npm package lock for `@tombi-toml/cli-sunos-x64`

## Validation

- `pnpm install --lockfile-only --frozen-lockfile`
- `npm install --package-lock-only --ignore-scripts --offline`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`
