### PR TITLE
fix(cargo): resolve completion paths from file URIs

### DIFF
--- a/extensions/tombi-extension-cargo/src/completion.rs
+++ b/extensions/tombi-extension-cargo/src/completion.rs
@@ -70,13 +70,15 @@ pub async fn completion(
         return Ok(Some(completions));
     }
 
-    let cargo_toml_path = std::path::Path::new(text_document_uri.path());
+    let Ok(cargo_toml_path) = text_document_uri.to_file_path() else {
+        return Ok(None);
+    };
 
     if let Some(Accessor::Key(first)) = accessors.first() {
         if first == "workspace" {
             completion_workspace(
                 document_tree,
-                cargo_toml_path,
+                &cargo_toml_path,
                 position,
                 accessors,
                 completion_hint,
@@ -89,7 +91,7 @@ pub async fn completion(
         } else {
             completion_member(
                 document_tree,
-                cargo_toml_path,
+                &cargo_toml_path,
                 position,
                 accessors,
                 completion_hint,


### PR DESCRIPTION
## Summary

- convert the Cargo TOML document URI with `Url::to_file_path()` before workspace-member lookup
- keep completion behavior unchanged for valid file URIs while handling Windows drive-letter paths correctly
- reuse the existing declarative Cargo completion coverage for workspace dependencies with features

Closes #2068

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast` (2183 tests)
- `cargo test --workspace --doc --locked`
- `cargo shear`
- `cargo build --verbose --locked`
- `git diff --check`
