### PR TITLE
fix(parser): prevent stack overflows from deeply nested values

### DIFF
--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -7,6 +7,13 @@ use tombi_json_syntax::{SyntaxKind, T};
 use tombi_json_value::Number;
 use tombi_text::Range;
 
+/// Maximum nesting depth for arrays and objects.
+///
+/// Bounds recursion in `parse_value`/`parse_array`/`parse_object` so a deeply
+/// nested (but finite) document cannot exhaust the thread stack and abort the
+/// process. Matches `serde_json`'s default recursion limit.
+const MAX_RECURSION_DEPTH: usize = 128;
+
 /// Parser for JSON documents
 pub struct Parser<'a> {
     source: &'a str,
@@ -34,7 +41,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let root = self.parse_value()?;
+        let root = self.parse_value(0)?;
 
         // Skip trailing trivia
         while let Some(token) = self.peek() {
@@ -162,7 +169,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_value(&mut self) -> Result<ValueNode, crate::parser::Error> {
+    fn parse_value(&mut self, depth: usize) -> Result<ValueNode, crate::parser::Error> {
         match self.peek() {
             Some(token) => {
                 match token.kind() {
@@ -209,8 +216,8 @@ impl<'a> Parser<'a> {
 
                         Ok(ValueNode::Bool(BoolNode { value, range }))
                     }
-                    T!['['] => self.parse_array(),
-                    T!['{'] => self.parse_object(),
+                    T!['['] => self.parse_array(depth),
+                    T!['{'] => self.parse_object(depth),
                     _ => Err(Error::InvalidValue),
                 }
             }
@@ -218,7 +225,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_array(&mut self) -> Result<ValueNode, crate::parser::Error> {
+    fn parse_array(&mut self, depth: usize) -> Result<ValueNode, crate::parser::Error> {
+        if depth >= MAX_RECURSION_DEPTH {
+            return Err(Error::RecursionLimitExceeded {
+                limit: MAX_RECURSION_DEPTH,
+            });
+        }
+
         // Consume the opening bracket
         let open_token = self.expect(T!['['])?;
         let start_range = open_token.range();
@@ -239,7 +252,7 @@ impl<'a> Parser<'a> {
         // Parse array elements
         loop {
             // Parse value
-            let value = self.parse_value()?;
+            let value = self.parse_value(depth + 1)?;
             items.push(value);
 
             // Check for comma or closing bracket
@@ -283,7 +296,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_object(&mut self) -> Result<ValueNode, crate::parser::Error> {
+    fn parse_object(&mut self, depth: usize) -> Result<ValueNode, crate::parser::Error> {
+        if depth >= MAX_RECURSION_DEPTH {
+            return Err(Error::RecursionLimitExceeded {
+                limit: MAX_RECURSION_DEPTH,
+            });
+        }
+
         // Consume the opening brace
         let open_token = self.expect(T!['{'])?;
         let start_range = open_token.range();
@@ -327,7 +346,7 @@ impl<'a> Parser<'a> {
             self.expect(T![:])?;
 
             // Parse value
-            let value = self.parse_value()?;
+            let value = self.parse_value(depth + 1)?;
 
             // Store key and value
             properties.insert(key, value);
@@ -423,6 +442,17 @@ pub fn parse(source: &str) -> Result<ValueNode, crate::parser::Error> {
 mod tests {
     use super::*;
 
+    macro_rules! test_json_parser {
+        ($(#[$meta:meta])* $name:ident, $source:expr, |$result:ident| $assertion:block) => {
+            $(#[$meta])*
+            #[test]
+            fn $name() {
+                let $result = parse(&$source);
+                assert!($assertion);
+            }
+        };
+    }
+
     #[test]
     fn test_parse_null() {
         let source = "null";
@@ -504,4 +534,28 @@ mod tests {
         let value_node = parse(source).unwrap();
         assert!(value_node.is_object());
     }
+
+    test_json_parser!(
+        nesting_at_limit_is_accepted,
+        format!("{}1{}", "[".repeat(128), "]".repeat(128)),
+        |result| { result.is_ok() }
+    );
+
+    test_json_parser!(
+        nesting_beyond_limit_is_rejected,
+        format!("{}1{}", "[".repeat(129), "]".repeat(129)),
+        |result| { matches!(result, Err(Error::RecursionLimitExceeded { .. })) }
+    );
+
+    test_json_parser!(
+        deeply_nested_arrays_do_not_overflow_stack,
+        "[".repeat(500_000),
+        |result| { result.is_err() }
+    );
+
+    test_json_parser!(
+        deeply_nested_objects_do_not_overflow_stack,
+        "{\"a\":".repeat(500_000),
+        |result| { result.is_err() }
+    );
 }

--- a/crates/tombi-json/src/parser/error.rs
+++ b/crates/tombi-json/src/parser/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     UnexpectedEof,
     #[error("Invalid value")]
     InvalidValue,
+    #[error("Maximum nesting depth ({limit}) exceeded")]
+    RecursionLimitExceeded { limit: usize },
     #[error("Expected colon")]
     ExpectedColon,
     #[error("Duplicate key: {0}")]

--- a/crates/tombi-parser/src/error.rs
+++ b/crates/tombi-parser/src/error.rs
@@ -65,6 +65,9 @@ pub enum ErrorKind {
 
     #[error("forbidden last period in keys")]
     ForbiddenKeysLastPeriod,
+
+    #[error("maximum nesting depth exceeded")]
+    RecursionLimitExceeded,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -106,6 +109,7 @@ impl Error {
             ErrorKind::ExpectedBraceEnd => "expected-brace-end",
             ErrorKind::ExpectedLineBreak => "expected-line-break",
             ErrorKind::ForbiddenKeysLastPeriod => "forbidden-keys-last-period",
+            ErrorKind::RecursionLimitExceeded => "recursion-limit-exceeded",
         }
     }
 

--- a/crates/tombi-parser/src/lib.rs
+++ b/crates/tombi-parser/src/lib.rs
@@ -273,4 +273,15 @@ macro_rules! test_parser {
         }
     };
 
+    {#[test] fn $name:ident($source:expr) -> Assert(|$parsed:ident| $assertion:block)} => {
+        #[test]
+        fn $name() {
+            tombi_test_lib::init_log();
+
+            let $parsed = $crate::parse(textwrap::dedent(&$source).trim());
+
+            assert!($assertion);
+        }
+    };
+
 }

--- a/crates/tombi-parser/src/parse/value.rs
+++ b/crates/tombi-parser/src/parse/value.rs
@@ -3,7 +3,11 @@ use tombi_syntax::{SyntaxKind::*, T};
 use super::Parse;
 use crate::parse::key::eat_keys;
 use crate::support::{leading_comments, peek_leading_comments, trailing_comment};
-use crate::{ErrorKind::*, parser::Parser, token_set::TS_COMMEMT_OR_LINE_END};
+use crate::{
+    ErrorKind::*,
+    parser::{MAX_RECURSION_DEPTH, Parser},
+    token_set::TS_COMMEMT_OR_LINE_END,
+};
 
 impl Parse for tombi_ast::Value {
     fn parse(p: &mut Parser<'_>) {
@@ -23,8 +27,8 @@ impl Parse for tombi_ast::Value {
             | LOCAL_DATE_TIME
             | LOCAL_DATE
             | LOCAL_TIME => parse_literal_value(p),
-            T!('[') => tombi_ast::Array::parse(p),
-            T!('{') => tombi_ast::InlineTable::parse(p),
+            T!('[') => parse_nested(p, <tombi_ast::Array as Parse>::parse),
+            T!('{') => parse_nested(p, <tombi_ast::InlineTable as Parse>::parse),
             BARE_KEY => {
                 // NOTE: This is a hack to make code completion more comfortable.
 
@@ -44,6 +48,65 @@ impl Parse for tombi_ast::Value {
             _ => parse_invalid_value(p, n),
         }
     }
+}
+
+/// Parse a nested array/inline table, bounding recursion depth.
+///
+/// Past [`MAX_RECURSION_DEPTH`] the nested value is skipped as an invalid token
+/// instead of recursing, so a deeply nested document cannot overflow the stack.
+fn parse_nested(p: &mut Parser<'_>, parse_inner: fn(&mut Parser<'_>)) {
+    if p.nested_depth() >= MAX_RECURSION_DEPTH {
+        skip_too_deep_value(p);
+    } else {
+        p.enter_nested();
+        parse_inner(p);
+        p.exit_nested();
+    }
+}
+
+/// Consume an over-nested bracketed region without recursing.
+///
+/// Iteratively skips the balanced `[...]` / `{...}` span (or up to EOF for an
+/// unterminated one) and reports a single `RecursionLimitExceeded` error.
+fn skip_too_deep_value(p: &mut Parser<'_>) {
+    let m = p.start();
+
+    leading_comments(p);
+
+    let start_range = p.current_range();
+    let mut end_range = start_range;
+    let mut bracket_depth: usize = 0;
+    loop {
+        match p.current() {
+            EOF => break,
+            T!('[') | T!('{') => {
+                bracket_depth += 1;
+                end_range = p.current_range();
+                p.bump_any();
+            }
+            T!(']') | T!('}') => {
+                end_range = p.current_range();
+                p.bump_any();
+                bracket_depth -= 1;
+                if bracket_depth == 0 {
+                    break;
+                }
+            }
+            _ => {
+                end_range = p.current_range();
+                p.bump_any();
+            }
+        }
+    }
+
+    p.error(crate::Error::new(
+        RecursionLimitExceeded,
+        start_range + end_range,
+    ));
+
+    trailing_comment(p);
+
+    m.complete(p, INVALID_TOKEN);
 }
 
 fn parse_literal_value(p: &mut Parser<'_>) {
@@ -78,4 +141,52 @@ fn parse_invalid_value(p: &mut Parser<'_>, n: usize) {
     trailing_comment(p);
 
     m.complete(p, INVALID_TOKEN);
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{ErrorKind::RecursionLimitExceeded, test_parser};
+
+    test_parser! {
+        #[test]
+        fn nesting_within_limit(
+            format!("key = {}1{}", "[".repeat(128), "]".repeat(128))
+        ) -> Assert(|parsed| {
+            parsed.errors.is_empty()
+        })
+    }
+
+    test_parser! {
+        #[test]
+        fn nesting_beyond_limit(
+            format!("key = {}1{}", "[".repeat(129), "]".repeat(129))
+        ) -> Assert(|parsed| {
+            parsed
+                .errors
+                .iter()
+                .any(|error| error.kind() == RecursionLimitExceeded)
+        })
+    }
+
+    test_parser! {
+        #[test]
+        fn deeply_nested_arrays_do_not_overflow_stack(
+            format!("key = {}", "[".repeat(500_000))
+        ) -> Assert(|parsed| {
+            let has_errors = !parsed.errors.is_empty();
+            drop(parsed);
+            has_errors
+        })
+    }
+
+    test_parser! {
+        #[test]
+        fn deeply_nested_inline_tables_do_not_overflow_stack(
+            format!("key = {}", "{a=".repeat(300_000))
+        ) -> Assert(|parsed| {
+            let has_errors = !parsed.errors.is_empty();
+            drop(parsed);
+            has_errors
+        })
+    }
 }

--- a/crates/tombi-parser/src/parser.rs
+++ b/crates/tombi-parser/src/parser.rs
@@ -5,11 +5,19 @@ use tombi_syntax::{
 
 use crate::{Event, marker::Marker, token_set::TokenSet};
 
+/// Maximum nesting depth for arrays and inline tables.
+///
+/// Bounds recursion through `Value::parse` so a deeply nested (but finite)
+/// document cannot exhaust the thread stack and abort the process. Matches
+/// `serde_json`'s default recursion limit.
+pub(crate) const MAX_RECURSION_DEPTH: usize = 128;
+
 #[derive(Debug)]
 pub(crate) struct Parser<'t> {
     source: &'t str,
     input_tokens: &'t [tombi_lexer::Token],
     pos: usize,
+    depth: usize,
     pub tokens: Vec<tombi_lexer::Token>,
     pub(crate) events: Vec<crate::Event>,
 }
@@ -20,9 +28,28 @@ impl<'t> Parser<'t> {
             source,
             input_tokens,
             pos: 0, // Start from the beginning to preserve leading trivia
+            depth: 0,
             tokens: Vec::new(),
             events: Vec::new(),
         }
+    }
+
+    /// Current array/inline-table nesting depth.
+    #[inline]
+    pub(crate) fn nested_depth(&self) -> usize {
+        self.depth
+    }
+
+    /// Enter a nested array/inline table. Pair with [`Self::exit_nested`].
+    #[inline]
+    pub(crate) fn enter_nested(&mut self) {
+        self.depth += 1;
+    }
+
+    /// Leave a nested array/inline table.
+    #[inline]
+    pub(crate) fn exit_nested(&mut self) {
+        self.depth -= 1;
     }
 
     pub(crate) fn finish(mut self) -> (Vec<tombi_lexer::Token>, Vec<crate::Event>) {


### PR DESCRIPTION
## Summary

- cap TOML array and inline-table nesting at 128 levels
- cap JSON array and object nesting at the same depth
- recover iteratively from over-nested TOML values and report a dedicated parser error
- add regression coverage for boundary-depth and extremely deep inputs

## Verification

- `cargo fmt --all`
- `cargo test -p tombi-parser -p tombi-json --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast` (2158 passed)
- `cargo test --workspace --doc --locked`