### PR TITLE
fix(npm): identify WASM package repositories

### DIFF
--- a/typescript/@tombi-toml/wasm-lib/package.json
+++ b/typescript/@tombi-toml/wasm-lib/package.json
@@ -2,6 +2,11 @@
   "name": "@tombi-toml/wasm-lib",
   "version": "0.0.0-dev",
   "description": "Tombi formatter and linter for WebAssembly",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tombi-toml/tombi.git",
+    "directory": "typescript/@tombi-toml/wasm-lib"
+  },
   "type": "module",
   "files": [
     "dist"

--- a/typescript/@tombi-toml/wasm-lsp/package.json
+++ b/typescript/@tombi-toml/wasm-lsp/package.json
@@ -2,6 +2,11 @@
   "name": "@tombi-toml/wasm-lsp",
   "version": "0.0.0-dev",
   "description": "Tombi Language Server for WebAssembly",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tombi-toml/tombi.git",
+    "directory": "typescript/@tombi-toml/wasm-lsp"
+  },
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- add repository metadata to the `@tombi-toml/wasm-lib` package
- add repository metadata to the `@tombi-toml/wasm-lsp` package
- preserve the package-specific directory when the manifests are reused for unscoped aliases

## Background

The v1.3.4 npm release failed while publishing `@tombi-toml/wasm-lib` through trusted publishing:

https://github.com/tombi-toml/tombi/actions/runs/31648772550/job/94291776329

npm trusted publishing requires the package repository URL to match the GitHub repository. The WASM package manifests did not declare `repository`, unlike the existing CLI package manifest that published successfully in the same job.

The npm-side trusted publisher configuration still needs to authorize `release_npm.yml` with the `tombi-release` environment for each new WASM package.

## Validation

- `cargo fmt --all --check`
- `pnpm exec biome format typescript/@tombi-toml/wasm-lib/package.json typescript/@tombi-toml/wasm-lsp/package.json`
- `pnpm exec biome lint typescript/@tombi-toml/wasm-lib/package.json typescript/@tombi-toml/wasm-lsp/package.json`
- `pnpm --dir typescript/@tombi-toml/wasm-lib test`
- `pnpm --dir typescript/@tombi-toml/wasm-lsp test`
- `npm pack <package> --dry-run --json` for both packages; each archive contains 8 entries including the WASM output
- verified the unscoped alias manifest transformation retains the repository metadata
- `git diff --check`
