### PR TITLE
feat(lsp): add multi-line string completion suggestions

### DIFF
--- a/crates/tombi-extension/src/completion.rs
+++ b/crates/tombi-extension/src/completion.rs
@@ -221,7 +221,7 @@ impl CompletionContent {
 
     pub fn new_type_hint_string(
         kind: CompletionKind,
-        quote: char,
+        quote: &str,
         detail: impl Into<String>,
         edit: Option<CompletionEdit>,
         schema_uri: Option<&SchemaUri>,

--- a/crates/tombi-extension/src/completion/completion_edit.rs
+++ b/crates/tombi-extension/src/completion/completion_edit.rs
@@ -97,7 +97,7 @@ impl CompletionEdit {
     }
 
     pub fn new_string_literal(
-        quote: char,
+        quote: &str,
         position: tombi_text::Position,
         completion_hint: Option<CompletionHint>,
     ) -> Option<Self> {

--- a/crates/tombi-lsp/src/completion/value/string.rs
+++ b/crates/tombi-lsp/src/completion/value/string.rs
@@ -69,7 +69,10 @@ impl FindCompletionContents for tombi_document_tree::String {
                             return None;
                         }
 
-                        if completion_content.label == "\"\"" || completion_content.label == "''" {
+                        if matches!(
+                            completion_content.label.as_str(),
+                            "\"\"" | "''" | "\"\"\"\"\"\"" | "''''''"
+                        ) {
                             return None;
                         }
 
@@ -230,16 +233,21 @@ pub fn type_hint_string(
     schema_uri: Option<&SchemaUri>,
     completion_hint: Option<CompletionHint>,
 ) -> Vec<CompletionContent> {
-    [('\"', "BasicString"), ('\'', "LiteralString")]
-        .into_iter()
-        .map(|(quote, detail)| {
-            CompletionContent::new_type_hint_string(
-                CompletionKind::String,
-                quote,
-                detail,
-                CompletionEdit::new_string_literal(quote, position, completion_hint),
-                schema_uri,
-            )
-        })
-        .collect()
+    [
+        ("\"", "BasicString"),
+        ("'", "LiteralString"),
+        ("\"\"\"", "MultiLineBasicString"),
+        ("'''", "MultiLineLiteralString"),
+    ]
+    .into_iter()
+    .map(|(quote, detail)| {
+        CompletionContent::new_type_hint_string(
+            CompletionKind::String,
+            quote,
+            detail,
+            CompletionEdit::new_string_literal(quote, position, completion_hint),
+            schema_uri,
+        )
+    })
+    .collect()
 }

--- a/crates/tombi-lsp/tests/test_completion_edit.rs
+++ b/crates/tombi-lsp/tests/test_completion_edit.rs
@@ -1035,6 +1035,26 @@ mod completion_edit {
 
         test_completion_edit! {
             #[tokio::test]
+            async fn key_dot_select_multi_line_basic_string(
+                "key.█",
+                Select("\"\"\"\"\"\""),
+            ) -> Ok(
+                "key = \"\"\"$1\"\"\"$0"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
+            async fn key_dot_select_multi_line_literal_string(
+                "key.█",
+                Select("''''''"),
+            ) -> Ok(
+                "key = '''$1'''$0"
+            );
+        }
+
+        test_completion_edit! {
+            #[tokio::test]
             async fn key_dot_select_today_offset_date_time(
                 "key.█",
                 Select(today_offset_date_time()),

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -465,7 +465,9 @@ mod completion_labels {
                 "\"https://www.schemastore.org/api/json/catalog.json\"",
                 "\"tombi://www.schemastore.org/api/json/catalog.json\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -481,7 +483,9 @@ mod completion_labels {
                 "\"https://www.schemastore.org/api/json/catalog.json\"",
                 "\"tombi://www.schemastore.org/api/json/catalog.json\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -704,7 +708,9 @@ mod completion_labels {
                 "\"tombi://www.schemastore.org/pyproject.json\"",
                 "\"tombi://www.schemastore.org/tombi.json\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -1011,7 +1017,7 @@ mod completion_labels {
                 ]
                 "#,
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
-            ) -> Ok(["\"builtin-hook\"", "\"\"", "''"]);
+            ) -> Ok(["\"builtin-hook\"", "\"\"", "\"\"\"\"\"\"", "''", "''''''"]);
         }
     }
 
@@ -1134,7 +1140,9 @@ mod completion_labels {
                 },
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
     }
@@ -1362,7 +1370,9 @@ mod completion_labels {
             ) -> Ok([
                 "include-group",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 "{}",
             ]);
         }
@@ -1905,7 +1915,9 @@ mod completion_labels {
                 "\"chrono\"",
                 "\"serde\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -1934,7 +1946,9 @@ mod completion_labels {
                 "version",
                 "workspace = true",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 "{}",
             ]);
         }
@@ -1964,7 +1978,9 @@ mod completion_labels {
                 "version",
                 "workspace = true",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 "{}",
             ]);
         }
@@ -1998,7 +2014,9 @@ mod completion_labels {
                 "\"0.1.0\"",
                 "\"*\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2045,7 +2063,9 @@ mod completion_labels {
                 "\"0.1.0\"",
                 "\"*\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2165,7 +2185,9 @@ mod completion_labels {
                 "\"chrono\"",
                 "\"serde\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2183,7 +2205,9 @@ mod completion_labels {
                 "\"chrono\"",
                 "\"serde\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2203,7 +2227,9 @@ mod completion_labels {
                 "\"extras\"",
                 "\"flag\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2220,7 +2246,9 @@ mod completion_labels {
                 SchemaPath(cargo_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2290,7 +2318,9 @@ mod completion_labels {
                 "\"chrono\"",
                 "\"serde\"",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
 
@@ -2323,7 +2353,9 @@ mod completion_labels {
                 "\"MIT\"",
                 "workspace = true",
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 "{}",
             ]);
         }
@@ -2681,7 +2713,9 @@ mod completion_labels {
                 SchemaPath(string_format_test_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 today_local_date(),
             ]);
         }
@@ -2695,7 +2729,9 @@ mod completion_labels {
                 SchemaPath(string_format_test_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 today_local_time(),
             ]);
         }
@@ -2709,7 +2745,9 @@ mod completion_labels {
                 SchemaPath(string_format_test_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 today_local_date_time(),
             ]);
         }
@@ -2723,7 +2761,9 @@ mod completion_labels {
                 SchemaPath(string_format_test_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
                 today_offset_date_time(),
             ]);
         }
@@ -2737,7 +2777,9 @@ mod completion_labels {
                 SchemaPath(string_format_test_schema_path()),
             ) -> Ok([
                 "\"\"",
+                "\"\"\"\"\"\"",
                 "''",
+                "''''''",
             ]);
         }
     }
@@ -2752,7 +2794,9 @@ mod completion_labels {
                 #[tokio::test]
                 async fn $name($source $(, $arg)*) -> Ok([
                     "\"\"",
+                    "\"\"\"\"\"\"",
                     "''",
+                    "''''''",
                     today_local_time(),
                     today_local_date(),
                     today_local_date_time(),


### PR DESCRIPTION
## Summary

- add multi-line basic and literal string completion suggestions
- insert opening and closing delimiters with the cursor placed between them
- preserve existing completion behavior while editing string values

This lets editor users select ready-to-edit multi-line string snippets for schema-backed and unconstrained string values.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tombi-lsp --test test_completion_labels`
- `cargo test -p tombi-lsp --test test_completion_edit`
- `cargo test -p tombi-extension`

Closes #2054