### PR TITLE
fix(docs): use pointer cursor for header logo

### DIFF
--- a/docs/src/components/header/HeaderLogo.tsx
+++ b/docs/src/components/header/HeaderLogo.tsx
@@ -64,7 +64,7 @@ export function HeaderLogo() {
             <A
               id={props.id}
               href="/"
-              class={`${props.linkClass} outline-none items-center no-underline transition-all duration-300 ease-in-out focus-visible:ring-2 focus-visible:ring-tombi-focus focus:rounded-lg relative cursor-pointer md:cursor-default`}
+              class={`${props.linkClass} outline-none items-center no-underline transition-all duration-300 ease-in-out focus-visible:ring-2 focus-visible:ring-tombi-focus focus:rounded-lg relative cursor-pointer`}
               onClick={(e) => handleLogoClick(e, props)}
               onKeyDown={(e) => handleLogoKeyDown(e, props)}
             >


### PR DESCRIPTION
## Summary

- keep the pointer cursor over the header logo at desktop widths
- remove the responsive class that reset the linked logo to the default cursor

## Validation

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`