### PR TITLE
fix(zed): disable unsupported doctests

### DIFF
--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+doctest = false
 path = "src/lib.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- mark the Zed extension library as not supporting doctests
- suppress the routine cdylib doctest warning during normal test runs

## Testing

- `cargo test -p zed-tombi`
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`