### PR TITLE
Allow comment directives to suppress schema resolution warnings

### DIFF
--- a/crates/tombi-cache/src/error.rs
+++ b/crates/tombi-cache/src/error.rs
@@ -23,17 +23,3 @@ pub enum Error {
         reason: String,
     },
 }
-
-impl Error {
-    #[inline]
-    pub fn code(&self) -> &'static str {
-        match self {
-            Self::CacheFileReadFailed { .. } => "cache-file-read-failed",
-            Self::CacheFileParentDirectoryNotFound { .. } => {
-                "cache-file-parent-directory-not-found"
-            }
-            Self::CacheFileSaveFailed { .. } => "cache-file-save-failed",
-            Self::CacheDirectoryRemoveFailed { .. } => "cache-directory-remove-failed",
-        }
-    }
-}

--- a/crates/tombi-comment-directive/src/value.rs
+++ b/crates/tombi-comment-directive/src/value.rs
@@ -411,6 +411,12 @@ impl From<&ErrorRuleOptions> for SeverityLevelDefaultError {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "jsonschema", schemars(deny_unknown_fields))]
 pub struct CommonLintRules {
+    /// # Schema resolution
+    ///
+    /// Warn when a schema cannot be resolved.
+    ///
+    pub schema_resolution: Option<WarnRuleOptions>,
+
     /// # Type mismatch
     ///
     /// Check if the value is of the correct type.

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -51,12 +51,7 @@ impl<'a> Linter<'a> {
                 )
                 .await;
             if let Some((err, range)) = error_with_range {
-                self.diagnostics
-                    .push(tombi_diagnostic::Diagnostic::new_warning(
-                        err.to_string(),
-                        err.code(),
-                        range,
-                    ));
+                self.diagnostics.push(err.to_warning_diagnostic(range));
             };
 
             let (tombi_document_comment_directive, diagnostics) =

--- a/crates/tombi-linter/tests/integration/not_schema.rs
+++ b/crates/tombi-linter/tests/integration/not_schema.rs
@@ -15,7 +15,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 

--- a/crates/tombi-linter/tests/integration/schema_resolution_error.rs
+++ b/crates/tombi-linter/tests/integration/schema_resolution_error.rs
@@ -15,7 +15,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -27,7 +27,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -39,7 +39,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -51,7 +51,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -63,7 +63,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -75,7 +75,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -87,7 +87,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -99,7 +99,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -111,7 +111,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -123,7 +123,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -145,7 +145,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -157,7 +157,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -170,7 +170,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -183,7 +183,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -196,7 +196,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING },
+        { code: "schema-resolution", level: Level::WARNING },
         { code: "table-strict-additional-keys", level: Level::WARNING }
     ])
 }
@@ -210,7 +210,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -223,7 +223,7 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
     ])
 }
 
@@ -236,6 +236,29 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
-        { code: "invalid-json-pointer", level: Level::WARNING }
+        { code: "schema-resolution", level: Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_nested_schema_resolution_warning_disabled(
+        r#"
+        direct = 1 # tombi: lint.rules.schema-resolution.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_schema_resolution_warning_disabled_keeps_other_diagnostics(
+        r#"
+        [unevaluated-properties-error]
+        extra = 1 # tombi: lint.rules.schema-resolution.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "table-strict-additional-keys", level: Level::WARNING }
     ])
 }

--- a/crates/tombi-schema-store/src/error.rs
+++ b/crates/tombi-schema-store/src/error.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use crate::{CatalogUri, SchemaUri};
 
+pub const SCHEMA_RESOLUTION_DIAGNOSTIC_CODE: &str = "schema-resolution";
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum Error {
     #[error("failed to lock document: {schema_uri}")]
@@ -110,6 +112,10 @@ pub enum Error {
 impl Error {
     #[inline]
     pub fn to_warning_diagnostic(&self, range: tombi_text::Range) -> tombi_diagnostic::Diagnostic {
-        tombi_diagnostic::Diagnostic::new_warning(self.to_string(), "schema-error", range)
+        tombi_diagnostic::Diagnostic::new_warning(
+            self.to_string(),
+            SCHEMA_RESOLUTION_DIAGNOSTIC_CODE,
+            range,
+        )
     }
 }

--- a/crates/tombi-schema-store/src/error.rs
+++ b/crates/tombi-schema-store/src/error.rs
@@ -109,40 +109,7 @@ pub enum Error {
 
 impl Error {
     #[inline]
-    pub fn code(&self) -> &'static str {
-        match self {
-            Self::DocumentLockError { .. } => "document-lock-error",
-            Self::ReferenceLockError { .. } => "reference-lock-error",
-            Self::SchemaLockError => "schema-lock-error",
-            Self::DefinitionNotFound { .. } => "definition-not-found",
-            Self::CatalogPathConvertUriFailed { .. } => "catalog-path-convert-url-failed",
-            Self::CatalogFileParseFailed { .. } => "catalog-file-parse-failed",
-            Self::CatalogUriFetchFailed { .. } => "catalog-url-fetch-failed",
-            Self::CatalogFileNotFound { .. } => "catalog-file-not-found",
-            Self::InvalidCatalogFileUri { .. } => "invalid-catalog-file-url",
-            Self::CatalogFileReadFailed { .. } => "catalog-file-read-failed",
-            Self::InvalidSchemaUri { .. } => "invalid-schema-uri",
-            Self::InvalidSchemaUriOrFilePath { .. } => "invalid-schema-uri-or-file-path",
-            Self::SchemaFileNotFound { .. } => "schema-file-not-found",
-            Self::SchemaResourceNotFound { .. } => "schema-resource-not-found",
-            Self::SchemaFileReadFailed { .. } => "schema-file-read-failed",
-            Self::SchemaFileParseFailed { .. } => "schema-file-parse-failed",
-            Self::SchemaFetchFailed { .. } => "schema-fetch-failed",
-            Self::UnsupportedSourceUri { .. } => "unsupported-source-url",
-            Self::SourceUriParseFailed { .. } => "source-url-parse-failed",
-            Self::InvalidFilePath { .. } => "invalid-file-path",
-            Self::InvalidJsonFormat { .. } => "invalid-json-format",
-            Self::InvalidJsonPointer { .. } => "invalid-json-pointer",
-            Self::InvalidJsonSchemaReference { .. } => "invalid-json-schema-reference",
-            Self::UnsupportedReference { .. } => "unsupported-reference",
-            Self::UnsupportedUriScheme { .. } => "unsupported-url-scheme",
-            Self::SchemaMustBeObjectOrBoolean { .. } => "schema-must-be-object-or-boolean",
-            Self::CacheError(error) => error.code(),
-        }
-    }
-
-    #[inline]
     pub fn to_warning_diagnostic(&self, range: tombi_text::Range) -> tombi_diagnostic::Diagnostic {
-        tombi_diagnostic::Diagnostic::new_warning(self.to_string(), self.code(), range)
+        tombi_diagnostic::Diagnostic::new_warning(self.to_string(), "schema-error", range)
     }
 }

--- a/crates/tombi-schema-store/src/lib.rs
+++ b/crates/tombi-schema-store/src/lib.rs
@@ -10,7 +10,7 @@ mod store;
 mod value_type;
 mod x_taplo;
 
-pub use error::Error;
+pub use error::{Error, SCHEMA_RESOLUTION_DIAGNOSTIC_CODE};
 pub use http_client::*;
 use itertools::{Either, Itertools};
 pub use json_schema_dialect::JsonSchemaDialect;

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -329,6 +329,18 @@ pub(crate) fn with_lint_diagnostics(
     }
 }
 
+pub(crate) fn schema_resolution_diagnostic(
+    error: &tombi_schema_store::Error,
+    range: tombi_text::Range,
+    common_rules: Option<&tombi_comment_directive::value::CommonLintRules>,
+) -> Option<tombi_diagnostic::Diagnostic> {
+    (!common_rules
+        .and_then(|rules| rules.schema_resolution.as_ref())
+        .and_then(|rule| rule.disabled)
+        .unwrap_or_default())
+    .then(|| error.to_warning_diagnostic(range))
+}
+
 pub(crate) fn has_error_level_diagnostics(error: &crate::Error) -> bool {
     error
         .diagnostics

--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -47,11 +47,9 @@ where
             return Ok(crate::EvaluatedLocations::new());
         };
 
-        total_diagnostics.extend(
-            resolution_errors
-                .into_iter()
-                .map(|err| err.to_warning_diagnostic(value.range())),
-        );
+        total_diagnostics.extend(resolution_errors.into_iter().filter_map(|err| {
+            crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
+        }));
 
         for resolved_schema in &resolved_schemas {
             match value
@@ -104,6 +102,7 @@ where
                 if_then_else_schema,
                 current_schema,
                 schema_context,
+                common_rules,
             )
             .await
             {

--- a/crates/tombi-validator/src/validate/any_of.rs
+++ b/crates/tombi-validator/src/validate/any_of.rs
@@ -53,6 +53,7 @@ where
                 if_then_else_schema,
                 current_schema,
                 schema_context,
+                common_rules,
             )
             .await
             {
@@ -88,11 +89,9 @@ where
             }
         };
 
-        total_diagnostics.extend(
-            resolution_errors
-                .into_iter()
-                .map(|err| err.to_warning_diagnostic(value.range())),
-        );
+        total_diagnostics.extend(resolution_errors.into_iter().filter_map(|err| {
+            crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
+        }));
 
         let mut total_error = crate::Error::new();
         let mut matched = false;

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -131,6 +131,7 @@ async fn validate_array(
     lint_rules: Option<&ArrayCommonLintRules>,
 ) -> Result<crate::EvaluatedLocations, crate::Error> {
     let mut total_diagnostics = vec![];
+    let common_rules = lint_rules.map(|rules| &rules.common);
     let mut validation_result = crate::EvaluatedLocations::new();
     let mut evaluated = vec![false; array_value.values().len()];
     let has_unevaluated_items = array_schema.unevaluated_items_schema.is_some()
@@ -143,6 +144,7 @@ async fn validate_array(
             if_then_else_schema,
             current_schema,
             schema_context,
+            common_rules,
         )
         .await
     {
@@ -169,7 +171,13 @@ async fn validate_array(
                     {
                         Ok(overflow_schema) => overflow_schema,
                         Err(err) => {
-                            total_diagnostics.push(err.to_warning_diagnostic(array_value.range()));
+                            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                                &err,
+                                array_value.range(),
+                                common_rules,
+                            ) {
+                                total_diagnostics.push(diagnostic);
+                            }
                             None
                         }
                     }
@@ -208,7 +216,13 @@ async fn validate_array(
                     }
                     Ok(None) => {}
                     Err(err) => {
-                        total_diagnostics.push(err.to_warning_diagnostic(value.range()));
+                        if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                            &err,
+                            value.range(),
+                            common_rules,
+                        ) {
+                            total_diagnostics.push(diagnostic);
+                        }
                     }
                 }
             } else if let Some(overflow) = &overflow_schema {
@@ -264,7 +278,13 @@ async fn validate_array(
             }
             Ok(None) => {}
             Err(err) => {
-                total_diagnostics.push(err.to_warning_diagnostic(array_value.range()));
+                if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                    &err,
+                    array_value.range(),
+                    common_rules,
+                ) {
+                    total_diagnostics.push(diagnostic);
+                }
             }
         }
     }
@@ -280,7 +300,13 @@ async fn validate_array(
         {
             Ok(contains_schema) => contains_schema,
             Err(err) => {
-                total_diagnostics.push(err.to_warning_diagnostic(array_value.range()));
+                if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                    &err,
+                    array_value.range(),
+                    common_rules,
+                ) {
+                    total_diagnostics.push(diagnostic);
+                }
                 None
             }
         },
@@ -374,7 +400,13 @@ async fn validate_array(
             {
                 Ok(unevaluated_schema) => unevaluated_schema,
                 Err(err) => {
-                    total_diagnostics.push(err.to_warning_diagnostic(array_value.range()));
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        array_value.range(),
+                        common_rules,
+                    ) {
+                        total_diagnostics.push(diagnostic);
+                    }
                     None
                 }
             }

--- a/crates/tombi-validator/src/validate/if_then_else.rs
+++ b/crates/tombi-validator/src/validate/if_then_else.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use tombi_comment_directive::value::CommonLintRules;
 use tombi_document_tree::ValueImpl;
 use tombi_schema_store::CurrentSchema;
 
@@ -14,6 +15,7 @@ pub async fn validate_if_then_else<T>(
     if_then_else_schema: &tombi_schema_store::IfThenElseSchema,
     current_schema: &CurrentSchema<'_>,
     schema_context: &tombi_schema_store::SchemaContext<'_>,
+    common_rules: Option<&CommonLintRules>,
 ) -> Result<crate::EvaluatedLocations, crate::Error>
 where
     T: Validate + ValueImpl + Sync + Send,
@@ -45,10 +47,16 @@ where
                 .validate(accessors, Some(&if_current_schema), schema_context)
                 .await
         }
-        Ok(None) => return Ok(crate::EvaluatedLocations::new()),
-        Err(err) => {
-            return Err(vec![err.to_warning_diagnostic(value.range())].into());
+        Err(err)
+            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                &err,
+                value.range(),
+                common_rules,
+            ) =>
+        {
+            return Err(vec![diagnostic].into());
         }
+        Ok(None) | Err(_) => return Ok(crate::EvaluatedLocations::new()),
     };
 
     // Per JSON Schema spec: branching is based on assertion result.
@@ -69,13 +77,16 @@ where
                         .await;
                     return merge_if_result(branch_result, if_result);
                 }
-                Ok(None) => {}
-                Err(err) => {
-                    return merge_if_result(
-                        Err(vec![err.to_warning_diagnostic(value.range())].into()),
-                        if_result,
-                    );
+                Err(err)
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        value.range(),
+                        common_rules,
+                    ) =>
+                {
+                    return merge_if_result(Err(vec![diagnostic].into()), if_result);
                 }
+                Ok(None) | Err(_) => {}
             }
         }
 
@@ -96,10 +107,16 @@ where
                         .validate(accessors, Some(&else_current_schema), schema_context)
                         .await;
                 }
-                Ok(None) => {}
-                Err(err) => {
-                    return Err(vec![err.to_warning_diagnostic(value.range())].into());
+                Err(err)
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        value.range(),
+                        common_rules,
+                    ) =>
+                {
+                    return Err(vec![diagnostic].into());
                 }
+                Ok(None) | Err(_) => {}
             }
         }
     }

--- a/crates/tombi-validator/src/validate/if_then_else.rs
+++ b/crates/tombi-validator/src/validate/if_then_else.rs
@@ -47,16 +47,16 @@ where
                 .validate(accessors, Some(&if_current_schema), schema_context)
                 .await
         }
-        Err(err)
-            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
-                &err,
-                value.range(),
-                common_rules,
-            ) =>
-        {
-            return Err(vec![diagnostic].into());
+        Err(err) => {
+            if let Some(diagnostic) =
+                crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
+            {
+                return Err(vec![diagnostic].into());
+            }
+
+            return Ok(crate::EvaluatedLocations::new());
         }
-        Ok(None) | Err(_) => return Ok(crate::EvaluatedLocations::new()),
+        Ok(None) => return Ok(crate::EvaluatedLocations::new()),
     };
 
     // Per JSON Schema spec: branching is based on assertion result.
@@ -77,16 +77,16 @@ where
                         .await;
                     return merge_if_result(branch_result, if_result);
                 }
-                Err(err)
+                Err(err) => {
                     if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
                         &err,
                         value.range(),
                         common_rules,
-                    ) =>
-                {
-                    return merge_if_result(Err(vec![diagnostic].into()), if_result);
+                    ) {
+                        return merge_if_result(Err(vec![diagnostic].into()), if_result);
+                    }
                 }
-                Ok(None) | Err(_) => {}
+                Ok(None) => {}
             }
         }
 
@@ -107,16 +107,16 @@ where
                         .validate(accessors, Some(&else_current_schema), schema_context)
                         .await;
                 }
-                Err(err)
+                Err(err) => {
                     if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
                         &err,
                         value.range(),
                         common_rules,
-                    ) =>
-                {
-                    return Err(vec![diagnostic].into());
+                    ) {
+                        return Err(vec![diagnostic].into());
+                    }
                 }
-                Ok(None) | Err(_) => {}
+                Ok(None) => {}
             }
         }
     }

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -33,10 +33,16 @@ where
                 .validate(accessors, Some(&current_schema), schema_context)
                 .await,
         ),
-        Ok(None) => false,
-        Err(err) => {
-            return Err(vec![err.to_warning_diagnostic(value.range())].into());
+        Err(err)
+            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                &err,
+                value.range(),
+                common_rules,
+            ) =>
+        {
+            return Err(vec![diagnostic].into());
         }
+        Ok(None) | Err(_) => false,
     };
 
     if matches_not_schema {

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -33,16 +33,16 @@ where
                 .validate(accessors, Some(&current_schema), schema_context)
                 .await,
         ),
-        Err(err)
-            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
-                &err,
-                value.range(),
-                common_rules,
-            ) =>
-        {
-            return Err(vec![diagnostic].into());
+        Err(err) => {
+            if let Some(diagnostic) =
+                crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
+            {
+                return Err(vec![diagnostic].into());
+            }
+
+            false
         }
-        Ok(None) | Err(_) => false,
+        Ok(None) => false,
     };
 
     if matches_not_schema {

--- a/crates/tombi-validator/src/validate/one_of.rs
+++ b/crates/tombi-validator/src/validate/one_of.rs
@@ -51,6 +51,7 @@ where
                 if_then_else_schema,
                 current_schema,
                 schema_context,
+                common_rules,
             )
             .await
             {
@@ -88,11 +89,9 @@ where
             }
         };
         let has_resolution_errors = !resolution_errors.is_empty();
-        total_diagnostics.extend(
-            resolution_errors
-                .into_iter()
-                .map(|err| err.to_warning_diagnostic(value.range())),
-        );
+        total_diagnostics.extend(resolution_errors.into_iter().filter_map(|err| {
+            crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
+        }));
 
         let total_count = resolved_schemas.len();
         if total_count == 0 {

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -138,6 +138,7 @@ async fn validate_table(
 ) -> Result<crate::EvaluatedLocations, crate::Error> {
     let mut total_score = TYPE_MATCHED_SCORE;
     let mut total_diagnostics = vec![];
+    let common_rules = table_rules.map(|rules| &rules.common);
     let evaluated_locations = {
         let mut visited_schema_values = HashSet::new();
         collect_evaluated_properties_from_table_schema(
@@ -155,10 +156,9 @@ async fn validate_table(
     for (key, value) in table_value.key_values() {
         let key_rules = get_tombi_key_rules_and_diagnostics(key.comment_directives())
             .await
-            .0
-            .map(|rules| rules.value);
-
-        let key_rules = key_rules.as_ref();
+            .0;
+        let key_common_rules = key_rules.as_ref().map(|rules| &rules.common);
+        let key_rules = key_rules.as_ref().map(|rules| &rules.value);
 
         let accessor_raw_text = &key.value;
         let accessor = Accessor::Key(accessor_raw_text.to_owned());
@@ -207,7 +207,13 @@ async fn validate_table(
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    total_diagnostics.push(err.to_warning_diagnostic(key.range() + value.range()));
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        key.range() + value.range(),
+                        key_common_rules,
+                    ) {
+                        total_diagnostics.push(diagnostic);
+                    }
                 }
             }
         }
@@ -255,8 +261,13 @@ async fn validate_table(
                         }
                         Ok(None) => {}
                         Err(err) => {
-                            total_diagnostics
-                                .push(err.to_warning_diagnostic(key.range() + value.range()));
+                            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                                &err,
+                                key.range() + value.range(),
+                                key_common_rules,
+                            ) {
+                                total_diagnostics.push(diagnostic);
+                            }
                         }
                     }
                 }
@@ -336,8 +347,13 @@ async fn validate_table(
                     }
                     Ok(None) => {}
                     Err(err) => {
-                        total_diagnostics
-                            .push(err.to_warning_diagnostic(key.range() + value.range()));
+                        if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                            &err,
+                            key.range() + value.range(),
+                            key_common_rules,
+                        ) {
+                            total_diagnostics.push(diagnostic);
+                        }
                     }
                 }
             }
@@ -370,8 +386,13 @@ async fn validate_table(
                         }
                         Ok(None) => {}
                         Err(err) => {
-                            total_diagnostics
-                                .push(err.to_warning_diagnostic(key.range() + value.range()));
+                            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                                &err,
+                                key.range() + value.range(),
+                                key_common_rules,
+                            ) {
+                                total_diagnostics.push(diagnostic);
+                            }
                         }
                     }
                 }
@@ -615,7 +636,13 @@ async fn validate_table(
                         }
                         Ok(None) => {}
                         Err(err) => {
-                            total_diagnostics.push(err.to_warning_diagnostic(table_value.range()));
+                            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                                &err,
+                                table_value.range(),
+                                common_rules,
+                            ) {
+                                total_diagnostics.push(diagnostic);
+                            }
                         }
                     }
                 }
@@ -685,7 +712,13 @@ async fn validate_table(
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    total_diagnostics.push(err.to_warning_diagnostic(table_value.range()));
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        table_value.range(),
+                        common_rules,
+                    ) {
+                        total_diagnostics.push(diagnostic);
+                    }
                 }
             }
         }
@@ -773,7 +806,13 @@ async fn validate_table(
             {
                 Ok(property_name_current_schema) => property_name_current_schema,
                 Err(err) => {
-                    total_diagnostics.push(err.to_warning_diagnostic(table_value.range()));
+                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                        &err,
+                        table_value.range(),
+                        common_rules,
+                    ) {
+                        total_diagnostics.push(diagnostic);
+                    }
                     None
                 }
             }
@@ -814,6 +853,7 @@ async fn validate_table(
             if_then_else_schema,
             current_schema,
             schema_context,
+            common_rules,
         )
         .await
     {

--- a/docs/src/routes/docs/comment-directive/tombi-value-directive.mdx
+++ b/docs/src/routes/docs/comment-directive/tombi-value-directive.mdx
@@ -12,6 +12,8 @@ import { Note, Tip } from "~/components/Highlight";
     - [format.rules.array-values-order](#format-rules-array-values-order)
 - [lint](#lint-rules)
   - [lint.rules](#lint-rules)
+    - [lint.rules.schema-resolution](#lint-rules-schema-resolution)
+      - [lint.rules.schema-resolution.disabled](#lint-rules-schema-resolution-disabled)
     - [lint.rules.unused-noqa](#lint-rules-unused-noqa)
       - [lint.rules.unused-noqa.disabled](#lint-rules-unused-noqa-disabled)
     - [lint.rules.type-mismatch](#lint-rules-type-mismatch)
@@ -156,6 +158,21 @@ Value comment directives allow you to disable specific lint rules for individual
 This disable setting is a temporary workaround for incorrect JSON Schema.  
 Please consider contacting the JSON Schema provider (e.g., [Schema Store](https://www.schemastore.org)) to fix the JSON Schema.
 </Note>
+
+### lint.rules.schema-resolution
+
+Warn when a JSON Schema cannot be resolved.
+
+### lint.rules.schema-resolution.disabled
+
+Disable schema-resolution warnings for a specific value.
+
+- **Type**: `boolean`
+- **Values**: `true`
+
+```toml
+dependency = "1.0" # tombi: lint.rules.schema-resolution.disabled = true
+```
 
 ### lint.rules.unused-noqa
 

--- a/www.schemastore.tombi/tombi-array-directive.json
+++ b/www.schemastore.tombi/tombi-array-directive.json
@@ -120,6 +120,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -257,12 +269,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -275,12 +287,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-array-of-table-directive.json
+++ b/www.schemastore.tombi/tombi-array-of-table-directive.json
@@ -120,6 +120,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -305,12 +317,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -323,12 +335,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-boolean-directive.json
+++ b/www.schemastore.tombi/tombi-boolean-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -171,12 +183,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -189,12 +201,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-float-directive.json
+++ b/www.schemastore.tombi/tombi-float-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -231,12 +243,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -249,12 +261,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-inline-table-directive.json
+++ b/www.schemastore.tombi/tombi-inline-table-directive.json
@@ -120,6 +120,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -269,12 +281,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -287,12 +299,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-integer-directive.json
+++ b/www.schemastore.tombi/tombi-integer-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -231,12 +243,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -249,12 +261,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-key-array-directive.json
+++ b/www.schemastore.tombi/tombi-key-array-directive.json
@@ -204,6 +204,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-array-of-table-directive.json
+++ b/www.schemastore.tombi/tombi-key-array-of-table-directive.json
@@ -156,6 +156,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-boolean-directive.json
+++ b/www.schemastore.tombi/tombi-key-boolean-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-directive.json
+++ b/www.schemastore.tombi/tombi-key-directive.json
@@ -68,6 +68,18 @@
     "WithCommonExtensibleLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -204,12 +216,12 @@
       },
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -222,12 +234,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-key-float-directive.json
+++ b/www.schemastore.tombi/tombi-key-float-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-inline-table-directive.json
+++ b/www.schemastore.tombi/tombi-key-inline-table-directive.json
@@ -156,6 +156,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-integer-directive.json
+++ b/www.schemastore.tombi/tombi-key-integer-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-local-date-directive.json
+++ b/www.schemastore.tombi/tombi-key-local-date-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-local-date-time-directive.json
+++ b/www.schemastore.tombi/tombi-key-local-date-time-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-local-time-directive.json
+++ b/www.schemastore.tombi/tombi-key-local-time-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-offset-date-time-directive.json
+++ b/www.schemastore.tombi/tombi-key-offset-date-time-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-string-directive.json
+++ b/www.schemastore.tombi/tombi-key-string-directive.json
@@ -154,6 +154,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-key-table-directive.json
+++ b/www.schemastore.tombi/tombi-key-table-directive.json
@@ -156,6 +156,18 @@
             }
           ]
         },
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",

--- a/www.schemastore.tombi/tombi-local-date-directive.json
+++ b/www.schemastore.tombi/tombi-local-date-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -171,12 +183,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -189,12 +201,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-local-date-time-directive.json
+++ b/www.schemastore.tombi/tombi-local-date-time-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -171,12 +183,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -189,12 +201,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-local-time-directive.json
+++ b/www.schemastore.tombi/tombi-local-time-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -171,12 +183,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -189,12 +201,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-offset-date-time-directive.json
+++ b/www.schemastore.tombi/tombi-offset-date-time-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -171,12 +183,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -189,12 +201,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-parent-table-directive.json
+++ b/www.schemastore.tombi/tombi-parent-table-directive.json
@@ -120,6 +120,18 @@
     "WithCommonExtensibleLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -268,12 +280,12 @@
       },
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -286,12 +298,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-root-table-directive.json
+++ b/www.schemastore.tombi/tombi-root-table-directive.json
@@ -120,6 +120,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -281,12 +293,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -299,12 +311,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-string-directive.json
+++ b/www.schemastore.tombi/tombi-string-directive.json
@@ -70,6 +70,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -219,12 +231,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -237,12 +249,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"

--- a/www.schemastore.tombi/tombi-table-directive.json
+++ b/www.schemastore.tombi/tombi-table-directive.json
@@ -120,6 +120,18 @@
     "WithCommonLintRules": {
       "type": "object",
       "properties": {
+        "schema-resolution": {
+          "title": "Schema resolution",
+          "description": "Warn when a schema cannot be resolved.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WarnRuleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "type-mismatch": {
           "title": "Type mismatch",
           "description": "Check if the value is of the correct type.",
@@ -269,12 +281,12 @@
       "additionalProperties": false,
       "x-tombi-table-keys-order": "ascending"
     },
-    "ErrorRuleOptions": {
+    "WarnRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Error rule disabled",
-          "description": "If `true`, Error is disabled for this value.",
+          "title": "Warn rule disabled",
+          "description": "If `true`, Warn is disabled for this value.",
           "type": [
             "boolean",
             "null"
@@ -287,12 +299,12 @@
       },
       "additionalProperties": false
     },
-    "WarnRuleOptions": {
+    "ErrorRuleOptions": {
       "type": "object",
       "properties": {
         "disabled": {
-          "title": "Warn rule disabled",
-          "description": "If `true`, Warn is disabled for this value.",
+          "title": "Error rule disabled",
+          "description": "If `true`, Error is disabled for this value.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
## Summary

- report schema-store failures with the unified schema-resolution warning code
- allow lint.rules.schema-resolution.disabled comment directives to suppress warnings before diagnostics are emitted
- add integration coverage, documentation, and regenerated directive schemas

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast (2143 passed)
- cargo test --workspace --doc --locked
- cargo xtask codegen jsonschema
- pnpm -C docs lint:check
- pnpm -C docs build

## Note

- pnpm -C docs format:check currently reports an unrelated pre-existing formatting difference in docs/src/components/Table.tsx; this PR does not modify that file.