### PR TITLE
fix(docs): use pointer cursor for header buttons

### DIFF
--- a/docs/src/components/button/IconButton.tsx
+++ b/docs/src/components/button/IconButton.tsx
@@ -12,7 +12,7 @@ interface IconButtonProps {
 
 export const IconButton: ParentComponent<IconButtonProps> = (props) => {
   const baseClasses =
-    "text-white hover:text-white/80 transition-colors bg-transparent border-0 p-2 btn-focus";
+    "text-white hover:text-white/80 transition-colors bg-transparent border-0 p-2 btn-focus cursor-pointer";
 
   return (
     <button

--- a/docs/src/components/header/HeaderDropdownItem.tsx
+++ b/docs/src/components/header/HeaderDropdownItem.tsx
@@ -74,7 +74,7 @@ export function HeaderDropdownItem(
           <button
             type="button"
             onClick={toggleOpen}
-            class="w-8 h-16 p-x-8 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/10 bg-transparent border-none rounded"
+            class="w-8 h-16 p-x-8 flex items-center justify-center text-white/60 hover:text-white hover:bg-white/10 bg-transparent border-none rounded cursor-pointer"
             aria-expanded={isExpanded()}
             aria-label={isExpanded() ? "Collapse section" : "Expand section"}
             tabindex={props.isExpanded ? 0 : -1}


### PR DESCRIPTION
## Summary

- show a pointer cursor for header icon buttons, including mobile search
- show the same pointer cursor for mobile navigation expand/collapse buttons

## Testing

- `cargo fmt --all --check`
- `pnpm exec biome format docs/src/components/button/IconButton.tsx docs/src/components/header/HeaderDropdownItem.tsx`
- `pnpm exec biome lint docs/src/components/button/IconButton.tsx docs/src/components/header/HeaderDropdownItem.tsx`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`