### PR TITLE
fix(docs): restore typecheck

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
     },
   },
   vite: {
-    // @ts-expect-error
     base: process.env.BASE_URL,
     plugins: [
       mdx.withImports({})({

--- a/docs/doc-index.json
+++ b/docs/doc-index.json
@@ -156,6 +156,7 @@
     "children": [
       {
         "title": "Schema Document Directive",
+        "description": "Select a JSON Schema for a document with a comment directive.",
         "path": "/docs/comment-directive/schema-document-directive"
       },
       {

--- a/docs/src/components/Table.tsx
+++ b/docs/src/components/Table.tsx
@@ -1,7 +1,7 @@
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 
-export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
+export function Table(props: JSX.HTMLAttributes<HTMLTableElement>) {
   const { children, ...tableProps } = props;
   let shellRef: HTMLDivElement | undefined;
   let scrollRef: HTMLDivElement | undefined;
@@ -107,7 +107,8 @@ export function Table(props: JSX.TableHTMLAttributes<HTMLTableElement>) {
       const shellRect = shellRef.getBoundingClientRect();
       const stickyHeight = clonedHead.getBoundingClientRect().height;
       const shouldStick =
-        shellRect.top <= stickyTop && shellRect.bottom > stickyTop + stickyHeight;
+        shellRect.top <= stickyTop &&
+        shellRect.bottom > stickyTop + stickyHeight;
 
       shellRef.dataset.stickyActive = shouldStick ? "true" : "false";
       if (!shouldStick) {

--- a/docs/src/components/header/HeaderDropdown.tsx
+++ b/docs/src/components/header/HeaderDropdown.tsx
@@ -11,9 +11,18 @@ interface HeaderDropdownProps {
 }
 
 const menuItems: DocIndex[] = [
-  { title: "Home", path: "/" },
-  { title: "Docs", path: "/docs", children: docIndex },
-  { title: "Playground", path: "/playground" },
+  { title: "Home", description: "Tombi home page.", path: "/" },
+  {
+    title: "Docs",
+    description: "Tombi documentation.",
+    path: "/docs",
+    children: docIndex,
+  },
+  {
+    title: "Playground",
+    description: "Try Tombi in the browser.",
+    path: "/playground",
+  },
 ];
 
 export function HeaderDropdown(props: HeaderDropdownProps) {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -9,11 +9,13 @@
     "jsxImportSource": "solid-js",
     "allowJs": true,
     "strict": true,
+    "skipLibCheck": true,
     "noEmit": true,
     "types": ["vinxi/types/client"],
     "isolatedModules": true,
     "resolveJsonModule": true,
     "paths": {
+      "solid-mdx": ["./node_modules/solid-mdx/types/index.d.ts"],
       "~/*": ["./src/*"]
     }
   }


### PR DESCRIPTION
## Summary

- resolve the bundled solid-mdx declarations and isolate broken dependency declarations
- satisfy the DocIndex description contract without weakening it
- use the supported Solid table attribute type

## Verification

- pnpm --dir docs typecheck
- pnpm --dir docs lint:check
- pnpm --dir docs exec biome format app.config.ts doc-index.json src/components/Table.tsx src/components/header/HeaderDropdown.tsx tsconfig.json
- pnpm --dir docs build