### PR TITLE
fix: replace retired VS Code Marketplace badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/tombi-toml.tombi?label=VS%20Code%20Marketplace&logo=visual-studio-code&labelColor=374151&color=60a5fa)](https://marketplace.visualstudio.com/items?itemName=tombi-toml.tombi)
+[![VS Code Marketplace](https://vsmarketplacebadges.dev/version/tombi-toml.tombi.svg?label=VS%20Code%20Marketplace&logo=visual-studio-code&labelColor=374151&color=60a5fa)](https://marketplace.visualstudio.com/items?itemName=tombi-toml.tombi)
 [![Open VSX Registry](https://img.shields.io/open-vsx/v/tombi-toml/tombi?label=Open%20VSX%20Registry&labelColor=374151&color=60a5fa)](https://open-vsx.org/extension/tombi-toml/tombi)
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/28017-tombi?label=JetBrains%20Marketplace&labelColor=374151&color=60a5fa)](https://plugins.jetbrains.com/plugin/28017-tombi)
 [![Zed Extension](https://img.shields.io/badge/Zed%20Extension-v0.2.0-blue?labelColor=374151&color=60a5fa)](https://zed.dev/extensions/tombi)


### PR DESCRIPTION
## Summary

- replace the retired Shields.io Visual Studio Marketplace badge endpoint
- use the VS Code-approved `vsmarketplacebadges.dev` provider while preserving the existing badge styling and Marketplace link

## Tests

- `git diff --check`
- verified the badge endpoint returns `VS Code Marketplace: v1.2.4`
- verified the Marketplace page returns HTTP 200