### PR TITLE
feat(formatter): add key quote style option

### DIFF
--- a/crates/tombi-config/src/format.rs
+++ b/crates/tombi-config/src/format.rs
@@ -182,6 +182,13 @@ pub struct FormatRules {
     #[cfg_attr(feature = "jsonschema", schemars(default = "bool::default"))]
     pub key_value_equals_sign_alignment: Option<bool>,
 
+    /// # The preferred quote character for keys
+    ///
+    /// Choose which quote style the formatter prefers for quoted keys.
+    /// If unspecified, `string-quote-style` is used.
+    #[cfg_attr(feature = "jsonschema", schemars(default))]
+    pub key_quote_style: Option<StringQuoteStyle>,
+
     /// # The preferred quote character for strings
     ///
     /// Choose which quote style the formatter prefers for basic strings.
@@ -318,6 +325,7 @@ impl FormatRules {
             key_value_equals_sign_alignment: self
                 .key_value_equals_sign_alignment
                 .or(override_rules.key_value_equals_sign_alignment),
+            key_quote_style: self.key_quote_style.or(override_rules.key_quote_style),
             string_quote_style: self
                 .string_quote_style
                 .or(override_rules.string_quote_style),

--- a/crates/tombi-formatter/src/format/key.rs
+++ b/crates/tombi-formatter/src/format/key.rs
@@ -16,14 +16,13 @@ impl Format for WithAlignmentHint<&tombi_ast::Keys> {
             .keys()
             .map(|key| match key {
                 tombi_ast::Key::BareKey(it) => it.syntax().text().to_string(),
-                tombi_ast::Key::BasicString(it) => format_basic_string_quote_style(
-                    it.token().unwrap().text(),
-                    f.string_quote_style(),
-                )
-                .into_owned(),
+                tombi_ast::Key::BasicString(it) => {
+                    format_basic_string_quote_style(it.token().unwrap().text(), f.key_quote_style())
+                        .into_owned()
+                }
                 tombi_ast::Key::LiteralString(it) => format_literal_string_quote_style(
                     it.token().unwrap().text(),
-                    f.string_quote_style(),
+                    f.key_quote_style(),
                 )
                 .into_owned(),
             })

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -308,6 +308,11 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
+    pub(crate) fn key_quote_style(&self) -> tombi_config::StringQuoteStyle {
+        self.definitions.key_quote_style
+    }
+
+    #[inline]
     pub(crate) fn date_time_delimiter(&self) -> Option<&str> {
         self.definitions.date_time_delimiter
     }

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -17,6 +17,7 @@ pub struct FormatDefinitions {
     pub indent_sub_tables: bool,
     pub indent_table_key_values: bool,
     pub indent_width: u8,
+    pub key_quote_style: StringQuoteStyle,
     pub string_quote_style: StringQuoteStyle,
     pub trailing_comment_alignment: bool,
     pub trailing_comment_space: String,
@@ -102,6 +103,11 @@ impl FormatDefinitions {
                     .unwrap_or_default()
                     .value() as usize,
             ),
+            key_quote_style: options
+                .rules
+                .as_ref()
+                .and_then(|rules| rules.key_quote_style.or(rules.string_quote_style))
+                .unwrap_or_default(),
             string_quote_style: options
                 .rules
                 .as_ref()

--- a/crates/tombi-formatter/tests/test_format_options.rs
+++ b/crates/tombi-formatter/tests/test_format_options.rs
@@ -1436,6 +1436,71 @@ mod format_options {
 
         test_format! {
             #[tokio::test]
+            async fn test_key_quote_style_defaults_to_string_quote_style(
+                r#"
+                'key' = 'value'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                "key" = "value"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_key_quote_style_single(
+                r#"
+                "key" = 'value'
+
+                [target."cfg(unix)".dependencies]
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        key_quote_style: Some(StringQuoteStyle::Single),
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                'key' = "value"
+
+                [target.'cfg(unix)'.dependencies]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_key_quote_style_preserve(
+                r#"
+                'single' = 'value'
+                "double" = 'value'
+                "#,
+                FormatOptions {
+                    rules: Some(FormatRules {
+                        key_quote_style: Some(StringQuoteStyle::Preserve),
+                        string_quote_style: Some(StringQuoteStyle::Double),
+                        ..Default::default()
+                    }),
+                }
+            ) -> Ok(
+                r#"
+                'single' = "value"
+                "double" = "value"
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_string_quote_style_double(
                 r#"
                 key = 'value'

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -55,6 +55,7 @@ Therefore, it is recommended to place `tombi.toml` only at the root of your proj
     - [format.rules.indent-width](#format-rules-indent-width)
     - [format.rules.inline-table-brace-space-width](#format-rules-inline-table-brace-space-width)
     - [format.rules.inline-table-comma-space-width](#format-rules-inline-table-comma-space-width)
+    - [format.rules.key-quote-style](#format-rules-key-quote-style)
     - [format.rules.key-value-equals-sign-alignment](#format-rules-key-value-equals-sign-alignment)
     - [format.rules.key-value-equals-sign-space-width](#format-rules-key-value-equals-sign-space-width)
     - [format.rules.line-ending](#format-rules-line-ending)
@@ -178,6 +179,7 @@ indent-table-key-value-pairs = false
 indent-width = 2
 inline-table-brace-space-width = 1
 inline-table-comma-space-width = 1
+key-quote-style = "double"
 key-value-equals-sign-alignment = false
 key-value-equals-sign-space-width = 1
 line-ending = "lf"
@@ -266,6 +268,7 @@ indent-table-key-value-pairs = true
 indent-width = 4
 inline-table-brace-space-width = 0
 inline-table-comma-space-width = 1
+key-quote-style = "single"
 key-value-equals-sign-alignment = true
 key-value-equals-sign-space-width = 1
 line-ending = "crlf"
@@ -566,6 +569,17 @@ The number of spaces after the comma in a single line inline table.
 key = { a = 1, b = 2 }
 #             ^  <- this
 ```
+
+### format.rules.key-quote-style
+
+The preferred quote character for quoted keys.
+
+- Type: `"double" | "single" | "preserve"`
+- Default: uses `string-quote-style`
+- Enum Values:
+  - `double`: Prefer the double quote like `"key"`
+  - `single`: Prefer the single quote like `'key'`
+  - `preserve`: Preserve the original quote
 
 ### format.rules.key-value-equals-sign-alignment
 

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -326,6 +326,19 @@
           ],
           "default": false
         },
+        "key-quote-style": {
+          "title": "The preferred quote character for keys",
+          "description": "Choose which quote style the formatter prefers for quoted keys.\nIf unspecified, `string-quote-style` is used.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringQuoteStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "string-quote-style": {
           "title": "The preferred quote character for strings",
           "description": "Choose which quote style the formatter prefers for basic strings.",


### PR DESCRIPTION
## Summary

- add `format.rules.key-quote-style` for independently controlling quoted TOML keys
- preserve existing behavior by falling back to `string-quote-style` when unspecified
- document the option and regenerate the bundled Tombi JSON schema

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run -p tombi-formatter --locked` (343 passed)
- `cargo nextest run --workspace --locked --no-fail-fast` (2161 passed)
- `cargo test --workspace --doc --locked`
- `pnpm exec biome lint .`
- `pnpm -C docs build`
- `cargo run -p xtask -- codegen jsonschema` (clean regeneration)

Closes #2046