### PR TITLE
fix(ci): repair versioned release builds

### DIFF
--- a/rust/tombi-wasm/Cargo.toml
+++ b/rust/tombi-wasm/Cargo.toml
@@ -10,6 +10,9 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory"]
+
 [dependencies]
 console_error_panic_hook.workspace = true
 futures = { workspace = true, optional = true }

--- a/xtask/src/command/set_version.rs
+++ b/xtask/src/command/set_version.rs
@@ -89,7 +89,13 @@ fn set_package_json_versions(sh: &Shell, version: &str) -> anyhow::Result<()> {
             let package_json = path.join("package.json");
             if package_json.exists() {
                 let mut patch = Patch::new(sh, &package_json)?;
-                patch.replace(&format!(r#""{DEV_VERSION}""#), &format!(r#""{version}""#));
+                // The npm publish preparation derives optional dependency versions from the
+                // root package version. Replacing every occurrence here would make the
+                // workspace manifest disagree with pnpm-lock.yaml before `pnpm run`/`exec`.
+                patch.replace(
+                    &format!(r#""version": "{DEV_VERSION}""#),
+                    &format!(r#""version": "{version}""#),
+                );
                 patch.commit(sh)?;
             }
         }


### PR DESCRIPTION
## Summary

- keep npm package manifests consistent with the frozen pnpm lockfile during versioned CLI and WASM builds
- enable bulk-memory support when wasm-pack optimizes release artifacts
- preserve the existing npm publish step that assigns the release version to all platform dependencies

## Root cause

pnpm 11 verifies dependency state before pnpm run and pnpm exec. The version task replaced every development-version occurrence, including optional dependency ranges, so the manifest no longer matched pnpm-lock.yaml. The new WASM release job also reached a wasm-opt validation failure because bulk-memory instructions were not enabled.

## Validation

- cargo fmt --all -- --check
- cargo test -p xtask
- tagged set-version integration check for v1.3.0
- pnpm install --lockfile-only --frozen-lockfile --ignore-scripts after version stamping
- npm package generation check confirming all optional CLI dependencies become 1.3.0
- pnpm --dir rust/tombi-wasm build
- pnpm --dir rust/tombi-wasm test
- git diff --check