### PR TITLE
ci: test winget manifest invocation

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -1,5 +1,5 @@
 name: Generate winget manifest
-description: Generate the tombi winget manifest with wingetcreate, inject InstallationMetadata, and validate it.
+description: Generate, validate, install, and invoke the tombi winget manifest.
 
 inputs:
   release-tag:
@@ -106,3 +106,115 @@ runs:
         }
         $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
         winget validate --manifest $manifestVersionDir --ignore-warnings
+
+    - name: Install and invoke generated winget manifest
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        $manifestRoot = Join-Path $PWD $env:OUTPUT_DIR
+        $installerManifest = Get-ChildItem -Path $manifestRoot -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
+        if (-not $installerManifest) {
+          throw "winget installer manifest was not generated."
+        }
+
+        $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
+        $packageInstallDir = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Packages\tombi-toml.tombi__DefaultSource"
+        $directExecutable = Join-Path $packageInstallDir "tombi.exe"
+        $aliasExecutable = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links\tombi.exe"
+        $installed = $false
+        $localManifestFilesEnabled = $false
+        $testFailure = $null
+        $cleanupFailures = [System.Collections.Generic.List[string]]::new()
+
+        function Assert-TombiVersion([string] $executable, [string] $kind) {
+          if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
+            throw "The $kind tombi executable was not installed at $executable."
+          }
+
+          $output = (& $executable --version 2>&1 | Out-String).Trim()
+          $exitCode = $LASTEXITCODE
+          Write-Host "$kind invocation output: $output"
+          if ($exitCode -ne 0) {
+            throw "The $kind tombi executable returned exit code $exitCode for --version."
+          }
+
+          $expected = "^tombi $([regex]::Escape($env:VERSION)) \(x86_64-pc-windows-msvc\)$"
+          if ($output -notmatch $expected) {
+            throw "The $kind tombi executable returned an unexpected version: $output"
+          }
+
+          return $output
+        }
+
+        try {
+          winget settings --enable LocalManifestFiles
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to enable the winget LocalManifestFiles setting (exit code $LASTEXITCODE)."
+          }
+          $localManifestFilesEnabled = $true
+
+          winget install `
+            --manifest $manifestVersionDir `
+            --accept-package-agreements `
+            --accept-source-agreements `
+            --disable-interactivity `
+            --ignore-warnings `
+            --verbose-logs
+          if ($LASTEXITCODE -ne 0) {
+            throw "winget install failed with exit code $LASTEXITCODE."
+          }
+          $installed = $true
+
+          # Match the two executable paths invoked by the winget validation service.
+          $directVersion = Assert-TombiVersion $directExecutable "direct"
+          $aliasVersion = Assert-TombiVersion $aliasExecutable "portable alias"
+          if ($directVersion -ne $aliasVersion) {
+            throw "The direct and portable alias tombi version outputs differ."
+          }
+        }
+        catch {
+          $testFailure = $_
+          $wingetLogDir = Join-Path $env:LOCALAPPDATA "Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\DiagOutputDir"
+          if (Test-Path -LiteralPath $wingetLogDir -PathType Container) {
+            Write-Host "Recent winget diagnostic logs:"
+            Get-ChildItem -LiteralPath $wingetLogDir -Filter "*.log" |
+              Sort-Object LastWriteTime -Descending |
+              Select-Object -First 3 |
+              ForEach-Object {
+                Write-Host "--- $($_.FullName) ---"
+                Get-Content -LiteralPath $_.FullName -Tail 200
+              }
+          }
+        }
+        finally {
+          $installationExists = $installed `
+            -or (Test-Path -LiteralPath $directExecutable -PathType Leaf) `
+            -or (Test-Path -LiteralPath $aliasExecutable -PathType Leaf)
+          if ($installationExists) {
+            winget uninstall `
+              --id tombi-toml.tombi `
+              --exact `
+              --accept-source-agreements `
+              --disable-interactivity
+            if ($LASTEXITCODE -ne 0) {
+              $cleanupFailures.Add("winget uninstall failed with exit code $LASTEXITCODE.")
+            }
+          }
+
+          if ($localManifestFilesEnabled) {
+            winget settings --disable LocalManifestFiles
+            if ($LASTEXITCODE -ne 0) {
+              $cleanupFailures.Add("Failed to disable the winget LocalManifestFiles setting (exit code $LASTEXITCODE).")
+            }
+          }
+        }
+
+        if ($testFailure) {
+          $cleanupFailures | ForEach-Object { Write-Warning $_ }
+          throw $testFailure
+        }
+        if ($cleanupFailures.Count -gt 0) {
+          throw ($cleanupFailures -join " ")
+        }

--- a/.github/workflows/ci_winget_manifest.yml
+++ b/.github/workflows/ci_winget_manifest.yml
@@ -1,0 +1,60 @@
+name: CI WinGet Manifest
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/actions/generate-winget-manifest/**
+      - .github/actions/setup-wingetcreate/**
+      - .github/workflows/ci_winget_manifest.yml
+      - .github/workflows/release_cli_vscode.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  WINGETCREATE_VERSION: 1.12.8.0
+
+jobs:
+  test-winget-manifest:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve latest stable release
+        id: release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $headers = @{
+            "Accept" = "application/vnd.github+json"
+            "Authorization" = "Bearer $env:GITHUB_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $release = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/tombi-toml/tombi/releases/latest"
+          if ($release.tag_name -notmatch '^v(\d+\.\d+\.\d+)$') {
+            throw "Latest release tag is not a stable version: $($release.tag_name)"
+          }
+
+          "release_tag=$($release.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Setup wingetcreate
+        id: wingetcreate
+        uses: ./.github/actions/setup-wingetcreate
+        with:
+          version: ${{ env.WINGETCREATE_VERSION }}
+
+      - name: Generate and test winget manifest
+        uses: ./.github/actions/generate-winget-manifest
+        with:
+          release-tag: ${{ steps.release.outputs.release_tag }}
+          version: ${{ steps.release.outputs.version }}
+          wingetcreate-path: ${{ steps.wingetcreate.outputs.path }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -537,7 +537,7 @@ jobs:
             throw "Latest release tag is not a stable version: $($latestRelease.tag_name)"
           }
 
-          Write-Host "Using latest stable release $($latestRelease.tag_name) for winget dry-run validation."
+          Write-Host "Using latest stable release $($latestRelease.tag_name) for winget manifest validation and invocation."
           "release_tag=$($latestRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "stable_version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
@@ -547,7 +547,7 @@ jobs:
         with:
           version: ${{ env.WINGETCREATE_VERSION }}
 
-      - name: Generate and validate winget manifest
+      - name: Generate and test winget manifest
         uses: ./.github/actions/generate-winget-manifest
         with:
           release-tag: ${{ steps.winget-release.outputs.release_tag }}
@@ -594,7 +594,7 @@ jobs:
         with:
           version: ${{ env.WINGETCREATE_VERSION }}
 
-      - name: Generate and validate winget manifest
+      - name: Generate and test winget manifest
         if: steps.stable-version.outputs.stable_version != ''
         uses: ./.github/actions/generate-winget-manifest
         with:


### PR DESCRIPTION
## Summary

- install the generated WinGet local manifest during validation
- invoke both the installed executable and portable alias with `--version`
- print recent WinGet diagnostic logs on failure and clean up the package and local-manifest setting
- run the WinGet manifest E2E on relevant pull requests before the release workflow uses it

## Validation

- `cargo fmt --all -- --check`
- parsed the changed action and workflows as YAML
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci_winget_manifest.yml .github/workflows/release_cli_vscode.yml`
- `git diff --check`

The `CI WinGet Manifest` check provides the Windows-hosted end-to-end execution of the local-manifest install path.