### PR TITLE
ci: disable LTO for Illumos smoke build

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -61,7 +61,8 @@ jobs:
     env:
       TOMBI_TARGET: x86_64-unknown-illumos
       TOMBI_DIST_CARGO: cross
-      CARGO_PROFILE_RELEASE_LTO: "fat"
+      # This artifact is only used by the OmniOS smoke test, not published.
+      CARGO_PROFILE_RELEASE_LTO: "false"
       # Don't strip illumos binaries because stripping on a different platform
       # breaks illumos observability tooling such as pstack. See
       # https://github.com/oxidecomputer/helios/issues/147.


### PR DESCRIPTION
## Summary

- disable fat LTO for the temporary Illumos smoke-test artifact
- keep fat LTO enabled for published CLI, PyPI, and npm release workflows
- document why the CI-only override differs from release builds

## Validation

- `mise x actionlint@1.7.12 -- actionlint .github/workflows/ci_install_script.yml`
- YAML parse via Ruby `YAML.load_file`
- `CARGO_PROFILE_RELEASE_LTO=false cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`