### PR TITLE
fix(date-time): accept leap second 60 in date-time values

### DIFF
--- a/crates/tombi-date-time/src/private/date_time.rs
+++ b/crates/tombi-date-time/src/private/date_time.rs
@@ -208,7 +208,7 @@ impl std::str::FromStr for DateTime {
                 return Err(crate::parse::Error::InvalidMinute);
             }
             // 00-58, 00-59, 00-60 based on leap second rules
-            if time.second >= 60 {
+            if time.second > 60 {
                 return Err(crate::parse::Error::InvalidSecond);
             }
             if time.nanosecond > 999_999_999 {

--- a/crates/tombi-date-time/tests/test_deserialize.rs
+++ b/crates/tombi-date-time/tests/test_deserialize.rs
@@ -102,9 +102,39 @@ fn test_offset_date_time_deserialization(
     );
 }
 
+// A second of 60 is a leap second, which the TOML ABNF allows:
+// `time-second = 2DIGIT ; 00-58, 00-59, 00-60 based on leap second rules`
+#[test]
+fn test_local_time_deserialization_with_leap_second() {
+    let json = json!("23:59:60");
+    let time: LocalTime = serde_json::from_value(json).unwrap();
+    pretty_assertions::assert_eq!(time, LocalTime::from_hms(23, 59, 60));
+}
+
+#[test]
+fn test_local_date_time_deserialization_with_leap_second() {
+    let json = json!("1990-12-31T23:59:60");
+    let date_time: LocalDateTime = serde_json::from_value(json).unwrap();
+    pretty_assertions::assert_eq!(
+        date_time,
+        LocalDateTime::from_ymd_hms(1990, 12, 31, 23, 59, 60)
+    );
+}
+
+#[test]
+fn test_offset_date_time_deserialization_with_leap_second() {
+    let json = json!("1990-12-31T23:59:60Z");
+    let date_time: OffsetDateTime = serde_json::from_value(json).unwrap();
+    pretty_assertions::assert_eq!(
+        date_time,
+        OffsetDateTime::from_ymd_hms(1990, 12, 31, 23, 59, 60, TimeZoneOffset::Z)
+    );
+}
+
 #[rstest]
 #[case(json!("invalid-date-time"), tombi_date_time::parse::Error::InvalidFormat)]
 #[case(json!("2021-01-01T12:00:00+25:00"), tombi_date_time::parse::Error::InvalidTimeZoneOffsetHour)]
+#[case(json!("2021-01-01T12:00:61"), tombi_date_time::parse::Error::InvalidSecond)]
 #[case(json!(true), "invalid type: boolean `true`, expected a TOML DateTime")]
 fn test_invalid_date_time_deserialization(
     #[case] input: serde_json::Value,

--- a/crates/tombi-date-time/tests/test_serialize.rs
+++ b/crates/tombi-date-time/tests/test_serialize.rs
@@ -86,3 +86,31 @@ fn test_offset_date_time_serialization(#[case] offset: TimeZoneOffset, #[case] e
 
     pretty_assertions::assert_eq!(serde_json::to_value(date_time).unwrap(), json!(expected));
 }
+
+// A leap second must survive a round trip, not just parse.
+#[test]
+fn test_local_time_serialization_with_leap_second() {
+    let time = LocalTime::from_hms(23, 59, 60);
+
+    pretty_assertions::assert_eq!(serde_json::to_value(time).unwrap(), json!("23:59:60"));
+}
+
+#[test]
+fn test_local_date_time_serialization_with_leap_second() {
+    let date_time = LocalDateTime::from_ymd_hms(1990, 12, 31, 23, 59, 60);
+
+    pretty_assertions::assert_eq!(
+        serde_json::to_value(date_time).unwrap(),
+        json!("1990-12-31T23:59:60")
+    );
+}
+
+#[test]
+fn test_offset_date_time_serialization_with_leap_second() {
+    let date_time = OffsetDateTime::from_ymd_hms(1990, 12, 31, 23, 59, 60, TimeZoneOffset::Z);
+
+    pretty_assertions::assert_eq!(
+        serde_json::to_value(date_time).unwrap(),
+        json!("1990-12-31T23:59:60Z")
+    );
+}


### PR DESCRIPTION
## Problem

`23:59:60` is valid TOML, but tombi rejects it.

The TOML ABNF is fine with a leap second:

    time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules

Funny part is that exact line is already in the parser as a comment, sitting
right on top of the check that throws 60 out:

    // 00-58, 00-59, 00-60 based on leap second rules
    if time.second >= 60 {
        return Err(crate::parse::Error::InvalidSecond);
    }

So the check disagrees with a few things right next to it:

1. its own comment, which is the ABNF line saying 00-60
2. its own error message, which says "second must be between 0 and 60"
3. `tombi-validator`'s `format/time.rs`, which already does `second > 60`
   with the comment `// 60 seconds allowed for leap second`

Pretty sure it's just a slip and not on purpose. The hour check is `>= 24`
(max 23) and the minute check is `>= 60` (max 59), both correct. The second
check picked up that same shape, but seconds can actually hit 60, so it wants
`> 60`.

Hits all three date-time types that carry a time:

    1990-12-31T23:59:60Z   -> InvalidSecond
    1990-12-31T23:59:60    -> InvalidSecond
    23:59:60               -> InvalidSecond

`1990-12-31T23:59:60Z` is the real leap second from the end of 1990, and it's
the example RFC 3339 uses in section 5.8.

## Why nobody noticed

toml-test just doesn't cover `:60`. There's no valid case with a leap second
in it, so nothing ever walked this path. Closest thing is
`invalid/datetime/second-over.toml`, and that one uses `:61`, not `:60`:

    # time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
    #                           ; rules
    d = 2006-01-01T00:00:61-00:00

So the suite kind of assumes 60 is fine without ever testing it. That `:61`
case still fails after this change, which is what we want, and the tests below
fill the hole.

## Fix

Swapped `time.second >= 60` for `time.second > 60`. 60 gets in, 61 still
doesn't. That was the only place that needed touching. Minute and
offset-minute stay on `>= 60` since those genuinely stop at 59.

## What I checked

Ran it through `decode`, the same binary toml-test uses:

    odt = 1990-12-31T23:59:60Z   -> {"type":"datetime","value":"1990-12-31T23:59:60Z"}
    ldt = 1990-12-31T23:59:60    -> {"type":"datetime-local","value":"1990-12-31T23:59:60"}
    lt  = 23:59:60               -> {"type":"time-local","value":"23:59:60"}

Same on `--toml-version v1.0.0` and `v1.1.0`. `:61` still errors out with
"second must be between 0 and 60".

For tests I just added cases to the `rstest` blocks already living in
`tests/test_deserialize.rs` and `tests/test_serialize.rs`: a leap second for
local time, local date-time and offset date-time, a round trip so it comes
back out right, and `:61` tacked onto the invalid list that was already there.

`cargo test -p tombi-date-time` goes from 37 to 44, all green.
`tombi-parser`, `tombi-document-tree` and `tombi-validator` come out unchanged.

## Severity

Spec conformance thing, valid TOML getting rejected. Not a crash, nothing
security related.
