### PR TITLE
chore(deps): enforce five-day release age

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
-    "pnpm": ">=9.12.2"
+    "pnpm": ">=11.20.0"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
@@ -17,36 +17,5 @@
     "@biomejs/biome": "^2.3.8",
     "@types/node": "^24.10.1",
     "typescript": "^5.9.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "@azure/msal-node": "5.2.2",
-      "@babel/core": "7.29.6",
-      "@vinxi/plugin-mdx>esbuild": "0.28.1",
-      "binary-install>axios": "0.31.1",
-      "binary-install>tar": "7.5.21",
-      "brace-expansion": "5.0.9",
-      "dompurify": "3.4.13",
-      "esbuild": "0.28.1",
-      "fast-uri": "3.1.5",
-      "form-data": "4.0.6",
-      "h3": "1.15.11",
-      "js-yaml": "4.3.1",
-      "linkify-it": "5.0.2",
-      "markdown-it": "14.2.0",
-      "minimatch": "10.2.5",
-      "nitropack": "2.13.4",
-      "postcss": "8.5.23",
-      "qs": "6.15.2",
-      "seroval": "1.5.3",
-      "tar": "7.5.21",
-      "tmp": "0.2.7",
-      "undici": "7.29.0",
-      "vitest>vite": "^7.3.5",
-      "ws": "8.21.0"
-    },
-    "patchedDependencies": {
-      "serve-handler@6.1.7": "patches/serve-handler@6.1.7.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,40 @@ packages:
   - "editors/vscode"
   - "rust/tombi-wasm"
   - "typescript/@tombi-toml/*"
-minimumReleaseAge: 2880
+overrides:
+  "@azure/msal-node": 5.2.2
+  "@babel/core": 7.29.6
+  "@vinxi/plugin-mdx>esbuild": 0.28.1
+  "binary-install>axios": 0.31.1
+  "binary-install>tar": 7.5.21
+  brace-expansion: 5.0.9
+  dompurify: 3.4.13
+  esbuild: 0.28.1
+  fast-uri: 3.1.5
+  form-data: 4.0.6
+  h3: 1.15.11
+  js-yaml: 4.3.1
+  linkify-it: 5.0.2
+  markdown-it: 14.2.0
+  minimatch: 10.2.5
+  nitropack: 2.13.4
+  postcss: 8.5.23
+  qs: 6.15.2
+  seroval: 1.5.3
+  tar: 7.5.21
+  tmp: 0.2.7
+  undici: 7.29.0
+  "vitest>vite": ^7.3.5
+  ws: 8.21.0
+patchedDependencies:
+  "serve-handler@6.1.7": patches/serve-handler@6.1.7.patch
+minimumReleaseAge: 7200
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+trustLockfile: false
+allowBuilds:
+  "@parcel/watcher": false
+  "@vscode/vsce-sign": false
+  esbuild: false
+  keytar: false
+  wasm-pack: false


### PR DESCRIPTION
## Summary

- upgrade pnpm to 11.20.0 so the release-age policy is actually enforced
- quarantine direct and transitive npm packages for five days, including versions without publication timestamps
- migrate overrides and patched dependencies to pnpm-workspace.yaml and explicitly deny dependency lifecycle builds

## Why

The repository pinned pnpm 10.12.1, which predates minimumReleaseAge support. As a result, the existing two-day setting was silently ignored. This change uses a mature pnpm release and enables strict lockfile revalidation so an existing lockfile cannot bypass the policy.

OSV Scanner detects known vulnerabilities, but it neither selects dependency versions nor opens remediation PRs. Dependabot remains responsible for update PRs; this policy adds a five-day quarantine before newly published npm packages can be installed.

## Verification

- CI=true pnpm install --frozen-lockfile
- cargo fmt --all -- --check
- pnpm exec biome check package.json
- parsed pnpm-workspace.yaml with Ruby YAML
- git diff --check
- pnpm -C docs typecheck
- pnpm -C docs format:check
- pnpm -C docs lint:check
- BASE_URL=/tombi pnpm -C docs build
- pnpm -C editors/vscode typecheck
- pnpm -C editors/vscode format:check
- pnpm -C editors/vscode lint:check
- pnpm -C editors/vscode test
- pnpm -C editors/vscode build
- pnpm --dir rust/tombi-wasm build:docs
- OSV Scanner v2.3.8: no vulnerabilities
- confirmed pnpm@11.21.0 is rejected as too new by the five-day policy
- confirmed the serve-handler patch is still applied