### PR TITLE
fix(docs): enable playground hover and completion

### DIFF
--- a/docs/src/global.d.ts
+++ b/docs/src/global.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="@solidjs/start/env" />
+
+declare module "monaco-editor/editor/contrib/hover/browser/hoverContribution";
+declare module "monaco-editor/editor/contrib/suggest/browser/suggestController";

--- a/docs/src/utils/monaco-editor.ts
+++ b/docs/src/utils/monaco-editor.ts
@@ -21,6 +21,11 @@ export function loadMonacoEditor(): Promise<Monaco> {
       getWorker: () => new EditorWorker(),
     };
 
+    await Promise.all([
+      import("monaco-editor/editor/contrib/hover/browser/hoverContribution"),
+      import("monaco-editor/editor/contrib/suggest/browser/suggestController"),
+    ]);
+
     const monaco = await import("monaco-editor/editor");
 
     if (!tomlRegistered) {

--- a/rust/tombi-wasm/tests/lsp-smoke.mjs
+++ b/rust/tombi-wasm/tests/lsp-smoke.mjs
@@ -390,7 +390,7 @@ input.push(
     id: 6,
     method: "textDocument/hover",
     params: {
-      position: { line: 0, character: 2 },
+      position: { line: 2, character: 5 },
       textDocument: { uri: "file:///workspace/tombi.toml" },
     },
   }),


### PR DESCRIPTION
## Summary

- load the Monaco hover contribution used to render LSP hover results
- load the Monaco suggest controller used to display completion candidates
- exercise hover on the default `format.rules` table in the WASM LSP smoke test

## Verification

- `pnpm -C docs typecheck`
- `pnpm -C docs format:check`
- `pnpm -C docs lint:check`
- `pnpm --dir rust/tombi-wasm build:lsp`
- `pnpm --dir rust/tombi-wasm test:lsp`
- `BASE_URL=/tombi pnpm -C docs build`