### PR TITLE
fix(docs): correct production asset base paths

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
     },
   },
   vite: {
-    base: process.env.BASE_URL,
+    // Vinxi combines server.baseURL with its /_build client base. Overriding
+    // Vite's base here would omit /_build from dynamically preloaded assets.
     optimizeDeps: {
       esbuildOptions: {
         target: ["es2020", "edge88", "firefox78", "chrome87", "safari14.1"],

--- a/docs/src/app.tsx
+++ b/docs/src/app.tsx
@@ -12,7 +12,7 @@ import Layout from "./routes/layout";
 export default function App() {
   return (
     <Router
-      base={import.meta.env.BASE_URL || undefined}
+      base={import.meta.env.SERVER_BASE_URL || undefined}
       root={(props) => (
         <MetaProvider>
           <MDXProvider components={components}>

--- a/docs/src/components/ImageTabs.tsx
+++ b/docs/src/components/ImageTabs.tsx
@@ -20,7 +20,7 @@ export default function ImageTabs(props: ImageTabsProps) {
   const currentSrc = () => {
     let src = current()?.src || "";
     if (src.startsWith("/")) {
-      src = `${import.meta.env.BASE_URL}${src}`;
+      src = `${import.meta.env.SERVER_BASE_URL}${src}`;
     }
     return src;
   };

--- a/docs/src/components/InstallationMethodGrid.tsx
+++ b/docs/src/components/InstallationMethodGrid.tsx
@@ -199,7 +199,7 @@ export const InstallationMethodGrid: Component<InstallationMethodGridProps> = (
             >
               <div class="flex flex-col items-center gap-2">
                 <img
-                  src={`${import.meta.env.BASE_URL}${
+                  src={`${import.meta.env.SERVER_BASE_URL}${
                     isDarkMode() && method.imageDark
                       ? method.imageDark
                       : method.image

--- a/docs/src/components/LinkCard.tsx
+++ b/docs/src/components/LinkCard.tsx
@@ -9,7 +9,7 @@ interface LinkCardProps {
 
 export const LinkCard: Component<LinkCardProps> = (props) => {
   if (props.image.startsWith("/")) {
-    props.image = `${import.meta.env.BASE_URL}${props.image}`;
+    props.image = `${import.meta.env.SERVER_BASE_URL}${props.image}`;
   }
   return (
     <div

--- a/docs/src/components/header/HeaderLogo.tsx
+++ b/docs/src/components/header/HeaderLogo.tsx
@@ -13,14 +13,14 @@ type LogoProps = {
 const logoProps: LogoProps[] = [
   {
     id: "mobile-logo",
-    src: `${import.meta.env.BASE_URL}/icon.svg`,
+    src: `${import.meta.env.SERVER_BASE_URL}/icon.svg`,
     class: "h-16 w-16",
     linkClass: "md:hidden flex",
     preventDefault: true,
   },
   {
     id: "desktop-logo",
-    src: `${import.meta.env.BASE_URL}/tombi-transparent.svg`,
+    src: `${import.meta.env.SERVER_BASE_URL}/tombi-transparent.svg`,
     class: "h-16 w-auto",
     linkClass: "hidden md:flex",
     preventDefault: false,

--- a/docs/src/components/header/index.tsx
+++ b/docs/src/components/header/index.tsx
@@ -13,7 +13,7 @@ export function Header() {
   let previousActiveElement: HTMLElement | null = null;
 
   const getPageTitle = () => {
-    const base = import.meta.env.BASE_URL;
+    const base = import.meta.env.SERVER_BASE_URL;
     let path = location.pathname;
     if (base && path.startsWith(base)) {
       path = path.slice(base.length) || "/";

--- a/docs/src/entry-server.tsx
+++ b/docs/src/entry-server.tsx
@@ -8,7 +8,10 @@ export default createHandler(() => (
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link rel="icon" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
+          <link
+            rel="icon"
+            href={`${import.meta.env.SERVER_BASE_URL}/favicon.ico`}
+          />
           {assets}
         </head>
         <body class="m-0 p-0">

--- a/docs/src/routes/index.tsx
+++ b/docs/src/routes/index.tsx
@@ -68,7 +68,7 @@ export default function Home() {
         <h1 class="sr-only">Tombi</h1>
         <div class="relative py-8 w-screen -mx-[calc((100vw-100%)/2)] overflow-hidden bg-gradient-to-b from-gray-900 to-gray-500">
           <img
-            src={`${import.meta.env.BASE_URL}/tombi-transparent.svg`}
+            src={`${import.meta.env.SERVER_BASE_URL}/tombi-transparent.svg`}
             alt="Tombi Logo"
             class="w-auto max-h-80 mx-auto px-8"
           />
@@ -92,7 +92,7 @@ export default function Home() {
         </div>
 
         <img
-          src={`${import.meta.env.BASE_URL}/demo.gif`}
+          src={`${import.meta.env.SERVER_BASE_URL}/demo.gif`}
           alt="Tombi Demo"
           class="w-full my-16"
         />

--- a/docs/src/utils/path.ts
+++ b/docs/src/utils/path.ts
@@ -1,5 +1,5 @@
 export function normalizePath(path: string): string {
-  const base = import.meta.env.BASE_URL || "/";
+  const base = import.meta.env.SERVER_BASE_URL || "/";
   const baseNormalized =
     base && base !== "/" ? (base.endsWith("/") ? base.slice(0, -1) : base) : "";
   let normalized = path.trim();

--- a/docs/src/utils/tombi-wasm.ts
+++ b/docs/src/utils/tombi-wasm.ts
@@ -77,9 +77,9 @@ export function loadTombiWasm(): Promise<TombiWasm> {
   if (wasmPromise) return wasmPromise;
 
   wasmPromise = (async () => {
-    const baseUrl = import.meta.env.BASE_URL.endsWith("/")
-      ? import.meta.env.BASE_URL
-      : `${import.meta.env.BASE_URL}/`;
+    const baseUrl = import.meta.env.SERVER_BASE_URL.endsWith("/")
+      ? import.meta.env.SERVER_BASE_URL
+      : `${import.meta.env.SERVER_BASE_URL}/`;
     const moduleUrl = new URL(
       `${baseUrl}wasm/tombi_wasm.js`,
       window.location.origin,


### PR DESCRIPTION
## Summary

- let Vinxi retain its `/_build` client asset base instead of overriding it with the site base URL
- use the server/site base URL for application routes, public images, and the WASM loader
- keep local page URLs under `/playground` while GitHub Pages assets load from `/tombi/_build`

## Verification

- `BASE_URL=/tombi pnpm --dir docs build`
- `pnpm --dir docs typecheck`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs format:check`
- production preview at `/tombi/playground/` with page, Monaco CSS, WASM JS, WASM binary, editor worker, and editor bundle returning HTTP 200
- direct WASM format/lint smoke test
- `git diff --check`
