### PR TITLE
docs(wasm): respect format diagnostic severity

### DIFF
--- a/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
+++ b/docs/src/routes/docs/wasm/tombi-wasm-lib.mdx
@@ -31,7 +31,11 @@ try {
   }
 
   for (const diagnostic of diagnostics) {
-    console.error(diagnostic.message);
+    if (diagnostic.level === "error") {
+      console.error(diagnostic.message);
+    } else {
+      console.warn(diagnostic.message);
+    }
   }
 } catch (error) {
   console.error((error as TombiWasmError).message);


### PR DESCRIPTION
## Summary

- log format diagnostics with console.error for errors
- log format diagnostics with console.warn for warnings
- align the format example with the existing lint example

## Validation

- pnpm --dir docs format:check
- pnpm --dir docs lint:check
- pnpm --dir docs typecheck
- BASE_URL=/tombi pnpm --dir docs build
- git diff --check