### PR TITLE
Add WebAssembly documentation

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,6 +36,7 @@ jobs:
             extensions/**
             rust/serde_tombi/**
             rust/tombi-wasm/**
+            typescript/@tombi-toml/wasm-lib/**
             typescript/@tombi-toml/wasm-lsp/**
             .github/actions/relevant-changes/**
             .node-version

--- a/docs/doc-index.json
+++ b/docs/doc-index.json
@@ -118,6 +118,23 @@
     ]
   },
   {
+    "title": "WebAssembly",
+    "description": "Run Tombi's formatter, linter, and Language Server in JavaScript and browsers.",
+    "path": "/docs/wasm",
+    "children": [
+      {
+        "title": "Formatter and Linter",
+        "description": "Use the tombi-wasm-lib package for formatting and linting.",
+        "path": "/docs/wasm/tombi-wasm-lib"
+      },
+      {
+        "title": "Language Server",
+        "description": "Use the tombi-wasm-lsp package and its Web Worker adapter.",
+        "path": "/docs/wasm/tombi-wasm-lsp"
+      }
+    ]
+  },
+  {
     "title": "Editors",
     "description": "Use Tombi in your favorite editor with official extensions.",
     "path": "/docs/editors",

--- a/docs/src/routes/docs/wasm/index.mdx
+++ b/docs/src/routes/docs/wasm/index.mdx
@@ -1,0 +1,21 @@
+# WebAssembly
+
+Tombi's WebAssembly support is published as two npm packages. They are separated so
+an application only downloads the runtime it needs:
+
+| Package | Contents |
+| --- | --- |
+| [`tombi-wasm-lib`](/docs/wasm/tombi-wasm-lib) | Formatter and linter |
+| [`tombi-wasm-lsp`](/docs/wasm/tombi-wasm-lsp) | Language Server |
+
+Install only the package required by your application:
+
+```sh
+pnpm add tombi-wasm-lib
+pnpm add tombi-wasm-lsp
+```
+
+The two packages are built from the shared `tombi-wasm` Rust crate. The `lib` and
+`lsp` features produce independent WASM artifacts.
+
+<a href="/playground" class="inline-block px-4 py-2 rounded bg-[--color-primary] text-white no-underline hover:opacity-90">Try the WASM Playground</a>

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -1,0 +1,60 @@
+# `tombi-wasm-lib`
+
+`tombi-wasm-lib` provides Tombi's formatter and linter for browsers and other
+JavaScript environments.
+
+## Install
+
+```sh
+pnpm add tombi-wasm-lib
+```
+
+## Use the formatter and linter
+
+Initialize the WASM module before calling `format` or `lint`:
+
+```ts
+import init, { format, lint } from "tombi-wasm-lib";
+
+await init();
+
+const source = '[package]\nname="example"\n';
+const formatted = await format(source, "Cargo.toml");
+
+try {
+  const diagnostics = await lint(formatted, "Cargo.toml");
+
+  if (!diagnostics) {
+    console.log("No diagnostics");
+  } else {
+    console.error(diagnostics);
+  }
+} catch (error) {
+  // Configuration and execution errors are rejected.
+  console.error(error);
+}
+```
+
+Both functions return a Promise. The optional file path selects matching
+configuration and formatter/linter options. The optional third argument selects the
+TOML version. It uses the same `v1.x.x` notation as `toml-version` in `tombi.toml`:
+
+```ts
+await format(source, "Cargo.toml", "v1.1.0");
+await lint(source, "Cargo.toml", "v1.0.0");
+```
+
+If omitted, Tombi uses `toml-version` from the matching `tombi.toml`; when it is
+not configured, the default is `v1.0.0`. An explicitly passed third argument takes
+precedence. The supported values are `v1.0.0`, `v1.1.0-preview`, and `v1.1.0`.
+
+The equivalent `tombi.toml` setting is:
+
+```toml
+toml-version = "v1.1.0"
+```
+
+`lint` resolves to `undefined` when there are no diagnostics, or to a `diagnostics`
+array when the TOML contains problems. Configuration and execution errors reject the
+Promise. `format` rejects when formatting diagnostics prevent it from producing a
+formatted result.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -70,21 +70,15 @@ try {
 `undefined` when there are no diagnostics. Configuration and execution errors reject
 the Promise.
 
-For both functions, the optional file path selects matching configuration and
-formatter/linter options. The optional third argument selects the TOML version. It
-uses the same `v1.x.x` notation as `toml-version` in `tombi.toml`:
+Both functions accept an optional file path for matching configuration and
+formatter/linter options, followed by an optional TOML version:
 
 ```ts
 await format(source, "Cargo.toml", "v1.1.0");
 await lint(source, "Cargo.toml", "v1.0.0");
 ```
 
-If omitted, Tombi uses `toml-version` from the matching `tombi.toml`; when it is
-not configured, the default is `v1.0.0`. An explicitly passed third argument takes
-precedence. The supported values are `v1.0.0`, `v1.1.0-preview`, and `v1.1.0`.
-
-The equivalent `tombi.toml` setting is:
-
-```toml
-toml-version = "v1.1.0"
-```
+The version uses the same notation as `toml-version` in `tombi.toml`. If omitted,
+Tombi uses the matching configuration value, or `v1.0.0` when it is not configured.
+An explicitly passed version takes precedence. Supported values are `v1.0.0`,
+`v1.1.0-preview`, and `v1.1.0`.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -78,7 +78,6 @@ await format(source, "Cargo.toml", "v1.1.0");
 await lint(source, "Cargo.toml", "v1.0.0");
 ```
 
-The version uses the same notation as `toml-version` in `tombi.toml`. If omitted,
-Tombi uses the matching configuration value, or `v1.0.0` when it is not configured.
-An explicitly passed version takes precedence. Supported values are `v1.0.0`,
-`v1.1.0-preview`, and `v1.1.0`.
+If the TOML version is not specified, Tombi reads it from the matching
+`tombi.toml`. If it is not configured there either, Tombi uses the default
+version `v1.0.0`.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -48,18 +48,11 @@ const source = `
 name = "example"
 `;
 
-type Diagnostic = {
-  message: string;
-  range: {
-    start: { line: number; column: number };
-  };
-};
-
 try {
   const diagnostics = await lint(source, "Cargo.toml");
 
   if (diagnostics) {
-    for (const diagnostic of diagnostics as Diagnostic[]) {
+    for (const diagnostic of diagnostics) {
       console.error(
         `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`,
       );

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -18,7 +18,8 @@ import init, { format } from "tombi-wasm-lib";
 
 await init();
 
-const source = `[package]
+const source = `
+[package]
 name = "example"
 `;
 
@@ -42,7 +43,8 @@ import init, { lint } from "tombi-wasm-lib";
 
 await init();
 
-const source = `[package]
+const source = `
+[package]
 name = "example"
 `;
 

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -9,35 +9,58 @@ JavaScript environments.
 pnpm add tombi-wasm-lib
 ```
 
-## Use the formatter and linter
+## Format TOML
 
-Initialize the WASM module before calling `format` or `lint`:
+Initialize the WASM module before calling `format`:
 
 ```ts
-import init, { format, lint } from "tombi-wasm-lib";
+import init, { format } from "tombi-wasm-lib";
 
 await init();
 
-const source = '[package]\nname="example"\n';
-const formatted = await format(source, "Cargo.toml");
+const source = `[package]
+name = "example"
+`;
 
 try {
-  const diagnostics = await lint(formatted, "Cargo.toml");
-
-  if (!diagnostics) {
-    console.log("No diagnostics");
-  } else {
-    console.error(diagnostics);
-  }
-} catch (error) {
-  // Configuration and execution errors are rejected.
+  const formatted = await format(source, "Cargo.toml");
+  console.log(formatted);
+} catch (error: unknown) {
   console.error(error);
 }
 ```
 
-Both functions return a Promise. The optional file path selects matching
-configuration and formatter/linter options. The optional third argument selects the
-TOML version. It uses the same `v1.x.x` notation as `toml-version` in `tombi.toml`:
+`format` returns the formatted TOML as a Promise. Configuration errors and
+formatting diagnostics reject the Promise.
+
+## Lint TOML
+
+Initialize the WASM module before calling `lint`:
+
+```ts
+import init, { lint } from "tombi-wasm-lib";
+
+await init();
+
+const source = `[package]
+name = "example"
+`;
+
+try {
+  await lint(source, "Cargo.toml");
+  console.log("No diagnostics");
+} catch (error: unknown) {
+  console.error(error);
+}
+```
+
+`lint` resolves to `undefined` when there are no diagnostics. When the TOML contains
+problems, the diagnostics array is provided as the Promise rejection value.
+Configuration errors also reject the Promise.
+
+For both functions, the optional file path selects matching configuration and
+formatter/linter options. The optional third argument selects the TOML version. It
+uses the same `v1.x.x` notation as `toml-version` in `tombi.toml`:
 
 ```ts
 await format(source, "Cargo.toml", "v1.1.0");
@@ -53,8 +76,3 @@ The equivalent `tombi.toml` setting is:
 ```toml
 toml-version = "v1.1.0"
 ```
-
-`lint` resolves to `undefined` when there are no diagnostics, or to a `diagnostics`
-array when the TOML contains problems. Configuration and execution errors reject the
-Promise. `format` rejects when formatting diagnostics prevent it from producing a
-formatted result.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -49,16 +49,22 @@ name = "example"
 `;
 
 try {
-  await lint(source, "Cargo.toml");
-  console.log("No diagnostics");
+  const diagnostics = await lint(source, "Cargo.toml");
+
+  if (diagnostics) {
+    console.error(diagnostics);
+  } else {
+    console.log("No diagnostics");
+  }
 } catch (error: unknown) {
+  // Configuration and execution errors reject the Promise.
   console.error(error);
 }
 ```
 
-`lint` resolves to `undefined` when there are no diagnostics. When the TOML contains
-problems, the diagnostics array is provided as the Promise rejection value.
-Configuration errors also reject the Promise.
+`lint` resolves to a diagnostics array when the TOML contains problems, or to
+`undefined` when there are no diagnostics. Configuration and execution errors reject
+the Promise.
 
 For both functions, the optional file path selects matching configuration and
 formatter/linter options. The optional third argument selects the TOML version. It

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -48,11 +48,22 @@ const source = `
 name = "example"
 `;
 
+type Diagnostic = {
+  message: string;
+  range: {
+    start: { line: number; column: number };
+  };
+};
+
 try {
   const diagnostics = await lint(source, "Cargo.toml");
 
   if (diagnostics) {
-    console.error(diagnostics);
+    for (const diagnostic of diagnostics as Diagnostic[]) {
+      console.error(
+        `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`,
+      );
+    }
   } else {
     console.log("No diagnostics");
   }

--- a/docs/src/routes/docs/wasm/tombi-wasm-lsp.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lsp.mdx
@@ -1,0 +1,81 @@
+# `tombi-wasm-lsp`
+
+`tombi-wasm-lsp` provides Tombi's Language Server for browsers and other JavaScript
+environments. It also includes a Web Worker adapter at
+`tombi-wasm-lsp/worker`.
+
+## Install
+
+```sh
+pnpm add tombi-wasm-lsp
+```
+
+## Run the Language Server
+
+The package exposes `serve` for hosts that provide browser-compatible streams.
+`ServerConfig` receives an async iterator of `Uint8Array` input chunks and a
+`WritableStream` for output:
+
+```ts
+import init, { ServerConfig, serve } from "tombi-wasm-lsp";
+
+await init();
+
+const input = new ReadableStream<Uint8Array>({
+  start(controller) {
+    // Enqueue LSP-framed messages here.
+  },
+});
+const output = new WritableStream<Uint8Array>({
+  write(chunk) {
+    // Read LSP-framed responses here.
+    console.log(chunk);
+  },
+});
+
+await serve(new ServerConfig(input.values(), output));
+```
+
+Messages use standard LSP JSON-RPC framing (`Content-Length` followed by a JSON
+message). Browser hosts should represent the virtual workspace with
+`textDocument/didOpen`, synchronize edits with `textDocument/didChange`, and send
+`textDocument/didSave` when appropriate.
+
+Before starting a server, preload files that are not opened in the editor with
+`set_workspace_entries`:
+
+```ts
+import { set_workspace_entries } from "tombi-wasm-lsp";
+
+set_workspace_entries([
+  {
+    uri: "file:///workspace/tombi.toml",
+    text: "[format]\nnewline = \"lf\"\n",
+  },
+]);
+```
+
+Use `kind: "directory"` for directory entries; file entries default to
+`kind: "file"`.
+
+## Run in a Web Worker
+
+For a browser editor, run the Language Server in a Web Worker so parsing and
+diagnostics do not block the UI thread:
+
+```ts
+const worker = new Worker(
+  new URL("tombi-wasm-lsp/worker", import.meta.url),
+  { type: "module" },
+);
+
+worker.addEventListener("message", (event) => {
+  if (event.data.type === "ready") {
+    // Send LSP JSON-RPC messages with worker.postMessage(...).
+  }
+});
+```
+
+The worker forwards messages through `postMessage` and emits `{ type: "ready" }`
+after the WASM module and Language Server have started. It accepts standard LSP
+JSON-RPC messages and mirrors opened `file:` documents into the in-memory workspace.


### PR DESCRIPTION
## Summary

- add a WebAssembly overview page
- document `tombi-wasm-lib` formatter/linter usage
- document `tombi-wasm-lsp` Language Server and Web Worker usage
- add the pages to the docs navigation and search index

## Validation

- `pnpm -C docs run generate-search-index`
- `pnpm -C docs run typecheck`
- Biome checks for docs metadata and MDX files