### PR TITLE
refactor(config): remove obsolete line width default

### DIFF
--- a/crates/tombi-config/src/types/line_width.rs
+++ b/crates/tombi-config/src/types/line_width.rs
@@ -12,12 +12,6 @@ impl LineWidth {
     }
 }
 
-impl Default for LineWidth {
-    fn default() -> Self {
-        Self(NonZeroU8::new(80).unwrap())
-    }
-}
-
 impl TryFrom<u8> for LineWidth {
     type Error = &'static str;
 

--- a/docs/src/routes/docs/configuration.mdx
+++ b/docs/src/routes/docs/configuration.mdx
@@ -186,8 +186,6 @@ key-quote-style = "double"
 key-value-equals-sign-alignment = false
 key-value-equals-sign-space-width = 1
 line-ending = "lf"
-# Omit line-width for no line-width limit.
-line-width = 80
 string-quote-style = "double"
 table-blank-lines = 1
 trailing-comment-alignment = false


### PR DESCRIPTION
## Summary

- remove the obsolete `Default` implementation that still made `LineWidth::default()` return `80`
- remove the stale `line-width = 80` entry from the full configuration example
- keep omitted `line-width` documented and implemented as unlimited

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast`
- `cargo test --workspace --doc --locked`
- `cargo test -p tombi-config --all-features --locked`
- `cargo xtask codegen jsonschema`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi PATH=/Users/s23467/.cargo/bin:$PATH pnpm --dir docs build`
- `git diff --check`
