### PR TITLE
Revert "fix(ci): make Pages deployment retries resilient (#2065)"

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -77,12 +77,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          name: github-pages-${{ github.run_attempt }}
           path: "./docs/.output/public"
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
-        with:
-          artifact_name: github-pages-${{ github.run_attempt }}
-          timeout: 900000


### PR DESCRIPTION
## Summary

Reverts tombi-toml/tombi#2065.

The failing builds were caused by GitHub Pages deployments remaining in deployment_queued, not by the repository build. The configured 900000 ms timeout is ineffective because actions/deploy-pages clamps timeout values to its 600000 ms maximum. The run-attempt-specific artifact name only addresses duplicate artifacts on rerun and does not resolve the Pages backend queue.

## Verification

- mise x actionlint@1.7.12 -- actionlint .github/workflows/deploy_docs.yml
- cargo fmt --all -- --check
- Ruby YAML parse
- git diff --check
- confirmed the workflow matches the parent of #2065