### PR TITLE
fix: restore README package badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [![Open VSX Registry](https://img.shields.io/open-vsx/v/tombi-toml/tombi?label=Open%20VSX%20Registry&labelColor=374151&color=60a5fa)](https://open-vsx.org/extension/tombi-toml/tombi)
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/28017-tombi?label=JetBrains%20Marketplace&labelColor=374151&color=60a5fa)](https://plugins.jetbrains.com/plugin/28017-tombi)
 [![Zed Extension](https://img.shields.io/badge/Zed%20Extension-v0.2.0-blue?labelColor=374151&color=60a5fa)](https://zed.dev/extensions/tombi)
-[![homebrew](https://img.shields.io/homebrew/v/tombi.jpg?labelColor=374151&color=60a5fa)](https://formulae.brew.sh/formula/tombi)
-[![pypi](https://img.shields.io/pypi/v/tombi.jpg?labelColor=374151&color=60a5fa)](https://pypi.python.org/pypi/tombi)
-[![npm](https://img.shields.io/npm/v/tombi.jpg?labelColor=374151&color=60a5fa)](https://www.npmjs.com/package/tombi)
+[![homebrew](https://img.shields.io/homebrew/v/tombi.svg?labelColor=374151&color=60a5fa)](https://formulae.brew.sh/formula/tombi)
+[![pypi](https://img.shields.io/pypi/v/tombi.svg?labelColor=374151&color=60a5fa)](https://pypi.python.org/pypi/tombi)
+[![npm](https://img.shields.io/npm/v/tombi.svg?labelColor=374151&color=60a5fa)](https://www.npmjs.com/package/tombi)
 [![toml-test](https://github.com/tombi-toml/tombi/actions/workflows/toml-test.yml/badge.svg)](https://github.com/tombi-toml/tombi/actions)
 [![GitHub license](https://badgen.net/github/license/tombi-toml/tombi?style=flat-square&labelColor=374151)](https://github.com/tombi-toml/tombi/blob/main/LICENSE)
 

--- a/xtask/src/command/dist.rs
+++ b/xtask/src/command/dist.rs
@@ -100,7 +100,10 @@ fn dist_editor_vscode(
 
     let readme_path = vscode_path.join("README.md");
     let readme = sh.read_file(&readme_path)?;
-    let readme = readme.replace("tombi.svg", "tombi.jpg");
+    let readme = readme.replace(
+        "https://raw.githubusercontent.com/tombi-toml/tombi/refs/heads/main/docs/public/tombi.svg",
+        "https://raw.githubusercontent.com/tombi-toml/tombi/refs/heads/main/docs/public/tombi.jpg",
+    );
     sh.write_file(&readme_path, &readme)?;
 
     if !target.server_path.exists() {


### PR DESCRIPTION
## Summary

- restore the Homebrew, PyPI, and npm Shields.io badges using the supported SVG format
- limit the VS Code packaging README rewrite to the project logo URL so badge URLs remain unchanged

## Tests

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- verified the packaged README transformation preserves all three Shields.io SVG badge URLs