### PR TITLE
fix(formatter): preserve inline table trailing commas

### DIFF
--- a/crates/tombi-ast-editor/src/rule/array_values_order/boolean.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/boolean.rs
@@ -51,11 +51,10 @@ pub async fn create_boolean_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/integer.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/integer.rs
@@ -53,11 +53,10 @@ pub async fn create_integer_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/local_date.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/local_date.rs
@@ -48,11 +48,10 @@ pub async fn create_local_date_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/local_date_time.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/local_date_time.rs
@@ -48,11 +48,10 @@ pub async fn create_local_date_time_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/local_time.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/local_time.rs
@@ -48,11 +48,10 @@ pub async fn create_local_time_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/offset_date_time.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/offset_date_time.rs
@@ -48,11 +48,10 @@ pub async fn create_offset_date_time_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-ast-editor/src/rule/array_values_order/string.rs
+++ b/crates/tombi-ast-editor/src/rule/array_values_order/string.rs
@@ -53,11 +53,10 @@ pub async fn create_string_sortable_values<'a>(
                         continue;
                     };
 
-                    for (key_value, comma) in group.key_values_with_comma() {
+                    for key_value in group.key_values() {
                         let Some(keys) = key_value.keys() else {
                             continue;
                         };
-                        let comma = comma.unwrap_or(tombi_ast::Comma::cast(make_comma()).unwrap());
 
                         let mut keys_iter = keys.keys();
                         if let (Some(key), None) = (keys_iter.next(), keys_iter.next()) {

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -250,6 +250,66 @@ mod table_keys_order {
 
         test_format! {
             #[tokio::test]
+            async fn test_dependency_groups_singleline_include_group_v1_1_0(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+                [dependency-groups]
+                dev = [
+                  "maturin>=1.5,<2.0",
+                  "pytest>=9.0.3",
+                  "ruff>=0.7.4",
+                  { include-group = "stub" },
+                ]
+                "#,
+                SchemaPath(pyproject_schema_path()),
+            ) -> Ok(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+
+                [dependency-groups]
+                dev = [
+                  "maturin>=1.5,<2.0",
+                  "pytest>=9.0.3",
+                  "ruff>=0.7.4",
+                  { include-group = "stub" },
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
+            async fn test_dependency_groups_multiline_include_group_v1_1_0(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+                [dependency-groups]
+                dev = [
+                  "maturin>=1.5,<2.0",
+                  "pytest>=9.0.3",
+                  "ruff>=0.7.4",
+                  { include-group = "stub", },
+                ]
+                "#,
+                SchemaPath(pyproject_schema_path()),
+            ) -> Ok(
+                r#"
+                #:tombi toml-version = "v1.1.0"
+
+                [dependency-groups]
+                dev = [
+                  "maturin>=1.5,<2.0",
+                  "pytest>=9.0.3",
+                  "ruff>=0.7.4",
+                  {
+                    include-group = "stub",
+                  },
+                ]
+                "#
+            )
+        }
+
+        test_format! {
+            #[tokio::test]
             async fn test_dependency_groups_multiple_lines_include_group_with_comment_directive_array_values_order_ascending(
                 r#"
                 [dependency-groups]


### PR DESCRIPTION
## Summary

- preserve the outer array delimiter when array values are reordered
- stop using inline-table key/value commas as array delimiters
- add TOML 1.1 pyproject regression coverage for inline tables both with and without an inner trailing comma

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `cargo shear`
- `cargo build --workspace --verbose --locked`
