### PR TITLE
docs: remove TOML v1.1 preview from playground

### DIFF
--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -437,7 +437,6 @@ export default function Playground() {
               >
                 <option value="v1.1.0">TOML v1.1.0</option>
                 <option value="v1.0.0">TOML v1.0.0</option>
-                <option value="v1.1.0-preview">TOML v1.1 preview</option>
               </select>
             </label>
 


### PR DESCRIPTION
## Summary

- remove the obsolete TOML v1.1 preview option from the docs playground
- keep the released TOML v1.1.0 and TOML v1.0.0 options

## Validation

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`