### PR TITLE
fix(schema): validate literal branches by instance type

### DIFF
--- a/crates/tombi-linter/tests/integration/adjacent_applicators_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/adjacent_applicators_test_schema.rs
@@ -420,3 +420,119 @@ test_lint! {
         },
     ])
 }
+
+test_lint! {
+    #[test]
+    fn test_issue_2116_const_true_branch_does_not_match_string(
+        r#"
+        issue_2116_mise_var = "v1.0.0"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_overlapping_numeric_type_union_accepts_integer_once(
+        r#"
+        overlapping_numeric_type_union = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_null_schema_rejects_toml_value(
+        r#"
+        null_only = "not null"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_null_schema_rejects_array(
+        r#"
+        null_only = []
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_null_schema_rejects_table(
+        r#"
+        [null_only]
+        value = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_const_null_schema_rejects_toml_value(
+        r#"
+        const_null_only = "not null"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_enum_null_schema_rejects_toml_value(
+        r#"
+        enum_null_only = "not null"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_one_of_reports_multiple_matches_despite_other_failed_branches(
+        r#"
+        mixed_branch_overlap = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::OneOfMultipleMatch {
+        valid_count: 2,
+        total_count: 3,
+    }])
+}
+
+test_lint! {
+    #[test]
+    fn test_unsatisfiable_literal_additional_property_is_not_dropped(
+        r#"
+        [unsatisfiable_literal_properties]
+        value = "anything"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_empty_enum_additional_property_is_not_dropped(
+        r#"
+        [unsatisfiable_empty_enum_properties]
+        value = "anything"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Nothing])
+}
+
+test_lint! {
+    #[test]
+    fn test_nested_one_of_failure_is_independent_of_disabled_diagnostic(
+        r#"
+        severity_independent_nested_one_of = true # tombi: lint.rules.one-of-multiple-match.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}

--- a/crates/tombi-linter/tests/integration/adjacent_applicators_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/adjacent_applicators_test_schema.rs
@@ -536,3 +536,219 @@ test_lint! {
         SchemaPath(schema_path()),
     ) -> Ok(_)
 }
+
+test_lint! {
+    #[test]
+    fn test_disabled_boolean_const_does_not_change_one_of_result(
+        r#"
+        disabled_boolean_const_branch = false # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_boolean_enum_does_not_change_one_of_result(
+        r#"
+        disabled_boolean_enum_branch = false # tombi: lint.rules.enum.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_integer_const_does_not_change_one_of_result(
+        r#"
+        disabled_integer_const_branch = 2 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_integer_enum_does_not_change_one_of_result(
+        r#"
+        disabled_integer_enum_branch = 2 # tombi: lint.rules.enum.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_float_const_does_not_change_one_of_result(
+        r#"
+        disabled_float_const_branch = 2.5 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_float_enum_does_not_change_one_of_result(
+        r#"
+        disabled_float_enum_branch = 2.5 # tombi: lint.rules.enum.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_number_const_with_integer_does_not_change_one_of_result(
+        r#"
+        disabled_number_const_integer_branch = 2 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_float_const_uses_exact_json_number_equality(
+        r#"
+        exact_float_const = 0.3
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([tombi_validator::DiagnosticKind::Const {
+        expected: "0.30000000000000004".to_string(),
+        actual: "0.3".to_string(),
+    }])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_string_min_length_does_not_change_one_of_result(
+        r#"
+        disabled_string_min_branch = "x" # tombi: lint.rules.string-min-length.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_integer_maximum_does_not_change_one_of_result(
+        r#"
+        disabled_integer_maximum_branch = 2 # tombi: lint.rules.integer-maximum.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_float_maximum_does_not_change_one_of_result(
+        r#"
+        disabled_float_maximum_branch = 2.5 # tombi: lint.rules.float-maximum.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_offset_date_time_const_does_not_change_one_of_result(
+        r#"
+        disabled_offset_date_time_const_branch = 2024-01-02T00:00:00Z # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_local_date_time_const_does_not_change_one_of_result(
+        r#"
+        disabled_local_date_time_const_branch = 2024-01-02T00:00:00 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_local_date_const_does_not_change_one_of_result(
+        r#"
+        disabled_local_date_const_branch = 2024-01-02 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_local_time_const_does_not_change_one_of_result(
+        r#"
+        disabled_local_time_const_branch = 00:00:01 # tombi: lint.rules.const-value.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_array_min_items_does_not_change_one_of_result(
+        r#"
+        disabled_array_min_branch = [1] # tombi: lint.rules.array-min-values.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_table_min_properties_does_not_change_one_of_result(
+        r#"
+        # tombi: lint.rules.table-min-keys.disabled = true
+        disabled_table_min_branch = {}
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_disabled_not_diagnostic_does_not_change_one_of_result(
+        r#"
+        disabled_not_branch = true # tombi: lint.rules.not-schema-match.disabled = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}

--- a/crates/tombi-linter/tests/integration/format_annotation_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/format_annotation_test_schema.rs
@@ -62,3 +62,15 @@ test_lint! {
         SchemaPath(format_assertion_vocab_test_schema_path()),
     ) -> Ok(_)
 }
+
+test_lint! {
+    #[test]
+    fn test_disabled_format_assertion_does_not_change_one_of_result(
+        r#"
+        ipv4_branch = "not-an-ip" # tombi: lint.rules.string-format.disabled = true
+        "#,
+        SchemaPath(format_assertion_vocab_test_schema_path()),
+    ) -> Diagnostics([
+        { code: "unused-noqa", level: tombi_diagnostic::Level::WARNING }
+    ])
+}

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -1020,6 +1020,33 @@ mod hover_keys_value {
 
         test_hover_keys_value!(
             #[tokio::test]
+            async fn issue_2116_const_branch_hover_uses_literal_type(
+                r#"
+                issue_2116_mise_var = "v1.█0.0"
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok({
+                "Keys": "issue_2116_mise_var",
+                "Value": "(String ^ Integer ^ Boolean ^ Table)?",
+                "Enum": ["true"]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn overlapping_numeric_type_union_projects_integer_instance_once(
+                r#"
+                overlapping_numeric_type_union = █1
+                "#,
+                SchemaPath(adjacent_applicators_test_schema_path()),
+            ) -> Ok({
+                "Keys": "overlapping_numeric_type_union",
+                "Value": "Integer?"
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
             async fn same_type_enum_one_of_hover_keeps_branch_values(
                 r#"
                 same_type_enum_one_of = "r█ed"

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -190,10 +190,9 @@ impl Referable<SchemaView> {
             let semantic_schema = Some(Arc::new(super::SemanticSchema::from_object_node(
                 object, dialect,
             )));
-            let schema_view = if semantic_schema
-                .as_deref()
-                .is_some_and(super::SemanticSchema::has_type_assertion)
-            {
+            let schema_view = if semantic_schema.as_deref().is_some_and(|schema| {
+                schema.has_type_assertion() || schema.has_direct_literal_assertion()
+            }) {
                 semantic_schema.as_ref().and_then(|semantic_schema| {
                     semantic_schema.completion_projection_with_collectors(
                         string_formats,

--- a/crates/tombi-schema-store/src/schema/semantic_schema.rs
+++ b/crates/tombi-schema-store/src/schema/semantic_schema.rs
@@ -140,6 +140,14 @@ impl SemanticSchema {
         matches!(self, Self::Object(object) if object.type_assertion.is_some())
     }
 
+    /// Returns whether this schema object itself contains a finite, generic
+    /// literal assertion. Unlike type-specific keywords, `const` and `enum`
+    /// constrain every instance and therefore safely determine presentation
+    /// types even when `type` is absent.
+    pub fn has_direct_literal_assertion(&self) -> bool {
+        matches!(self, Self::Object(object) if object.assertions.const_value.is_some() || object.assertions.enum_values.is_some())
+    }
+
     /// Returns whether an instance type is admitted by the schema's explicit
     /// `type` assertion. Keywords for other types never imply a type here.
     pub fn accepts_instance_type(&self, instance_type: SchemaType) -> bool {
@@ -388,12 +396,20 @@ impl SemanticSchema {
             return Some(super::SchemaView::Null);
         }
         match schemas.len() {
-            0 => None,
+            // An object schema can be valid while admitting no instance, for
+            // example `{ "type": "string", "const": true }` or
+            // `{ "enum": [] }`. Keep that semantic result as an explicit
+            // false view instead of dropping the schema from its parent.
+            0 => Some(super::SchemaView::Nothing(self.range())),
             1 => schemas.into_iter().next().and_then(|schema| match schema {
                 super::Referable::Resolved { value, .. } => std::sync::Arc::try_unwrap(value).ok(),
                 super::Referable::Ref { .. } => None,
             }),
-            _ => Some(super::SchemaView::OneOf(super::OneOfSchema {
+            // A set of admitted presentation types is inclusive. In
+            // particular, a JSON integer is also a JSON number, so projecting
+            // this as `oneOf` would incorrectly require exactly one type view
+            // to validate.
+            _ => Some(super::SchemaView::AnyOf(super::AnyOfSchema {
                 schemas: std::sync::Arc::new(tokio::sync::RwLock::new(schemas)),
                 ..Default::default()
             })),

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -530,7 +530,12 @@ where
     if diagnostics.is_empty() {
         Ok(crate::Valid::new())
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed: false,
+            match_evidence: Default::default(),
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     }
 }
 
@@ -870,6 +875,22 @@ mod tests {
         };
         assert!(is_assertion_success(&Ok(crate::Valid::new())));
         assert!(is_assertion_success(&Err(warning_only_invalid)));
+    }
+
+    #[test]
+    fn assertion_success_is_independent_of_diagnostic_level() {
+        let lint_only_error = crate::Invalid {
+            assertion_failed: false,
+            match_evidence: Default::default(),
+            diagnostics: vec![tombi_diagnostic::Diagnostic::new_error(
+                "lint error",
+                "lint-code",
+                tombi_text::Range::default(),
+            )],
+            local_evaluated_locations: crate::Valid::default(),
+        };
+
+        assert!(is_assertion_success(&Err(lint_only_error)));
     }
 
     #[test]

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -192,7 +192,10 @@ pub fn project_current_schema_for_value(
     ) && !current_schema
         .semantic_schema
         .as_deref()
-        .is_some_and(|schema| schema.has_direct_constraints_for_type(instance_type))
+        .is_some_and(|schema| {
+            schema.has_direct_type_assertion()
+                || schema.has_direct_constraints_for_type(instance_type)
+        })
     {
         return None;
     }
@@ -672,7 +675,9 @@ where
         if current_schema
             .semantic_schema
             .as_deref()
-            .is_some_and(|schema| !schema.has_type_assertion())
+            .is_some_and(|schema| {
+                !schema.has_type_assertion() && !schema.has_direct_literal_assertion()
+            })
         {
             let (one_of, any_of, all_of, not) = current_schema.schema_view.adjacent_applicators();
             validate_adjacent_applicators(

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -152,6 +152,11 @@ async fn validate_array(
         )
         .await
     {
+        assertion_failed |= error.assertion_failed;
+        validation_result
+            .match_evidence
+            .merge_from(*error.match_evidence);
+        validation_result.merge_from(error.local_evaluated_locations);
         total_diagnostics.extend(error.diagnostics);
     }
 
@@ -715,9 +720,6 @@ async fn validate_array(
         }
     }
 
-    assertion_failed |= total_diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.level() == tombi_diagnostic::Level::ERROR);
     let base_result = if total_diagnostics.is_empty() && !assertion_failed {
         Ok(validation_result)
     } else {
@@ -753,10 +755,18 @@ async fn validate_array_without_schema(
     schema_context: &tombi_schema_store::SchemaContext<'_>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut total_diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
+    let mut local_evaluated_locations = crate::Valid::new();
 
     // Validate without schema
     for (index, value) in array_value.values().iter().enumerate() {
-        if let Err(crate::Invalid { diagnostics, .. }) = value
+        if let Err(crate::Invalid {
+            assertion_failed: child_assertion_failed,
+            match_evidence: child_match_evidence,
+            diagnostics,
+            local_evaluated_locations: child_evaluated_locations,
+        }) = value
             .validate(
                 &accessors
                     .iter()
@@ -768,14 +778,22 @@ async fn validate_array_without_schema(
             )
             .await
         {
+            assertion_failed |= child_assertion_failed;
+            match_evidence.merge_descendant_from(&child_match_evidence);
+            local_evaluated_locations.merge_from(child_evaluated_locations);
             total_diagnostics.extend(diagnostics);
         }
     }
 
-    if total_diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    if total_diagnostics.is_empty() && !assertion_failed {
+        Ok(local_evaluated_locations)
     } else {
-        Err(total_diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics: total_diagnostics,
+            local_evaluated_locations,
+        })
     }
 }
 

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -99,7 +99,7 @@ impl Validate for tombi_document_tree::Array {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/boolean.rs
+++ b/crates/tombi-validator/src/validate/boolean.rs
@@ -99,7 +99,7 @@ impl Validate for tombi_document_tree::Boolean {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/boolean.rs
+++ b/crates/tombi-validator/src/validate/boolean.rs
@@ -136,31 +136,36 @@ async fn validate_boolean(
     lint_rules: Option<&BooleanCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
 
     let value = boolean_value.value();
     let range = boolean_value.range();
 
-    if let Some(const_value) = &boolean_schema.const_value
-        && value != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &boolean_schema.const_value {
+        let matched = value == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.to_string(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.to_string(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -174,22 +179,25 @@ async fn validate_boolean(
         );
     }
 
-    if let Some(r#enum) = &boolean_schema.r#enum
-        && !r#enum.contains(&value)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &boolean_schema.r#enum {
+        let matched = r#enum.contains(&value);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -216,10 +224,17 @@ async fn validate_boolean(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/float.rs
+++ b/crates/tombi-validator/src/validate/float.rs
@@ -135,31 +135,36 @@ async fn validate_float(
     lint_rules: Option<&FloatCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
 
     let value = float_value.value();
     let range = float_value.range();
 
-    if let Some(const_value) = &float_schema.const_value
-        && (value - *const_value).abs() > f64::EPSILON
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &float_schema.const_value {
+        let matched = value == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.to_string(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.to_string(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -173,22 +178,25 @@ async fn validate_float(
         );
     }
 
-    if let Some(r#enum) = &float_schema.r#enum
-        && !r#enum.contains(&value)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &float_schema.r#enum {
+        let matched = r#enum.contains(&value);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -205,6 +213,7 @@ async fn validate_float(
     if let Some(maximum) = &float_schema.maximum
         && !check_maximum(&value, maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -239,6 +248,7 @@ async fn validate_float(
     if let Some(minimum) = &float_schema.minimum
         && !check_minimum(&value, minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -273,6 +283,7 @@ async fn validate_float(
     if let Some(exclusive_maximum) = &float_schema.exclusive_maximum
         && !check_exclusive_maximum(&value, exclusive_maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -307,6 +318,7 @@ async fn validate_float(
     if let Some(exclusive_minimum) = &float_schema.exclusive_minimum
         && !check_exclusive_minimum(&value, exclusive_minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -341,6 +353,7 @@ async fn validate_float(
     if let Some(multiple_of) = &float_schema.multiple_of
         && !is_multiple_of_with_tolerance(value, *multiple_of)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -385,10 +398,17 @@ async fn validate_float(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/float.rs
+++ b/crates/tombi-validator/src/validate/float.rs
@@ -98,7 +98,7 @@ impl Validate for tombi_document_tree::Float {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/integer.rs
+++ b/crates/tombi-validator/src/validate/integer.rs
@@ -149,30 +149,35 @@ async fn validate_integer_schema(
     lint_rules: Option<&IntegerCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value = integer_value.value();
     let range = integer_value.range();
 
-    if let Some(const_value) = &integer_schema.const_value
-        && value != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &integer_schema.const_value {
+        let matched = value == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.to_string(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.to_string(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -186,22 +191,25 @@ async fn validate_integer_schema(
         );
     }
 
-    if let Some(r#enum) = &integer_schema.r#enum
-        && !r#enum.contains(&value)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &integer_schema.r#enum {
+        let matched = r#enum.contains(&value);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -218,6 +226,7 @@ async fn validate_integer_schema(
     if let Some(maximum) = &integer_schema.maximum
         && !check_maximum(&value, maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -252,6 +261,7 @@ async fn validate_integer_schema(
     if let Some(minimum) = &integer_schema.minimum
         && !check_minimum(&value, minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -286,6 +296,7 @@ async fn validate_integer_schema(
     if let Some(exclusive_maximum) = &integer_schema.exclusive_maximum
         && !check_exclusive_maximum(&value, exclusive_maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -320,6 +331,7 @@ async fn validate_integer_schema(
     if let Some(exclusive_minimum) = &integer_schema.exclusive_minimum
         && !check_exclusive_minimum(&value, exclusive_minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -354,6 +366,7 @@ async fn validate_integer_schema(
     if let Some(multiple_of) = &integer_schema.multiple_of
         && value % *multiple_of != 0
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -398,10 +411,17 @@ async fn validate_integer_schema(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(
@@ -432,53 +452,62 @@ async fn validate_float_schema_for_integer(
     lint_rules: Option<&IntegerCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value = integer_value.value() as f64;
     let range = integer_value.range();
 
-    if let Some(const_value) = &float_schema.const_value
-        && (value - *const_value).abs() > f64::EPSILON
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &float_schema.const_value {
+        let matched = value == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.to_string(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.to_string(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     }
 
-    if let Some(r#enum) = &float_schema.r#enum
-        && !r#enum.contains(&value)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &float_schema.r#enum {
+        let matched = r#enum.contains(&value);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value.to_string(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value.to_string(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     }
 
     if let Some(maximum) = &float_schema.maximum
         && !check_maximum(&value, maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -502,6 +531,7 @@ async fn validate_float_schema_for_integer(
     if let Some(minimum) = &float_schema.minimum
         && !check_minimum(&value, minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -525,6 +555,7 @@ async fn validate_float_schema_for_integer(
     if let Some(exclusive_maximum) = &float_schema.exclusive_maximum
         && !check_exclusive_maximum(&value, exclusive_maximum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -548,6 +579,7 @@ async fn validate_float_schema_for_integer(
     if let Some(exclusive_minimum) = &float_schema.exclusive_minimum
         && !check_exclusive_minimum(&value, exclusive_minimum)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -572,6 +604,7 @@ async fn validate_float_schema_for_integer(
         && *multiple_of > 0.0
         && !is_multiple_of_with_tolerance(value, *multiple_of)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -605,10 +638,17 @@ async fn validate_float_schema_for_integer(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/integer.rs
+++ b/crates/tombi-validator/src/validate/integer.rs
@@ -112,7 +112,7 @@ impl Validate for tombi_document_tree::Integer {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/local_date.rs
+++ b/crates/tombi-validator/src/validate/local_date.rs
@@ -125,30 +125,35 @@ async fn validate_local_date(
     lint_rules: Option<&LocalDateCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value_string = local_date_value.value().to_string();
     let range = local_date_value.range();
 
-    if let Some(const_value) = &local_date_schema.const_value
-        && value_string != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &local_date_schema.const_value {
+        let matched = value_string == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.clone(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.clone(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -162,22 +167,25 @@ async fn validate_local_date(
         );
     }
 
-    if let Some(r#enum) = &local_date_schema.r#enum
-        && !r#enum.contains(&value_string)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &local_date_schema.r#enum {
+        let matched = r#enum.contains(&value_string);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -204,10 +212,17 @@ async fn validate_local_date(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/local_date.rs
+++ b/crates/tombi-validator/src/validate/local_date.rs
@@ -88,7 +88,7 @@ impl Validate for LocalDate {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/local_date_time.rs
+++ b/crates/tombi-validator/src/validate/local_date_time.rs
@@ -127,30 +127,35 @@ async fn validate_local_date_time(
     lint_rules: Option<&LocalDateTimeCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value_string = local_date_time_value.value().to_string();
     let range = local_date_time_value.range();
 
-    if let Some(const_value) = &local_date_time_schema.const_value
-        && value_string != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &local_date_time_schema.const_value {
+        let matched = value_string == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.clone(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.clone(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -164,22 +169,25 @@ async fn validate_local_date_time(
         );
     }
 
-    if let Some(r#enum) = &local_date_time_schema.r#enum
-        && !r#enum.contains(&value_string)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &local_date_time_schema.r#enum {
+        let matched = r#enum.contains(&value_string);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -206,10 +214,17 @@ async fn validate_local_date_time(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/local_date_time.rs
+++ b/crates/tombi-validator/src/validate/local_date_time.rs
@@ -90,7 +90,7 @@ impl Validate for LocalDateTime {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/local_time.rs
+++ b/crates/tombi-validator/src/validate/local_time.rs
@@ -125,30 +125,35 @@ async fn validate_local_time(
     lint_rules: Option<&LocalTimeCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value_string = local_time_value.value().to_string();
     let range = local_time_value.range();
 
-    if let Some(const_value) = &local_time_schema.const_value
-        && value_string != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &local_time_schema.const_value {
+        let matched = value_string == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.clone(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.clone(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -162,22 +167,25 @@ async fn validate_local_time(
         );
     }
 
-    if let Some(r#enum) = &local_time_schema.r#enum
-        && !r#enum.contains(&value_string)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &local_time_schema.r#enum {
+        let matched = r#enum.contains(&value_string);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -204,10 +212,17 @@ async fn validate_local_time(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/local_time.rs
+++ b/crates/tombi-validator/src/validate/local_time.rs
@@ -88,7 +88,7 @@ impl Validate for LocalTime {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/not_schema.rs
+++ b/crates/tombi-validator/src/validate/not_schema.rs
@@ -60,7 +60,13 @@ where
             &mut diagnostics,
         );
 
-        return Err(diagnostics.into());
+        return Err(crate::Invalid {
+            // `not` is an assertion independently of whether its diagnostic is enabled.
+            assertion_failed: true,
+            match_evidence: Default::default(),
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        });
     } else if common_rules
         .and_then(|rules| rules.not_schema_match.as_ref())
         .and_then(|rules| rules.disabled)

--- a/crates/tombi-validator/src/validate/offset_date_time.rs
+++ b/crates/tombi-validator/src/validate/offset_date_time.rs
@@ -90,7 +90,7 @@ impl Validate for OffsetDateTime {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/crates/tombi-validator/src/validate/offset_date_time.rs
+++ b/crates/tombi-validator/src/validate/offset_date_time.rs
@@ -127,30 +127,35 @@ async fn validate_offset_date_time(
     lint_rules: Option<&OffsetDateTimeCommonLintRules>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
     let value_string = offset_date_time_value.value().to_string();
     let range = offset_date_time_value.range();
 
-    if let Some(const_value) = &offset_date_time_schema.const_value
-        && value_string != *const_value
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| {
-                rules
-                    .const_value
-                    .as_ref()
-                    .map(SeverityLevelDefaultError::from)
-            })
-            .unwrap_or_default();
+    if let Some(const_value) = &offset_date_time_schema.const_value {
+        let matched = value_string == *const_value;
+        match_evidence.mark_root_value_assertion(matched, true);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| {
+                    rules
+                        .const_value
+                        .as_ref()
+                        .map(SeverityLevelDefaultError::from)
+                })
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Const {
-                expected: const_value.clone(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Const {
+                    expected: const_value.clone(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.const_value.as_ref())
         .and_then(|rules| rules.disabled)
@@ -164,22 +169,25 @@ async fn validate_offset_date_time(
         );
     }
 
-    if let Some(r#enum) = &offset_date_time_schema.r#enum
-        && !r#enum.contains(&value_string)
-    {
-        let level = lint_rules
-            .map(|rules| &rules.common)
-            .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
-            .unwrap_or_default();
+    if let Some(r#enum) = &offset_date_time_schema.r#enum {
+        let matched = r#enum.contains(&value_string);
+        match_evidence.mark_root_value_assertion(matched, r#enum.len() == 1);
+        if !matched {
+            assertion_failed = true;
+            let level = lint_rules
+                .map(|rules| &rules.common)
+                .and_then(|rules| rules.r#enum().map(SeverityLevelDefaultError::from))
+                .unwrap_or_default();
 
-        crate::Diagnostic {
-            kind: Box::new(crate::DiagnosticKind::Enum {
-                expected: r#enum.iter().map(ToString::to_string).collect(),
-                actual: value_string.clone(),
-            }),
-            range,
+            crate::Diagnostic {
+                kind: Box::new(crate::DiagnosticKind::Enum {
+                    expected: r#enum.iter().map(ToString::to_string).collect(),
+                    actual: value_string.clone(),
+                }),
+                range,
+            }
+            .push_diagnostic_with_level(level, &mut diagnostics);
         }
-        .push_diagnostic_with_level(level, &mut diagnostics);
     } else if lint_rules
         .and_then(|rules| rules.common.r#enum())
         .and_then(|rules| rules.disabled)
@@ -206,10 +214,17 @@ async fn validate_offset_date_time(
         );
     }
 
-    let base_result = if diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    let base_result = if diagnostics.is_empty() && !assertion_failed {
+        let mut valid = crate::Valid::new();
+        valid.match_evidence = match_evidence;
+        Ok(valid)
     } else {
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     };
 
     crate::validate::merge_validation_results(

--- a/crates/tombi-validator/src/validate/one_of.rs
+++ b/crates/tombi-validator/src/validate/one_of.rs
@@ -173,6 +173,32 @@ where
 
             unreachable!("one_of_schema must have exactly one valid schema");
         } else {
+            if valid_count > 1 {
+                crate::Diagnostic {
+                    kind: Box::new(crate::DiagnosticKind::OneOfMultipleMatch {
+                        valid_count,
+                        total_count,
+                    }),
+                    range: value.range(),
+                }
+                .push_diagnostic_with_level(
+                    common_rules
+                        .and_then(|rules| rules.one_of_multiple_match.as_ref())
+                        .map(SeverityLevelDefaultError::from)
+                        .unwrap_or_default(),
+                    &mut total_diagnostics,
+                );
+
+                return Err(crate::Invalid {
+                    // `oneOf` cardinality is an assertion independently of
+                    // whether its diagnostic is enabled.
+                    assertion_failed: true,
+                    match_evidence: Default::default(),
+                    diagnostics: total_diagnostics,
+                    local_evaluated_locations: base_evaluated_locations,
+                });
+            }
+
             let mut error = each_results
                 .into_iter()
                 .fold(crate::Invalid::new(), |mut a, b| {
@@ -195,30 +221,11 @@ where
                 );
             }
 
-            if !error.assertion_failed && valid_count > 1 {
-                crate::Diagnostic {
-                    kind: Box::new(crate::DiagnosticKind::OneOfMultipleMatch {
-                        valid_count,
-                        total_count,
-                    }),
-                    range: value.range(),
-                }
-                .push_diagnostic_with_level(
-                    common_rules
-                        .and_then(|rules| rules.one_of_multiple_match.as_ref())
-                        .map(SeverityLevelDefaultError::from)
-                        .unwrap_or_default(),
-                    &mut total_diagnostics,
-                );
-
-                Err(total_diagnostics.into())
-            } else {
-                error.prepend_diagnostics(total_diagnostics);
-                error
-                    .local_evaluated_locations
-                    .merge_from(base_evaluated_locations);
-                Err(error)
-            }
+            error.prepend_diagnostics(total_diagnostics);
+            error
+                .local_evaluated_locations
+                .merge_from(base_evaluated_locations);
+            Err(error)
         }
     }
     .boxed()

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -263,7 +263,7 @@ where
                 if total_diagnostics.is_empty() {
                     Ok(result)
                 } else {
-                    Err(total_diagnostics.into())
+                    crate::validate::with_lint_diagnostics(Ok(result), total_diagnostics)
                 }
             }
             Err(mut error) => {
@@ -308,7 +308,12 @@ where
     }
     .push_diagnostic_with_level(level, &mut diagnostics);
 
-    Err(diagnostics.into())
+    Err(crate::Invalid {
+        assertion_failed: false,
+        match_evidence: Default::default(),
+        diagnostics,
+        local_evaluated_locations: Default::default(),
+    })
 }
 
 async fn validate_string<T>(
@@ -352,7 +357,7 @@ where
             if diagnostics.is_empty() {
                 Ok(result)
             } else {
-                Err(diagnostics.into())
+                crate::validate::with_lint_diagnostics(Ok(result), diagnostics)
             }
         }
         Err(error) => Err(error),
@@ -474,6 +479,7 @@ pub(crate) fn validate_raw_string<'a>(
     if let Some(max_length) = &string_schema.max_length
         && length > *max_length
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -508,6 +514,7 @@ pub(crate) fn validate_raw_string<'a>(
     if let Some(min_length) = &string_schema.min_length
         && length < *min_length
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -557,6 +564,7 @@ pub(crate) fn validate_raw_string<'a>(
             StringFormat::JsonPointer => format::json_pointer::validate_format(value),
         }
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -593,6 +601,7 @@ pub(crate) fn validate_raw_string<'a>(
             Regex::new(pattern).inspect_err(|_| log::warn!("Invalid regex pattern: {:?}", pattern))
         && !regex.is_match(value)
     {
+        assertion_failed = true;
         let level = lint_rules
             .map(|rules| &rules.value)
             .and_then(|rules| {
@@ -624,9 +633,6 @@ pub(crate) fn validate_raw_string<'a>(
         );
     }
 
-    assertion_failed |= diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.level() == tombi_diagnostic::Level::ERROR);
     if diagnostics.is_empty() && !assertion_failed {
         let mut valid = crate::Valid::new();
         valid.match_evidence = match_evidence;
@@ -685,6 +691,11 @@ fn validate_string_as_date_format(
         }
         .push_diagnostic_with_level(level, &mut diagnostics);
 
-        Err(diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed: true,
+            match_evidence: Default::default(),
+            diagnostics,
+            local_evaluated_locations: Default::default(),
+        })
     }
 }

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -199,7 +199,7 @@ where
                         result
                     }
                 }
-                SchemaView::Null => return Ok(crate::Valid::new()),
+                SchemaView::Null => handle_nothing_schema(string_value),
                 SchemaView::Anything(_) => handle_anything_schema(string_value),
                 SchemaView::Nothing(_) => handle_nothing_schema(string_value),
                 // When the schema expects a TOML date/time type but the value is a string,

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -962,6 +962,9 @@ async fn validate_table(
         )
         .await
     {
+        assertion_failed |= error.assertion_failed;
+        match_evidence.merge_from(*error.match_evidence);
+        evaluated_locations.merge_from(error.local_evaluated_locations);
         total_diagnostics.extend(error.diagnostics);
     }
 
@@ -969,9 +972,6 @@ async fn validate_table(
         .comment_directives()
         .map(|directives| directives.cloned().collect_vec());
     evaluated_locations.match_evidence = match_evidence.clone();
-    assertion_failed |= total_diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.level() == tombi_diagnostic::Level::ERROR);
     let base_result = if total_diagnostics.is_empty() && !assertion_failed {
         Ok(evaluated_locations)
     } else {
@@ -1440,16 +1440,31 @@ async fn validate_table_without_schema(
     schema_context: &tombi_schema_store::SchemaContext<'_>,
 ) -> Result<crate::Valid, crate::Invalid> {
     let mut total_diagnostics = vec![];
+    let mut assertion_failed = false;
+    let mut match_evidence = Box::<crate::MatchEvidence>::default();
+    let mut local_evaluated_locations = crate::Valid::new();
 
     // Validate without schema
     for (key, value) in table_value.key_values() {
-        if let Err(crate::Invalid { diagnostics, .. }) =
-            key.validate(accessors, None, schema_context).await
+        if let Err(crate::Invalid {
+            assertion_failed: child_assertion_failed,
+            match_evidence: child_match_evidence,
+            diagnostics,
+            local_evaluated_locations: child_evaluated_locations,
+        }) = key.validate(accessors, None, schema_context).await
         {
+            assertion_failed |= child_assertion_failed;
+            match_evidence.merge_descendant_from(&child_match_evidence);
+            local_evaluated_locations.merge_from(child_evaluated_locations);
             total_diagnostics.extend(diagnostics);
         }
 
-        if let Err(crate::Invalid { diagnostics, .. }) = value
+        if let Err(crate::Invalid {
+            assertion_failed: child_assertion_failed,
+            match_evidence: child_match_evidence,
+            diagnostics,
+            local_evaluated_locations: child_evaluated_locations,
+        }) = value
             .validate(
                 &accessors
                     .iter()
@@ -1461,14 +1476,22 @@ async fn validate_table_without_schema(
             )
             .await
         {
+            assertion_failed |= child_assertion_failed;
+            match_evidence.merge_descendant_from(&child_match_evidence);
+            local_evaluated_locations.merge_from(child_evaluated_locations);
             total_diagnostics.extend(diagnostics);
         }
     }
 
-    if total_diagnostics.is_empty() {
-        Ok(crate::Valid::new())
+    if total_diagnostics.is_empty() && !assertion_failed {
+        Ok(local_evaluated_locations)
     } else {
-        Err(total_diagnostics.into())
+        Err(crate::Invalid {
+            assertion_failed,
+            match_evidence,
+            diagnostics: total_diagnostics,
+            local_evaluated_locations,
+        })
     }
 }
 

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -106,7 +106,7 @@ impl Validate for tombi_document_tree::Table {
                         )
                         .await
                     }
-                    SchemaView::Null => return Ok(crate::Valid::new()),
+                    SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
                     _ => {

--- a/schemas/adjacent-applicators-test.schema.json
+++ b/schemas/adjacent-applicators-test.schema.json
@@ -203,6 +203,55 @@
     "enum_with_numeric_sibling": {
       "enum": [9, 12],
       "minimum": 10
+    },
+    "issue_2116_mise_var": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "const": true },
+        { "type": "object" }
+      ]
+    },
+    "overlapping_numeric_type_union": {
+      "type": ["integer", "number"]
+    },
+    "null_only": {
+      "type": "null"
+    },
+    "const_null_only": {
+      "const": null
+    },
+    "enum_null_only": {
+      "enum": [null]
+    },
+    "mixed_branch_overlap": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "const": true },
+        { "type": "string" }
+      ]
+    },
+    "unsatisfiable_literal_properties": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "const": true
+      }
+    },
+    "unsatisfiable_empty_enum_properties": {
+      "type": "object",
+      "additionalProperties": {
+        "enum": []
+      }
+    },
+    "severity_independent_nested_one_of": {
+      "type": "boolean",
+      "not": {
+        "oneOf": [
+          { "type": "boolean" },
+          { "const": true }
+        ]
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/adjacent-applicators-test.schema.json
+++ b/schemas/adjacent-applicators-test.schema.json
@@ -252,6 +252,128 @@
           { "const": true }
         ]
       }
+    },
+    "disabled_boolean_const_branch": {
+      "oneOf": [
+        { "const": true },
+        { "type": "boolean" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_boolean_enum_branch": {
+      "oneOf": [
+        { "enum": [true] },
+        { "type": "boolean" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_integer_const_branch": {
+      "oneOf": [
+        { "const": 1 },
+        { "type": "integer" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_integer_enum_branch": {
+      "oneOf": [
+        { "enum": [1] },
+        { "type": "integer" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_float_const_branch": {
+      "oneOf": [
+        { "const": 1.5 },
+        { "type": "number" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_float_enum_branch": {
+      "oneOf": [
+        { "enum": [1.5] },
+        { "type": "number" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_number_const_integer_branch": {
+      "oneOf": [
+        { "type": "number", "const": 1.5 },
+        { "type": "integer" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_string_min_branch": {
+      "oneOf": [
+        { "type": "string", "minLength": 3 },
+        { "type": "string" },
+        { "type": "boolean" }
+      ]
+    },
+    "disabled_integer_maximum_branch": {
+      "oneOf": [
+        { "type": "integer", "maximum": 1 },
+        { "type": "integer" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_float_maximum_branch": {
+      "oneOf": [
+        { "type": "number", "maximum": 1.5 },
+        { "type": "number" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_offset_date_time_const_branch": {
+      "oneOf": [
+        { "type": "string", "format": "date-time", "const": "2024-01-01T00:00:00Z" },
+        { "type": "string", "format": "date-time" },
+        { "type": "boolean" }
+      ]
+    },
+    "disabled_local_date_time_const_branch": {
+      "oneOf": [
+        { "type": "string", "format": "partial-date-time", "const": "2024-01-01T00:00:00" },
+        { "type": "string", "format": "partial-date-time" },
+        { "type": "boolean" }
+      ]
+    },
+    "disabled_local_date_const_branch": {
+      "oneOf": [
+        { "type": "string", "format": "date", "const": "2024-01-01" },
+        { "type": "string", "format": "date" },
+        { "type": "boolean" }
+      ]
+    },
+    "disabled_local_time_const_branch": {
+      "oneOf": [
+        { "type": "string", "format": "partial-time", "const": "00:00:00" },
+        { "type": "string", "format": "partial-time" },
+        { "type": "boolean" }
+      ]
+    },
+    "disabled_array_min_branch": {
+      "oneOf": [
+        { "type": "array", "minItems": 2 },
+        { "type": "array" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_table_min_branch": {
+      "oneOf": [
+        { "type": "object", "minProperties": 1 },
+        { "type": "object" },
+        { "type": "string" }
+      ]
+    },
+    "disabled_not_branch": {
+      "oneOf": [
+        { "not": { "const": true } },
+        { "const": true },
+        { "type": "string" }
+      ]
+    },
+    "exact_float_const": {
+      "const": 0.30000000000000004
     }
   },
   "additionalProperties": false

--- a/schemas/format-assertion-vocab-test.schema.json
+++ b/schemas/format-assertion-vocab-test.schema.json
@@ -15,6 +15,13 @@
     "ipv4_addr": {
       "type": "string",
       "format": "ipv4"
+    },
+    "ipv4_branch": {
+      "oneOf": [
+        { "type": "string", "format": "ipv4" },
+        { "type": "string" },
+        { "type": "boolean" }
+      ]
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

- project const and enum schemas onto the matching TOML instance type before merging adjacent applicators
- preserve assertion validity independently from diagnostic severity, including disabled lint diagnostics
- apply the same assertion semantics across scalar, date-time, array, table, conditional, and not-schema validation paths
- add regression coverage for Issue #2116 and cross-type assertion/annotation behavior

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace --locked --no-fail-fast (2222 passed)
- cargo test --workspace --doc --locked

Fixes #2116