### PR TITLE
feat(docs): add browser-based TOML playground

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
       - id: filter
         uses: ./.github/actions/relevant-changes
@@ -32,11 +32,18 @@ jobs:
           head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           paths: |
             docs/**
+            crates/**
+            extensions/**
+            rust/serde_tombi/**
+            rust/tombi-wasm/**
             .github/actions/relevant-changes/**
             .node-version
             .npmrc
+            Cargo.toml
+            Cargo.lock
             pnpm-lock.yaml
             pnpm-workspace.yaml
+            rust-toolchain.toml
             .github/workflows/deploy_docs.yml
 
   deploy:
@@ -63,7 +70,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./docs
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install WASM target
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Build
         working-directory: ./docs

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ libcairo.2.dylib
 
 # node
 node_modules
+/docs/public/wasm/
 
 # envrc
 .direnv/

--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,9 @@
       "**/*.mdx",
       "**/*.json",
       "**/typescript/@tombi-toml/tombi/bin/tombi/**",
+      "!docs/.output",
+      "!docs/.vinxi",
+      "!docs/public/wasm",
       "!**/*.js"
     ]
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "dev": "pnpm run prebuild && vinxi dev",
-    "prebuild": "pnpm run generate-search-index",
+    "prebuild": "pnpm run build:wasm && pnpm run generate-search-index",
+    "build:wasm": "pnpm --dir ../rust/tombi-wasm build:docs",
     "build": "pnpm run prebuild && vinxi build",
     "start": "vinxi start",
     "format": "biome format --fix",
@@ -24,6 +25,7 @@
     "mdast-util-gfm": "^3.1.0",
     "mdast-util-gfm-table": "^2.0.0",
     "mdast-util-mdx": "^3.0.0",
+    "monaco-editor": "^0.56.0",
     "prismjs": "^1.30.0",
     "solid-highlight": "^0.1.26",
     "solid-icons": "^1.1.0",

--- a/docs/scripts/generate-search-index.ts
+++ b/docs/scripts/generate-search-index.ts
@@ -53,7 +53,7 @@ function generateSearchIndex() {
   });
 
   const outputPath = join(process.cwd(), "src/search-index.json");
-  writeFileSync(outputPath, JSON.stringify(documents, null, 2));
+  writeFileSync(outputPath, `${JSON.stringify(documents, null, 2)}\n`);
 
   console.log(`Generated search index: ${outputPath}`);
   console.log(`Total documents: ${documents.length}`);

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -1,23 +1,542 @@
+import type { editor as MonacoEditor } from "monaco-editor";
+import { FaSolidFeather } from "solid-icons/fa";
+import {
+  TbAlertTriangle,
+  TbCheck,
+  TbFileCode,
+  TbLoader2,
+} from "solid-icons/tb";
+import {
+  createEffect,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
 import { PageHeading } from "~/components/PageHeading";
+import { DEFAULT_URL } from "~/remark/page-heading";
+import { loadMonacoEditor, type Monaco } from "~/utils/monaco-editor";
+import {
+  loadTombiWasm,
+  normalizeWasmError,
+  type TombiDiagnostic,
+  type TombiWasm,
+} from "~/utils/tombi-wasm";
+import "~/styles/playground.css";
+
+const SAMPLE_SOURCE = `toml-version = "v1.1.0"
+
+[format.rules]
+line-width = 100
+
+[lint.rules]
+key-empty = "warn"
+`;
+
+type RunState = "loading" | "ready" | "linting" | "formatting" | "error";
+
+function diagnosticKey(diagnostic: TombiDiagnostic): string {
+  const start = diagnostic.range?.start;
+  return [
+    diagnostic.level,
+    diagnostic.code,
+    diagnostic.message,
+    start?.line,
+    start?.column,
+  ].join(":");
+}
+
+function uniqueDiagnostics(diagnostics: TombiDiagnostic[]): TombiDiagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const key = diagnosticKey(diagnostic);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function toMonacoColumn(
+  content: string,
+  lineNumber: number,
+  graphemeColumn: number,
+): number {
+  const line = content.split(/\r?\n/)[lineNumber] ?? "";
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  const prefix = Array.from(segmenter.segment(line))
+    .slice(0, graphemeColumn)
+    .map(({ segment }) => segment)
+    .join("");
+  return prefix.length + 1;
+}
 
 export default function Playground() {
+  const [source, setSource] = createSignal(SAMPLE_SOURCE);
+  const [fileName, setFileName] = createSignal("tombi.toml");
+  const [tomlVersion, setTomlVersion] = createSignal("v1.1.0");
+  const [diagnostics, setDiagnostics] = createSignal<TombiDiagnostic[]>([]);
+  const [wasm, setWasm] = createSignal<TombiWasm>();
+  const [monaco, setMonaco] = createSignal<Monaco>();
+  const [codeEditor, setCodeEditor] =
+    createSignal<MonacoEditor.IStandaloneCodeEditor>();
+  const [editorLoading, setEditorLoading] = createSignal(true);
+  const [editorError, setEditorError] = createSignal<string>();
+  const [formatShortcut, setFormatShortcut] = createSignal("Ctrl+S");
+  const [runState, setRunState] = createSignal<RunState>("loading");
+  const [statusMessage, setStatusMessage] = createSignal(
+    "Loading the Tombi WebAssembly runtime…",
+  );
+  let lintSequence = 0;
+  let lastLintKey = "";
+  let editorContainer: HTMLDivElement | undefined;
+
+  const lintKey = (content: string, filePath: string, version: string) =>
+    JSON.stringify([content, filePath, version]);
+
+  const lintSource = async (
+    runtime: TombiWasm,
+    content: string,
+    filePath: string,
+    version: string,
+    successMessage = "No issues found.",
+  ) => {
+    const sequence = ++lintSequence;
+    const key = lintKey(content, filePath, version);
+    let nextDiagnostics: TombiDiagnostic[] = [];
+    let fatalError: string | undefined;
+
+    setRunState("linting");
+    setStatusMessage("Linting…");
+
+    try {
+      await runtime.lint(content, filePath || undefined, version);
+    } catch (error) {
+      const failure = normalizeWasmError(error);
+      nextDiagnostics = uniqueDiagnostics(failure.diagnostics);
+      fatalError = failure.error;
+    }
+
+    if (sequence !== lintSequence) return;
+
+    lastLintKey = key;
+    setDiagnostics(nextDiagnostics);
+
+    if (fatalError) {
+      setRunState("error");
+      setStatusMessage(fatalError);
+      return;
+    }
+
+    setRunState("ready");
+    setStatusMessage(
+      nextDiagnostics.length === 0
+        ? successMessage
+        : `${nextDiagnostics.length} issue${nextDiagnostics.length === 1 ? "" : "s"} found.`,
+    );
+  };
+
+  const formatAndLint = async (runtime = wasm()) => {
+    if (!runtime || runState() === "formatting") return;
+
+    const sequence = ++lintSequence;
+    const currentSource = source();
+    const currentFileName = fileName().trim();
+    const currentVersion = tomlVersion();
+    let formattedSource: string;
+
+    setRunState("formatting");
+    setStatusMessage("Formatting…");
+
+    try {
+      formattedSource = await runtime.format(
+        currentSource,
+        currentFileName || undefined,
+        currentVersion,
+      );
+    } catch (error) {
+      if (sequence !== lintSequence) return;
+
+      const failure = normalizeWasmError(error);
+      const nextDiagnostics = uniqueDiagnostics(failure.diagnostics);
+      lastLintKey = lintKey(currentSource, currentFileName, currentVersion);
+      setDiagnostics(nextDiagnostics);
+      setRunState(failure.error ? "error" : "ready");
+      setStatusMessage(
+        failure.error ||
+          `${nextDiagnostics.length} issue${nextDiagnostics.length === 1 ? "" : "s"} found.`,
+      );
+      return;
+    }
+
+    if (sequence !== lintSequence) return;
+
+    await lintSource(
+      runtime,
+      formattedSource,
+      currentFileName,
+      currentVersion,
+      "Formatted successfully. No issues found.",
+    );
+
+    if (
+      lastLintKey === lintKey(formattedSource, currentFileName, currentVersion)
+    ) {
+      setSource(formattedSource);
+    }
+  };
+
+  createEffect(() => {
+    const runtime = wasm();
+    const currentSource = source();
+    const currentFileName = fileName().trim();
+    const currentVersion = tomlVersion();
+    const key = lintKey(currentSource, currentFileName, currentVersion);
+
+    if (!runtime || key === lastLintKey) return;
+
+    const timeout = window.setTimeout(() => {
+      if (key !== lastLintKey) {
+        void lintSource(
+          runtime,
+          currentSource,
+          currentFileName,
+          currentVersion,
+        );
+      }
+    }, 250);
+
+    onCleanup(() => window.clearTimeout(timeout));
+  });
+
+  createEffect(() => {
+    const editor = codeEditor();
+    const currentSource = source();
+    const model = editor?.getModel();
+    if (!model || model.getValue() === currentSource) return;
+
+    model.pushEditOperations(
+      [],
+      [{ range: model.getFullModelRange(), text: currentSource }],
+      () => null,
+    );
+  });
+
+  createEffect(() => {
+    const monacoApi = monaco();
+    const editor = codeEditor();
+    const currentDiagnostics = diagnostics();
+    const currentSource = source();
+    const model = editor?.getModel();
+    if (!monacoApi || !editor || !model) return;
+
+    const markers = currentDiagnostics.map((diagnostic) => {
+      const start = diagnostic.range?.start ?? { line: 0, column: 0 };
+      const end = diagnostic.range?.end ?? start;
+      const startLineNumber = start.line + 1;
+      const endLineNumber = end.line + 1;
+      const startColumn = toMonacoColumn(
+        currentSource,
+        start.line,
+        start.column,
+      );
+      let endColumn = toMonacoColumn(currentSource, end.line, end.column);
+
+      if (startLineNumber === endLineNumber && endColumn <= startColumn) {
+        endColumn = startColumn + 1;
+      }
+
+      const range = model.validateRange({
+        startLineNumber,
+        startColumn,
+        endLineNumber,
+        endColumn,
+      });
+
+      return {
+        severity:
+          diagnostic.level.toUpperCase() === "WARNING"
+            ? monacoApi.MarkerSeverity.Warning
+            : monacoApi.MarkerSeverity.Error,
+        code: diagnostic.code || undefined,
+        message: diagnostic.message,
+        source: "Tombi",
+        startLineNumber: range.startLineNumber,
+        startColumn: range.startColumn,
+        endLineNumber: range.endLineNumber,
+        endColumn: range.endColumn,
+      };
+    });
+
+    monacoApi.editor.setModelMarkers(model, "tombi", markers);
+  });
+
+  onMount(() => {
+    let disposed = false;
+    let editor: MonacoEditor.IStandaloneCodeEditor | undefined;
+    let model: MonacoEditor.ITextModel | undefined;
+    let themeObserver: MutationObserver | undefined;
+
+    onCleanup(() => {
+      disposed = true;
+      themeObserver?.disconnect();
+      editor?.dispose();
+      model?.dispose();
+    });
+
+    void (async () => {
+      try {
+        const monacoApi = await loadMonacoEditor();
+        if (disposed || !editorContainer) return;
+
+        const updateTheme = () => {
+          monacoApi.editor.setTheme(
+            document.documentElement.classList.contains("dark")
+              ? "vs-dark"
+              : "vs",
+          );
+        };
+
+        model = monacoApi.editor.createModel(source(), "toml");
+        const createdEditor = monacoApi.editor.create(editorContainer, {
+          model,
+          ariaLabel: "TOML editor",
+          automaticLayout: true,
+          fontFamily:
+            '"Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace',
+          fontSize: 14,
+          folding: false,
+          glyphMargin: false,
+          hideCursorInOverviewRuler: true,
+          lineDecorationsWidth: 8,
+          lineNumbers: "on",
+          lineNumbersMinChars: 5,
+          minimap: { enabled: false },
+          overviewRulerBorder: false,
+          padding: { top: 16, bottom: 16 },
+          renderValidationDecorations: "on",
+          scrollBeyondLastLine: false,
+          tabSize: 2,
+        });
+        editor = createdEditor;
+        createdEditor.onDidChangeModelContent(() => {
+          updateSource(createdEditor.getValue());
+        });
+
+        updateTheme();
+        themeObserver = new MutationObserver(updateTheme);
+        themeObserver.observe(document.documentElement, {
+          attributeFilter: ["class"],
+          attributes: true,
+        });
+
+        setMonaco(monacoApi);
+        setCodeEditor(createdEditor);
+        setEditorLoading(false);
+      } catch (error) {
+        if (disposed) return;
+        setEditorLoading(false);
+        setEditorError(
+          error instanceof Error ? error.message : "Unable to load the editor.",
+        );
+      }
+    })();
+  });
+
+  onMount(async () => {
+    try {
+      const runtime = await loadTombiWasm();
+      setWasm(runtime);
+      await lintSource(runtime, source(), fileName().trim(), tomlVersion());
+    } catch (error) {
+      const failure = normalizeWasmError(error);
+      setRunState("error");
+      setStatusMessage(
+        failure.error || "Unable to load the Tombi WebAssembly runtime.",
+      );
+    }
+  });
+
+  onMount(() => {
+    const isApplePlatform = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    setFormatShortcut(isApplePlatform ? "⌘S" : "Ctrl+S");
+
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (!event.metaKey && !event.ctrlKey) return;
+
+      if (event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        void formatAndLint();
+      }
+    };
+
+    window.addEventListener("keydown", handleShortcut, { capture: true });
+    onCleanup(() =>
+      window.removeEventListener("keydown", handleShortcut, { capture: true }),
+    );
+  });
+
+  const updateSource = (value: string) => {
+    lintSequence += 1;
+    setSource(value);
+  };
+
+  const goToDiagnostic = (diagnostic: TombiDiagnostic) => {
+    const editor = codeEditor();
+    const start = diagnostic.range?.start;
+    if (!editor || !start) return;
+
+    const position = {
+      lineNumber: start.line + 1,
+      column: toMonacoColumn(source(), start.line, start.column),
+    };
+    editor.setPosition(position);
+    editor.revealPositionInCenter(position);
+    editor.focus();
+  };
+
   return (
     <>
       <PageHeading
-        title="Playground"
-        description="Tombi's interactive playground."
-        og_url={`${import.meta.env.BASE_URL}/playground`}
+        title="TOML Playground | Tombi"
+        description="Format and lint TOML instantly with Tombi running locally in your browser."
+        og_url={`${DEFAULT_URL}playground`}
       />
-      <div class="flex flex-col items-center justify-center min-h-[60vh]">
-        <h1 class="text-4xl font-bold mb-4">🚧 Planned Feature 🚧</h1>
-        <div class="text-xl text-gray-600 dark:text-gray-400 text-center">
-          <p class="my-4">
-            The Tombi Playground is planned as a future feature.
-          </p>
-          <p class="my-4">
-            We aim to provide an interactive TOML formatting experience.
-          </p>
-        </div>
+
+      <div class="playground-shell">
+        <section class="playground-workspace" aria-label="TOML playground">
+          <div class="playground-toolbar">
+            <label class="playground-field">
+              <span>File name</span>
+              <div class="playground-input-wrap">
+                <TbFileCode aria-hidden="true" />
+                <input
+                  type="text"
+                  value={fileName()}
+                  placeholder="tombi.toml"
+                  spellcheck={false}
+                  onInput={(event) => {
+                    lintSequence += 1;
+                    setFileName(event.currentTarget.value);
+                  }}
+                />
+              </div>
+            </label>
+
+            <label class="playground-field playground-version-field">
+              <span>TOML version</span>
+              <select
+                value={tomlVersion()}
+                onChange={(event) => {
+                  lintSequence += 1;
+                  setTomlVersion(event.currentTarget.value);
+                }}
+              >
+                <option value="v1.1.0">TOML v1.1.0</option>
+                <option value="v1.0.0">TOML v1.0.0</option>
+                <option value="v1.1.0-preview">TOML v1.1 preview</option>
+              </select>
+            </label>
+
+            <div class="playground-actions">
+              <button
+                type="button"
+                class="playground-button playground-button-primary"
+                title={`Format (${formatShortcut()})`}
+                aria-keyshortcuts={
+                  formatShortcut() === "⌘S" ? "Meta+S" : "Control+S"
+                }
+                onClick={() => void formatAndLint()}
+                disabled={!wasm() || runState() === "formatting"}
+              >
+                <Show
+                  when={runState() !== "formatting"}
+                  fallback={
+                    <TbLoader2 class="playground-spinner" aria-hidden="true" />
+                  }
+                >
+                  <FaSolidFeather aria-hidden="true" />
+                </Show>
+                {runState() === "formatting" ? "Formatting…" : "Format"}
+              </button>
+            </div>
+          </div>
+
+          <section class="playground-editor-card">
+            <div
+              class="playground-editor"
+              classList={{
+                "is-loading": editorLoading() || Boolean(editorError()),
+              }}
+              ref={editorContainer}
+            >
+              <Show when={editorLoading()}>
+                <div class="playground-editor-loading">
+                  <TbLoader2 class="playground-spinner" aria-hidden="true" />
+                  Loading editor…
+                </div>
+              </Show>
+              <Show when={editorError()}>
+                {(message) => (
+                  <div class="playground-editor-error" role="alert">
+                    <TbAlertTriangle aria-hidden="true" />
+                    {message()}
+                  </div>
+                )}
+              </Show>
+            </div>
+          </section>
+
+          <section class="playground-results" aria-live="polite">
+            <div
+              class="playground-status"
+              data-state={runState()}
+              data-has-diagnostics={diagnostics().length > 0}
+            >
+              <Show
+                when={runState() === "ready" || runState() === "error"}
+                fallback={
+                  <TbLoader2 class="playground-spinner" aria-hidden="true" />
+                }
+              >
+                <Show
+                  when={runState() !== "error" && diagnostics().length === 0}
+                  fallback={<TbAlertTriangle aria-hidden="true" />}
+                >
+                  <TbCheck aria-hidden="true" />
+                </Show>
+              </Show>
+              <span>{statusMessage()}</span>
+            </div>
+
+            <Show when={diagnostics().length > 0}>
+              <div class="playground-diagnostics">
+                <For each={diagnostics()}>
+                  {(diagnostic) => {
+                    const line = (diagnostic.range?.start.line ?? 0) + 1;
+                    const column = (diagnostic.range?.start.column ?? 0) + 1;
+                    return (
+                      <button
+                        type="button"
+                        data-level={diagnostic.level?.toLowerCase()}
+                        onClick={() => goToDiagnostic(diagnostic)}
+                      >
+                        <div class="playground-diagnostic-meta">
+                          <span>{diagnostic.level || "ERROR"}</span>
+                          <code>{diagnostic.code || "syntax"}</code>
+                          <span>
+                            Line {line}, column {column}
+                          </span>
+                        </div>
+                        <p>{diagnostic.message}</p>
+                      </button>
+                    );
+                  }}
+                </For>
+              </div>
+            </Show>
+          </section>
+        </section>
       </div>
     </>
   );

--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -1,0 +1,433 @@
+.playground-shell {
+  --playground-border: #d9dee9;
+  --playground-muted: #667085;
+  --playground-panel: #ffffff;
+  --playground-editor: #f8fafc;
+  padding: 2.5rem 0 4rem;
+}
+
+.playground-workspace {
+  overflow: hidden;
+  border: 1px solid var(--playground-border);
+  border-radius: 1rem;
+  background: var(--playground-panel);
+  box-shadow: 0 18px 45px rgb(15 23 42 / 8%);
+}
+
+.playground-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  border-bottom: 1px solid var(--playground-border);
+  padding: 1rem;
+  background: linear-gradient(180deg, #fff, #fbfcff);
+}
+
+.playground-field {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 16rem;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.playground-version-field {
+  flex: 0 1 12rem;
+}
+
+.playground-field > span {
+  color: #475467;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.playground-input-wrap {
+  position: relative;
+}
+
+.playground-input-wrap svg {
+  position: absolute;
+  top: 50%;
+  left: 0.75rem;
+  width: 1rem;
+  height: 1rem;
+  color: #667085;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.playground-field input,
+.playground-field select {
+  box-sizing: border-box;
+  width: 100%;
+  height: 2.65rem;
+  border: 1px solid #cbd2df;
+  border-radius: 0.55rem;
+  background: #fff;
+  color: #101828;
+  font: inherit;
+  font-size: 0.88rem;
+  outline: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.playground-field input {
+  padding: 0 0.8rem 0 2.25rem;
+}
+
+.playground-field select {
+  appearance: none;
+  padding: 0 3.25rem 0 0.75rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23667085' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-position: right 10px center;
+  background-repeat: no-repeat;
+  background-size: 15px;
+}
+
+.playground-field input:focus,
+.playground-field select:focus {
+  border-color: #3333ff;
+  box-shadow: 0 0 0 3px rgb(51 51 255 / 14%);
+}
+
+.playground-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.65rem;
+}
+
+.playground-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 0.55rem;
+  font: inherit;
+  font-size: 0.83rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease,
+    color 160ms ease, transform 160ms ease;
+}
+
+.playground-button {
+  min-height: 2.65rem;
+  border: 1px solid transparent;
+  padding: 0 1rem;
+}
+
+.playground-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.playground-button:not(:disabled):active {
+  transform: translateY(1px);
+}
+
+.playground-button:focus-visible {
+  outline: 2px solid #3333ff;
+  outline-offset: 2px;
+}
+
+.playground-button-primary {
+  background: #000066;
+  color: #fff;
+}
+
+.playground-button-primary:not(:disabled):hover {
+  background: #000099;
+}
+
+.playground-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.playground-editor-card {
+  min-width: 0;
+  background: var(--playground-panel);
+}
+
+.playground-editor {
+  position: relative;
+  width: 100%;
+  height: 36rem;
+  background: var(--playground-editor);
+}
+
+.playground-editor.is-loading {
+  display: grid;
+  place-items: center;
+}
+
+.playground-editor-loading,
+.playground-editor-error {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--playground-muted);
+  font-size: 0.85rem;
+  font-weight: 650;
+}
+
+.playground-editor-error {
+  max-width: 36rem;
+  padding: 1rem;
+  color: #b42318;
+}
+
+.playground-editor-error svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+}
+
+.playground-results {
+  border-top: 1px solid var(--playground-border);
+  padding: 1rem;
+}
+
+.playground-status {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: #166534;
+  font-size: 0.85rem;
+  font-weight: 650;
+}
+
+.playground-status[data-state="loading"],
+.playground-status[data-state="linting"],
+.playground-status[data-state="formatting"] {
+  color: #1d4ed8;
+}
+
+.playground-status[data-state="error"],
+.playground-status[data-has-diagnostics="true"] {
+  color: #b42318;
+}
+
+.playground-status svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+}
+
+.playground-spinner {
+  animation: playground-spin 0.8s linear infinite;
+}
+
+.playground-diagnostics {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.9rem;
+}
+
+.playground-diagnostics > button {
+  width: 100%;
+  border: 1px solid #fecaca;
+  border-left: 3px solid #ef4444;
+  border-radius: 0.55rem;
+  padding: 0.75rem 0.85rem;
+  background: #fff7f7;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.playground-diagnostics > button:hover {
+  border-color: #ef4444;
+  background: #fff1f1;
+}
+
+.playground-diagnostics > button[data-level="warning"] {
+  border-color: #fed7aa;
+  border-left-color: #f97316;
+  background: #fffaf5;
+}
+
+.playground-diagnostic-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.35rem;
+  color: #667085;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.playground-diagnostic-meta > span:first-child {
+  color: #b42318;
+}
+
+.playground-diagnostic-meta code {
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.35rem;
+  background: #fee2e2;
+  color: #991b1b;
+  font-size: 0.68rem;
+  text-transform: none;
+}
+
+.playground-diagnostics > button p {
+  margin: 0;
+  color: #344054;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+@keyframes playground-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+:root.dark .playground-shell {
+  --playground-border: #3c485b;
+  --playground-muted: #98a2b3;
+  --playground-panel: #202b3a;
+  --playground-editor: #182230;
+}
+
+:root.dark .playground-workspace {
+  box-shadow: 0 18px 45px rgb(0 0 0 / 22%);
+}
+
+:root.dark .playground-toolbar {
+  background: linear-gradient(180deg, #202b3a, #1d2735);
+}
+
+:root.dark .playground-field > span {
+  color: #d0d5dd;
+}
+
+:root.dark .playground-field input,
+:root.dark .playground-field select {
+  border-color: #475467;
+  background-color: #182230;
+  color: #f2f4f7;
+}
+
+:root.dark .playground-editor-error {
+  color: #fda29b;
+}
+
+:root.dark .playground-status {
+  color: #6ce9a6;
+}
+
+:root.dark .playground-status[data-state="loading"],
+:root.dark .playground-status[data-state="linting"],
+:root.dark .playground-status[data-state="formatting"] {
+  color: #84adff;
+}
+
+:root.dark .playground-status[data-state="error"],
+:root.dark .playground-status[data-has-diagnostics="true"] {
+  color: #f97066;
+}
+
+:root.dark .playground-diagnostics > button {
+  border-color: #633b43;
+  border-left-color: #f97066;
+  background: rgb(240 68 56 / 6%);
+}
+
+:root.dark .playground-diagnostics > button:hover {
+  border-color: #b5474f;
+  background: rgb(240 68 56 / 10%);
+}
+
+:root.dark .playground-diagnostics > button[data-level="warning"] {
+  border-color: #694d2c;
+  border-left-color: #fdb022;
+  background: rgb(247 144 9 / 6%);
+}
+
+:root.dark .playground-diagnostics > button[data-level="warning"]:hover {
+  border-color: #b77a24;
+  background: rgb(247 144 9 / 10%);
+}
+
+:root.dark .playground-diagnostic-meta {
+  color: #98a2b3;
+}
+
+:root.dark .playground-diagnostic-meta > span:first-child {
+  color: #f97066;
+}
+
+:root.dark .playground-diagnostic-meta code {
+  background: rgb(240 68 56 / 16%);
+  color: #fda29b;
+}
+
+:root.dark
+  .playground-diagnostics
+  > button[data-level="warning"]
+  .playground-diagnostic-meta
+  > span:first-child {
+  color: #fdb022;
+}
+
+:root.dark
+  .playground-diagnostics
+  > button[data-level="warning"]
+  .playground-diagnostic-meta
+  code {
+  background: rgb(247 144 9 / 16%);
+  color: #fec84b;
+}
+
+:root.dark .playground-diagnostics > button p {
+  color: #f2f4f7;
+}
+
+@media (max-width: 900px) {
+  .playground-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .playground-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .playground-editor {
+    height: 30rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .playground-shell {
+    padding-top: 1.5rem;
+  }
+
+  .playground-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playground-field,
+  .playground-version-field {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .playground-actions,
+  .playground-button {
+    flex: 1;
+  }
+
+  .playground-editor {
+    height: 26rem;
+  }
+}

--- a/docs/src/utils/monaco-editor.ts
+++ b/docs/src/utils/monaco-editor.ts
@@ -1,0 +1,90 @@
+export type Monaco = typeof import("monaco-editor/editor");
+
+let monacoPromise: Promise<Monaco> | undefined;
+let tomlRegistered = false;
+
+export function loadMonacoEditor(): Promise<Monaco> {
+  if (monacoPromise) return monacoPromise;
+
+  monacoPromise = (async () => {
+    const { default: EditorWorker } = await import(
+      "monaco-editor/editor/editor.worker?worker&inline"
+    );
+
+    (
+      globalThis as typeof globalThis & {
+        MonacoEnvironment?: {
+          getWorker: () => Worker;
+        };
+      }
+    ).MonacoEnvironment = {
+      getWorker: () => new EditorWorker(),
+    };
+
+    const monaco = await import("monaco-editor/editor");
+
+    if (!tomlRegistered) {
+      monaco.languages.register({ id: "toml" });
+      monaco.languages.setLanguageConfiguration("toml", {
+        comments: { lineComment: "#" },
+        brackets: [
+          ["[", "]"],
+          ["{", "}"],
+        ],
+        autoClosingPairs: [
+          { open: "[", close: "]" },
+          { open: "{", close: "}" },
+          { open: '"', close: '"' },
+          { open: "'", close: "'" },
+        ],
+        surroundingPairs: [
+          { open: "[", close: "]" },
+          { open: "{", close: "}" },
+          { open: '"', close: '"' },
+          { open: "'", close: "'" },
+        ],
+      });
+      monaco.languages.setMonarchTokensProvider("toml", {
+        tokenizer: {
+          root: [
+            [/\s+/, "white"],
+            [/#.*$/, "comment"],
+            [/\[\[.*?\]\]|\[.*?\]/, "type.identifier"],
+            [/"""/, { token: "string.quote", next: "@multilineBasic" }],
+            [/'''/, { token: "string.quote", next: "@multilineLiteral" }],
+            [/"([^"\\]|\\.)*"/, "string"],
+            [/'[^']*'/, "string"],
+            [/\b(?:true|false)\b/, "keyword"],
+            [
+              /\b\d{4}-\d{2}-\d{2}(?:[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?)?\b/,
+              "number",
+            ],
+            [
+              /\b(?:inf|nan|[+-]?(?:0x[0-9a-fA-F_]+|0o[0-7_]+|0b[01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?))\b/,
+              "number",
+            ],
+            [/[A-Za-z0-9_-]+(?=\s*=)/, "variable.name"],
+            [/[=,.]/, "delimiter"],
+          ],
+          multilineBasic: [
+            [/"""/, { token: "string.quote", next: "@pop" }],
+            [/\\./, "string.escape"],
+            [/./, "string"],
+          ],
+          multilineLiteral: [
+            [/'''/, { token: "string.quote", next: "@pop" }],
+            [/./, "string"],
+          ],
+        },
+      });
+      tomlRegistered = true;
+    }
+
+    return monaco;
+  })().catch((error) => {
+    monacoPromise = undefined;
+    throw error;
+  });
+
+  return monacoPromise;
+}

--- a/docs/src/utils/tombi-wasm.ts
+++ b/docs/src/utils/tombi-wasm.ts
@@ -1,0 +1,98 @@
+export interface TombiPosition {
+  line: number;
+  column: number;
+}
+
+export interface TombiRange {
+  start: TombiPosition;
+  end: TombiPosition;
+}
+
+export interface TombiDiagnostic {
+  level: "ERROR" | "WARNING" | string;
+  code: string;
+  message: string;
+  range?: TombiRange;
+  source_file?: string | null;
+}
+
+export interface TombiWasm {
+  format(
+    source: string,
+    filePath?: string,
+    tomlVersion?: string,
+  ): Promise<string>;
+  lint(source: string, filePath?: string, tomlVersion?: string): Promise<void>;
+}
+
+interface TombiWasmModule extends TombiWasm {
+  default(): Promise<unknown>;
+}
+
+export interface TombiWasmFailure {
+  error?: string;
+  diagnostics: TombiDiagnostic[];
+}
+
+let wasmPromise: Promise<TombiWasm> | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeWasmError(error: unknown): TombiWasmFailure {
+  if (isRecord(error)) {
+    const diagnostics = Array.isArray(error.diagnostics)
+      ? error.diagnostics.filter(isRecord).map((diagnostic) => ({
+          level:
+            typeof diagnostic.level === "string" ? diagnostic.level : "ERROR",
+          code: typeof diagnostic.code === "string" ? diagnostic.code : "",
+          message:
+            typeof diagnostic.message === "string"
+              ? diagnostic.message
+              : "Unknown Tombi diagnostic",
+          range: isRecord(diagnostic.range)
+            ? (diagnostic.range as unknown as TombiRange)
+            : undefined,
+          source_file:
+            typeof diagnostic.source_file === "string"
+              ? diagnostic.source_file
+              : null,
+        }))
+      : [];
+
+    return {
+      error: typeof error.error === "string" ? error.error : undefined,
+      diagnostics,
+    };
+  }
+
+  return {
+    error: error instanceof Error ? error.message : String(error),
+    diagnostics: [],
+  };
+}
+
+export function loadTombiWasm(): Promise<TombiWasm> {
+  if (wasmPromise) return wasmPromise;
+
+  wasmPromise = (async () => {
+    const baseUrl = import.meta.env.BASE_URL.endsWith("/")
+      ? import.meta.env.BASE_URL
+      : `${import.meta.env.BASE_URL}/`;
+    const moduleUrl = new URL(
+      `${baseUrl}wasm/tombi_wasm.js`,
+      window.location.origin,
+    ).href;
+    const module = (await import(
+      /* @vite-ignore */ moduleUrl
+    )) as TombiWasmModule;
+    await module.default();
+    return module;
+  })().catch((error) => {
+    wasmPromise = undefined;
+    throw error;
+  });
+
+  return wasmPromise;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       mdast-util-mdx:
         specifier: ^3.0.0
         version: 3.0.0
+      monaco-editor:
+        specifier: ^0.56.0
+        version: 0.56.0
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -1377,6 +1380,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2266,6 +2272,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -3055,6 +3064,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3304,6 +3318,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -6005,6 +6022,9 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7018,6 +7038,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -7893,6 +7917,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
@@ -8391,6 +8417,11 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  monaco-editor@0.56.0:
+    dependencies:
+      dompurify: 3.4.8
+      marked: 14.0.0
 
   mrmime@2.0.1: {}
 

--- a/rust/tombi-wasm/package.json
+++ b/rust/tombi-wasm/package.json
@@ -4,6 +4,7 @@
   "description": "TOML formatter WASM demo",
   "scripts": {
     "build:wasm": "wasm-pack build --locked --target web --out-dir dist/pkg",
+    "build:docs": "wasm-pack build --locked --target web --out-dir ../../docs/public/wasm",
     "build:copy": "cp -r www/* dist/",
     "build": "mkdir -p dist && pnpm run build:wasm && pnpm run build:copy",
     "dev": "pnpm run build && serve dist",

--- a/rust/tombi-wasm/src/lib.rs
+++ b/rust/tombi-wasm/src/lib.rs
@@ -1,10 +1,18 @@
 use std::str::FromStr;
 
 use js_sys::Promise;
+use serde::Serialize;
+use serde_wasm_bindgen::Serializer;
 use tombi_config::TomlVersion;
 use tombi_diagnostic::Diagnostic;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 use wasm_bindgen_futures::future_to_promise;
+
+fn serialize_error(error: &impl Serialize) -> JsValue {
+    error
+        .serialize(&Serializer::json_compatible())
+        .expect("WASM errors must be serializable")
+}
 
 #[wasm_bindgen(start)]
 pub fn start() {
@@ -93,7 +101,7 @@ pub fn format(source: String, file_path: Option<String>, toml_version: Option<St
     future_to_promise(async move {
         match inner_format(source, file_path, toml_version).await {
             Ok(t) => Ok(JsValue::from_str(&t)),
-            Err(e) => Err(serde_wasm_bindgen::to_value(&e).unwrap()),
+            Err(e) => Err(serialize_error(&e)),
         }
     })
 }
@@ -178,7 +186,7 @@ pub fn lint(source: String, file_path: Option<String>, toml_version: Option<Stri
     future_to_promise(async move {
         match inner_lint(source, file_path, toml_version).await {
             Ok(_) => Ok(JsValue::NULL),
-            Err(e) => Err(serde_wasm_bindgen::to_value(&e).unwrap()),
+            Err(e) => Err(serialize_error(&e)),
         }
     })
 }


### PR DESCRIPTION
## Summary

- add a browser-based TOML playground backed by Tombi WebAssembly
- provide Monaco editing with live lint diagnostics and formatting via the Format button or the platform save shortcut
- build the WASM package as part of docs development/deployment and include the relevant Rust surfaces in docs CI

## Validation

- `BASE_URL=/tombi pnpm --dir docs build`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint`
- `pnpm --dir docs typecheck`
- `mise x actionlint@1.7.12 -- actionlint .github/workflows/deploy_docs.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `git diff --check origin/main...HEAD`