### PR TITLE
docs(wasm): add error type hints to examples

### DIFF
--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -14,7 +14,7 @@ pnpm add tombi-wasm-lib
 Initialize the WASM module before calling `format`:
 
 ```ts
-import init, { format } from "tombi-wasm-lib";
+import init, { format, type FormatError } from "tombi-wasm-lib";
 
 await init();
 
@@ -26,8 +26,8 @@ name = "example"
 try {
   const formatted = await format(source, "Cargo.toml");
   console.log(formatted);
-} catch (error: unknown) {
-  console.error(error);
+} catch (error) {
+  console.error(error as FormatError);
 }
 ```
 
@@ -41,7 +41,7 @@ rejections.
 Initialize the WASM module before calling `lint`:
 
 ```ts
-import init, { lint } from "tombi-wasm-lib";
+import init, { lint, type LintError } from "tombi-wasm-lib";
 
 await init();
 
@@ -62,9 +62,9 @@ try {
   } else {
     console.log("No diagnostics");
   }
-} catch (error: unknown) {
+} catch (error) {
   // Configuration and execution errors reject the Promise.
-  console.error(error);
+  console.error(error as LintError);
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add `FormatError` type hints to the `format` example
- Add `LintError` type hints to the `lint` example

## Test
- `pnpm typecheck` (in `docs`)
- `git diff --check