### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/ci_install_script.yml
+++ b/.github/workflows/ci_install_script.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_nix.yml
+++ b/.github/workflows/ci_nix.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   TOMBI_CACHE_HOME: ${{ github.workspace }}/.cache/tombi
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci_vscode_extensions.yml
+++ b/.github/workflows/ci_vscode_extensions.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -56,7 +60,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Check Biome schema version
         run: |
           node <<'NODE'

--- a/.github/workflows/ci_winget_manifest.yml
+++ b/.github/workflows/ci_winget_manifest.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   WINGETCREATE_VERSION: 1.12.8.0
 

--- a/.github/workflows/toml-test.yml
+++ b/.github/workflows/toml-test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- cancel superseded PR and main CI workflow runs with concurrency groups
- cover the PR-triggered WinGet manifest workflow as well
- enforce the existing pnpm lockfile in VS Code extension CI

## Validation
- `git diff --check`
- Ruby YAML parse for all `.github/workflows/*.yml`

This PR does not change release workflows or package versions.