### PR TITLE
feat(wasm): export format and lint error types

### DIFF
--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -33,6 +33,8 @@ try {
 
 `format` returns the formatted TOML as a Promise. Configuration errors and
 formatting diagnostics reject the Promise.
+The package exports the corresponding `FormatError` type for handling these
+rejections.
 
 ## Lint TOML
 
@@ -68,7 +70,7 @@ try {
 
 `lint` resolves to a diagnostics array when the TOML contains problems, or to
 `undefined` when there are no diagnostics. Configuration and execution errors reject
-the Promise.
+the Promise; the corresponding rejection shape is exported as `LintError`.
 
 Both functions accept an optional file path for matching configuration and
 formatter/linter options, followed by an optional TOML version:

--- a/typescript/@tombi-toml/wasm-lib/package.json
+++ b/typescript/@tombi-toml/wasm-lib/package.json
@@ -8,12 +8,12 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/tombi_wasm.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/tombi_wasm.js"
     }
   },
   "scripts": {
-    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lib/dist --out-name tombi_wasm -- --no-default-features --features lib",
+    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lib/dist --out-name tombi_wasm -- --no-default-features --features lib && cp ../../typescript/@tombi-toml/wasm-lib/types.d.ts ../../typescript/@tombi-toml/wasm-lib/dist/index.d.ts",
     "test": "pnpm run build && node ../../../rust/tombi-wasm/tests/lib-smoke.mjs",
     "clean": "rm -rf dist"
   },

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -1,0 +1,30 @@
+export * from "./tombi_wasm";
+
+/** A diagnostic reported by Tombi. */
+export interface Diagnostic {
+  level: "ERROR" | "WARNING";
+  code: string;
+  message: string;
+  range: Range;
+  source_file: string | null;
+}
+
+/** A zero-based position in a TOML document. */
+export interface Position {
+  line: number;
+  column: number;
+}
+
+/** A range in a TOML document. */
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+/** An error reported when formatting fails. */
+export type FormatError = { error: string } | { diagnostics: Diagnostic[] };
+
+/** An error reported when linting cannot be executed. */
+export interface LintError {
+  error: string;
+}


### PR DESCRIPTION
## Summary

- Export `FormatError`, `LintError`, and diagnostic-related types from `@tombi-toml/wasm-lib`.
- Make the package build generate `dist/index.d.ts` as the public type entrypoint.
- Document the exported rejection types.

## Verification

- `cargo check -p tombi-wasm --target wasm32-unknown-unknown --features lib`
- `pnpm --filter @tombi-toml/wasm-lib build`
- `node rust/tombi-wasm/tests/lib-smoke.mjs`
- `pnpm exec biome check typescript/@tombi-toml/wasm-lib/package.json typescript/@tombi-toml/wasm-lib/types.d.ts`
- `cargo fmt --all -- --check`
