### PR TITLE
fix(deps): update js-yaml to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "fast-uri": "3.1.5",
       "form-data": "4.0.6",
       "h3": "1.15.11",
-      "js-yaml": "4.3.0",
+      "js-yaml": "4.3.1",
       "linkify-it": "5.0.2",
       "markdown-it": "14.2.0",
       "minimatch": "10.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   fast-uri: 3.1.5
   form-data: 4.0.6
   h3: 1.15.11
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.2
   markdown-it: 14.2.0
   minimatch: 10.2.5
@@ -2903,8 +2903,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -5873,7 +5873,7 @@ snapshots:
       '@textlint/types': 15.5.4
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -7394,7 +7394,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -7706,7 +7706,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8799,7 +8799,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- update the root pnpm override for `js-yaml` from 4.3.0 to 4.3.1
- regenerate `pnpm-lock.yaml` to remove GHSA-5p4m-2wfm-xmqj
- restore the failing OSV Scanner workflow from https://github.com/tombi-toml/tombi/actions/runs/31372386545

## Validation

- OSV Scanner v2.3.8: `No issues found` across Cargo, pnpm, npm, and uv lockfiles
- `pnpm install --frozen-lockfile --offline`
- `pnpm exec biome check package.json`
- `pnpm -C docs typecheck`
- `pnpm -C editors/vscode typecheck`
- `cargo fmt --all --check`
- `git diff --check`