### PR TITLE
feat(formatter): change the default line-width to unlimited

### DIFF
--- a/crates/tombi-config/src/format.rs
+++ b/crates/tombi-config/src/format.rs
@@ -242,8 +242,8 @@ pub struct FormatRules {
 
     /// # The maximum line width
     ///
-    /// The formatter will try to keep lines within this width.
-    #[cfg_attr(feature = "jsonschema", schemars(default = "LineWidth::default"))]
+    /// The formatter will try to keep lines within this width when specified.
+    /// If omitted, there is no line-width limit.
     pub line_width: Option<LineWidth>,
 
     /// # The number of blank lines between tables.

--- a/crates/tombi-formatter/src/format/value/array.rs
+++ b/crates/tombi-formatter/src/format/value/array.rs
@@ -74,7 +74,8 @@ pub(crate) fn exceeds_line_width(
             .count();
     }
 
-    Ok(length > f.line_width() as usize)
+    Ok(f.line_width()
+        .is_some_and(|line_width| length > line_width as usize))
 }
 
 fn format_multiline_array(

--- a/crates/tombi-formatter/src/format/value/inline_table.rs
+++ b/crates/tombi-formatter/src/format/value/inline_table.rs
@@ -81,7 +81,8 @@ pub(crate) fn exceeds_line_width(
             .count();
     }
 
-    Ok(length > f.line_width() as usize)
+    Ok(f.line_width()
+        .is_some_and(|line_width| length > line_width as usize))
 }
 
 fn format_multiline_inline_table(
@@ -473,6 +474,14 @@ mod tests {
               ] },
             ] }
             "#,
+            TomlVersion::V1_0_0
+        ) -> Ok(source)
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn inline_table_with_long_array_without_line_width(
+            r#"hello = { a = 1, b = "very long string", c = -10, d = 2025-02-01, version = ["asdfgnfdsdfghgfdsxcvbvcxcvb"] }"#,
             TomlVersion::V1_0_0
         ) -> Ok(source)
     }

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -228,7 +228,7 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
-    pub(crate) const fn line_width(&self) -> u8 {
+    pub(crate) const fn line_width(&self) -> Option<u8> {
         self.definitions.line_width
     }
 

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -9,7 +9,7 @@ use tombi_config::{DateTimeDelimiter, FormatOptions, IndentStyle, StringQuoteSty
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[derive(Debug, Default, Clone)]
 pub struct FormatDefinitions {
-    pub line_width: u8,
+    pub line_width: Option<u8>,
     pub line_ending: tombi_config::LineEnding,
     pub group_blank_lines_limit: u8,
     pub table_blank_lines: u8,
@@ -37,8 +37,7 @@ impl FormatDefinitions {
                 .rules
                 .as_ref()
                 .and_then(|rules| rules.line_width)
-                .unwrap_or_default()
-                .value(),
+                .map(|line_width| line_width.value()),
             line_ending: options
                 .rules
                 .as_ref()

--- a/crates/tombi-formatter/tests/test_x_tombi_order.rs
+++ b/crates/tombi-formatter/tests/test_x_tombi_order.rs
@@ -109,12 +109,7 @@ mod table_keys_order {
                 version = "1.0.0"
                 description = "Reserved package for tombi"
                 requires-python = ">=3.10"
-                dependencies = [
-                  "maturin>=1.5,<2.0",
-                  "tombi-cli>=0.0.0",
-                  "tombi-formatter>=0.0.0",
-                  "tombi-linter>=0.0.0"
-                ]
+                dependencies = ["maturin>=1.5,<2.0", "tombi-cli>=0.0.0", "tombi-formatter>=0.0.0", "tombi-linter>=0.0.0"]
                 "#
             )
         }

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -184,6 +184,7 @@ key-quote-style = "double"
 key-value-equals-sign-alignment = false
 key-value-equals-sign-space-width = 1
 line-ending = "lf"
+# Omit line-width for no line-width limit.
 line-width = 80
 string-quote-style = "double"
 table-blank-lines = 1
@@ -632,12 +633,13 @@ The type of line ending.
 
 ### format.rules.line-width
 
-The maximum line width.
+The maximum line width. If omitted, the formatter does not apply a line-width limit.
 
-The formatter will try to keep lines within this width.
+When specified, the formatter will try to keep lines within this width. Explicit multiline
+hints, such as a trailing comma, are still respected without a line-width setting.
 
 - Type: `Number`
-- Default: `80`
+- Default: no limit
 
 ### format.rules.string-quote-style
 

--- a/docs/src/routes/docs/formatter/magic-trailing-comma.mdx
+++ b/docs/src/routes/docs/formatter/magic-trailing-comma.mdx
@@ -20,7 +20,7 @@ items = [
 items = ["aaaa", "bbbb", "cccc"]
 ```
 
-If the line width is too wide, the array will be expanded to multiple lines, but the final element does not receive a trailing comma automatically.
+If `line-width` is configured and the array exceeds that width, the array will be expanded to multiple lines, but the final element does not receive a trailing comma automatically. When `line-width` is omitted, arrays are not expanded based on line width.
 
 ```toml
 # Before formatting

--- a/rust/serde_tombi/src/ser.rs
+++ b/rust/serde_tombi/src/ser.rs
@@ -1140,14 +1140,7 @@ zzz = "1.0"
         let toml = to_string_async(&test)
             .await
             .expect("TOML serialization failed");
-        let expected = r#"
-dependencies = [
-  { name = "serde", version = "1" },
-  { name = "tokio", version = "1" }
-]
-"#
-        .strip_prefix("\n")
-        .unwrap();
+        let expected = r#"dependencies = [{ name = "serde", version = "1" }, { name = "tokio", version = "1" }]"#;
 
         toml_text_assert_eq!(toml, expected);
     }

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -389,7 +389,7 @@
         },
         "line-width": {
           "title": "The maximum line width",
-          "description": "The formatter will try to keep lines within this width.",
+          "description": "The formatter will try to keep lines within this width when specified.\nIf omitted, there is no line-width limit.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineWidth"
@@ -397,8 +397,7 @@
             {
               "type": "null"
             }
-          ],
-          "default": 80
+          ]
         },
         "table-blank-lines": {
           "title": "The number of blank lines between tables.",


### PR DESCRIPTION
## Summary

Implement the TOML 1.0 formatting rule that inline tables must not contain newlines.

Closes #2099.

## Changes

- Treat an omitted `line-width` as having no width limit.
- Keep TOML 1.0 inline tables on a single line, including when they contain arrays.
- Preserve explicit multiline formatting hints such as trailing commas.
- Update formatter tests, serde expectations, documentation, and the generated JSON Schema.

## Validation

- `cargo xtask codegen jsonschema`
- `cargo test -p tombi-config`
- `cargo test -p tombi-formatter`
- `cargo test -p serde_tombi`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check