### PR TITLE
ci: finalize illumos install checks

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -177,7 +177,10 @@ jobs:
 
             # Test that the install script works.
             mkdir -p smoke/install-dir
-            sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1
+            if ! sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1; then
+              cat smoke/install.log
+              exit 1
+            fi
             cat smoke/install.log
             grep "Detected system: x86_64-unknown-illumos" smoke/install.log
 

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -177,9 +177,7 @@ jobs:
 
             # Test that the install script works.
             mkdir -p smoke/install-dir
-            # TODO: This is going to fail until the first illumos release -- remove the
-            # `|| true` once available.
-            sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1 || true
+            sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1
             cat smoke/install.log
             grep "Detected system: x86_64-unknown-illumos" smoke/install.log
 

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      illumos: ${{ steps.filter-illumos.outputs.relevant }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -25,17 +24,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - id: filter
-        uses: ./.github/actions/relevant-changes
-        with:
-          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          paths: |
-            docs/public/install.sh
-            xtask/src/command/dist.rs
-            .github/workflows/release_cli_vscode.yml
-            .github/actions/relevant-changes/**
-            .github/workflows/ci_install_script.yml
-      - id: filter-illumos
         uses: ./.github/actions/relevant-changes
         with:
           base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
@@ -63,7 +51,7 @@ jobs:
 
   build-cli-illumos:
     needs: detect-changes
-    if: needs.detect-changes.outputs.illumos == 'true'
+    if: needs.detect-changes.outputs.relevant == 'true'
     name: Build CLI (x86_64-unknown-illumos)
     runs-on: ubuntu-24.04
     defaults:
@@ -211,7 +199,7 @@ jobs:
           persist-credentials: false
 
       - name: Add install directory to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Resolve release artifact metadata
         env:

--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -177,12 +177,15 @@ jobs:
 
             # Test that the install script works.
             mkdir -p smoke/install-dir
+            PATH="${PWD}/smoke/install-dir:${PATH}"
+            export PATH
             if ! sh ./docs/public/install.sh --install-dir smoke/install-dir > smoke/install.log 2>&1; then
               cat smoke/install.log
               exit 1
             fi
             cat smoke/install.log
             grep "Detected system: x86_64-unknown-illumos" smoke/install.log
+            tombi --version
 
   test-install-script:
     needs: detect-changes

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -91,43 +91,81 @@ jobs:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             vscode_target: linux-x64
+            cli_extension: tar.gz
+            use_cross: false
+            strip: symbols
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             vscode_target: linux-arm64
+            cli_extension: tar.gz
+            use_cross: false
+            strip: symbols
           - os: ubuntu-24.04
             target: arm-unknown-linux-gnueabihf
             vscode_target: linux-armhf
+            cli_extension: tar.gz
+            use_cross: false
+            strip: symbols
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             vscode_target: win32-x64
+            cli_extension: zip
+            use_cross: false
+            strip: symbols
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             vscode_target: win32-arm64
+            cli_extension: zip
+            use_cross: false
+            strip: symbols
           - os: macos-14
             target: x86_64-apple-darwin
             vscode_target: darwin-x64
+            cli_extension: tar.gz
+            use_cross: false
+            strip: symbols
           - os: macos-14
             target: aarch64-apple-darwin
             vscode_target: darwin-arm64
+            cli_extension: tar.gz
+            use_cross: false
+            strip: symbols
+          - os: ubuntu-24.04
+            target: x86_64-unknown-illumos
+            vscode_target: ""
+            cli_extension: tar.gz
+            use_cross: true
+            # Don't strip illumos binaries because stripping on a different
+            # platform breaks observability tooling such as pstack. See
+            # https://github.com/oxidecomputer/helios/issues/147.
+            strip: none
       fail-fast: false
     env:
       TOMBI_TARGET: ${{ matrix.target }}
       VSCODE_TARGET: ${{ matrix.vscode_target }}
+      TOMBI_DIST_CARGO: ${{ matrix.use_cross && 'cross' || 'cargo' }}
+      CARGO_PROFILE_RELEASE_STRIP: ${{ matrix.strip }}
       GITHUB_REF: ${{ (github.ref) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update stable
-          rustup target add ${{ matrix.target }}
+        run: rustup update --no-self-update stable
+      - name: Install Rust target
+        if: matrix.use_cross == false
+        run: rustup target add ${{ matrix.target }}
+      - name: Install cross
+        if: matrix.use_cross == true
+        run: .github/scripts/install-cross.sh
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: matrix.vscode_target != ''
         with:
           run_install: false
 
       - name: Install Node.js
+        if: matrix.vscode_target != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
@@ -142,9 +180,11 @@ jobs:
         run: sudo apt-get install gcc-arm-linux-gnueabihf
 
       - run: pnpm install && pnpm run build
+        if: matrix.vscode_target != ''
         working-directory: ./editors/vscode
 
       - run: which pnpm
+        if: matrix.vscode_target != ''
 
       - uses: ./.github/actions/set-version
 
@@ -162,69 +202,27 @@ jobs:
 
       - name: Publish VSCode Extension
         run: npx vsce publish --no-dependencies --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/')
+        if: matrix.vscode_target != '' && startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
 
       - name: Publish OpenVSX Extension
         run: npx ovsx publish --no-dependencies --pat ${{ secrets.OPEN_VSX_ACCESS_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: startsWith(github.ref, 'refs/tags/')
+        if: matrix.vscode_target != '' && startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
         timeout-minutes: 5
 
       - name: Upload tombi-cli artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: matrix.os != 'windows-latest'
         with:
-          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.tar.gz
-          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.tar.gz
-
-      - name: Upload tombi-cli artifacts (Windows)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: matrix.os == 'windows-latest'
-        with:
-          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.zip
-          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.zip
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.${{ matrix.cli_extension }}
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.${{ matrix.cli_extension }}
 
       - name: Upload tombi-vscode artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.vscode_target != ''
         with:
           name: tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
           path: dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
-
-  release-cli-illumos:
-    name: dist (x86_64-unknown-illumos)
-    runs-on: ubuntu-24.04
-    needs: [delete-old-dev-artifacts]
-    defaults:
-      run:
-        shell: bash
-    env:
-      TOMBI_TARGET: x86_64-unknown-illumos
-      TOMBI_DIST_CARGO: cross
-      GITHUB_REF: ${{ (github.ref) }}
-      # Don't strip illumos binaries because stripping on a different platform
-      # breaks illumos observability tooling such as pstack. See
-      # https://github.com/oxidecomputer/helios/issues/147.
-      CARGO_PROFILE_RELEASE_STRIP: "none"
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
-      - name: Install Rust toolchain
-        run: rustup update --no-self-update stable
-      - name: Install cross
-        run: .github/scripts/install-cross.sh
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: ./.github/actions/set-version
-      - name: Run xtask dist
-        run: cargo xtask dist
-        env:
-          RUST_BACKTRACE: "1"
-      - name: Upload tombi-cli artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
-          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
 
   check-release-notes:
     needs: detect-changes
@@ -248,7 +246,7 @@ jobs:
           fi
 
   release-notes:
-    needs: [release-cli-and-vscode, release-cli-illumos, check-release-notes]
+    needs: [release-cli-and-vscode, check-release-notes]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -91,81 +91,43 @@ jobs:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             vscode_target: linux-x64
-            cli_extension: tar.gz
-            use_cross: false
-            strip: symbols
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             vscode_target: linux-arm64
-            cli_extension: tar.gz
-            use_cross: false
-            strip: symbols
           - os: ubuntu-24.04
             target: arm-unknown-linux-gnueabihf
             vscode_target: linux-armhf
-            cli_extension: tar.gz
-            use_cross: false
-            strip: symbols
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             vscode_target: win32-x64
-            cli_extension: zip
-            use_cross: false
-            strip: symbols
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             vscode_target: win32-arm64
-            cli_extension: zip
-            use_cross: false
-            strip: symbols
           - os: macos-14
             target: x86_64-apple-darwin
             vscode_target: darwin-x64
-            cli_extension: tar.gz
-            use_cross: false
-            strip: symbols
           - os: macos-14
             target: aarch64-apple-darwin
             vscode_target: darwin-arm64
-            cli_extension: tar.gz
-            use_cross: false
-            strip: symbols
-          - os: ubuntu-24.04
-            target: x86_64-unknown-illumos
-            vscode_target: ""
-            cli_extension: tar.gz
-            use_cross: true
-            # Don't strip illumos binaries because stripping on a different
-            # platform breaks observability tooling such as pstack. See
-            # https://github.com/oxidecomputer/helios/issues/147.
-            strip: none
       fail-fast: false
     env:
       TOMBI_TARGET: ${{ matrix.target }}
       VSCODE_TARGET: ${{ matrix.vscode_target }}
-      TOMBI_DIST_CARGO: ${{ matrix.use_cross && 'cross' || 'cargo' }}
-      CARGO_PROFILE_RELEASE_STRIP: ${{ matrix.strip }}
       GITHUB_REF: ${{ (github.ref) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        run: rustup update --no-self-update stable
-      - name: Install Rust target
-        if: matrix.use_cross == false
-        run: rustup target add ${{ matrix.target }}
-      - name: Install cross
-        if: matrix.use_cross == true
-        run: .github/scripts/install-cross.sh
+        run: |
+          rustup update --no-self-update stable
+          rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        if: matrix.vscode_target != ''
         with:
           run_install: false
 
       - name: Install Node.js
-        if: matrix.vscode_target != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
@@ -180,11 +142,9 @@ jobs:
         run: sudo apt-get install gcc-arm-linux-gnueabihf
 
       - run: pnpm install && pnpm run build
-        if: matrix.vscode_target != ''
         working-directory: ./editors/vscode
 
       - run: which pnpm
-        if: matrix.vscode_target != ''
 
       - uses: ./.github/actions/set-version
 
@@ -202,27 +162,69 @@ jobs:
 
       - name: Publish VSCode Extension
         run: npx vsce publish --no-dependencies --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: matrix.vscode_target != '' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
 
       - name: Publish OpenVSX Extension
         run: npx ovsx publish --no-dependencies --pat ${{ secrets.OPEN_VSX_ACCESS_TOKEN }} --packagePath "../../dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix" --skip-duplicate
-        if: matrix.vscode_target != '' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         working-directory: ./editors/vscode
         timeout-minutes: 5
 
       - name: Upload tombi-cli artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.os != 'windows-latest'
         with:
-          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.${{ matrix.cli_extension }}
-          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.${{ matrix.cli_extension }}
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.tar.gz
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.tar.gz
+
+      - name: Upload tombi-cli artifacts (Windows)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.os == 'windows-latest'
+        with:
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.zip
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ matrix.target }}.zip
 
       - name: Upload tombi-vscode artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: matrix.vscode_target != ''
         with:
           name: tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
           path: dist/tombi-vscode-${{ env.TOMBI_VERSION }}-${{ matrix.vscode_target }}.vsix
+
+  release-cli-illumos:
+    name: dist (x86_64-unknown-illumos)
+    runs-on: ubuntu-24.04
+    needs: [delete-old-dev-artifacts]
+    defaults:
+      run:
+        shell: bash
+    env:
+      TOMBI_TARGET: x86_64-unknown-illumos
+      TOMBI_DIST_CARGO: cross
+      GITHUB_REF: ${{ (github.ref) }}
+      # Don't strip illumos binaries because stripping on a different platform
+      # breaks illumos observability tooling such as pstack. See
+      # https://github.com/oxidecomputer/helios/issues/147.
+      CARGO_PROFILE_RELEASE_STRIP: "none"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update stable
+      - name: Install cross
+        run: .github/scripts/install-cross.sh
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/set-version
+      - name: Run xtask dist
+        run: cargo xtask dist
+        env:
+          RUST_BACKTRACE: "1"
+      - name: Upload tombi-cli artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
+          path: dist/tombi-cli-${{ env.TOMBI_VERSION }}-${{ env.TOMBI_TARGET }}.tar.gz
 
   check-release-notes:
     needs: detect-changes
@@ -246,7 +248,7 @@ jobs:
           fi
 
   release-notes:
-    needs: [release-cli-and-vscode, check-release-notes]
+    needs: [release-cli-and-vscode, release-cli-illumos, check-release-notes]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- remove the pre-release `|| true` fallback so OmniOS install failures fail CI
- add the custom install directory to `PATH`, print failures, and execute the installed `tombi --version`
- replace the temporary illumos-specific relevant-changes filter with the shared install CI filter
- quote `GITHUB_PATH` in the shared install test

The independent `release-cli-illumos` job remains explicit because `cross`, no stripping, and no VS Code artifact are permanent platform differences. No release matrix parameters are added. npm packaging remains unchanged because `@tombi-toml/cli-sunos-x64` is not published yet.

Follow-up to https://github.com/tombi-toml/tombi/pull/2014#discussion_r3600514220.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci_install_script.yml .github/workflows/release_cli_vscode.yml`
- parsed both workflows with Ruby Psych
- `cargo test -p xtask command::dist::tests --locked`
- verified v1.2.2 contains `tombi-cli-1.2.2-x86_64-unknown-illumos.tar.gz`
- verified npm still has `tombi@1.2.1` as latest and no published `@tombi-toml/cli-sunos-x64` package