### PR TITLE
fix(docs): match overscroll background to theme

### DIFF
--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -4,6 +4,12 @@
 :root {
   --docs-fixed-header-height: 80px;
   --docs-sticky-table-offset: 0px;
+  --docs-page-background: #f9fafb;
+  background-color: var(--docs-page-background);
+}
+
+:root.dark {
+  --docs-page-background: #1f2937;
 }
 
 html {
@@ -19,6 +25,7 @@ body {
     "Helvetica Neue", sans-serif;
   overflow-x: hidden;
   max-width: 100vw;
+  background-color: var(--docs-page-background);
 }
 
 /* Modern Scrollbar Styles */


### PR DESCRIPTION
## Summary

- set the document root background so browser overscroll does not reveal white
- keep the overscroll background aligned with the existing light and dark page colors

## Testing

- `cargo fmt --all --check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs build`
- `git diff --check`

## Notes

- `pnpm --dir docs typecheck` still reports pre-existing errors in the docs app and dependency declarations, unrelated to this CSS-only change
