### PR TITLE
fix(docs): remove diagnostic card accent border

### DIFF
--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -232,7 +232,6 @@
 .playground-diagnostics > button {
   width: 100%;
   border: 1px solid #fecaca;
-  border-left: 3px solid #ef4444;
   border-radius: 0.55rem;
   padding: 0.75rem 0.85rem;
   background: #fff7f7;
@@ -250,7 +249,6 @@
 
 .playground-diagnostics > button[data-level="warning"] {
   border-color: #fed7aa;
-  border-left-color: #f97316;
   background: #fffaf5;
 }
 
@@ -340,7 +338,6 @@
 
 :root.dark .playground-diagnostics > button {
   border-color: #633b43;
-  border-left-color: #f97066;
   background: rgb(240 68 56 / 6%);
 }
 
@@ -351,7 +348,6 @@
 
 :root.dark .playground-diagnostics > button[data-level="warning"] {
   border-color: #694d2c;
-  border-left-color: #fdb022;
   background: rgb(247 144 9 / 6%);
 }
 


### PR DESCRIPTION
## Summary

- remove the thick left accent border from playground diagnostic cards
- keep a uniform border in error, warning, and dark-mode variants

## Verification

- `pnpm --dir docs typecheck`
- `pnpm --dir docs lint:check`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`