### PR TITLE
feat(wasm): return structured format and lint results

### DIFF
--- a/crates/tombi-diagnostic/src/level.rs
+++ b/crates/tombi-diagnostic/src/level.rs
@@ -1,6 +1,7 @@
 use nu_ansi_term::{Color, Style};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Level {
     ERROR,
     WARNING,

--- a/crates/tombi-diagnostic/src/lib.rs
+++ b/crates/tombi-diagnostic/src/lib.rs
@@ -8,23 +8,11 @@ pub use printer::Print;
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "wasm", derive(serde::Serialize))]
 pub struct Diagnostic {
-    #[cfg_attr(feature = "wasm", serde(serialize_with = "serialize_level"))]
     level: level::Level,
     code: String,
     message: String,
     range: tombi_text::Range,
     source_file: Option<std::path::PathBuf>,
-}
-
-#[cfg(feature = "wasm")]
-fn serialize_level<S>(level: &level::Level, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(match level {
-        level::Level::ERROR => "error",
-        level::Level::WARNING => "warning",
-    })
 }
 
 impl Diagnostic {

--- a/crates/tombi-diagnostic/src/lib.rs
+++ b/crates/tombi-diagnostic/src/lib.rs
@@ -8,11 +8,23 @@ pub use printer::Print;
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(feature = "wasm", derive(serde::Serialize))]
 pub struct Diagnostic {
+    #[cfg_attr(feature = "wasm", serde(serialize_with = "serialize_level"))]
     level: level::Level,
     code: String,
     message: String,
     range: tombi_text::Range,
     source_file: Option<std::path::PathBuf>,
+}
+
+#[cfg(feature = "wasm")]
+fn serialize_level<S>(level: &level::Level, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(match level {
+        level::Level::ERROR => "error",
+        level::Level::WARNING => "warning",
+    })
 }
 
 impl Diagnostic {

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -64,7 +64,7 @@ try {
     for (const diagnostic of diagnostics) {
       const message = `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`;
 
-      if (diagnostic.level === "ERROR") {
+      if (diagnostic.level === "error") {
         console.error(message);
       } else {
         console.warn(message);

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -85,7 +85,7 @@ automatically discovered `tombi.toml` configuration:
 
 ```ts
 const config = {
-  context: `
+  content: `
 toml-version = "v1.1.0"
 
 [format.rules]
@@ -97,13 +97,13 @@ indent-width = 4
 await format(source, "Cargo.toml", { config });
 await lint(source, "Cargo.toml", { config });
 
-// The configuration context can be passed as a string shorthand. Its path
+// The configuration content can be passed as a string shorthand. Its path
 // defaults to `tombi.toml` next to `sourcePath`.
-await format(source, "Cargo.toml", { config: config.context });
+await format(source, "Cargo.toml", { config: config.content });
 ```
 
 The `config` property is optional. When omitted, Tombi discovers `tombi.toml`
-as before. When an object is provided, `config.context` replaces the discovered
+as before. When an object is provided, `config.content` replaces the discovered
 configuration and `config.path` supplies the base path for relative schema paths
 and `[[overrides]]`. A string is shorthand for the configuration text, with a
 path of `tombi.toml` next to `sourcePath`. If the TOML version is not configured,

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -14,7 +14,7 @@ pnpm add tombi-wasm-lib
 Initialize the WASM module before calling `format`:
 
 ```ts
-import init, { format, type FormatError } from "tombi-wasm-lib";
+import init, { format, type TombiWasmError } from "tombi-wasm-lib";
 
 await init();
 
@@ -24,24 +24,31 @@ name = "example"
 `;
 
 try {
-  const formatted = await format(source, "Cargo.toml");
-  console.log(formatted);
+  const { formatted, diagnostics } = await format(source, "Cargo.toml");
+
+  if (formatted !== undefined) {
+    console.log(formatted);
+  } else {
+    for (const diagnostic of diagnostics) {
+      console.error(diagnostic.message);
+    }
+  }
 } catch (error) {
-  console.error(error as FormatError);
+  console.error(error as TombiWasmError);
 }
 ```
 
-`format` returns the formatted TOML as a Promise. Configuration errors and
-formatting diagnostics reject the Promise.
-The package exports the corresponding `FormatError` type for handling these
-rejections.
+`format` resolves to an object containing the formatted TOML and diagnostics.
+On success, the result contains `formatted`. When document diagnostics prevent
+formatting, the result instead contains `diagnostics`. Configuration and execution
+errors reject the Promise as `TombiWasmError`.
 
 ## Lint TOML
 
 Initialize the WASM module before calling `lint`:
 
 ```ts
-import init, { lint, type LintError } from "tombi-wasm-lib";
+import init, { lint, type TombiWasmError } from "tombi-wasm-lib";
 
 await init();
 
@@ -51,7 +58,7 @@ name = "example"
 `;
 
 try {
-  const diagnostics = await lint(source, "Cargo.toml");
+  const { diagnostics } = await lint(source, "Cargo.toml");
 
   if (diagnostics) {
     for (const diagnostic of diagnostics) {
@@ -64,22 +71,40 @@ try {
   }
 } catch (error) {
   // Configuration and execution errors reject the Promise.
-  console.error(error as LintError);
+  console.error(error as TombiWasmError);
 }
 ```
 
-`lint` resolves to a diagnostics array when the TOML contains problems, or to
-`undefined` when there are no diagnostics. Configuration and execution errors reject
-the Promise; the corresponding rejection shape is exported as `LintError`.
+`lint` resolves to an object whose optional `diagnostics` property is present when
+diagnostics were reported. Configuration and execution errors reject the Promise
+as `TombiWasmError`.
 
-Both functions accept an optional file path for matching configuration and
-formatter/linter options, followed by an optional TOML version:
+Both functions accept a source path for matching `[[overrides]]`, followed by
+an optional options object. Pass `config` to replace the
+automatically discovered `tombi.toml` configuration:
 
 ```ts
-await format(source, "Cargo.toml", "v1.1.0");
-await lint(source, "Cargo.toml", "v1.0.0");
+const config = {
+  context: `
+toml-version = "v1.1.0"
+
+[format.rules]
+indent-width = 4
+`,
+  path: "/workspace/tombi.toml",
+};
+
+await format(source, "Cargo.toml", { config });
+await lint(source, "Cargo.toml", { config });
+
+// The configuration context can be passed as a string shorthand. Its path
+// defaults to `tombi.toml` next to `sourcePath`.
+await format(source, "Cargo.toml", { config: config.context });
 ```
 
-If the TOML version is not specified, Tombi reads it from the matching
-`tombi.toml`. If it is not configured there either, Tombi uses the default
-version `v1.0.0`.
+The `config` property is optional. When omitted, Tombi discovers `tombi.toml`
+as before. When an object is provided, `config.context` replaces the discovered
+configuration and `config.path` supplies the base path for relative schema paths
+and `[[overrides]]`. A string is shorthand for the configuration text, with a
+path of `tombi.toml` next to `sourcePath`. If the TOML version is not configured,
+Tombi uses the default version `v1.0.0`.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -83,8 +83,8 @@ try {
 no diagnostics were reported. Configuration and execution errors reject the Promise
 as `TombiWasmError`.
 
-Both functions accept an optional options object as the third argument. Pass
-`config` to replace the automatically discovered configuration:
+Both functions accept an optional options object as the third argument. `config`
+replaces the automatically discovered configuration and accepts an object or string:
 
 ```ts
 const config = {
@@ -105,10 +105,5 @@ await lint(source, "Cargo.toml", { config });
 await format(source, "Cargo.toml", { config: config.content });
 ```
 
-The `config` property is optional. When omitted, Tombi discovers its configuration
-as before and uses the default configuration values when no configuration file is
-found. When an object is provided, `config.content` replaces the discovered
-configuration and `config.path` supplies the base path for relative schema paths
-and `[[overrides]]`. A string is shorthand for the content of a virtual
-`tombi.toml`. If the TOML version is not configured, Tombi uses the default version
-`v1.0.0`.
+When `config` is omitted, Tombi uses automatic discovery and falls back to the
+default configuration if no configuration file is found.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -83,9 +83,8 @@ try {
 no diagnostics were reported. Configuration and execution errors reject the Promise
 as `TombiWasmError`.
 
-Both functions accept a source path for matching `[[overrides]]`, followed by
-an optional options object. Pass `config` to replace the
-automatically discovered `tombi.toml` configuration:
+Both functions accept an optional options object as the third argument. Pass
+`config` to replace the automatically discovered configuration:
 
 ```ts
 const config = {

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -28,20 +28,20 @@ try {
 
   if (formatted !== undefined) {
     console.log(formatted);
-  } else {
-    for (const diagnostic of diagnostics) {
-      console.error(diagnostic.message);
-    }
+  }
+
+  for (const diagnostic of diagnostics) {
+    console.error(diagnostic.message);
   }
 } catch (error) {
   console.error(error as TombiWasmError);
 }
 ```
 
-`format` resolves to an object containing the formatted TOML and diagnostics.
-On success, the result contains `formatted`. When document diagnostics prevent
-formatting, the result instead contains `diagnostics`. Configuration and execution
-errors reject the Promise as `TombiWasmError`.
+`format` resolves to an object containing the formatted TOML when formatting
+succeeds and an array of diagnostics. The diagnostics array is empty when none were
+reported. When diagnostics prevent formatting, `formatted` is `undefined`.
+Configuration and execution errors reject the Promise as `TombiWasmError`.
 
 ## Lint TOML
 
@@ -60,7 +60,7 @@ name = "example"
 try {
   const { diagnostics } = await lint(source, "Cargo.toml");
 
-  if (diagnostics) {
+  if (diagnostics.length > 0) {
     for (const diagnostic of diagnostics) {
       console.error(
         `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`,
@@ -75,8 +75,8 @@ try {
 }
 ```
 
-`lint` resolves to an object whose optional `diagnostics` property is present when
-diagnostics were reported. Configuration and execution errors reject the Promise
+`lint` resolves to an object containing a diagnostics array. The array is empty when
+no diagnostics were reported. Configuration and execution errors reject the Promise
 as `TombiWasmError`.
 
 Both functions accept a source path for matching `[[overrides]]`, followed by

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -40,7 +40,7 @@ try {
 
 `format` resolves to an object containing the formatted TOML when formatting
 succeeds and an array of diagnostics. The diagnostics array is empty when none were
-reported. When diagnostics prevent formatting, `formatted` is `undefined`.
+reported. When diagnostics prevent formatting, `formatted` is omitted.
 Configuration and execution errors reject the Promise as `TombiWasmError`.
 
 ## Lint TOML

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -97,14 +97,15 @@ indent-width = 4
 await format(source, "Cargo.toml", { config });
 await lint(source, "Cargo.toml", { config });
 
-// The configuration content can be passed as a string shorthand. Its path
-// defaults to `tombi.toml` next to `sourcePath`.
+// The configuration content can be passed as a string shorthand. It is
+// treated as the content of a virtual `tombi.toml`.
 await format(source, "Cargo.toml", { config: config.content });
 ```
 
-The `config` property is optional. When omitted, Tombi discovers `tombi.toml`
-as before. When an object is provided, `config.content` replaces the discovered
+The `config` property is optional. When omitted, Tombi discovers its configuration
+as before and uses the default configuration values when no configuration file is
+found. When an object is provided, `config.content` replaces the discovered
 configuration and `config.path` supplies the base path for relative schema paths
-and `[[overrides]]`. A string is shorthand for the configuration text, with a
-path of `tombi.toml` next to `sourcePath`. If the TOML version is not configured,
-Tombi uses the default version `v1.0.0`.
+and `[[overrides]]`. A string is shorthand for the content of a virtual
+`tombi.toml`. If the TOML version is not configured, Tombi uses the default version
+`v1.0.0`.

--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -62,9 +62,13 @@ try {
 
   if (diagnostics.length > 0) {
     for (const diagnostic of diagnostics) {
-      console.error(
-        `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`,
-      );
+      const message = `${diagnostic.message} (${diagnostic.range.start.line}:${diagnostic.range.start.column})`;
+
+      if (diagnostic.level === "ERROR") {
+        console.error(message);
+      } else {
+        console.warn(message);
+      }
     }
   } else {
     console.log("No diagnostics");

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -10,8 +10,9 @@ use tombi_config::{
 /// If [crate::from_str_async] is used to parse the Config, it will cause a stack overflow due to circular references.
 /// Therefore, [crate::config::from_str], which does not use schema_store and is not async, is called to prevent stack overflow.
 ///
-/// This function is not public and is only used internally.
-pub(crate) fn from_str(
+/// This parser uses the TOML version required by Tombi configuration files and
+/// avoids recursively loading configuration while deserializing `Config`.
+pub fn from_str(
     toml_text: &str,
     config_path: &std::path::Path,
 ) -> Result<Config, crate::de::Error> {

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -31,16 +31,19 @@ fn serialize(value: &impl Serialize) -> JsValue {
 
 fn serialize_format_result(result: FormatResult) -> JsValue {
     let object = Object::new();
-    let (formatted, diagnostics) = match result {
-        FormatResult::Formatted(formatted) => (
-            JsValue::from_str(&formatted),
-            serialize(&Vec::<Diagnostic>::new()),
-        ),
-        FormatResult::Diagnostics(diagnostics) => (JsValue::UNDEFINED, serialize(&diagnostics)),
+    let diagnostics = match result {
+        FormatResult::Formatted(formatted) => {
+            Reflect::set(
+                &object,
+                &JsValue::from_str("formatted"),
+                &JsValue::from_str(&formatted),
+            )
+            .expect("WASM format results must be writable");
+            serialize(&Vec::<Diagnostic>::new())
+        }
+        FormatResult::Diagnostics(diagnostics) => serialize(&diagnostics),
     };
 
-    Reflect::set(&object, &JsValue::from_str("formatted"), &formatted)
-        .expect("WASM format results must be writable");
     Reflect::set(&object, &JsValue::from_str("diagnostics"), &diagnostics)
         .expect("WASM format results must be writable");
     object.into()

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -1,59 +1,97 @@
-use std::str::FromStr;
-
-use js_sys::Promise;
-use serde::Serialize;
+use js_sys::{Object, Promise, Reflect};
+use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::Serializer;
-use tombi_config::TomlVersion;
 use tombi_diagnostic::Diagnostic;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 use wasm_bindgen_futures::future_to_promise;
 
-fn serialize_error(error: &impl Serialize) -> JsValue {
-    error
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Options {
+    config: Option<ConfigInput>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ConfigInput {
+    File { context: String, path: String },
+    Text(String),
+}
+
+enum FormatResult {
+    Formatted(String),
+    Diagnostics(Vec<Diagnostic>),
+}
+
+fn serialize(value: &impl Serialize) -> JsValue {
+    value
         .serialize(&Serializer::json_compatible())
-        .expect("WASM errors must be serializable")
+        .expect("WASM values must be serializable")
+}
+
+fn serialize_format_result(result: FormatResult) -> JsValue {
+    let object = Object::new();
+    let (formatted, diagnostics) = match result {
+        FormatResult::Formatted(formatted) => (JsValue::from_str(&formatted), JsValue::UNDEFINED),
+        FormatResult::Diagnostics(diagnostics) => (JsValue::UNDEFINED, serialize(&diagnostics)),
+    };
+
+    Reflect::set(&object, &JsValue::from_str("formatted"), &formatted)
+        .expect("WASM format results must be writable");
+    Reflect::set(&object, &JsValue::from_str("diagnostics"), &diagnostics)
+        .expect("WASM format results must be writable");
+    object.into()
+}
+
+fn deserialize_options(options: JsValue) -> Result<Options, String> {
+    if options.is_null() || options.is_undefined() {
+        Ok(Options::default())
+    } else {
+        serde_wasm_bindgen::from_value(options).map_err(|error| error.to_string())
+    }
+}
+
+fn load_config(
+    options: Options,
+    source_path: &std::path::Path,
+) -> Result<(tombi_config::Config, Option<std::path::PathBuf>), String> {
+    if let Some(config) = options.config {
+        let (config_context, config_path) = match config {
+            ConfigInput::File { context, path } => (context, std::path::PathBuf::from(path)),
+            ConfigInput::Text(context) => (
+                context,
+                source_path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new(""))
+                    .join(tombi_config::TOMBI_TOML_FILENAME),
+            ),
+        };
+        let config = serde_tombi::config::from_str(&config_context, &config_path)
+            .map_err(|error| error.to_string())?;
+        Ok((config, Some(config_path)))
+    } else {
+        serde_tombi::config::load_with_path(std::env::current_dir().ok())
+            .map_err(|error| error.to_string())
+    }
 }
 
 #[wasm_bindgen]
-pub fn format(source: String, file_path: Option<String>, toml_version: Option<String>) -> Promise {
+pub fn format(source: String, source_path: String, options: JsValue) -> Promise {
     #[derive(serde::Serialize, Debug)]
-    #[serde(untagged)]
-    #[serde(rename_all = "camelCase")]
-    enum FormatError {
-        Error { error: String },
-        Diagnostics { diagnostics: Vec<Diagnostic> },
+    struct FormatError {
+        error: String,
     }
 
     async fn inner_format(
         source: String,
-        file_path: Option<String>,
-        toml_version: Option<String>,
-    ) -> Result<String, FormatError> {
-        let requested_toml_version = match toml_version {
-            Some(v) => match TomlVersion::from_str(&v) {
-                Ok(v) => Some(v),
-                Err(_) => {
-                    return Err(FormatError::Error {
-                        error: "Invalid TOML version".to_string(),
-                    });
-                }
-            },
-            None => None,
-        };
-
+        source_path: String,
+        options: JsValue,
+    ) -> Result<FormatResult, FormatError> {
+        let source_path = std::path::PathBuf::from(source_path);
+        let options = deserialize_options(options).map_err(|error| FormatError { error })?;
         let (config, config_path) =
-            match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
-                Ok((config, config_path)) => (config, config_path),
-                Err(err) => {
-                    return Err(FormatError::Error {
-                        error: err.to_string(),
-                    });
-                }
-            };
-
-        let toml_version = requested_toml_version
-            .or(config.toml_version)
-            .unwrap_or_default();
+            load_config(options, &source_path).map_err(|error| FormatError { error })?;
+        let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();
         let schema_store =
@@ -68,82 +106,62 @@ pub fn format(source: String, file_path: Option<String>, toml_version: Option<St
             .await
             .map_err(|e| e.to_string())
         {
-            return Err(FormatError::Error { error });
+            return Err(FormatError { error });
         }
 
-        let file_path_buf = file_path.map(std::path::PathBuf::from);
-
         // Get format options with override support
-        let Some(format_options) = tombi_glob::get_format_options(
-            &config,
-            file_path_buf.as_deref(),
-            config_path.as_deref(),
-        ) else {
+        let Some(format_options) =
+            tombi_glob::get_format_options(&config, Some(&source_path), config_path.as_deref())
+        else {
             // If formatting is disabled, return the source as-is
-            return Ok(source);
+            return Ok(FormatResult::Formatted(source));
         };
 
         match tombi_formatter::Formatter::new(
             toml_version,
             &format_options,
-            file_path_buf.as_deref().map(itertools::Either::Right),
+            Some(itertools::Either::Right(&source_path)),
             &schema_store,
         )
         .format(&source)
         .await
         {
-            Ok(t) => Ok(t),
-            Err(diagnostics) => Err(FormatError::Diagnostics { diagnostics }),
+            Ok(formatted) => Ok(FormatResult::Formatted(formatted)),
+            Err(diagnostics) => Ok(FormatResult::Diagnostics(diagnostics)),
         }
     }
 
     future_to_promise(async move {
-        match inner_format(source, file_path, toml_version).await {
-            Ok(t) => Ok(JsValue::from_str(&t)),
-            Err(e) => Err(serialize_error(&e)),
+        match inner_format(source, source_path, options).await {
+            Ok(result) => Ok(serialize_format_result(result)),
+            Err(error) => Err(serialize(&error)),
         }
     })
 }
 
 #[wasm_bindgen]
-pub fn lint(source: String, file_path: Option<String>, toml_version: Option<String>) -> Promise {
+pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
     #[derive(serde::Serialize, Debug)]
-    #[serde(untagged)]
-    #[serde(rename_all = "camelCase")]
-    enum LintError {
-        Error { error: String },
+    struct LintResult {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        diagnostics: Option<Vec<Diagnostic>>,
+    }
+
+    #[derive(serde::Serialize, Debug)]
+    struct LintError {
+        error: String,
     }
 
     async fn inner_lint(
         source: String,
-        file_path: Option<String>,
-        toml_version: Option<String>,
-    ) -> Result<Option<Vec<Diagnostic>>, LintError> {
-        let requested_toml_version = match toml_version {
-            Some(v) => match TomlVersion::from_str(&v) {
-                Ok(v) => Some(v),
-                Err(_) => {
-                    return Err(LintError::Error {
-                        error: "Invalid TOML version".to_string(),
-                    });
-                }
-            },
-            None => None,
-        };
-
+        source_path: String,
+        options: JsValue,
+    ) -> Result<LintResult, LintError> {
+        let source_path = std::path::PathBuf::from(source_path);
+        let options = deserialize_options(options).map_err(|error| LintError { error })?;
         let (config, config_path) =
-            match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
-                Ok((config, config_path)) => (config, config_path),
-                Err(err) => {
-                    return Err(LintError::Error {
-                        error: err.to_string(),
-                    });
-                }
-            };
-
-        let toml_version = requested_toml_version
-            .or(config.toml_version)
-            .unwrap_or_default();
+            load_config(options, &source_path).map_err(|error| LintError { error })?;
+        let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();
         let schema_store =
@@ -158,38 +176,37 @@ pub fn lint(source: String, file_path: Option<String>, toml_version: Option<Stri
             .await
             .map_err(|e| e.to_string())
         {
-            return Err(LintError::Error { error });
+            return Err(LintError { error });
         }
-
-        let file_path_buf = file_path.map(std::path::PathBuf::from);
 
         // Get lint options with override support
         let Some(lint_options) =
-            tombi_glob::get_lint_options(&config, file_path_buf.as_deref(), config_path.as_deref())
+            tombi_glob::get_lint_options(&config, Some(&source_path), config_path.as_deref())
         else {
             // If linting is disabled, return success
-            return Ok(None);
+            return Ok(LintResult { diagnostics: None });
         };
 
         match tombi_linter::Linter::new(
             toml_version,
             &lint_options,
-            file_path_buf.as_deref().map(itertools::Either::Right),
+            Some(itertools::Either::Right(&source_path)),
             &schema_store,
         )
         .lint(&source)
         .await
         {
-            Ok(_) => Ok(None),
-            Err(diagnostics) => Ok(Some(diagnostics)),
+            Ok(_) => Ok(LintResult { diagnostics: None }),
+            Err(diagnostics) => Ok(LintResult {
+                diagnostics: Some(diagnostics),
+            }),
         }
     }
 
     future_to_promise(async move {
-        match inner_lint(source, file_path, toml_version).await {
-            Ok(Some(diagnostics)) => Ok(serialize_error(&diagnostics)),
-            Ok(None) => Ok(JsValue::UNDEFINED),
-            Err(e) => Err(serialize_error(&e)),
+        match inner_lint(source, source_path, options).await {
+            Ok(result) => Ok(serialize(&result)),
+            Err(error) => Err(serialize(&error)),
         }
     })
 }

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -14,7 +14,7 @@ struct Options {
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum ConfigInput {
-    File { context: String, path: String },
+    File { content: String, path: String },
     Text(String),
 }
 
@@ -56,17 +56,17 @@ fn load_config(
     source_path: &std::path::Path,
 ) -> Result<(tombi_config::Config, Option<std::path::PathBuf>), String> {
     if let Some(config) = options.config {
-        let (config_context, config_path) = match config {
-            ConfigInput::File { context, path } => (context, std::path::PathBuf::from(path)),
-            ConfigInput::Text(context) => (
-                context,
+        let (config_content, config_path) = match config {
+            ConfigInput::File { content, path } => (content, std::path::PathBuf::from(path)),
+            ConfigInput::Text(content) => (
+                content,
                 source_path
                     .parent()
                     .unwrap_or_else(|| std::path::Path::new(""))
                     .join(tombi_config::TOMBI_TOML_FILENAME),
             ),
         };
-        let config = serde_tombi::config::from_str(&config_context, &config_path)
+        let config = serde_tombi::config::from_str(&config_content, &config_path)
             .map_err(|error| error.to_string())?;
         Ok((config, Some(config_path)))
     } else {

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -32,7 +32,10 @@ fn serialize(value: &impl Serialize) -> JsValue {
 fn serialize_format_result(result: FormatResult) -> JsValue {
     let object = Object::new();
     let (formatted, diagnostics) = match result {
-        FormatResult::Formatted(formatted) => (JsValue::from_str(&formatted), JsValue::UNDEFINED),
+        FormatResult::Formatted(formatted) => (
+            JsValue::from_str(&formatted),
+            serialize(&Vec::<Diagnostic>::new()),
+        ),
         FormatResult::Diagnostics(diagnostics) => (JsValue::UNDEFINED, serialize(&diagnostics)),
     };
 
@@ -138,8 +141,7 @@ pub fn format(source: String, source_path: String, options: JsValue) -> Promise 
 pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
     #[derive(serde::Serialize, Debug)]
     struct LintResult {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        diagnostics: Option<Vec<Diagnostic>>,
+        diagnostics: Vec<Diagnostic>,
     }
 
     #[derive(serde::Serialize, Debug)]
@@ -178,7 +180,9 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
             tombi_glob::get_lint_options(&config, Some(&source_path), config_path.as_deref())
         else {
             // If linting is disabled, return success
-            return Ok(LintResult { diagnostics: None });
+            return Ok(LintResult {
+                diagnostics: Vec::new(),
+            });
         };
 
         match tombi_linter::Linter::new(
@@ -190,10 +194,10 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
         .lint(&source)
         .await
         {
-            Ok(_) => Ok(LintResult { diagnostics: None }),
-            Err(diagnostics) => Ok(LintResult {
-                diagnostics: Some(diagnostics),
+            Ok(_) => Ok(LintResult {
+                diagnostics: Vec::new(),
             }),
+            Err(diagnostics) => Ok(LintResult { diagnostics }),
         }
     }
 

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -53,17 +53,13 @@ fn deserialize_options(options: JsValue) -> Result<Options, String> {
 
 fn load_config(
     options: Options,
-    source_path: &std::path::Path,
 ) -> Result<(tombi_config::Config, Option<std::path::PathBuf>), String> {
     if let Some(config) = options.config {
         let (config_content, config_path) = match config {
             ConfigInput::File { content, path } => (content, std::path::PathBuf::from(path)),
             ConfigInput::Text(content) => (
                 content,
-                source_path
-                    .parent()
-                    .unwrap_or_else(|| std::path::Path::new(""))
-                    .join(tombi_config::TOMBI_TOML_FILENAME),
+                std::path::PathBuf::from(tombi_config::TOMBI_TOML_FILENAME),
             ),
         };
         let config = serde_tombi::config::from_str(&config_content, &config_path)
@@ -89,8 +85,7 @@ pub fn format(source: String, source_path: String, options: JsValue) -> Promise 
     ) -> Result<FormatResult, FormatError> {
         let source_path = std::path::PathBuf::from(source_path);
         let options = deserialize_options(options).map_err(|error| FormatError { error })?;
-        let (config, config_path) =
-            load_config(options, &source_path).map_err(|error| FormatError { error })?;
+        let (config, config_path) = load_config(options).map_err(|error| FormatError { error })?;
         let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();
@@ -159,8 +154,7 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
     ) -> Result<LintResult, LintError> {
         let source_path = std::path::PathBuf::from(source_path);
         let options = deserialize_options(options).map_err(|error| LintError { error })?;
-        let (config, config_path) =
-            load_config(options, &source_path).map_err(|error| LintError { error })?;
+        let (config, config_path) = load_config(options).map_err(|error| LintError { error })?;
         let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -6,9 +6,13 @@ import init, { format, lint } from "../../../typescript/@tombi-toml/wasm-lib/dis
 const wasm = await readFile(new URL("../../../typescript/@tombi-toml/wasm-lib/dist/tombi_wasm_bg.wasm", import.meta.url));
 await init({ module_or_path: wasm });
 
+assert.deepEqual(await format("", "playground.toml"), {
+  formatted: "",
+  diagnostics: [],
+});
 assert.deepEqual(await format("key=1", "playground.toml"), {
   formatted: "key = 1\n",
-  diagnostics: undefined,
+  diagnostics: [],
 });
 assert.deepEqual(
   await format("key={nested=1}", "playground.toml", {
@@ -16,7 +20,7 @@ assert.deepEqual(
   }),
   {
     formatted: "key = { nested = 1 }\n",
-    diagnostics: undefined,
+    diagnostics: [],
   },
 );
 const formattedWithConfig = await format("[package]\nname=1", "Cargo.toml", {
@@ -43,7 +47,7 @@ enabled = false
     path: "/workspace/tombi.toml",
   },
 });
-assert.deepEqual(formatDisabledByOverride, { formatted: "key=1", diagnostics: undefined });
+assert.deepEqual(formatDisabledByOverride, { formatted: "key=1", diagnostics: [] });
 
 const formatError = await format("key =", "playground.toml", {
   config: { content: 'toml-version = "v1.1.0"', path: "tombi.toml" },
@@ -53,7 +57,7 @@ assert.ok(Object.hasOwn(formatError, "formatted"));
 assert.ok(Array.isArray(formatError.diagnostics));
 assert.ok(formatError.diagnostics.length > 0);
 
-assert.deepEqual(await lint("key = 1", "playground.toml"), {});
+assert.deepEqual(await lint("key = 1", "playground.toml"), { diagnostics: [] });
 const { diagnostics } = await lint("key =", "playground.toml", {
   config: { content: 'toml-version = "v1.1.0"', path: "tombi.toml" },
 });

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -53,7 +53,7 @@ const formatError = await format("key =", "playground.toml", {
   config: { content: 'toml-version = "v1.1.0"', path: "tombi.toml" },
 });
 assert.equal(formatError.formatted, undefined);
-assert.ok(Object.hasOwn(formatError, "formatted"));
+assert.equal(Object.hasOwn(formatError, "formatted"), false);
 assert.ok(Array.isArray(formatError.diagnostics));
 assert.ok(formatError.diagnostics.length > 0);
 

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -6,8 +6,61 @@ import init, { format, lint } from "../../../typescript/@tombi-toml/wasm-lib/dis
 const wasm = await readFile(new URL("../../../typescript/@tombi-toml/wasm-lib/dist/tombi_wasm_bg.wasm", import.meta.url));
 await init({ module_or_path: wasm });
 
-assert.equal(await format("key={nested=1}", "playground.toml", "v1.1.0"), "key = { nested = 1 }\n");
-assert.equal(await lint("key = 1", "playground.toml", "v1.1.0"), undefined);
-const diagnostics = await lint("key =", "playground.toml", "v1.1.0");
+assert.deepEqual(await format("key=1", "playground.toml"), {
+  formatted: "key = 1\n",
+  diagnostics: undefined,
+});
+assert.deepEqual(
+  await format("key={nested=1}", "playground.toml", {
+    config: 'toml-version = "v1.1.0"',
+  }),
+  {
+    formatted: "key = { nested = 1 }\n",
+    diagnostics: undefined,
+  },
+);
+const formattedWithConfig = await format("[package]\nname=1", "Cargo.toml", {
+  config: {
+    context: `
+[format.rules]
+indent-table-key-value-pairs = true
+indent-width = 4
+`,
+    path: "/workspace/tombi.toml",
+  },
+});
+assert.equal(formattedWithConfig.formatted, "[package]\n    name = 1\n");
+
+const formatDisabledByOverride = await format("key=1", "/workspace/generated/output.toml", {
+  config: {
+    context: `
+[[overrides]]
+files.include = ["generated/*.toml"]
+
+[overrides.format]
+enabled = false
+`,
+    path: "/workspace/tombi.toml",
+  },
+});
+assert.deepEqual(formatDisabledByOverride, { formatted: "key=1", diagnostics: undefined });
+
+const formatError = await format("key =", "playground.toml", {
+  config: { context: 'toml-version = "v1.1.0"', path: "tombi.toml" },
+});
+assert.equal(formatError.formatted, undefined);
+assert.ok(Object.hasOwn(formatError, "formatted"));
+assert.ok(Array.isArray(formatError.diagnostics));
+assert.ok(formatError.diagnostics.length > 0);
+
+assert.deepEqual(await lint("key = 1", "playground.toml"), {});
+const { diagnostics } = await lint("key =", "playground.toml", {
+  config: { context: 'toml-version = "v1.1.0"', path: "tombi.toml" },
+});
 assert.ok(Array.isArray(diagnostics));
 assert.ok(diagnostics.length > 0);
+
+await assert.rejects(format("key = 1", "playground.toml", { config: "invalid =" }), (error) => {
+  assert.equal(typeof error.error, "string");
+  return true;
+});

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -56,6 +56,7 @@ assert.equal(formatError.formatted, undefined);
 assert.equal(Object.hasOwn(formatError, "formatted"), false);
 assert.ok(Array.isArray(formatError.diagnostics));
 assert.ok(formatError.diagnostics.length > 0);
+assert.ok(formatError.diagnostics.every((diagnostic) => diagnostic.level === "error"));
 
 assert.deepEqual(await lint("key = 1", "playground.toml"), { diagnostics: [] });
 const { diagnostics } = await lint("key =", "playground.toml", {
@@ -63,6 +64,23 @@ const { diagnostics } = await lint("key =", "playground.toml", {
 });
 assert.ok(Array.isArray(diagnostics));
 assert.ok(diagnostics.length > 0);
+assert.ok(diagnostics.every((diagnostic) => diagnostic.level === "error"));
+
+const warningResult = await lint(
+  `
+[fruit.apple]
+color = "red"
+
+[animal]
+type = "mammal"
+
+[fruit.orange]
+color = "orange"
+`,
+  "playground.toml",
+);
+assert.ok(warningResult.diagnostics.length > 0);
+assert.ok(warningResult.diagnostics.every((diagnostic) => diagnostic.level === "warning"));
 
 await assert.rejects(format("key = 1", "playground.toml", { config: "invalid =" }), (error) => {
   assert.equal(typeof error.error, "string");

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -21,7 +21,7 @@ assert.deepEqual(
 );
 const formattedWithConfig = await format("[package]\nname=1", "Cargo.toml", {
   config: {
-    context: `
+    content: `
 [format.rules]
 indent-table-key-value-pairs = true
 indent-width = 4
@@ -33,7 +33,7 @@ assert.equal(formattedWithConfig.formatted, "[package]\n    name = 1\n");
 
 const formatDisabledByOverride = await format("key=1", "/workspace/generated/output.toml", {
   config: {
-    context: `
+    content: `
 [[overrides]]
 files.include = ["generated/*.toml"]
 
@@ -46,7 +46,7 @@ enabled = false
 assert.deepEqual(formatDisabledByOverride, { formatted: "key=1", diagnostics: undefined });
 
 const formatError = await format("key =", "playground.toml", {
-  config: { context: 'toml-version = "v1.1.0"', path: "tombi.toml" },
+  config: { content: 'toml-version = "v1.1.0"', path: "tombi.toml" },
 });
 assert.equal(formatError.formatted, undefined);
 assert.ok(Object.hasOwn(formatError, "formatted"));
@@ -55,7 +55,7 @@ assert.ok(formatError.diagnostics.length > 0);
 
 assert.deepEqual(await lint("key = 1", "playground.toml"), {});
 const { diagnostics } = await lint("key =", "playground.toml", {
-  config: { context: 'toml-version = "v1.1.0"', path: "tombi.toml" },
+  config: { content: 'toml-version = "v1.1.0"', path: "tombi.toml" },
 });
 assert.ok(Array.isArray(diagnostics));
 assert.ok(diagnostics.length > 0);

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -39,8 +39,8 @@ export type LintResult = {
 
 /**
  * An in-memory `tombi.toml` configuration.
- * When a string is provided, it is treated as the configuration content and
- * `tombi.toml` is assumed to exist next to `sourcePath`.
+ * When a string is provided, it is treated as the content of a virtual
+ * `tombi.toml`.
  */
 export type Config = { content: string; path: string } | string;
 

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -39,10 +39,10 @@ export type LintResult = {
 
 /**
  * An in-memory `tombi.toml` configuration.
- * When a string is provided, it is treated as the configuration context and
+ * When a string is provided, it is treated as the configuration content and
  * `tombi.toml` is assumed to exist next to `sourcePath`.
  */
-export type Config = { context: string; path: string } | string;
+export type Config = { content: string; path: string } | string;
 
 /** Options shared by the formatter and linter. */
 export interface Options {

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -21,10 +21,49 @@ export interface Range {
   end: Position;
 }
 
-/** An error reported when formatting fails. */
-export type FormatError = { error: string } | { diagnostics: Diagnostic[] };
+/** The result of formatting a TOML document. */
+export type FormatResult =
+  | {
+      formatted: string;
+      diagnostics: undefined;
+    }
+  | {
+      formatted: undefined;
+      diagnostics: Diagnostic[];
+    };
 
-/** An error reported when linting cannot be executed. */
-export interface LintError {
+/** The result of linting a TOML document. */
+export type LintResult = {
+  diagnostics?: Diagnostic[];
+};
+
+/**
+ * An in-memory `tombi.toml` configuration.
+ * When a string is provided, it is treated as the configuration context and
+ * `tombi.toml` is assumed to exist next to `sourcePath`.
+ */
+export type Config = { context: string; path: string } | string;
+
+/** Options shared by the formatter and linter. */
+export interface Options {
+  config?: Config;
+}
+
+/** Format a TOML document. */
+export function format(
+  source: string,
+  sourcePath: string,
+  options?: Options,
+): Promise<FormatResult>;
+
+/** Lint a TOML document. */
+export function lint(
+  source: string,
+  sourcePath: string,
+  options?: Options,
+): Promise<LintResult>;
+
+/** An error reported when an operation cannot be executed. */
+export interface TombiWasmError {
   error: string;
 }

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -2,7 +2,7 @@ export * from "./tombi_wasm";
 
 /** A diagnostic reported by Tombi. */
 export interface Diagnostic {
-  level: "ERROR" | "WARNING";
+  level: "error" | "warning";
   code: string;
   message: string;
   range: Range;

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -23,7 +23,7 @@ export interface Range {
 
 /** The result of formatting a TOML document. */
 export interface FormatResult {
-  formatted: string | undefined;
+  formatted?: string;
   diagnostics: Diagnostic[];
 }
 

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -22,20 +22,15 @@ export interface Range {
 }
 
 /** The result of formatting a TOML document. */
-export type FormatResult =
-  | {
-      formatted: string;
-      diagnostics: undefined;
-    }
-  | {
-      formatted: undefined;
-      diagnostics: Diagnostic[];
-    };
+export interface FormatResult {
+  formatted: string | undefined;
+  diagnostics: Diagnostic[];
+}
 
 /** The result of linting a TOML document. */
-export type LintResult = {
-  diagnostics?: Diagnostic[];
-};
+export interface LintResult {
+  diagnostics: Diagnostic[];
+}
 
 /**
  * An in-memory `tombi.toml` configuration.


### PR DESCRIPTION
## Summary

- return structured format and lint results with diagnostics separated from execution errors
- accept optional in-memory tombi.toml configuration as text or context/path, while preserving automatic discovery when omitted
- document the breaking WASM API and extend smoke coverage for success, diagnostics, config overrides, and rejection errors

## Breaking changes

- format now resolves to FormatResult instead of a string and returns document diagnostics in the resolved result
- lint now resolves to LintResult instead of an array or undefined
- both functions now take sourcePath and an optional Options object; the former TOML-version third argument is removed
- FormatError and LintError are replaced by TombiWasmError for rejected execution/configuration errors

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast (2169 passed; 1 leaky)
- cargo test --workspace --doc --locked
- pnpm --dir typescript/@tombi-toml/wasm-lib test
- pnpm --dir docs format:check
- pnpm --dir docs lint:check
- pnpm --dir docs typecheck
- BASE_URL=/tombi pnpm --dir docs build
- git diff --check

## Review

A separate subagent reviewed the new interface. Its two findings—handling an empty formatted string in docs and keeping runtime property presence aligned with the TypeScript discriminated union—were fixed before opening this PR.