### PR TITLE
fix(wasm): reject with standard errors

### DIFF
--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -34,7 +34,7 @@ try {
     console.error(diagnostic.message);
   }
 } catch (error) {
-  console.error(error as TombiWasmError);
+  console.error((error as TombiWasmError).message);
 }
 ```
 
@@ -75,7 +75,7 @@ try {
   }
 } catch (error) {
   // Configuration and execution errors reject the Promise.
-  console.error(error as TombiWasmError);
+  console.error((error as TombiWasmError).message);
 }
 ```
 

--- a/rust/tombi-wasm/src/formatter.rs
+++ b/rust/tombi-wasm/src/formatter.rs
@@ -1,4 +1,4 @@
-use js_sys::{Object, Promise, Reflect};
+use js_sys::{Error, Object, Promise, Reflect};
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::Serializer;
 use tombi_diagnostic::Diagnostic;
@@ -27,6 +27,12 @@ fn serialize(value: &impl Serialize) -> JsValue {
     value
         .serialize(&Serializer::json_compatible())
         .expect("WASM values must be serializable")
+}
+
+fn tombi_wasm_error(message: &str) -> JsValue {
+    let error = Error::new(message);
+    error.set_name("TombiWasmError");
+    error.into()
 }
 
 fn serialize_format_result(result: FormatResult) -> JsValue {
@@ -79,19 +85,14 @@ fn load_config(
 
 #[wasm_bindgen]
 pub fn format(source: String, source_path: String, options: JsValue) -> Promise {
-    #[derive(serde::Serialize, Debug)]
-    struct FormatError {
-        error: String,
-    }
-
     async fn inner_format(
         source: String,
         source_path: String,
         options: JsValue,
-    ) -> Result<FormatResult, FormatError> {
+    ) -> Result<FormatResult, String> {
         let source_path = std::path::PathBuf::from(source_path);
-        let options = deserialize_options(options).map_err(|error| FormatError { error })?;
-        let (config, config_path) = load_config(options).map_err(|error| FormatError { error })?;
+        let options = deserialize_options(options)?;
+        let (config, config_path) = load_config(options)?;
         let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();
@@ -102,13 +103,10 @@ pub fn format(source: String, source_path: String, options: JsValue) -> Promise 
                 cache: None,
             });
 
-        if let Err(error) = schema_store
+        schema_store
             .load_config(&config, config_path.as_deref())
             .await
-            .map_err(|e| e.to_string())
-        {
-            return Err(FormatError { error });
-        }
+            .map_err(|error| error.to_string())?;
 
         // Get format options with override support
         let Some(format_options) =
@@ -135,7 +133,7 @@ pub fn format(source: String, source_path: String, options: JsValue) -> Promise 
     future_to_promise(async move {
         match inner_format(source, source_path, options).await {
             Ok(result) => Ok(serialize_format_result(result)),
-            Err(error) => Err(serialize(&error)),
+            Err(error) => Err(tombi_wasm_error(&error)),
         }
     })
 }
@@ -147,19 +145,14 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
         diagnostics: Vec<Diagnostic>,
     }
 
-    #[derive(serde::Serialize, Debug)]
-    struct LintError {
-        error: String,
-    }
-
     async fn inner_lint(
         source: String,
         source_path: String,
         options: JsValue,
-    ) -> Result<LintResult, LintError> {
+    ) -> Result<LintResult, String> {
         let source_path = std::path::PathBuf::from(source_path);
-        let options = deserialize_options(options).map_err(|error| LintError { error })?;
-        let (config, config_path) = load_config(options).map_err(|error| LintError { error })?;
+        let options = deserialize_options(options)?;
+        let (config, config_path) = load_config(options)?;
         let toml_version = config.toml_version.unwrap_or_default();
 
         let schema_options = config.schema.as_ref();
@@ -170,13 +163,10 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
                 cache: None,
             });
 
-        if let Err(error) = schema_store
+        schema_store
             .load_config(&config, config_path.as_deref())
             .await
-            .map_err(|e| e.to_string())
-        {
-            return Err(LintError { error });
-        }
+            .map_err(|error| error.to_string())?;
 
         // Get lint options with override support
         let Some(lint_options) =
@@ -207,7 +197,7 @@ pub fn lint(source: String, source_path: String, options: JsValue) -> Promise {
     future_to_promise(async move {
         match inner_lint(source, source_path, options).await {
             Ok(result) => Ok(serialize(&result)),
-            Err(error) => Err(serialize(&error)),
+            Err(error) => Err(tombi_wasm_error(&error)),
         }
     })
 }

--- a/rust/tombi-wasm/tests/lib-smoke.mjs
+++ b/rust/tombi-wasm/tests/lib-smoke.mjs
@@ -83,6 +83,19 @@ assert.ok(warningResult.diagnostics.length > 0);
 assert.ok(warningResult.diagnostics.every((diagnostic) => diagnostic.level === "warning"));
 
 await assert.rejects(format("key = 1", "playground.toml", { config: "invalid =" }), (error) => {
-  assert.equal(typeof error.error, "string");
+  assert.ok(error instanceof Error);
+  assert.equal(error.name, "TombiWasmError");
+  assert.equal(typeof error.message, "string");
+  assert.ok(error.message.length > 0);
+  assert.equal(Object.hasOwn(error, "error"), false);
+  return true;
+});
+
+await assert.rejects(lint("key = 1", "playground.toml", { config: "invalid =" }), (error) => {
+  assert.ok(error instanceof Error);
+  assert.equal(error.name, "TombiWasmError");
+  assert.equal(typeof error.message, "string");
+  assert.ok(error.message.length > 0);
+  assert.equal(Object.hasOwn(error, "error"), false);
   return true;
 });

--- a/typescript/@tombi-toml/wasm-lib/types.d.ts
+++ b/typescript/@tombi-toml/wasm-lib/types.d.ts
@@ -59,6 +59,6 @@ export function lint(
 ): Promise<LintResult>;
 
 /** An error reported when an operation cannot be executed. */
-export interface TombiWasmError {
-  error: string;
+export interface TombiWasmError extends Error {
+  readonly name: "TombiWasmError";
 }


### PR DESCRIPTION
## Summary

- reject formatter and linter failures with native JavaScript `Error` objects
- expose `TombiWasmError` as an `Error` subtype with a stable name and standard message
- cover both APIs in the WASM smoke test and update documentation examples

## Breaking change

The rejection value no longer has an `error` property. Consumers should read the standard `message` property instead.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast` (2171 passed)
- `cargo test --workspace --doc --locked`
- `cargo clippy -p tombi-wasm --target wasm32-unknown-unknown --no-default-features --features lib --locked -- -D warnings`
- `pnpm --dir typescript/@tombi-toml/wasm-lib test`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build` (47 routes)
- `git diff --check`