### PR TITLE
fix(validator): handle oneOf with inferred table schemas

### DIFF
--- a/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
+++ b/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
@@ -955,6 +955,92 @@ mod draft2019_09_unevaluated_properties {
         );
     }
 
+    mod with_adjacent_one_of {
+        use super::*;
+
+        fn schema() -> JsonValue {
+            serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {
+                                "type": "object",
+                                "required": ["uri"],
+                                "properties": {
+                                    "uri": {"type": "string"}
+                                }
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    }
+                }
+            })
+        }
+
+        fn explicitly_typed_schema() -> JsonValue {
+            let mut schema = schema();
+            schema["properties"]["address"]["type"] = serde_json::json!("object");
+            schema
+        }
+
+        suite_test!(
+            #[tokio::test] async fn string_branch_is_valid(
+                r#"
+                address = "example"
+                "#,
+                JsonSchema(schema()),
+            ) -> Ok(_);
+        );
+
+        suite_test!(
+            #[tokio::test] async fn table_branch_is_valid(
+                r#"
+                [address]
+                uri = "example"
+                "#,
+                JsonSchema(schema()),
+            ) -> Ok(_);
+        );
+
+        suite_test!(
+            #[tokio::test] async fn table_branch_rejects_unevaluated_properties(
+                r#"
+                [address]
+                uri = "example"
+                extra = true
+                "#,
+                JsonSchema(schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "extra".to_string()
+                    },
+                    ((2, 0), (2, 12))
+                ),
+            ]);
+        );
+
+        suite_test!(
+            #[tokio::test] async fn explicit_object_type_rejects_string(
+                r#"
+                address = "example"
+                "#,
+                JsonSchema(explicitly_typed_schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::TypeMismatch {
+                        expected: tombi_schema_store::ValueType::Table,
+                        actual: tombi_document_tree::ValueType::String,
+                    },
+                    ((0, 10), (0, 19))
+                ),
+            ]);
+        );
+    }
+
     mod with_nested_properties {
         use super::*;
 

--- a/crates/tombi-schema-store/src/schema/table_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_schema.rs
@@ -28,6 +28,7 @@ use tombi_json::StringNode;
 
 #[derive(Debug, Default, Clone)]
 pub struct TableSchema {
+    type_inferred: bool,
     pub title: Option<String>,
     pub description: Option<String>,
     pub range: tombi_text::Range,
@@ -179,6 +180,7 @@ impl TableSchema {
         );
 
         Self {
+            type_inferred: false,
             title: object_node
                 .get("title")
                 .and_then(|v| v.as_str().map(|s| s.to_string())),
@@ -346,6 +348,16 @@ impl TableSchema {
 
     pub fn value_type(&self) -> crate::ValueType {
         crate::ValueType::Table
+    }
+
+    #[inline]
+    pub(crate) fn mark_type_inferred(&mut self) {
+        self.type_inferred = true;
+    }
+
+    #[inline]
+    pub fn is_type_inferred(&self) -> bool {
+        self.type_inferred
     }
 
     #[inline]

--- a/crates/tombi-schema-store/src/schema/value_schema.rs
+++ b/crates/tombi-schema-store/src/schema/value_schema.rs
@@ -132,14 +132,18 @@ impl ValueSchema {
 
         // Infer type from type-specific keywords when "type" is not explicitly specified
         if let Some(inferred_type) = Self::infer_type_from_keywords(object, dialect) {
-            return Self::new_single(
+            let mut value_schema = Self::new_single(
                 inferred_type,
                 object,
                 string_formats,
                 dialect,
                 anchor_collector,
                 dynamic_anchor_collector,
-            );
+            )?;
+            if let ValueSchema::Table(table_schema) = &mut value_schema {
+                table_schema.mark_type_inferred();
+            }
+            return Some(value_schema);
         }
 
         if object.get("oneOf").is_some() {
@@ -1720,7 +1724,22 @@ mod tests {
             r#"{ "properties": { "name": { "type": "string" } } }"#,
             Some(crate::JsonSchemaDialect::Draft07),
         );
-        std::assert_matches!(schema, Some(ValueSchema::Table(_)));
+        let Some(ValueSchema::Table(schema)) = schema else {
+            panic!("schema is not a Table schema");
+        };
+        assert!(schema.is_type_inferred());
+    }
+
+    #[test]
+    fn test_explicit_object_type_is_not_inferred() {
+        let schema = parse_schema_with_dialect(
+            r#"{ "type": "object", "properties": { "name": { "type": "string" } } }"#,
+            Some(crate::JsonSchemaDialect::Draft07),
+        );
+        let Some(ValueSchema::Table(schema)) = schema else {
+            panic!("schema is not a Table schema");
+        };
+        assert!(!schema.is_type_inferred());
     }
 
     #[test]

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -184,6 +184,31 @@ where
                         result
                     }
                 }
+                ValueSchema::Table(table_schema) if table_schema.is_type_inferred() => {
+                    let result = validate_adjacent_applicators(
+                        string_value,
+                        accessors,
+                        table_schema.one_of.as_deref(),
+                        table_schema.any_of.as_deref(),
+                        table_schema.all_of.as_deref(),
+                        table_schema.not.as_deref(),
+                        current_schema,
+                        schema_context,
+                        comment_directives.as_deref(),
+                        lint_rules.as_ref().map(|rules| &rules.common),
+                    )
+                    .await;
+                    if enable_key_empty_validation
+                        && should_validate_key_empty(Some(current_schema))
+                    {
+                        crate::validate::merge_validation_results(
+                            result,
+                            validate_key_empty_rule(string_value, key_rules.as_ref()),
+                        )
+                    } else {
+                        result
+                    }
+                }
                 ValueSchema::Null => return Ok(crate::EvaluatedLocations::new()),
                 ValueSchema::Anything(_) => handle_anything_schema(string_value),
                 ValueSchema::Nothing(_) => handle_nothing_schema(string_value),


### PR DESCRIPTION
Fixes #2042

## Summary

- track whether an object schema type was inferred from object-specific keywords
- validate adjacent applicators for string values instead of treating an inferred table type as an explicit object assertion
- add regression coverage for string and table branches, unevaluated properties, and explicit object types

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p tombi-schema-store -p tombi-validator`
- `cargo test --locked -p tombi-linter --lib`
- `cargo test --locked -p tombi-linter --test integration with_adjacent_one_of`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --verbose --locked`
