### PR TITLE
fix(docs): align icon and label order

### DIFF
--- a/docs/src/routes/index.tsx
+++ b/docs/src/routes/index.tsx
@@ -116,8 +116,8 @@ export default function Home() {
             class="text-xl group"
           >
             <div class="flex items-center gap-2">
-              Get Started{" "}
               <FaSolidFeather class="w-5 h-5 group-hover:animate-shake" />
+              Get Started
             </div>
           </LinkButton>
           <LinkButton
@@ -126,7 +126,8 @@ export default function Home() {
             class="text-xl"
           >
             <div class="flex items-center gap-2">
-              Go to GitHub <TbBrandGithubFilled class="w-6 h-6" />
+              <TbBrandGithubFilled class="w-6 h-6" />
+              Go to GitHub
             </div>
           </LinkButton>
         </div>


### PR DESCRIPTION
## Summary

- place the icon before the label in the home page Get Started button
- place the icon before the label in the home page Go to GitHub button
- align these buttons with the Playground icon-label order

## Validation

- pnpm --dir docs format:check
- pnpm --dir docs lint:check
- pnpm --dir docs typecheck
- cargo fmt --all -- --check
- BASE_URL=/tombi pnpm --dir docs build
- git diff --check