### PR TITLE
fix(intellij): align tombi binary resolution

### DIFF
--- a/editors/intellij/README.md
+++ b/editors/intellij/README.md
@@ -6,9 +6,10 @@
 
 ## Usage
 
-The plugin uses a Tombi executable already available in the project or on
-`PATH`. If one is not available, it downloads the latest Tombi release
-automatically.
+The plugin uses a Tombi executable from the selected project SDK, `.venv`,
+`node_modules`, or `PATH`. It also searches parent directories for hoisted npm
+installations. If a local executable is not available, it downloads the latest
+Tombi release automatically.
 
 You can select a specific executable in the plugin settings. Open any TOML file
 to start working.

--- a/editors/intellij/src/main/kotlin/tombi/configurations/Configurable.kt
+++ b/editors/intellij/src/main/kotlin/tombi/configurations/Configurable.kt
@@ -90,6 +90,7 @@ internal class TombiConfigurable : Configurable {
         val openProjects = projectManager.openProjects.filter { !it.isDefault && !it.isDisposed }
         
         openProjects.forEach { project ->
+            TombiServerSupportProvider.invalidate(project)
             val serverManager = LspServerManager.getInstance(project)
             
             serverManager.stopAndRestartIfNeeded(TombiServerSupportProvider::class.java)

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
@@ -70,9 +70,7 @@ internal object TombiBinaryDownloader {
         cacheDirectory: Path,
         platform: Platform,
     ): Path {
-        val latestReleaseUri = request("$RELEASES_URL/latest", 30_000).connect { response ->
-            URI.create(response.url)
-        }
+        val latestReleaseUri = latestReleaseUri()
         val version = versionFromLatestReleaseUri(latestReleaseUri)
         val versionDirectory = cacheDirectory.resolve("tombi-$version")
         val binaryPath = versionDirectory.resolve(platform.binaryName)
@@ -105,6 +103,11 @@ internal object TombiBinaryDownloader {
 
         return binaryPath
     }
+
+    internal fun latestReleaseUri(releasesUrl: String = RELEASES_URL): URI =
+        request("$releasesUrl/latest", 30_000).connect { response ->
+            response.connection.url.toURI()
+        }
 
     private fun request(url: String, readTimeoutMillis: Int) =
         HttpRequests.request(url)

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
@@ -1,20 +1,21 @@
 package tombi.server
 
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.io.HttpRequests
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import java.io.BufferedInputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
-import java.time.Duration
+import java.util.Comparator
 
 
 internal object TombiBinaryDownloader {
@@ -24,17 +25,14 @@ internal object TombiBinaryDownloader {
     @Synchronized
     fun downloadLatestOrCached(
         cacheDirectory: Path = PathManager.getSystemDir().resolve("tombi"),
-        client: HttpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(15))
-            .followRedirects(HttpClient.Redirect.ALWAYS)
-            .build(),
         osName: String = System.getProperty("os.name"),
         architecture: String = System.getProperty("os.arch"),
     ): String {
+        val platform = platform(osName, architecture)
         return try {
-            downloadLatest(cacheDirectory, client, platform(osName, architecture)).toString()
+            downloadLatest(cacheDirectory, platform).toString()
         } catch (error: Exception) {
-            newestCachedBinary(cacheDirectory)?.toString() ?: throw error
+            newestCachedBinary(cacheDirectory, platform.binaryName)?.toString() ?: throw error
         }
     }
 
@@ -70,20 +68,16 @@ internal object TombiBinaryDownloader {
 
     private fun downloadLatest(
         cacheDirectory: Path,
-        client: HttpClient,
         platform: Platform,
     ): Path {
-        val latestRequest = HttpRequest.newBuilder(URI.create("$RELEASES_URL/latest"))
-            .timeout(Duration.ofSeconds(30))
-            .GET()
-            .build()
-        val latestResponse = client.send(latestRequest, HttpResponse.BodyHandlers.discarding())
-        requireSuccess(latestResponse.statusCode(), latestResponse.uri())
-
-        val version = versionFromLatestReleaseUri(latestResponse.uri())
+        val latestReleaseUri = request("$RELEASES_URL/latest", 30_000).connect { response ->
+            URI.create(response.url)
+        }
+        val version = versionFromLatestReleaseUri(latestReleaseUri)
         val versionDirectory = cacheDirectory.resolve("tombi-$version")
         val binaryPath = versionDirectory.resolve(platform.binaryName)
         if (Files.isRegularFile(binaryPath)) {
+            cleanupOldCachedVersions(cacheDirectory, versionDirectory)
             return binaryPath
         }
 
@@ -94,25 +88,16 @@ internal object TombiBinaryDownloader {
         val extractedPath = Files.createTempFile(versionDirectory, "tombi-", ".tmp")
 
         try {
-            val assetRequest = HttpRequest.newBuilder(assetUri)
-                .timeout(Duration.ofMinutes(2))
-                .GET()
-                .build()
-            val assetResponse = client.send(assetRequest, HttpResponse.BodyHandlers.ofFile(archivePath))
-            requireSuccess(assetResponse.statusCode(), assetResponse.uri())
+            request(assetUri.toString(), 120_000).saveToFile(archivePath, null)
 
             BufferedInputStream(Files.newInputStream(archivePath)).use { input ->
                 Files.newOutputStream(extractedPath).use { output ->
-                    when (platform.archiveType) {
-                        ArchiveType.TAR_GZ ->
-                            extractFromTarGz(input, platform.binaryName, output)
-                        ArchiveType.ZIP ->
-                            extractFromZip(input, platform.binaryName, output)
-                    }
+                    extractArchive(input, platform.binaryName, platform.archiveType, output)
                 }
             }
             makeExecutable(extractedPath)
             moveIntoPlace(extractedPath, binaryPath)
+            cleanupOldCachedVersions(cacheDirectory, versionDirectory)
         } finally {
             Files.deleteIfExists(archivePath)
             Files.deleteIfExists(extractedPath)
@@ -121,10 +106,31 @@ internal object TombiBinaryDownloader {
         return binaryPath
     }
 
-    private fun extractFromTarGz(
-        input: java.io.InputStream,
+    private fun request(url: String, readTimeoutMillis: Int) =
+        HttpRequests.request(url)
+            .connectTimeout(15_000)
+            .readTimeout(readTimeoutMillis)
+            .redirectLimit(10)
+            .useProxy(true)
+            .productNameAsUserAgent()
+            .throwStatusCodeException(true)
+
+    internal fun extractArchive(
+        input: InputStream,
         binaryName: String,
-        output: java.io.OutputStream,
+        archiveType: ArchiveType,
+        output: OutputStream,
+    ) {
+        when (archiveType) {
+            ArchiveType.TAR_GZ -> extractFromTarGz(input, binaryName, output)
+            ArchiveType.ZIP -> extractFromZip(input, binaryName, output)
+        }
+    }
+
+    private fun extractFromTarGz(
+        input: InputStream,
+        binaryName: String,
+        output: OutputStream,
     ) {
         TarArchiveInputStream(GzipCompressorInputStream(input)).use { archive ->
             while (true) {
@@ -139,9 +145,9 @@ internal object TombiBinaryDownloader {
     }
 
     private fun extractFromZip(
-        input: java.io.InputStream,
+        input: InputStream,
         binaryName: String,
-        output: java.io.OutputStream,
+        output: OutputStream,
     ) {
         ZipArchiveInputStream(input).use { archive ->
             while (true) {
@@ -184,7 +190,7 @@ internal object TombiBinaryDownloader {
         }
     }
 
-    private fun newestCachedBinary(cacheDirectory: Path): Path? {
+    internal fun newestCachedBinary(cacheDirectory: Path, binaryName: String): Path? {
         if (!Files.isDirectory(cacheDirectory)) {
             return null
         }
@@ -195,9 +201,7 @@ internal object TombiBinaryDownloader {
                     val version = versionPattern.matchEntire(directory.fileName.toString().removePrefix("tombi-"))
                         ?.groupValues
                         ?.get(1)
-                    val binary = listOf("tombi", "tombi.exe")
-                        .map(directory::resolve)
-                        .firstOrNull(Files::isRegularFile)
+                    val binary = directory.resolve(binaryName).takeIf(Files::isRegularFile)
                     if (version != null && binary != null) {
                         Triple(versionComponents(version), version, binary)
                     } else {
@@ -209,6 +213,31 @@ internal object TombiBinaryDownloader {
                 .max { left, right -> compareVersions(left.first, right.first) }
                 .orElse(null)
                 ?.third
+        }
+    }
+
+    internal fun cleanupOldCachedVersions(cacheDirectory: Path, currentVersionDirectory: Path) {
+        runCatching {
+            if (!Files.isDirectory(cacheDirectory)) {
+                return
+            }
+            Files.list(cacheDirectory).use { entries ->
+                entries
+                    .filter { it != currentVersionDirectory }
+                    .filter(Files::isDirectory)
+                    .filter {
+                        versionPattern.matches(it.fileName.toString().removePrefix("tombi-"))
+                    }
+                    .forEach(::deleteRecursively)
+            }
+        }.onFailure { error ->
+            LOG.warn("Failed to remove old cached Tombi binaries", error)
+        }
+    }
+
+    private fun deleteRecursively(directory: Path) {
+        Files.walk(directory).use { entries ->
+            entries.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
         }
     }
 
@@ -225,12 +254,6 @@ internal object TombiBinaryDownloader {
         return 0
     }
 
-    private fun requireSuccess(statusCode: Int, uri: URI) {
-        check(statusCode in 200..299) {
-            "Request to $uri failed with HTTP $statusCode"
-        }
-    }
-
     internal data class Platform(
         val target: String,
         val binaryName: String,
@@ -241,4 +264,6 @@ internal object TombiBinaryDownloader {
         TAR_GZ("tar.gz"),
         ZIP("zip"),
     }
+
+    private val LOG = Logger.getInstance(TombiBinaryDownloader::class.java)
 }

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryDownloader.kt
@@ -2,10 +2,12 @@ package tombi.server
 
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.util.io.HttpRequests
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import tombi.message
 import java.io.BufferedInputStream
 import java.io.InputStream
 import java.io.OutputStream
@@ -27,10 +29,11 @@ internal object TombiBinaryDownloader {
         cacheDirectory: Path = PathManager.getSystemDir().resolve("tombi"),
         osName: String = System.getProperty("os.name"),
         architecture: String = System.getProperty("os.arch"),
+        indicator: ProgressIndicator? = null,
     ): String {
         val platform = platform(osName, architecture)
         return try {
-            downloadLatest(cacheDirectory, platform).toString()
+            downloadLatest(cacheDirectory, platform, indicator).toString()
         } catch (error: Exception) {
             newestCachedBinary(cacheDirectory, platform.binaryName)?.toString() ?: throw error
         }
@@ -69,7 +72,9 @@ internal object TombiBinaryDownloader {
     private fun downloadLatest(
         cacheDirectory: Path,
         platform: Platform,
+        indicator: ProgressIndicator?,
     ): Path {
+        indicator?.text = message("progress.checkingForUpdate")
         val latestReleaseUri = latestReleaseUri()
         val version = versionFromLatestReleaseUri(latestReleaseUri)
         val versionDirectory = cacheDirectory.resolve("tombi-$version")
@@ -86,7 +91,8 @@ internal object TombiBinaryDownloader {
         val extractedPath = Files.createTempFile(versionDirectory, "tombi-", ".tmp")
 
         try {
-            request(assetUri.toString(), 120_000).saveToFile(archivePath, null)
+            indicator?.text = message("progress.downloading", version)
+            request(assetUri.toString(), 120_000).saveToFile(archivePath, indicator)
 
             BufferedInputStream(Files.newInputStream(archivePath)).use { input ->
                 Files.newOutputStream(extractedPath).use { output ->

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryResolver.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryResolver.kt
@@ -6,41 +6,112 @@ import java.nio.file.Path
 
 
 internal object TombiBinaryResolver {
+    private const val MAX_NODE_MODULES_SEARCH_DEPTH = 8
+
     fun resolveLocal(
-        projectPath: Path?,
+        workspacePaths: List<Path>,
+        sdkHomePaths: List<Path>,
         configuredExecutable: String?,
         environment: Map<String, String> = EnvironmentUtil.getEnvironmentMap(),
         osName: String = System.getProperty("os.name"),
         userHome: String = System.getProperty("user.home"),
-    ): String? {
+    ): TombiCommand? {
         configuredExecutable
             ?.trim()
             ?.takeIf(String::isNotEmpty)
-            ?.let { return expandHome(it, userHome) }
+            ?.let { return TombiCommand(expandHome(it, userHome)) }
 
         val isWindows = osName.startsWith("Windows", ignoreCase = true)
         val binaryName = if (isWindows) "tombi.exe" else "tombi"
 
-        if (projectPath != null) {
-            val virtualEnvironmentDirectory = if (isWindows) "Scripts" else "bin"
-            val projectCandidates = mutableListOf(
-                projectPath.resolve(".venv").resolve(virtualEnvironmentDirectory).resolve(binaryName),
-                projectPath.resolve("node_modules").resolve(".bin").resolve(binaryName),
-            )
-            if (isWindows) {
-                projectCandidates.addAll(
-                    listOf("tombi.cmd", "tombi.ps1").map {
-                        projectPath.resolve("node_modules").resolve(".bin").resolve(it)
-                    },
+        resolveSdkInstall(sdkHomePaths, binaryName, isWindows)?.let {
+            return TombiCommand(it.toString())
+        }
+
+        workspacePaths.asSequence()
+            .map {
+                it.resolve(".venv")
+                    .resolve(if (isWindows) "Scripts" else "bin")
+                    .resolve(binaryName)
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?.let { return TombiCommand(it.toString()) }
+
+        resolveNodeModulesInstall(workspacePaths, environment, binaryName, isWindows)?.let {
+            return it
+        }
+
+        return findOnPath(tombiCandidateNames(binaryName, isWindows), environment, isWindows)
+            ?.let { TombiCommand(it.toString()) }
+    }
+
+    private fun resolveSdkInstall(
+        sdkHomePaths: List<Path>,
+        binaryName: String,
+        isWindows: Boolean,
+    ): Path? =
+        sdkHomePaths.asSequence()
+            .flatMap { sdkHomePath ->
+                if (Files.isRegularFile(sdkHomePath)) {
+                    sequenceOf(sdkHomePath.parent?.resolve(binaryName))
+                } else {
+                    sequenceOf(
+                        sdkHomePath.resolve(binaryName),
+                        sdkHomePath.resolve(if (isWindows) "Scripts" else "bin").resolve(binaryName),
+                    )
+                }
+            }
+            .filterNotNull()
+            .firstOrNull(Files::isRegularFile)
+
+    private fun resolveNodeModulesInstall(
+        workspacePaths: List<Path>,
+        environment: Map<String, String>,
+        binaryName: String,
+        isWindows: Boolean,
+    ): TombiCommand? {
+        val searchDirectories = workspacePaths.asSequence()
+            .flatMap(::nodeModulesSearchDirectories)
+            .distinct()
+            .toList()
+
+        val nodeScript = searchDirectories.asSequence()
+            .flatMap { directory ->
+                sequenceOf(
+                    directory.resolve("node_modules/@tombi-toml/tombi/bin/tombi"),
+                    directory.resolve("node_modules/tombi/bin/tombi"),
                 )
             }
-            projectCandidates.firstOrNull(Files::isRegularFile)?.let {
-                return it.toString()
+            .firstOrNull(Files::isRegularFile)
+
+        if (nodeScript != null) {
+            findOnPath(
+                if (isWindows) listOf("node.exe", "node.cmd") else listOf("node"),
+                environment,
+                isWindows,
+            )?.let { node ->
+                return TombiCommand(node.toString(), listOf(nodeScript.toString()))
+            }
+
+            if (!isWindows && Files.isExecutable(nodeScript)) {
+                return TombiCommand(nodeScript.toString())
             }
         }
 
-        return findOnPath(binaryName, environment, isWindows)
+        return searchDirectories.asSequence()
+            .flatMap { directory ->
+                nodeModulesCandidateNames(binaryName, isWindows).asSequence().map { candidateName ->
+                    directory.resolve("node_modules/.bin").resolve(candidateName)
+                }
+            }
+            .firstOrNull(Files::isRegularFile)
+            ?.let { TombiCommand(it.toString()) }
     }
+
+    private fun nodeModulesSearchDirectories(workspacePath: Path): Sequence<Path> =
+        generateSequence(workspacePath) { currentPath ->
+            currentPath.parent?.takeIf { it != currentPath }
+        }.take(MAX_NODE_MODULES_SEARCH_DEPTH + 1)
 
     private fun expandHome(path: String, userHome: String): String =
         when {
@@ -49,29 +120,36 @@ internal object TombiBinaryResolver {
             else -> path
         }
 
+    private fun tombiCandidateNames(binaryName: String, isWindows: Boolean): List<String> =
+        if (isWindows) {
+            listOf(binaryName, "tombi.cmd", "tombi.bat")
+        } else {
+            listOf(binaryName)
+        }
+
+    private fun nodeModulesCandidateNames(binaryName: String, isWindows: Boolean): List<String> =
+        if (isWindows) {
+            listOf("tombi.cmd", binaryName)
+        } else {
+            listOf(binaryName)
+        }
+
     private fun findOnPath(
-        binaryName: String,
+        candidateNames: List<String>,
         environment: Map<String, String>,
         isWindows: Boolean,
-    ): String? {
+    ): Path? {
         val pathValue = environment.entries
             .firstOrNull { (key, _) -> key.equals("PATH", ignoreCase = isWindows) }
             ?.value
             ?: return null
 
         val separator = if (isWindows) ';' else ':'
-        val candidateNames = if (isWindows) {
-            listOf(binaryName, "tombi.cmd", "tombi.bat")
-        } else {
-            listOf(binaryName)
-        }
-
         return pathValue
             .split(separator)
             .asSequence()
             .filter(String::isNotBlank)
             .flatMap { directory -> candidateNames.asSequence().map(Path.of(directory)::resolve) }
             .firstOrNull(Files::isRegularFile)
-            ?.toString()
     }
 }

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryResolver.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiBinaryResolver.kt
@@ -28,17 +28,16 @@ internal object TombiBinaryResolver {
             return TombiCommand(it.toString())
         }
 
-        workspacePaths.asSequence()
-            .map {
-                it.resolve(".venv")
-                    .resolve(if (isWindows) "Scripts" else "bin")
-                    .resolve(binaryName)
+        // Checked per workspace, matching the VSCode extension: a virtual environment
+        // wins over `node_modules` only within the same workspace, not across them.
+        workspacePaths.forEach { workspacePath ->
+            resolveVirtualEnvironmentInstall(workspacePath, binaryName, isWindows)?.let {
+                return TombiCommand(it.toString())
             }
-            .firstOrNull(Files::isRegularFile)
-            ?.let { return TombiCommand(it.toString()) }
 
-        resolveNodeModulesInstall(workspacePaths, environment, binaryName, isWindows)?.let {
-            return it
+            resolveNodeModulesInstall(workspacePath, environment, binaryName, isWindows)?.let {
+                return it
+            }
         }
 
         return findOnPath(tombiCandidateNames(binaryName, isWindows), environment, isWindows)
@@ -64,16 +63,23 @@ internal object TombiBinaryResolver {
             .filterNotNull()
             .firstOrNull(Files::isRegularFile)
 
+    private fun resolveVirtualEnvironmentInstall(
+        workspacePath: Path,
+        binaryName: String,
+        isWindows: Boolean,
+    ): Path? =
+        workspacePath.resolve(".venv")
+            .resolve(if (isWindows) "Scripts" else "bin")
+            .resolve(binaryName)
+            .takeIf(Files::isRegularFile)
+
     private fun resolveNodeModulesInstall(
-        workspacePaths: List<Path>,
+        workspacePath: Path,
         environment: Map<String, String>,
         binaryName: String,
         isWindows: Boolean,
     ): TombiCommand? {
-        val searchDirectories = workspacePaths.asSequence()
-            .flatMap(::nodeModulesSearchDirectories)
-            .distinct()
-            .toList()
+        val searchDirectories = nodeModulesSearchDirectories(workspacePath).toList()
 
         val nodeScript = searchDirectories.asSequence()
             .flatMap { directory ->
@@ -150,6 +156,16 @@ internal object TombiBinaryResolver {
             .asSequence()
             .filter(String::isNotBlank)
             .flatMap { directory -> candidateNames.asSequence().map(Path.of(directory)::resolve) }
-            .firstOrNull(Files::isRegularFile)
+            .firstOrNull { isRunnable(it, isWindows) }
     }
+
+    /**
+     * `PATH` entries have to be runnable to be worth reporting, mirroring the
+     * `which` lookup the VSCode extension relies on.
+     *
+     * The executable bit is only meaningful on POSIX file systems; on Windows
+     * runnability is decided by the extension, which [tombiCandidateNames] covers.
+     */
+    private fun isRunnable(path: Path, isWindows: Boolean): Boolean =
+        Files.isRegularFile(path) && (isWindows || Files.isExecutable(path))
 }

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiCommand.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiCommand.kt
@@ -1,0 +1,7 @@
+package tombi.server
+
+
+internal data class TombiCommand(
+    val executable: String,
+    val arguments: List<String> = emptyList(),
+)

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
@@ -38,7 +38,7 @@ internal val Project.path: Path?
 /**
  * "Describe" the language server.
  */
-internal class TombiServerDescriptor(project: Project, private val executable: String) :
+internal class TombiServerDescriptor(project: Project, private val command: TombiCommand) :
     ProjectWideLspServerDescriptor(project, PRESENTABLE_NAME) {
 
     /**
@@ -65,7 +65,8 @@ internal class TombiServerDescriptor(project: Project, private val executable: S
         withWorkingDirectory(project.path)
         withCharset(Charsets.UTF_8)
 
-        withExePath(executable)
+        withExePath(command.executable)
+        addParameters(command.arguments)
         addParameter("lsp")
     }
 

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerDescriptor.kt
@@ -32,7 +32,8 @@ internal val VirtualFile.isTOMLFile: Boolean
  * may include multiple directories.
  */
 internal val Project.path: Path?
-    get() = guessProjectDir()?.toNioPath() ?: basePath?.let { Path.of(it) }
+    get() = guessProjectDir()?.let { runCatching(it::toNioPath).getOrNull() }
+        ?: basePath?.let { runCatching { Path.of(it) }.getOrNull() }
 
 
 /**

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
@@ -4,7 +4,6 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
@@ -103,10 +102,10 @@ internal class TombiServerSupportProvider : LspServerSupportProvider {
 
         private fun registerProject(project: Project) {
             if (registeredProjects.add(project)) {
-                Disposer.register(project, Disposable {
+                Disposer.register(project) {
                     invalidate(project)
                     registeredProjects.remove(project)
-                })
+                }
             }
         }
 

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
@@ -3,8 +3,12 @@ package tombi.server
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
@@ -15,14 +19,16 @@ import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.LspServerSupportProvider.LspServerStarter
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
-import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.IncorrectOperationException
 import tombi.Icons
 import tombi.configurations.TombiConfigurable
 import tombi.configurations.tombiConfigurations
 import tombi.message
 import java.nio.file.Path
 import java.time.Duration
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 
 
@@ -40,40 +46,28 @@ internal class TombiServerSupportProvider : LspServerSupportProvider {
         LspServerWidgetItem(lspServer, currentFile, Icons._16, TombiConfigurable::class.java)
     
     override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerStarter) {
-        if (!file.isTOMLFile) {
+        if (!file.isTOMLFile || project.isDisposed) {
             return
         }
 
-        registerProject(project)
-        if ((retryAfterNanos[project] ?: 0) > System.nanoTime()) {
+        if (!registerProject(project) || isInRetryCooldown(project)) {
             return
         }
 
         val configuredExecutable = tombiConfigurations.executable
-        val workspacePaths = project.workspacePaths
-        val sdkHomePaths = project.sdkHomePaths
-
         val resolution = resolutions.computeIfAbsent(project) {
-            CompletableFuture.supplyAsync(
-                {
-                    TombiBinaryResolver.resolveLocal(
-                        workspacePaths = workspacePaths,
-                        sdkHomePaths = sdkHomePaths,
-                        configuredExecutable = configuredExecutable,
-                    ) ?: TombiCommand(TombiBinaryDownloader.downloadLatestOrCached())
-                },
-                AppExecutorUtil.getAppExecutorService(),
-            )
+            startResolution(project, configuredExecutable)
         }
 
         resolution.whenComplete { command, error ->
             if (error != null) {
-                if (resolutions.remove(project, resolution)) {
-                    retryAfterNanos[project] = System.nanoTime() + RETRY_DELAY.toNanos()
-                    val cause = error.cause ?: error
-                    LOG.warn("Failed to obtain a Tombi language server", cause)
-                    notifyDownloadFailure(project, cause)
+                if (!resolutions.remove(project, resolution) || error is CancellationException) {
+                    return@whenComplete
                 }
+                retryAfterNanos[project] = System.nanoTime() + RETRY_DELAY.toNanos()
+                val cause = if (error is CompletionException) error.cause ?: error else error
+                LOG.warn("Failed to obtain a Tombi language server", cause)
+                notifyDownloadFailure(project, cause)
                 return@whenComplete
             }
 
@@ -100,13 +94,94 @@ internal class TombiServerSupportProvider : LspServerSupportProvider {
             retryAfterNanos.remove(project)
         }
 
-        private fun registerProject(project: Project) {
-            if (registeredProjects.add(project)) {
+        /**
+         * Resolution runs as a cancellable background task so that the
+         * potentially long-running download reports progress to the user.
+         */
+        private fun startResolution(
+            project: Project,
+            configuredExecutable: String?,
+        ): CompletableFuture<TombiCommand> {
+            val resolution = CompletableFuture<TombiCommand>()
+            val task = object : Task.Backgroundable(
+                project,
+                message("progress.resolvingLanguageServer"),
+                true,
+            ) {
+                override fun run(indicator: ProgressIndicator) {
+                    resolution.complete(resolve(project, configuredExecutable, indicator))
+                }
+
+                override fun onThrowable(error: Throwable) {
+                    resolution.completeExceptionally(error)
+                }
+
+                override fun onCancel() {
+                    resolution.cancel(false)
+                }
+            }
+
+            // `fileOpened` is invoked from a read action on a background thread, where
+            // `ProgressManager.run` would have to `invokeAndWait` and risk a deadlock.
+            ApplicationManager.getApplication().invokeLater {
+                if (project.isDisposed) {
+                    resolution.cancel(false)
+                    return@invokeLater
+                }
+                ProgressManager.getInstance().run(task)
+            }
+
+            return resolution
+        }
+
+        private fun resolve(
+            project: Project,
+            configuredExecutable: String?,
+            indicator: ProgressIndicator,
+        ): TombiCommand {
+            // The module model may only be read under a read action.
+            val (workspacePaths, sdkHomePaths) = ReadAction.compute<Pair<List<Path>, List<Path>>, RuntimeException> {
+                if (project.isDisposed) {
+                    emptyList<Path>() to emptyList()
+                } else {
+                    project.workspacePaths to project.sdkHomePaths
+                }
+            }
+
+            TombiBinaryResolver.resolveLocal(
+                workspacePaths = workspacePaths,
+                sdkHomePaths = sdkHomePaths,
+                configuredExecutable = configuredExecutable,
+            )?.let { return it }
+
+            return TombiCommand(TombiBinaryDownloader.downloadLatestOrCached(indicator = indicator))
+        }
+
+        /**
+         * @return whether resolution may proceed for [project].
+         */
+        private fun registerProject(project: Project): Boolean {
+            if (!registeredProjects.add(project)) {
+                return true
+            }
+
+            return try {
                 Disposer.register(project) {
                     invalidate(project)
                     registeredProjects.remove(project)
                 }
+                true
+            } catch (error: IncorrectOperationException) {
+                registeredProjects.remove(project)
+                LOG.debug("Skipped Tombi resolution for an already disposed project", error)
+                false
             }
+        }
+
+        private fun isInRetryCooldown(project: Project): Boolean {
+            val retryAfter = retryAfterNanos[project] ?: return false
+            // Subtraction keeps the comparison correct across `nanoTime` wraparound.
+            return System.nanoTime() - retryAfter < 0
         }
 
         private fun notifyDownloadFailure(project: Project, error: Throwable) {
@@ -133,7 +208,7 @@ private val Project.workspacePaths: List<Path>
         path?.let(::add)
         ModuleManager.getInstance(this@workspacePaths).modules.forEach { module ->
             ModuleRootManager.getInstance(module).contentRoots.forEach { root ->
-                add(root.toNioPath())
+                runCatching { root.toNioPath() }.getOrNull()?.let(::add)
             }
         }
     }.toList()

--- a/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
+++ b/editors/intellij/src/main/kotlin/tombi/server/TombiServerSupportProvider.kt
@@ -1,8 +1,15 @@
 package tombi.server
 
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerManager
@@ -13,8 +20,9 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import tombi.Icons
 import tombi.configurations.TombiConfigurable
 import tombi.configurations.tombiConfigurations
-import java.nio.file.Files
+import tombi.message
 import java.nio.file.Path
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
@@ -37,40 +45,44 @@ internal class TombiServerSupportProvider : LspServerSupportProvider {
             return
         }
 
-        val configuredExecutable = tombiConfigurations.executable
-        TombiBinaryResolver.resolveLocal(project.path, configuredExecutable)?.let { executable ->
-            serverStarter.ensureServerStarted(TombiServerDescriptor(project, executable))
+        registerProject(project)
+        if ((retryAfterNanos[project] ?: 0) > System.nanoTime()) {
             return
         }
 
-        managedExecutable
-            ?.takeIf { Files.isRegularFile(Path.of(it)) }
-            ?.let { executable ->
-                serverStarter.ensureServerStarted(TombiServerDescriptor(project, executable))
-                return
-            }
+        val configuredExecutable = tombiConfigurations.executable
+        val workspacePaths = project.workspacePaths
+        val sdkHomePaths = project.sdkHomePaths
 
-        val resolution = managedResolutions.computeIfAbsent(project) {
+        val resolution = resolutions.computeIfAbsent(project) {
             CompletableFuture.supplyAsync(
-                { TombiBinaryDownloader.downloadLatestOrCached() },
+                {
+                    TombiBinaryResolver.resolveLocal(
+                        workspacePaths = workspacePaths,
+                        sdkHomePaths = sdkHomePaths,
+                        configuredExecutable = configuredExecutable,
+                    ) ?: TombiCommand(TombiBinaryDownloader.downloadLatestOrCached())
+                },
                 AppExecutorUtil.getAppExecutorService(),
             )
         }
 
-        resolution.whenComplete { executable, error ->
-            managedResolutions.remove(project, resolution)
-
+        resolution.whenComplete { command, error ->
             if (error != null) {
-                LOG.warn("Failed to obtain a Tombi language server", error)
+                if (resolutions.remove(project, resolution)) {
+                    retryAfterNanos[project] = System.nanoTime() + RETRY_DELAY.toNanos()
+                    val cause = error.cause ?: error
+                    LOG.warn("Failed to obtain a Tombi language server", cause)
+                    notifyDownloadFailure(project, cause)
+                }
                 return@whenComplete
             }
 
-            managedExecutable = executable
             ApplicationManager.getApplication().invokeLater {
                 if (!project.isDisposed) {
                     LspServerManager.getInstance(project).ensureServerStarted(
                         TombiServerSupportProvider::class.java,
-                        TombiServerDescriptor(project, executable),
+                        TombiServerDescriptor(project, command),
                     )
                 }
             }
@@ -78,9 +90,64 @@ internal class TombiServerSupportProvider : LspServerSupportProvider {
     }
 
     companion object {
+        private val RETRY_DELAY = Duration.ofMinutes(5)
         private val LOG = Logger.getInstance(TombiServerSupportProvider::class.java)
-        private val managedResolutions = ConcurrentHashMap<Project, CompletableFuture<String>>()
-        @Volatile
-        private var managedExecutable: String? = null
+        private val resolutions = ConcurrentHashMap<Project, CompletableFuture<TombiCommand>>()
+        private val retryAfterNanos = ConcurrentHashMap<Project, Long>()
+        private val registeredProjects = ConcurrentHashMap.newKeySet<Project>()
+
+        internal fun invalidate(project: Project) {
+            resolutions.remove(project)?.cancel(true)
+            retryAfterNanos.remove(project)
+        }
+
+        private fun registerProject(project: Project) {
+            if (registeredProjects.add(project)) {
+                Disposer.register(project, Disposable {
+                    invalidate(project)
+                    registeredProjects.remove(project)
+                })
+            }
+        }
+
+        private fun notifyDownloadFailure(project: Project, error: Throwable) {
+            ApplicationManager.getApplication().invokeLater {
+                if (project.isDisposed) {
+                    return@invokeLater
+                }
+                NotificationGroupManager.getInstance()
+                    .getNotificationGroup("Tombi")
+                    .createNotification(
+                        message("notification.languageServerUnavailable.title"),
+                        error.message ?: message("notification.languageServerUnavailable.content"),
+                        NotificationType.ERROR,
+                    )
+                    .notify(project)
+            }
+        }
     }
 }
+
+
+private val Project.workspacePaths: List<Path>
+    get() = buildSet {
+        path?.let(::add)
+        ModuleManager.getInstance(this@workspacePaths).modules.forEach { module ->
+            ModuleRootManager.getInstance(module).contentRoots.forEach { root ->
+                add(root.toNioPath())
+            }
+        }
+    }.toList()
+
+
+private val Project.sdkHomePaths: List<Path>
+    get() = buildSet {
+        ProjectRootManager.getInstance(this@sdkHomePaths).projectSdk?.homePath
+            ?.let { runCatching { Path.of(it) }.getOrNull() }
+            ?.let(::add)
+        ModuleManager.getInstance(this@sdkHomePaths).modules.forEach { module ->
+            ModuleRootManager.getInstance(module).sdk?.homePath
+                ?.let { runCatching { Path.of(it) }.getOrNull() }
+                ?.let(::add)
+        }
+    }.toList()

--- a/editors/intellij/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij/src/main/resources/META-INF/plugin.xml
@@ -38,5 +38,11 @@
 			id="tombi.server.TombiServerSupportProvider"
 			implementation="tombi.server.TombiServerSupportProvider"
 		/>
+
+		<notificationGroup
+			id="Tombi"
+			displayType="BALLOON"
+			isLogByDefault="true"
+		/>
 	</extensions>
 </idea-plugin>

--- a/editors/intellij/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,8 @@
 			id="Tombi"
 			displayType="BALLOON"
 			isLogByDefault="true"
+			bundle="messages.tombi"
+			key="notification.group.name"
 		/>
 	</extensions>
 </idea-plugin>

--- a/editors/intellij/src/main/resources/messages/tombi.properties
+++ b/editors/intellij/src/main/resources/messages/tombi.properties
@@ -3,3 +3,6 @@ languageServer.presentableName = Tombi
 configurations.displayName = Tombi
 configurations.executable.label = Executable:
 configurations.executable.placeholder = Automatic
+
+notification.languageServerUnavailable.title = Tombi language server is unavailable
+notification.languageServerUnavailable.content = Failed to find or download the Tombi language server.

--- a/editors/intellij/src/main/resources/messages/tombi.properties
+++ b/editors/intellij/src/main/resources/messages/tombi.properties
@@ -4,5 +4,10 @@ configurations.displayName = Tombi
 configurations.executable.label = Executable:
 configurations.executable.placeholder = Automatic
 
+notification.group.name = Tombi
 notification.languageServerUnavailable.title = Tombi language server is unavailable
 notification.languageServerUnavailable.content = Failed to find or download the Tombi language server.
+
+progress.resolvingLanguageServer = Resolving Tombi language server
+progress.checkingForUpdate = Checking for the latest Tombi release
+progress.downloading = Downloading Tombi {0}

--- a/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryDownloaderTest.kt
+++ b/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryDownloaderTest.kt
@@ -1,5 +1,6 @@
 package tombi.server
 
+import com.sun.net.httpserver.HttpServer
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
@@ -7,6 +8,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.net.InetSocketAddress
 import java.net.URI
 import java.nio.file.Files
 import java.util.Comparator
@@ -52,6 +54,32 @@ class TombiBinaryDownloaderTest {
                 URI.create("https://github.com/tombi-toml/tombi/releases/tag/v1.2.4"),
             ),
         )
+    }
+
+    @Test
+    fun `follows latest release redirect`() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/releases/latest") { exchange ->
+            exchange.responseHeaders.add("Location", "/releases/tag/v1.2.4")
+            exchange.sendResponseHeaders(302, -1)
+            exchange.close()
+        }
+        server.createContext("/releases/tag/v1.2.4") { exchange ->
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+        }
+        server.start()
+
+        try {
+            assertEquals(
+                URI.create("http://127.0.0.1:${server.address.port}/releases/tag/v1.2.4"),
+                TombiBinaryDownloader.latestReleaseUri(
+                    "http://127.0.0.1:${server.address.port}/releases",
+                ),
+            )
+        } finally {
+            server.stop(0)
+        }
     }
 
     @Test

--- a/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryDownloaderTest.kt
+++ b/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryDownloaderTest.kt
@@ -1,6 +1,15 @@
 package tombi.server
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.net.URI
+import java.nio.file.Files
+import java.util.Comparator
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -49,6 +58,105 @@ class TombiBinaryDownloaderTest {
     fun `rejects unsupported platform`() {
         assertFailsWith<IllegalStateException> {
             TombiBinaryDownloader.platform("FreeBSD", "x86_64")
+        }
+    }
+
+    @Test
+    fun `extracts tombi from tar gzip archive`() {
+        val binary = "tar binary".toByteArray()
+        val archive = ByteArrayOutputStream().also { bytes ->
+            GzipCompressorOutputStream(bytes).use { gzip ->
+                TarArchiveOutputStream(gzip).use { tar ->
+                    val entry = TarArchiveEntry("tombi-cli/tombi").apply {
+                        size = binary.size.toLong()
+                    }
+                    tar.putArchiveEntry(entry)
+                    tar.write(binary)
+                    tar.closeArchiveEntry()
+                }
+            }
+        }.toByteArray()
+        val extracted = ByteArrayOutputStream()
+
+        TombiBinaryDownloader.extractArchive(
+            ByteArrayInputStream(archive),
+            "tombi",
+            TombiBinaryDownloader.ArchiveType.TAR_GZ,
+            extracted,
+        )
+
+        assertEquals("tar binary", extracted.toString())
+    }
+
+    @Test
+    fun `extracts tombi from zip archive`() {
+        val archive = ByteArrayOutputStream().also { bytes ->
+            ZipArchiveOutputStream(bytes).use { zip ->
+                zip.putArchiveEntry(ZipArchiveEntry("tombi-cli/tombi.exe"))
+                zip.write("zip binary".toByteArray())
+                zip.closeArchiveEntry()
+            }
+        }.toByteArray()
+        val extracted = ByteArrayOutputStream()
+
+        TombiBinaryDownloader.extractArchive(
+            ByteArrayInputStream(archive),
+            "tombi.exe",
+            TombiBinaryDownloader.ArchiveType.ZIP,
+            extracted,
+        )
+
+        assertEquals("zip binary", extracted.toString())
+    }
+
+    @Test
+    fun `uses newest compatible cached binary`() {
+        val cacheDirectory = Files.createTempDirectory("tombi-downloader-test")
+        try {
+            val oldBinary = cacheDirectory.resolve("tombi-1.9.0/tombi")
+            val newestBinary = cacheDirectory.resolve("tombi-1.10.0/tombi")
+            val windowsBinary = cacheDirectory.resolve("tombi-2.0.0/tombi.exe")
+            listOf(oldBinary, newestBinary, windowsBinary).forEach { binary ->
+                Files.createDirectories(binary.parent)
+                Files.createFile(binary)
+            }
+            Files.createDirectories(cacheDirectory.resolve("not-a-version"))
+
+            assertEquals(
+                newestBinary,
+                TombiBinaryDownloader.newestCachedBinary(cacheDirectory, "tombi"),
+            )
+            assertEquals(
+                windowsBinary,
+                TombiBinaryDownloader.newestCachedBinary(cacheDirectory, "tombi.exe"),
+            )
+        } finally {
+            Files.walk(cacheDirectory).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
+        }
+    }
+
+    @Test
+    fun `removes old version caches after a successful resolution`() {
+        val cacheDirectory = Files.createTempDirectory("tombi-downloader-test")
+        try {
+            val oldVersion = cacheDirectory.resolve("tombi-1.9.0")
+            val currentVersion = cacheDirectory.resolve("tombi-1.10.0")
+            val unrelated = cacheDirectory.resolve("downloads")
+            listOf(oldVersion, currentVersion, unrelated).forEach(Files::createDirectories)
+            Files.createFile(oldVersion.resolve("tombi"))
+            Files.createFile(currentVersion.resolve("tombi"))
+
+            TombiBinaryDownloader.cleanupOldCachedVersions(cacheDirectory, currentVersion)
+
+            assertEquals(false, Files.exists(oldVersion))
+            assertEquals(true, Files.exists(currentVersion))
+            assertEquals(true, Files.exists(unrelated))
+        } finally {
+            Files.walk(cacheDirectory).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
         }
     }
 }

--- a/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryResolverTest.kt
+++ b/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryResolverTest.kt
@@ -12,13 +12,31 @@ class TombiBinaryResolverTest {
     @Test
     fun `configured executable takes priority and expands home`() {
         assertEquals(
-            "/home/test/bin/tombi",
-            TombiBinaryResolver.resolveLocal(
-                projectPath = null,
+            TombiCommand("/home/test/bin/tombi"),
+            resolveLocal(
                 configuredExecutable = "~/bin/tombi",
-                environment = emptyMap(),
-                osName = "Linux",
                 userHome = "/home/test",
+            ),
+        )
+    }
+
+    @Test
+    fun `selected SDK environment takes priority over project installations`() {
+        val sdk = Files.createTempDirectory("tombi-sdk")
+        val sdkPython = sdk.resolve("bin/python")
+        val sdkTombi = sdk.resolve("bin/tombi")
+        val project = Files.createTempDirectory("tombi-project")
+        sdkPython.parent.createDirectories()
+        sdkPython.createFile()
+        sdkTombi.createFile()
+        project.resolve(".venv/bin").createDirectories()
+        project.resolve(".venv/bin/tombi").createFile()
+
+        assertEquals(
+            TombiCommand(sdkTombi.toString()),
+            resolveLocal(
+                workspacePaths = listOf(project),
+                sdkHomePaths = listOf(sdkPython),
             ),
         )
     }
@@ -29,41 +47,71 @@ class TombiBinaryResolverTest {
         val venvTombi = project.resolve(".venv/bin/tombi")
         val nodeModulesTombi = project.resolve("node_modules/.bin/tombi")
         val pathDirectory = Files.createTempDirectory("tombi-path")
-        val pathTombi = pathDirectory.resolve("tombi")
         venvTombi.parent.createDirectories()
         nodeModulesTombi.parent.createDirectories()
         venvTombi.createFile()
         nodeModulesTombi.createFile()
-        pathTombi.createFile()
+        pathDirectory.resolve("tombi").createFile()
 
         assertEquals(
-            venvTombi.toString(),
-            TombiBinaryResolver.resolveLocal(
-                projectPath = project,
-                configuredExecutable = null,
+            TombiCommand(venvTombi.toString()),
+            resolveLocal(
+                workspacePaths = listOf(project),
                 environment = mapOf("PATH" to pathDirectory.toString()),
-                osName = "Linux",
             ),
         )
     }
 
     @Test
-    fun `node modules takes priority over path`() {
-        val project = Files.createTempDirectory("tombi-project")
-        val nodeModulesTombi = project.resolve("node_modules/.bin/tombi")
+    fun `finds npm package in parent directory and runs it with node`() {
+        val repository = Files.createTempDirectory("tombi-repository")
+        val project = repository.resolve("packages/example").createDirectories()
+        val nodeScript = repository.resolve("node_modules/@tombi-toml/tombi/bin/tombi")
+        val nodeDirectory = Files.createTempDirectory("node-path")
+        val node = nodeDirectory.resolve("node")
+        nodeScript.parent.createDirectories()
+        nodeScript.createFile()
+        node.createFile()
+
+        assertEquals(
+            TombiCommand(node.toString(), listOf(nodeScript.toString())),
+            resolveLocal(
+                workspacePaths = listOf(project),
+                environment = mapOf("PATH" to nodeDirectory.toString()),
+            ),
+        )
+    }
+
+    @Test
+    fun `finds hoisted node modules shim before path`() {
+        val repository = Files.createTempDirectory("tombi-repository")
+        val project = repository.resolve("packages/example").createDirectories()
+        val nodeModulesTombi = repository.resolve("node_modules/.bin/tombi")
         val pathDirectory = Files.createTempDirectory("tombi-path")
         nodeModulesTombi.parent.createDirectories()
         nodeModulesTombi.createFile()
         pathDirectory.resolve("tombi").createFile()
 
         assertEquals(
-            nodeModulesTombi.toString(),
-            TombiBinaryResolver.resolveLocal(
-                projectPath = project,
-                configuredExecutable = null,
+            TombiCommand(nodeModulesTombi.toString()),
+            resolveLocal(
+                workspacePaths = listOf(project),
                 environment = mapOf("PATH" to pathDirectory.toString()),
-                osName = "Linux",
             ),
+        )
+    }
+
+    @Test
+    fun `searches every workspace content root`() {
+        val firstWorkspace = Files.createTempDirectory("tombi-workspace")
+        val secondWorkspace = Files.createTempDirectory("tombi-workspace")
+        val nodeModulesTombi = secondWorkspace.resolve("node_modules/.bin/tombi")
+        nodeModulesTombi.parent.createDirectories()
+        nodeModulesTombi.createFile()
+
+        assertEquals(
+            TombiCommand(nodeModulesTombi.toString()),
+            resolveLocal(workspacePaths = listOf(firstWorkspace, secondWorkspace)),
         )
     }
 
@@ -73,12 +121,10 @@ class TombiBinaryResolverTest {
         val pathTombi = pathDirectory.resolve("tombi").createFile()
 
         assertEquals(
-            pathTombi.toString(),
-            TombiBinaryResolver.resolveLocal(
-                projectPath = Files.createTempDirectory("tombi-project"),
-                configuredExecutable = null,
+            TombiCommand(pathTombi.toString()),
+            resolveLocal(
+                workspacePaths = listOf(Files.createTempDirectory("tombi-project")),
                 environment = mapOf("PATH" to pathDirectory.toString()),
-                osName = "Linux",
             ),
         )
     }
@@ -91,25 +137,64 @@ class TombiBinaryResolverTest {
         nodeModulesTombi.createFile()
 
         assertEquals(
-            nodeModulesTombi.toString(),
-            TombiBinaryResolver.resolveLocal(
-                projectPath = project,
-                configuredExecutable = null,
-                environment = emptyMap(),
+            TombiCommand(nodeModulesTombi.toString()),
+            resolveLocal(
+                workspacePaths = listOf(project),
                 osName = "Windows 11",
             ),
         )
     }
 
     @Test
-    fun `returns null when no local installation exists`() {
+    fun `does not use PowerShell shim on Windows`() {
+        val project = Files.createTempDirectory("tombi-project")
+        val powerShellShim = project.resolve("node_modules/.bin/tombi.ps1")
+        powerShellShim.parent.createDirectories()
+        powerShellShim.createFile()
+
         assertNull(
-            TombiBinaryResolver.resolveLocal(
-                projectPath = Files.createTempDirectory("tombi-project"),
-                configuredExecutable = null,
-                environment = emptyMap(),
-                osName = "Linux",
+            resolveLocal(
+                workspacePaths = listOf(project),
+                osName = "Windows 11",
             ),
         )
     }
+
+    @Test
+    fun `does not search node modules beyond the VSCode depth limit`() {
+        val repository = Files.createTempDirectory("tombi-repository")
+        val project = (1..9).fold(repository) { path, index ->
+            path.resolve("level-$index").createDirectories()
+        }
+        val nodeModulesTombi = repository.resolve("node_modules/.bin/tombi")
+        nodeModulesTombi.parent.createDirectories()
+        nodeModulesTombi.createFile()
+
+        assertNull(resolveLocal(workspacePaths = listOf(project)))
+    }
+
+    @Test
+    fun `returns null when no local installation exists`() {
+        assertNull(
+            resolveLocal(
+                workspacePaths = listOf(Files.createTempDirectory("tombi-project")),
+            ),
+        )
+    }
+
+    private fun resolveLocal(
+        workspacePaths: List<java.nio.file.Path> = emptyList(),
+        sdkHomePaths: List<java.nio.file.Path> = emptyList(),
+        configuredExecutable: String? = null,
+        environment: Map<String, String> = emptyMap(),
+        osName: String = "Linux",
+        userHome: String = "/home/test",
+    ) = TombiBinaryResolver.resolveLocal(
+        workspacePaths = workspacePaths,
+        sdkHomePaths = sdkHomePaths,
+        configuredExecutable = configuredExecutable,
+        environment = environment,
+        osName = osName,
+        userHome = userHome,
+    )
 }

--- a/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryResolverTest.kt
+++ b/editors/intellij/src/test/kotlin/tombi/server/TombiBinaryResolverTest.kt
@@ -51,7 +51,7 @@ class TombiBinaryResolverTest {
         nodeModulesTombi.parent.createDirectories()
         venvTombi.createFile()
         nodeModulesTombi.createFile()
-        pathDirectory.resolve("tombi").createFile()
+        pathDirectory.resolve("tombi").createExecutableFile()
 
         assertEquals(
             TombiCommand(venvTombi.toString()),
@@ -71,7 +71,7 @@ class TombiBinaryResolverTest {
         val node = nodeDirectory.resolve("node")
         nodeScript.parent.createDirectories()
         nodeScript.createFile()
-        node.createFile()
+        node.createExecutableFile()
 
         assertEquals(
             TombiCommand(node.toString(), listOf(nodeScript.toString())),
@@ -90,7 +90,7 @@ class TombiBinaryResolverTest {
         val pathDirectory = Files.createTempDirectory("tombi-path")
         nodeModulesTombi.parent.createDirectories()
         nodeModulesTombi.createFile()
-        pathDirectory.resolve("tombi").createFile()
+        pathDirectory.resolve("tombi").createExecutableFile()
 
         assertEquals(
             TombiCommand(nodeModulesTombi.toString()),
@@ -118,7 +118,7 @@ class TombiBinaryResolverTest {
     @Test
     fun `returns path installation when no project installation exists`() {
         val pathDirectory = Files.createTempDirectory("tombi-path")
-        val pathTombi = pathDirectory.resolve("tombi").createFile()
+        val pathTombi = pathDirectory.resolve("tombi").createExecutableFile()
 
         assertEquals(
             TombiCommand(pathTombi.toString()),
@@ -181,6 +181,43 @@ class TombiBinaryResolverTest {
             ),
         )
     }
+
+    @Test
+    fun `prefers the first workspace node modules over a later workspace virtual environment`() {
+        val firstWorkspace = Files.createTempDirectory("tombi-workspace")
+        val secondWorkspace = Files.createTempDirectory("tombi-workspace")
+        val nodeModulesTombi = firstWorkspace.resolve("node_modules/.bin/tombi")
+        val venvTombi = secondWorkspace.resolve(".venv/bin/tombi")
+        nodeModulesTombi.parent.createDirectories()
+        venvTombi.parent.createDirectories()
+        nodeModulesTombi.createFile()
+        venvTombi.createFile()
+
+        assertEquals(
+            TombiCommand(nodeModulesTombi.toString()),
+            resolveLocal(workspacePaths = listOf(firstWorkspace, secondWorkspace)),
+        )
+    }
+
+    @Test
+    fun `ignores a non executable path entry`() {
+        val pathDirectory = Files.createTempDirectory("tombi-path")
+        pathDirectory.resolve("tombi").createFile()
+
+        assertNull(
+            resolveLocal(
+                workspacePaths = listOf(Files.createTempDirectory("tombi-project")),
+                environment = mapOf("PATH" to pathDirectory.toString()),
+            ),
+        )
+    }
+
+    /**
+     * `PATH` lookups require the executable bit, so fixtures standing in for a
+     * real installation have to set it.
+     */
+    private fun java.nio.file.Path.createExecutableFile(): java.nio.file.Path =
+        createFile().also { it.toFile().setExecutable(true, false) }
 
     private fun resolveLocal(
         workspacePaths: List<java.nio.file.Path> = emptyList(),


### PR DESCRIPTION
## Summary

- align IntelliJ local binary discovery with VSCode/Zed by checking selected SDK environments, project `.venv`, hoisted npm installations, and `PATH`
- move filesystem discovery off the EDT and use IntelliJ proxy-aware HTTP downloads with failure notifications and retry cooldown
- clean old managed binaries, ignore unsupported PowerShell shims, and cover archive extraction/cache fallback paths

## Verification

- `cd editors/intellij && ./gradlew check buildPlugin`