### PR TITLE
fix(npm): include WASM build output in published packages

### DIFF
--- a/typescript/@tombi-toml/wasm-lib/package.json
+++ b/typescript/@tombi-toml/wasm-lib/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lib/dist --out-name tombi_wasm -- --no-default-features --features lib && cp ../../typescript/@tombi-toml/wasm-lib/types.d.ts ../../typescript/@tombi-toml/wasm-lib/dist/index.d.ts",
+    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lib/dist --out-name tombi_wasm -- --no-default-features --features lib && rm ../../typescript/@tombi-toml/wasm-lib/dist/.gitignore && cp ../../typescript/@tombi-toml/wasm-lib/types.d.ts ../../typescript/@tombi-toml/wasm-lib/dist/index.d.ts",
     "test": "pnpm run build && node ../../../rust/tombi-wasm/tests/lib-smoke.mjs",
     "clean": "rm -rf dist"
   },

--- a/typescript/@tombi-toml/wasm-lsp/package.json
+++ b/typescript/@tombi-toml/wasm-lsp/package.json
@@ -14,7 +14,7 @@
     "./worker": "./dist/worker.js"
   },
   "scripts": {
-    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lsp/dist --out-name tombi_lsp_wasm -- --no-default-features --features lsp && cp src/lsp-worker.js ../../typescript/@tombi-toml/wasm-lsp/dist/worker.js",
+    "build": "rm -rf dist && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../typescript/@tombi-toml/wasm-lsp/dist --out-name tombi_lsp_wasm -- --no-default-features --features lsp && rm ../../typescript/@tombi-toml/wasm-lsp/dist/.gitignore && cp src/lsp-worker.js ../../typescript/@tombi-toml/wasm-lsp/dist/worker.js",
     "build:docs": "rm -f ../../../docs/public/wasm/tombi_lsp_wasm.d.ts ../../../docs/public/wasm/tombi_lsp_wasm.js ../../../docs/public/wasm/tombi_lsp_wasm_bg.wasm ../../../docs/public/wasm/tombi_lsp_wasm_bg.wasm.d.ts && cd ../../../rust/tombi-wasm && wasm-pack build --locked --target web --out-dir ../../docs/public/wasm --out-name tombi_lsp_wasm -- --no-default-features --features lsp && cp src/lsp-worker.js ../../docs/public/wasm/worker.js",
     "test": "pnpm run build && node ../../../rust/tombi-wasm/tests/lsp-smoke.mjs",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary

- remove the `.gitignore` generated by `wasm-pack` from both WASM package output directories
- allow npm's `files: ["dist"]` selection to include the generated JavaScript, WebAssembly, and type declaration files
- preserve the existing scoped and alias package publishing flow

## Background

The v1.3.3 npm release job initially failed because the new WASM package names did not yet exist for trusted publishing. During local bootstrap publication, `npm pack` also revealed that `wasm-pack` writes `dist/.gitignore` containing `*`. npm applies that ignore file while packing, so both WASM packages contained only `package.json` and omitted their actual build output.

This change removes that generated ignore file immediately after each build.

Failed job: https://github.com/tombi-toml/tombi/actions/runs/31611217652/job/94170802115

## Validation

- `pnpm --dir typescript/@tombi-toml/wasm-lib test`
- `pnpm --dir typescript/@tombi-toml/wasm-lsp test`
- `pnpm exec biome format typescript/@tombi-toml/wasm-lib/package.json typescript/@tombi-toml/wasm-lsp/package.json`
- `pnpm exec biome lint typescript/@tombi-toml/wasm-lib/package.json typescript/@tombi-toml/wasm-lsp/package.json`
- `npm pack <package> --dry-run --json` for both packages; each archive contains 8 entries including `.wasm`, `.js`, and `.d.ts` files
- `git diff --check`