### PR TITLE
fix(cli): stop LSP after exit notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "tombi-lsp",
  "tombi-regex",
  "tombi-schema-store",
+ "tower 0.5.2",
  "tower-lsp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ tombi-uri = { path = "crates/tombi-uri" }
 tombi-validator = { path = "crates/tombi-validator" }
 tombi-version-sort = { path = "crates/tombi-version-sort" }
 tombi-x-keyword = { path = "crates/tombi-x-keyword" }
+tower = { version = "0.5.2", default-features = false, features = ["util"] }
 tower-lsp = { version = "0.20.0", default-features = false }
 typed-builder = "0.21.0"
 ungrammar.version = "1.16.1"

--- a/rust/tombi-cli/Cargo.toml
+++ b/rust/tombi-cli/Cargo.toml
@@ -21,7 +21,7 @@ nu-ansi-term.workspace = true
 serde_tombi.workspace = true
 similar = { workspace = true, features = ["inline"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-std", "rt"] }
+tokio = { workspace = true, features = ["io-std", "macros", "rt", "sync"] }
 tombi-cache.workspace = true
 tombi-cli-options.workspace = true
 tombi-config.workspace = true
@@ -31,7 +31,11 @@ tombi-glob.workspace = true
 tombi-linter.workspace = true
 tombi-lsp.workspace = true
 tombi-schema-store = { workspace = true, features = ["native"] }
+tower.workspace = true
 tower-lsp = { workspace = true, features = ["runtime-tokio"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "time"] }
 
 [build-dependencies]
 tombi-regex.workspace = true

--- a/rust/tombi-cli/src/app/command/lsp.rs
+++ b/rust/tombi-cli/src/app/command/lsp.rs
@@ -1,4 +1,5 @@
 use crate::app::CommonArgs;
+use tower::ServiceExt as _;
 
 /// Run TOML Language Server.
 #[derive(Debug, clap::Args)]
@@ -20,9 +21,7 @@ pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
         );
 
         let (service, socket) = tombi_lsp::lsp_service(args.common.offline, args.common.no_cache);
-        tower_lsp::Server::new(tokio::io::stdin(), tokio::io::stdout(), socket)
-            .serve(service)
-            .await;
+        serve(tokio::io::stdin(), tokio::io::stdout(), socket, service).await;
 
         log::info!("Tombi LSP Server did shut down.");
     });
@@ -30,4 +29,56 @@ pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
     runtime.shutdown_timeout(std::time::Duration::from_secs(1));
 
     Ok(())
+}
+
+async fn serve<I, O>(
+    input: I,
+    output: O,
+    socket: tower_lsp::ClientSocket,
+    service: tower_lsp::LspService<tombi_lsp::Backend>,
+) where
+    I: tokio::io::AsyncRead + Unpin,
+    O: tokio::io::AsyncWrite,
+{
+    let (exit_tx, exit_rx) = tokio::sync::oneshot::channel();
+    let mut exit_tx = Some(exit_tx);
+    let service = service.map_request(move |request: tower_lsp::jsonrpc::Request| {
+        if request.method() == "exit"
+            && let Some(exit_tx) = exit_tx.take()
+        {
+            let _ = exit_tx.send(());
+        }
+        request
+    });
+
+    tokio::select! {
+        _ = tower_lsp::Server::new(input, output, socket).serve(service) => {}
+        _ = exit_rx => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::AsyncWriteExt as _;
+
+    #[tokio::test]
+    async fn exit_notification_stops_server_while_input_remains_open() {
+        let (mut client_input, server_input) = tokio::io::duplex(1024);
+        let (server_output, _client_output) = tokio::io::duplex(1024);
+        let (service, socket) = tombi_lsp::lsp_service(true, true);
+
+        client_input
+            .write_all(b"Content-Length: 33\r\n\r\n{\"jsonrpc\":\"2.0\",\"method\":\"exit\"}")
+            .await
+            .unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            super::serve(server_input, server_output, socket, service),
+        )
+        .await
+        .expect("the server must not wait for the client to close stdin");
+    }
 }


### PR DESCRIPTION
## Summary

- stop the CLI LSP transport as soon as it receives the `exit` notification
- avoid waiting for clients such as BBEdit to close stdin
- add a regression test that keeps the input stream open after sending `exit`

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `cargo shear`
- `git diff --check`

Fixes #1000