### PR TITLE
fix(docs): improve search result highlighting

### DIFF
--- a/docs/src/components/search/SearchResults.tsx
+++ b/docs/src/components/search/SearchResults.tsx
@@ -54,13 +54,7 @@ function HighlightedText(props: { text: string; matches: [number, number][] }) {
     <span>
       <For each={segments}>
         {(segment) => (
-          <span
-            class={
-              segment.isHighlight
-                ? "bg-yellow-200 dark:bg-yellow-800 rounded px-1"
-                : ""
-            }
-          >
+          <span class={segment.isHighlight ? "highlight-mark" : ""}>
             {segment.text}
           </span>
         )}
@@ -81,7 +75,7 @@ export function SearchResults(props: SearchResultsProps) {
             {(result) => (
               <A
                 href={result.url}
-                class="block p-4 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg mb-2 transition-colors border border-transparent dark:border-gray-800"
+                class="block no-underline p-4 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg mb-2 transition-colors border border-transparent dark:border-gray-800"
               >
                 <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-1">
                   <HighlightedText

--- a/docs/uno.config.ts
+++ b/docs/uno.config.ts
@@ -51,5 +51,9 @@ export default defineConfig({
   shortcuts: {
     "btn-focus":
       "focus:outline-none focus-visible:ring-2 focus-visible:ring-tombi-focus transition-colors focus:rounded-lg",
+    // Site-wide emphasis highlight (e.g. search match), aligned with the
+    // yellow accent used by CodeTabs / ImageTabs / Sidebar in dark mode.
+    "highlight-mark":
+      "bg-yellow-200 dark:bg-yellow dark:text-tombi-900 rounded px-1",
   },
 });


### PR DESCRIPTION
## Summary

- remove inherited link underlines from search result cards
- centralize matched-text styling in a reusable UnoCSS shortcut
- use the site's yellow accent with readable dark text in dark mode

## Validation

- `pnpm exec biome format docs/src/components/search/SearchResults.tsx docs/uno.config.ts`
- `pnpm exec biome lint docs/src/components/search/SearchResults.tsx docs/uno.config.ts`
- `pnpm -C docs build`
- confirmed the generated CSS contains the light and dark `.highlight-mark` rules

## Known baseline issues

- `pnpm -C docs typecheck` fails in existing unrelated files and dependency declarations, including `app.config.ts`, `HeaderDropdown.tsx`, `Table.tsx`, `solid-mdx`, Vinxi, and UnoCSS type declarations; neither changed file reports an error
- the package-wide `pnpm -C docs format:check` also scans ignored build output and reports existing formatting drift in `src/components/Table.tsx` and generated files; the changed files pass the targeted formatter check
