### PR TITLE
fix(deps): update DOMPurify to 3.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "binary-install>axios": "0.31.1",
       "binary-install>tar": "7.5.21",
       "brace-expansion": "5.0.9",
+      "dompurify": "3.4.13",
       "esbuild": "0.28.1",
       "fast-uri": "3.1.5",
       "form-data": "4.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   binary-install>axios: 0.31.1
   binary-install>tar: 7.5.21
   brace-expansion: 5.0.9
+  dompurify: 3.4.13
   esbuild: 0.28.1
   fast-uri: 3.1.5
   form-data: 4.0.6
@@ -2272,8 +2273,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7038,7 +7039,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.8:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8420,7 +8421,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.13
       marked: 14.0.0
 
   mrmime@2.0.1: {}


### PR DESCRIPTION
## Summary

- override transitive `dompurify` to `3.4.13`
- refresh `pnpm-lock.yaml`
- fix the four vulnerabilities reported by OSV Scanner run 31449192803

`monaco-editor@0.56.0` pins `dompurify@3.4.8`, and no newer Monaco release is available. Dependabot security updates are enabled, but the alerts are for this transitive lockfile dependency; Dependabot cannot produce an update without changing the parent constraint and does not add a repository-level override automatically.

## Verification

- `cargo fmt --all -- --check`
- `pnpm install --frozen-lockfile`
- `pnpm -C docs typecheck`
- `pnpm -C docs format:check`
- `pnpm -C docs lint:check`
- `BASE_URL=/tombi pnpm -C docs build`
- OSV Scanner v2.3.8 against the updated lockfile: 0 vulnerabilities, exit 0
- `git diff --check`

Fixes https://github.com/tombi-toml/tombi/actions/runs/31449192803