### PR TITLE
feat(docs): show format shortcut in playground

### DIFF
--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -450,7 +450,7 @@ export default function Playground() {
                   formatShortcut() === "⌘S" ? "Meta+S" : "Control+S"
                 }
                 onClick={() => void formatAndLint()}
-                disabled={!wasm() || runState() === "formatting"}
+                disabled={!wasm()}
                 aria-busy={runState() === "formatting"}
               >
                 <FaSolidFeather

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -83,7 +83,7 @@ export default function Playground() {
     createSignal<MonacoEditor.IStandaloneCodeEditor>();
   const [editorLoading, setEditorLoading] = createSignal(true);
   const [editorError, setEditorError] = createSignal<string>();
-  const [formatShortcut, setFormatShortcut] = createSignal("Ctrl + S");
+  const [formatShortcut, setFormatShortcut] = createSignal("Ctrl S");
   const [runState, setRunState] = createSignal<RunState>("loading");
   const [statusMessage, setStatusMessage] = createSignal(
     "Loading the Tombi WebAssembly runtime…",
@@ -362,7 +362,7 @@ export default function Playground() {
     const operatingSystem = detectOperatingSystem();
     const isApplePlatform =
       operatingSystem === "mac" || operatingSystem === "ios";
-    setFormatShortcut(isApplePlatform ? "Cmd + S" : "Ctrl + S");
+    setFormatShortcut(isApplePlatform ? "⌘S" : "Ctrl S");
 
     const handleShortcut = (event: KeyboardEvent) => {
       if (!event.metaKey && !event.ctrlKey) return;
@@ -447,7 +447,7 @@ export default function Playground() {
                 class="playground-button playground-button-primary"
                 title={`Format (${formatShortcut()})`}
                 aria-keyshortcuts={
-                  formatShortcut() === "Cmd + S" ? "Meta+S" : "Control+S"
+                  formatShortcut() === "⌘S" ? "Meta+S" : "Control+S"
                 }
                 onClick={() => void formatAndLint()}
                 disabled={!wasm() || runState() === "formatting"}

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -17,6 +17,7 @@ import {
 import { PageHeading } from "~/components/PageHeading";
 import { DEFAULT_URL } from "~/remark/page-heading";
 import { loadMonacoEditor, type Monaco } from "~/utils/monaco-editor";
+import { detectOperatingSystem } from "~/utils/platform";
 import {
   loadTombiWasm,
   normalizeWasmError,
@@ -82,7 +83,7 @@ export default function Playground() {
     createSignal<MonacoEditor.IStandaloneCodeEditor>();
   const [editorLoading, setEditorLoading] = createSignal(true);
   const [editorError, setEditorError] = createSignal<string>();
-  const [formatShortcut, setFormatShortcut] = createSignal("Ctrl+S");
+  const [formatShortcut, setFormatShortcut] = createSignal("Ctrl + S");
   const [runState, setRunState] = createSignal<RunState>("loading");
   const [statusMessage, setStatusMessage] = createSignal(
     "Loading the Tombi WebAssembly runtime…",
@@ -358,8 +359,10 @@ export default function Playground() {
   });
 
   onMount(() => {
-    const isApplePlatform = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-    setFormatShortcut(isApplePlatform ? "⌘S" : "Ctrl+S");
+    const operatingSystem = detectOperatingSystem();
+    const isApplePlatform =
+      operatingSystem === "mac" || operatingSystem === "ios";
+    setFormatShortcut(isApplePlatform ? "Cmd + S" : "Ctrl + S");
 
     const handleShortcut = (event: KeyboardEvent) => {
       if (!event.metaKey && !event.ctrlKey) return;
@@ -444,7 +447,7 @@ export default function Playground() {
                 class="playground-button playground-button-primary"
                 title={`Format (${formatShortcut()})`}
                 aria-keyshortcuts={
-                  formatShortcut() === "⌘S" ? "Meta+S" : "Control+S"
+                  formatShortcut() === "Cmd + S" ? "Meta+S" : "Control+S"
                 }
                 onClick={() => void formatAndLint()}
                 disabled={!wasm() || runState() === "formatting"}
@@ -458,6 +461,9 @@ export default function Playground() {
                   <FaSolidFeather aria-hidden="true" />
                 </Show>
                 {runState() === "formatting" ? "Formatting…" : "Format"}
+                <span class="playground-button-shortcut" aria-hidden="true">
+                  {formatShortcut()}
+                </span>
               </button>
             </div>
           </div>

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -451,6 +451,7 @@ export default function Playground() {
                 }
                 onClick={() => void formatAndLint()}
                 disabled={!wasm() || runState() === "formatting"}
+                aria-busy={runState() === "formatting"}
               >
                 <Show
                   when={runState() !== "formatting"}
@@ -460,7 +461,7 @@ export default function Playground() {
                 >
                   <FaSolidFeather aria-hidden="true" />
                 </Show>
-                {runState() === "formatting" ? "Formatting…" : "Format"}
+                Format
                 <span class="playground-button-shortcut" aria-hidden="true">
                   {formatShortcut()}
                 </span>

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -444,7 +444,7 @@ export default function Playground() {
             <div class="playground-actions">
               <button
                 type="button"
-                class="playground-button playground-button-primary"
+                class="playground-button playground-button-primary group"
                 title={`Format (${formatShortcut()})`}
                 aria-keyshortcuts={
                   formatShortcut() === "⌘S" ? "Meta+S" : "Control+S"
@@ -453,14 +453,10 @@ export default function Playground() {
                 disabled={!wasm() || runState() === "formatting"}
                 aria-busy={runState() === "formatting"}
               >
-                <Show
-                  when={runState() !== "formatting"}
-                  fallback={
-                    <TbLoader2 class="playground-spinner" aria-hidden="true" />
-                  }
-                >
-                  <FaSolidFeather aria-hidden="true" />
-                </Show>
+                <FaSolidFeather
+                  class="group-hover:animate-shake"
+                  aria-hidden="true"
+                />
                 Format
                 <span class="playground-button-shortcut" aria-hidden="true">
                   {formatShortcut()}

--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -141,6 +141,13 @@
   background: #000099;
 }
 
+.playground-button-shortcut {
+  color: rgb(255 255 255 / 62%);
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .playground-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;

--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -123,10 +123,6 @@
   height: 1rem;
 }
 
-.playground-button:not(:disabled):active {
-  transform: translateY(1px);
-}
-
 .playground-button:focus-visible {
   outline: 2px solid #3333ff;
   outline-offset: 2px;


### PR DESCRIPTION
## Summary

- show the Format shortcut directly in the playground button with subdued text
- display `Cmd + S` on macOS/iOS and `Ctrl + S` on other platforms
- reuse the existing platform detector and keep the tooltip and `aria-keyshortcuts` in sync

## Verification

- `BASE_URL=/tombi pnpm --dir docs build`
- `pnpm --dir docs typecheck`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs format:check`
- `git diff --check`
