### PR TITLE
feat(formatter): add comment-style rule

### DIFF
--- a/crates/tombi-config/src/format.rs
+++ b/crates/tombi-config/src/format.rs
@@ -8,10 +8,10 @@
 //! this structure is currently empty.
 
 use crate::{
-    ArrayBracketSpaceWidth, ArrayCommaSpaceWidth, BlankLines, BlankLinesLimit, DateTimeDelimiter,
-    IndentStyle, IndentWidth, InlineTableBraceSpaceWidth, InlineTableCommaSpaceWidth,
-    KeyValueEqualsSignSpaceWidth, LineEnding, LineWidth, StringQuoteStyle,
-    TrailingCommentSpaceWidth,
+    ArrayBracketSpaceWidth, ArrayCommaSpaceWidth, BlankLines, BlankLinesLimit, CommentStyle,
+    DateTimeDelimiter, IndentStyle, IndentWidth, InlineTableBraceSpaceWidth,
+    InlineTableCommaSpaceWidth, KeyValueEqualsSignSpaceWidth, LineEnding, LineWidth,
+    StringQuoteStyle, TrailingCommentSpaceWidth,
 };
 
 /// # Formatter options
@@ -56,6 +56,13 @@ pub struct FormatRules {
         schemars(default = "ArrayCommaSpaceWidth::default")
     )]
     pub array_comma_space_width: Option<ArrayCommaSpaceWidth>,
+
+    /// # The style used to format comments
+    ///
+    /// - `normalize`: Normalize comment text according to Tombi's formatting rules.
+    /// - `preserve`: Preserve the original comment text while formatting its placement normally.
+    #[cfg_attr(feature = "jsonschema", schemars(default = "CommentStyle::default"))]
+    pub comment_style: Option<CommentStyle>,
 
     /// # The delimiter between date and time
     ///
@@ -304,6 +311,7 @@ impl FormatRules {
             array_comma_space_width: self
                 .array_comma_space_width
                 .or(override_rules.array_comma_space_width),
+            comment_style: self.comment_style.or(override_rules.comment_style),
             date_time_delimiter: self
                 .date_time_delimiter
                 .or(override_rules.date_time_delimiter),

--- a/crates/tombi-config/src/types.rs
+++ b/crates/tombi-config/src/types.rs
@@ -1,6 +1,7 @@
 mod array_bracket_space_width;
 mod array_comma_space_width;
 mod blank_lines;
+mod comment_style;
 mod date_time_delimiter;
 mod glob_pattern;
 mod indent_style;
@@ -18,6 +19,7 @@ mod trailing_comment_space_width;
 pub use array_bracket_space_width::ArrayBracketSpaceWidth;
 pub use array_comma_space_width::ArrayCommaSpaceWidth;
 pub use blank_lines::{BlankLines, BlankLinesLimit};
+pub use comment_style::CommentStyle;
 pub use date_time_delimiter::DateTimeDelimiter;
 pub use glob_pattern::GlobPattern;
 pub use indent_style::IndentStyle;

--- a/crates/tombi-config/src/types/comment_style.rs
+++ b/crates/tombi-config/src/types/comment_style.rs
@@ -1,0 +1,13 @@
+/// The style used to format comments.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub enum CommentStyle {
+    /// Normalize comment text according to Tombi's formatting rules.
+    #[default]
+    Normalize,
+
+    /// Preserve the original comment text while formatting its placement normally.
+    Preserve,
+}

--- a/crates/tombi-formatter/src/format/comment.rs
+++ b/crates/tombi-formatter/src/format/comment.rs
@@ -128,6 +128,11 @@ fn format_comment(
     strip_leading_spaces: bool,
 ) -> Result<(), std::fmt::Error> {
     let comment_string = comment.to_string();
+
+    if f.comment_style() == tombi_config::CommentStyle::Preserve {
+        return write!(f, "{comment_string}");
+    }
+
     {
         // For the purpose of reading the JSON Schema path defined in the file by taplo,
         // we format in a different style from the tombi comment style.
@@ -192,7 +197,7 @@ fn format_comment(
 mod tests {
     use itertools::Itertools;
     use tombi_ast::AstNode;
-    use tombi_config::FormatRules;
+    use tombi_config::{CommentStyle, FormatRules};
 
     use crate::{Formatter, test_format};
 
@@ -280,6 +285,45 @@ mod tests {
     test_format! {
         #[tokio::test]
         async fn comment_without_space(r"#comment") -> Ok("# comment")
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn preserve_comment_style(
+            r##"
+            #DIRECTIVE key1="value1" key2="value2"
+            key="value"#TRAILING
+            #    dangling comment
+            "##,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    comment_style: Some(CommentStyle::Preserve),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(
+            r##"
+            #DIRECTIVE key1="value1" key2="value2"
+            key = "value"  #TRAILING
+            #    dangling comment
+            "##
+        )
+    }
+
+    test_format! {
+        #[tokio::test]
+        async fn preserve_comment_directive_style(
+            r##"
+            #:schema  https://www.schemastore.org/pyproject.json
+            #:tombi   toml-version   = 'v1.0.0'
+            "##,
+            FormatOptions {
+                rules: Some(FormatRules {
+                    comment_style: Some(CommentStyle::Preserve),
+                    ..Default::default()
+                }),
+            }
+        ) -> Ok(source)
     }
 
     test_format! {

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -308,6 +308,11 @@ impl<'a> Formatter<'a> {
     }
 
     #[inline]
+    pub(crate) fn comment_style(&self) -> tombi_config::CommentStyle {
+        self.definitions.comment_style
+    }
+
+    #[inline]
     pub(crate) fn key_quote_style(&self) -> tombi_config::StringQuoteStyle {
         self.definitions.key_quote_style
     }

--- a/crates/tombi-formatter/src/formatter/definitions.rs
+++ b/crates/tombi-formatter/src/formatter/definitions.rs
@@ -1,4 +1,4 @@
-use tombi_config::{DateTimeDelimiter, FormatOptions, IndentStyle, StringQuoteStyle};
+use tombi_config::{CommentStyle, DateTimeDelimiter, FormatOptions, IndentStyle, StringQuoteStyle};
 
 /// FormatDefinitions provides the definition of the format that does not have the freedom set by [`FormatOptions`][crate::FormatOptions].
 ///
@@ -26,6 +26,7 @@ pub struct FormatDefinitions {
     pub date_time_delimiter: Option<&'static str>,
     pub array_bracket_space: String,
     pub array_comma_space: String,
+    pub comment_style: CommentStyle,
     pub inline_table_brace_space: String,
     pub inline_table_comma_space: String,
 }
@@ -138,6 +139,11 @@ impl FormatDefinitions {
                     .unwrap_or_default()
                     .value() as usize,
             ),
+            comment_style: options
+                .rules
+                .as_ref()
+                .and_then(|rules| rules.comment_style)
+                .unwrap_or_default(),
             inline_table_brace_space: " ".repeat(
                 options
                     .rules

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -47,6 +47,7 @@ Therefore, it is recommended to place `tombi.toml` only at the root of your proj
   - [format.rules](#format-rules)
     - [format.rules.array-bracket-space-width](#format-rules-array-bracket-space-width)
     - [format.rules.array-comma-space-width](#format-rules-array-comma-space-width)
+    - [format.rules.comment-style](#format-rules-comment-style)
     - [format.rules.date-time-delimiter](#format-rules-date-time-delimiter)
     - [format.rules.group-blank-lines-limit](#format-rules-group-blank-lines-limit)
     - [format.rules.indent-style](#format-rules-indent-style)
@@ -172,6 +173,7 @@ respect-ignore-files = true
 [format.rules]
 array-bracket-space-width = 0
 array-comma-space-width = 1
+comment-style = "normalize"
 date-time-delimiter = "T"
 group-blank-lines-limit = 1
 indent-style = "space"
@@ -444,6 +446,18 @@ The number of spaces after the comma in a single line array.
 key = [ 1, 2, 3 ]
 #         ^  ^  <- this
 ```
+
+### format.rules.comment-style
+
+The style used to format comments.
+
+- Type: `"normalize" | "preserve"`
+- Default: `"normalize"`
+- Enum Values:
+  - `normalize`: Normalize comment text according to Tombi's formatting rules.
+  - `preserve`: Preserve the original comment text while formatting its placement normally.
+
+For example, comment indentation and the spacing before trailing comments are still controlled by the formatter.
 
 ### format.rules.date-time-delimiter
 

--- a/www.schemastore.org/tombi.json
+++ b/www.schemastore.org/tombi.json
@@ -221,6 +221,19 @@
           ],
           "default": 1
         },
+        "comment-style": {
+          "title": "The style used to format comments",
+          "description": "- `normalize`: Normalize comment text according to Tombi's formatting rules.\n- `preserve`: Preserve the original comment text while formatting its placement normally.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CommentStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "normalize"
+        },
         "date-time-delimiter": {
           "title": "The delimiter between date and time",
           "description": "In accordance with [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), you can use `T` or space character between date and time.\n\n- `T`: Use `T` between date and time like `2001-01-01T00:00:00`\n- `space`: Use space between date and time like `2001-01-01 00:00:00`\n- `preserve`: Preserve the original delimiter.",
@@ -440,6 +453,21 @@
       "format": "uint8",
       "minimum": 0,
       "maximum": 255
+    },
+    "CommentStyle": {
+      "description": "The style used to format comments.",
+      "oneOf": [
+        {
+          "description": "Normalize comment text according to Tombi's formatting rules.",
+          "type": "string",
+          "const": "normalize"
+        },
+        {
+          "description": "Preserve the original comment text while formatting its placement normally.",
+          "type": "string",
+          "const": "preserve"
+        }
+      ]
     },
     "DateTimeDelimiter": {
       "description": "DateTime delimiter",


### PR DESCRIPTION
## Summary

- add `format.rules.comment-style` with `normalize` and `preserve` modes
- preserve the original comment text while retaining formatter-controlled comment placement
- document the new rule and regenerate the configuration schema

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`

Related discussion: https://github.com/tombi-toml/tombi/discussions/2078