### PR TITLE
docs: add schemas[*].strict to the configuration index

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
   },
   vite: {
     base: process.env.BASE_URL,
+    optimizeDeps: {
+      esbuildOptions: {
+        target: ["es2020", "edge88", "firefox78", "chrome87", "safari14.1"],
+      },
+    },
     plugins: [
       mdx.withImports({})({
         jsx: true,

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -103,6 +103,7 @@ Therefore, it is recommended to place `tombi.toml` only at the root of your proj
   - [schemas[\*].path](#root-schema)
   - [schemas[\*].include](#root-schema)
   - [schemas[\*].exclude](#root-schema)
+  - [schemas[\*].strict](#root-schema)
   - [schemas[\*].format](#schemas-format)
     - [schemas[\*].format.rules](#schemas-format-rules)
       - [schemas[\*].format.rules.array-values-order](#schemas-format-rules-array-values-order)


### PR DESCRIPTION
## Problem

The documentation describes `schemas[*].strict`, but the option was missing from the configuration index.

Also, `pnpm dev` failed during Vite dependency optimization because Vite 6 targets Safari 14 while esbuild 0.28.1 treats destructuring as supported from Safari 14.1.

## Solution

- Add a link to `schemas[*].strict` in the configuration options index.
- Set the docs dependency optimizer target to Safari 14.1 while preserving the other Vite 6 default targets.

## Verification

- `pnpm -C docs dev`
- `pnpm -C docs format:check app.config.ts`
- `pnpm -C docs lint:check app.config.ts`
- `pnpm -C docs typecheck`
- `pnpm -C docs build`