### PR TITLE
fix(formatter): disable line width limit when unspecified

### DIFF
--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -74,7 +74,8 @@ pub(crate) fn exceeds_line_width(
             .count();
     }
 
-    Ok(length > f.line_width() as usize)
+    Ok(f.line_width()
+        .is_some_and(|line_width| length > line_width as usize))
 }
 
 fn format_multiline_array(

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -81,7 +81,8 @@ pub(crate) fn exceeds_line_width(
             .count();
     }
 
-    Ok(length > f.line_width() as usize)
+    Ok(f.line_width()
+        .is_some_and(|line_width| length > line_width as usize))
 }
 
 fn format_multiline_inline_table(
@@ -473,6 +474,14 @@ mod tests {
               ] },
             ] }
             "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_with_long_array_without_line_width(
+            r#"hello = { a = 1, b = "very long string", c = -10, d = 2025-02-01, version = ["asdfgnfdsdfghgfdsxcvbvcxcvb"] }"#,
             TomlVersion::V1_0_0
         ) -> Ok(source)
     }

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -228,7 +228,7 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
-    pub(crate) const fn line_width(&self) -> u8 {
+    pub(crate) const fn line_width(&self) -> Option<u8> {
         self.definitions.line_width
     }
 

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -9,7 +9,7 @@ use tombi_config::{DateTimeDelimiter, FormatOptions, IndentStyle, StringQuoteSty
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone)]
 pub struct FormatDefinitions {
-    pub line_width: u8,
+    pub line_width: Option<u8>,
     pub line_ending: tombi_config::LineEnding,
     pub group_blank_lines_limit: u8,
     pub table_blank_lines: u8,
@@ -37,8 +37,7 @@ impl FormatDefinitions {
                 .rules
                 .as_ref()
                 .and_then(|rules| rules.line_width)
-                .unwrap_or_default()
-                .value(),
+                .map(|line_width| line_width.value()),
             line_ending: options
                 .rules
                 .as_ref()

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -109,12 +109,7 @@ mod table_keys_order {
                 version = "1.0.0"
                 description = "Reserved package for tombi"
                 requires-python = ">=3.10"
-                dependencies = [
-                  "maturin>=1.5,<2.0",
-                  "tombi-cli>=0.0.0",
-                  "tombi-formatter>=0.0.0",
-                  "tombi-linter>=0.0.0"
-                ]
+                dependencies = ["maturin>=1.5,<2.0", "tombi-cli>=0.0.0", "tombi-formatter>=0.0.0", "tombi-linter>=0.0.0"]
                 "#
             )
         }

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -637,7 +637,7 @@ The maximum line width.
 The formatter will try to keep lines within this width.
 
 - Type: `Number`
-- Default: `80`
+- Default: no limit
 
 ### format.rules.string-quote-style
 

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -1140,14 +1140,7 @@ zzz = "1.0"
         let toml = to_string_async(&test)
             .await
             .expect("TOML serialization failed");
-        let expected = r#"
-dependencies = [
-  { name = "serde", version = "1" },
-  { name = "tokio", version = "1" }
-]
-"#
-        .strip_prefix("\n")
-        .unwrap();
+        let expected = r#"dependencies = [{ name = "serde", version = "1" }, { name = "tokio", version = "1" }]"#;
 
         toml_text_assert_eq!(toml, expected);
     }


### PR DESCRIPTION
## Summary

- Treat an omitted `format.rules.line-width` as unlimited.
- Preserve line wrapping when `line-width` is explicitly configured.
- Keep explicit multiline hints such as trailing commas unchanged.
- Update the formatter regression coverage and configuration documentation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p tombi-formatter`
