### PR TITLE
style: normalize diagnostic and log message casing

### DIFF
--- a/crates/tombi-ast-editor/src/edit.rs
+++ b/crates/tombi-ast-editor/src/edit.rs
@@ -166,7 +166,7 @@ fn edit_recursive<'a: 'b, 'b>(
                             let pattern = match tombi_regex::Regex::new(&property_key) {
                                 Ok(pattern) => pattern,
                                 Err(_) => {
-                                    log::warn!("Invalid regex pattern property: {}", property_key);
+                                    log::warn!("invalid regex pattern property: {}", property_key);
                                     continue;
                                 }
                             };

--- a/crates/tombi-ast-editor/src/rule/table_keys_order.rs
+++ b/crates/tombi-ast-editor/src/rule/table_keys_order.rs
@@ -413,7 +413,7 @@ async fn sort_targets<T>(
         }),
         TableKeysOrder::Schema => {
             let Some(table_schema) = table_schema else {
-                log::debug!("Table schema is not available, skipping schema sort");
+                log::debug!("table schema is not available, skipping schema sort");
                 return targets;
             };
             let mut new_targets = vec![];
@@ -501,7 +501,7 @@ async fn sort_table_targets<T>(
                     match tombi_regex::Regex::new(pattern_key) {
                         Ok(pattern) => pattern_regexes.push(pattern),
                         Err(_) => {
-                            log::warn!("Invalid regex pattern property: {}", pattern_key);
+                            log::warn!("invalid regex pattern property: {}", pattern_key);
                         }
                     }
                 }

--- a/crates/tombi-cache/src/lib.rs
+++ b/crates/tombi-cache/src/lib.rs
@@ -181,7 +181,7 @@ pub async fn refresh_cache() -> Result<bool, crate::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 async fn ensure_cache_dir(cache_dir_path: std::path::PathBuf) -> Option<std::path::PathBuf> {
     if let Err(error) = tokio::fs::create_dir_all(&cache_dir_path).await {
-        log::warn!("Failed to create cache directory: {error}");
+        log::warn!("failed to create cache directory: {error}");
         return None;
     }
 

--- a/crates/tombi-diagnostic/examples/diagnostics.rs
+++ b/crates/tombi-diagnostic/examples/diagnostics.rs
@@ -31,11 +31,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source_file = source_file();
 
     let warning = Diagnostic::new_warning(
-        "Some warning occured.",
+        "some warning occured.",
         "tombi-diagnostic",
         ((2, 1), (2, 3)),
     );
-    let error = Diagnostic::new_error("Some error occured.", "tombi-diagnostic", ((2, 1), (2, 3)));
+    let error = Diagnostic::new_error("some error occured.", "tombi-diagnostic", ((2, 1), (2, 3)));
 
     warning.print(&mut Pretty {
         use_ansi_color: true,

--- a/crates/tombi-extension/src/remote_cache.rs
+++ b/crates/tombi-extension/src/remote_cache.rs
@@ -33,7 +33,7 @@ pub async fn warm_remote_json_cache(
 
 async fn get_cached_remote_json_file_path(url: &str) -> Option<PathBuf> {
     let uri = tombi_uri::Uri::from_str(url)
-        .inspect_err(|err| log::warn!("Invalid URL for remote cache {url}: {err}"))
+        .inspect_err(|err| log::warn!("invalid URL for remote cache {url}: {err}"))
         .ok()?;
 
     get_cache_file_path(&uri).await
@@ -72,7 +72,7 @@ async fn fetch_cached_remote_json_from_path<T: DeserializeOwned>(
             {
                 return Some(cached_value);
             }
-            log::warn!("Failed to fetch remote metadata from {url}: {err}");
+            log::warn!("failed to fetch remote metadata from {url}: {err}");
             return None;
         }
     };
@@ -119,7 +119,7 @@ async fn warm_remote_json_cache_from_path(
             bytes
         }
         Err(err) => {
-            log::warn!("Failed to warm remote metadata cache from {url}: {err}");
+            log::warn!("failed to warm remote metadata cache from {url}: {err}");
             return false;
         }
     };
@@ -147,7 +147,7 @@ fn is_cache_fresh(cache_file_path: &Path, cache_options: Option<&tombi_cache::Op
         Ok(metadata) => metadata,
         Err(err) => {
             log::warn!(
-                "Failed to read cache metadata from {:?}: {err}",
+                "failed to read cache metadata from {:?}: {err}",
                 cache_file_path
             );
             return false;
@@ -158,7 +158,7 @@ fn is_cache_fresh(cache_file_path: &Path, cache_options: Option<&tombi_cache::Op
         Ok(modified) => modified,
         Err(err) => {
             log::warn!(
-                "Failed to read cache modified time from {:?}: {err}",
+                "failed to read cache modified time from {:?}: {err}",
                 cache_file_path
             );
             return false;
@@ -169,7 +169,7 @@ fn is_cache_fresh(cache_file_path: &Path, cache_options: Option<&tombi_cache::Op
         Ok(elapsed) => elapsed <= cache_ttl,
         Err(err) => {
             log::warn!(
-                "Failed to calculate cache age for {:?}: {err}",
+                "failed to calculate cache age for {:?}: {err}",
                 cache_file_path
             );
             false
@@ -189,7 +189,7 @@ async fn load_cached_json<T: DeserializeOwned>(
         }
         Ok(None) => None,
         Err(err) => {
-            log::warn!("Failed to read cached remote metadata from {url}: {err}");
+            log::warn!("failed to read cached remote metadata from {url}: {err}");
             None
         }
     }
@@ -213,7 +213,7 @@ fn parse_json<T: DeserializeOwned>(url: &str, bytes: &[u8]) -> Option<T> {
     match serde_json::from_slice(bytes) {
         Ok(value) => Some(value),
         Err(err) => {
-            log::warn!("Failed to parse remote metadata response from {url}: {err}");
+            log::warn!("failed to parse remote metadata response from {url}: {err}");
             None
         }
     }

--- a/crates/tombi-formatter/src/formatter.rs
+++ b/crates/tombi-formatter/src/formatter.rs
@@ -77,11 +77,11 @@ impl<'a> Formatter<'a> {
             }) {
                 Some(source_url_or_path) => {
                     log::info!(
-                        "Skip formatting for \"{source_url_or_path}\" due to `format.disable`"
+                        "skip formatting for \"{source_url_or_path}\" due to `format.disable`"
                     );
                 }
                 None => {
-                    log::info!("Skip formatting for stdin due to `format.disable`");
+                    log::info!("skip formatting for stdin due to `format.disable`");
                 }
             }
             return Ok(source.to_string());
@@ -106,7 +106,7 @@ impl<'a> Formatter<'a> {
         let (root, errors) = parsed.into_root_and_errors();
 
         if !errors.is_empty() {
-            log::trace!("TOML AST with parsing errors: {:#?}", root);
+            log::trace!("parsed TOML AST with errors: {:#?}", root);
 
             let mut diagnostics = vec![];
             for error in errors {
@@ -156,7 +156,7 @@ impl<'a> Formatter<'a> {
         .edit()
         .await;
 
-        log::trace!("TOML AST after editing: {:#?}", root);
+        log::trace!("edited TOML AST: {:#?}", root);
 
         let line_ending = {
             root.format(&mut self).unwrap();

--- a/crates/tombi-glob/src/file_search.rs
+++ b/crates/tombi-glob/src/file_search.rs
@@ -57,12 +57,12 @@ impl FileSearch {
         match FileInputType::from(files) {
             FileInputType::Stdin => FileSearch::Stdin,
             FileInputType::Project => {
-                log::debug!("Searching for TOML files using configured patterns...");
+                log::debug!("searching for TOML files using configured patterns...");
 
                 FileSearch::Files(search_pattern_matched_paths(&root, files_options).await)
             }
             FileInputType::Files => {
-                log::debug!("Searching for TOML files using user input patterns...");
+                log::debug!("searching for TOML files using user input patterns...");
 
                 let mut matched_paths = Vec::with_capacity(100);
 
@@ -86,7 +86,7 @@ impl FileSearch {
                         if path.is_file() {
                             if is_excluded(&path, &root, files_options.exclude.as_deref()) {
                                 log::debug!(
-                                    "Skipping {path:?} because it matches an exclude pattern"
+                                    "skipping {path:?} because it matches an exclude pattern"
                                 );
                                 matched_paths.push(FileSearchEntry::Skipped(path));
                             } else {
@@ -127,8 +127,8 @@ pub async fn search_pattern_matched_paths<P: AsRef<std::path::Path>>(
     root: P,
     files_options: FilesOptions,
 ) -> Vec<FileSearchEntry> {
-    log::debug!("Include patterns: {:?}", files_options.include);
-    log::debug!("Exclude patterns: {:?}", files_options.exclude);
+    log::debug!("include patterns: {:?}", files_options.include);
+    log::debug!("exclude patterns: {:?}", files_options.exclude);
 
     match WalkDir::new_with_options(root, files_options).walk().await {
         Ok(results) => results.into_iter().map(FileSearchEntry::Found).collect(),

--- a/crates/tombi-linter/src/diagnostic.rs
+++ b/crates/tombi-linter/src/diagnostic.rs
@@ -1,10 +1,10 @@
 #[derive(thiserror::Error, Debug)]
 pub enum DiagnosticKind {
-    #[error("Defining dotted keys out-of-order is discouraged")]
+    #[error("defining dotted keys out-of-order is discouraged")]
     DottedKeysOutOfOrder,
-    #[error("Defining tables out-of-order is discouraged")]
+    #[error("defining tables out-of-order is discouraged")]
     TablesOutOfOrder,
-    #[error("Trailing comma after key-value is not allowed")]
+    #[error("trailing comma after key-value is not allowed")]
     ForbiddenKeyValueTrailingComma,
     #[error("inline table must be single line in TOML v1.0.0 or earlier")]
     InlineTableMustSingleLine,

--- a/crates/tombi-linter/src/linter.rs
+++ b/crates/tombi-linter/src/linter.rs
@@ -73,11 +73,11 @@ impl<'a> Linter<'a> {
                 }) {
                     Some(source_url_or_path) => {
                         log::info!(
-                            "Skip linting for \"{source_url_or_path}\" due to `lint.disable`"
+                            "skip linting for \"{source_url_or_path}\" due to `lint.disable`"
                         );
                     }
                     None => {
-                        log::info!("Skip linting for stdin due to `lint.disable`");
+                        log::info!("skip linting for stdin due to `lint.disable`");
                     }
                 }
                 return Ok(());

--- a/crates/tombi-linter/src/rule/dotted_keys_out_of_order.rs
+++ b/crates/tombi-linter/src/rule/dotted_keys_out_of_order.rs
@@ -144,7 +144,7 @@ orange.color = "orange"
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining dotted keys out-of-order is discouraged")
+                .all(|d| d.message() == "defining dotted keys out-of-order is discouraged")
         );
     }
 
@@ -200,7 +200,7 @@ lsp.formatting.enabled = true
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining dotted keys out-of-order is discouraged")
+                .all(|d| d.message() == "defining dotted keys out-of-order is discouraged")
         );
     }
 
@@ -254,7 +254,7 @@ lsp.formatting.enabled = true
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining dotted keys out-of-order is discouraged")
+                .all(|d| d.message() == "defining dotted keys out-of-order is discouraged")
         );
     }
 }

--- a/crates/tombi-linter/src/rule/tables_out_of_order.rs
+++ b/crates/tombi-linter/src/rule/tables_out_of_order.rs
@@ -176,7 +176,7 @@ color = "orange"
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining tables out-of-order is discouraged")
+                .all(|d| d.message() == "defining tables out-of-order is discouraged")
         );
     }
 
@@ -236,7 +236,7 @@ name = "Nail"
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining tables out-of-order is discouraged")
+                .all(|d| d.message() == "defining tables out-of-order is discouraged")
         );
     }
 
@@ -273,7 +273,7 @@ name = "orange"
         assert!(
             diagnostics
                 .iter()
-                .all(|d| d.message() == "Defining tables out-of-order is discouraged")
+                .all(|d| d.message() == "defining tables out-of-order is discouraged")
         );
     }
 }

--- a/crates/tombi-linter/tests/integration/numeric_bounds_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/numeric_bounds_test_schema.rs
@@ -31,7 +31,7 @@ test_lint! {
     fn test_integer_maximum_is_inclusive(
         "integer_maximum = 11",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≤ 10, but found 11"])
+    ) -> Err(["the value must be ≤ 10, but found 11"])
 }
 
 test_lint! {
@@ -39,7 +39,7 @@ test_lint! {
     fn test_integer_minimum_is_inclusive(
         "integer_minimum = 9",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≥ 10, but found 9"])
+    ) -> Err(["the value must be ≥ 10, but found 9"])
 }
 
 test_lint! {
@@ -47,7 +47,7 @@ test_lint! {
     fn test_integer_exclusive_maximum_uses_schema_boundary(
         "integer_exclusive_maximum = -9223372036854775808",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be < -9223372036854775808, but found -9223372036854775808"])
+    ) -> Err(["the value must be < -9223372036854775808, but found -9223372036854775808"])
 }
 
 test_lint! {
@@ -55,7 +55,7 @@ test_lint! {
     fn test_integer_exclusive_minimum_uses_schema_boundary(
         "integer_exclusive_minimum = 9223372036854775807",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be > 9223372036854775807, but found 9223372036854775807"])
+    ) -> Err(["the value must be > 9223372036854775807, but found 9223372036854775807"])
 }
 
 test_lint! {
@@ -63,7 +63,7 @@ test_lint! {
     fn test_float_maximum_is_inclusive(
         "float_maximum = 10.5",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≤ 10, but found 10.5"])
+    ) -> Err(["the value must be ≤ 10, but found 10.5"])
 }
 
 test_lint! {
@@ -71,7 +71,7 @@ test_lint! {
     fn test_float_minimum_is_inclusive(
         "float_minimum = 9.5",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≥ 10, but found 9.5"])
+    ) -> Err(["the value must be ≥ 10, but found 9.5"])
 }
 
 test_lint! {
@@ -79,7 +79,7 @@ test_lint! {
     fn test_float_exclusive_maximum_is_exclusive(
         "float_exclusive_maximum = 10.0",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be < 10, but found 10"])
+    ) -> Err(["the value must be < 10, but found 10"])
 }
 
 test_lint! {
@@ -87,7 +87,7 @@ test_lint! {
     fn test_float_exclusive_minimum_is_exclusive(
         "float_exclusive_minimum = 10.0",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be > 10, but found 10"])
+    ) -> Err(["the value must be > 10, but found 10"])
 }
 
 test_lint! {
@@ -95,7 +95,7 @@ test_lint! {
     fn test_float_maximum_rejects_nan(
         "float_maximum = nan",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≤ 10, but found NaN"])
+    ) -> Err(["the value must be ≤ 10, but found NaN"])
 }
 
 test_lint! {
@@ -103,7 +103,7 @@ test_lint! {
     fn test_float_minimum_rejects_nan(
         "float_minimum = nan",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be ≥ 10, but found NaN"])
+    ) -> Err(["the value must be ≥ 10, but found NaN"])
 }
 
 test_lint! {
@@ -111,7 +111,7 @@ test_lint! {
     fn test_float_exclusive_maximum_rejects_nan(
         "float_exclusive_maximum = nan",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be < 10, but found NaN"])
+    ) -> Err(["the value must be < 10, but found NaN"])
 }
 
 test_lint! {
@@ -119,5 +119,5 @@ test_lint! {
     fn test_float_exclusive_minimum_rejects_nan(
         "float_exclusive_minimum = nan",
         SchemaPath(schema_path()),
-    ) -> Err(["The value must be > 10, but found NaN"])
+    ) -> Err(["the value must be > 10, but found NaN"])
 }

--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -136,13 +136,13 @@ impl Backend {
             }
 
             if !capabilities.workspace_diagnostic_refresh_support {
-                log::debug!("Client does not support workspace/diagnostic/refresh");
+                log::debug!("client does not support workspace/diagnostic/refresh");
                 return;
             }
         }
 
         if let Err(error) = self.client.workspace_diagnostic_refresh().await {
-            log::debug!("Failed to request diagnostic refresh: {error}");
+            log::debug!("failed to request diagnostic refresh: {error}");
         }
     }
 

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -300,7 +300,7 @@ impl FindCompletionContents for tombi_document_tree::Table {
                                         let Ok(pattern) = tombi_regex::Regex::new(&property_key)
                                         else {
                                             log::warn!(
-                                                "Invalid regex pattern property: {}",
+                                                "invalid regex pattern property: {}",
                                                 property_key
                                             );
                                             continue;

--- a/crates/tombi-lsp/src/config_manager.rs
+++ b/crates/tombi-lsp/src/config_manager.rs
@@ -62,7 +62,7 @@ impl ConfigManager {
             match serde_tombi::config::load_with_path(std::env::current_dir().ok()) {
                 Ok((config, config_path)) => (config, config_path),
                 Err(err) => {
-                    log::error!("Failed to load default config: {err}");
+                    log::error!("failed to load default config: {err}");
                     (Config::default(), None)
                 }
             };
@@ -144,7 +144,7 @@ impl ConfigManager {
                         });
 
                     if schema_store.is_empty().await {
-                        log::info!("Add new SchemaStore for {config_path_buf:?}");
+                        log::info!("add new SchemaStore for {config_path_buf:?}");
                         let associated_schemas = self.associated_schemas.read().await;
                         if let Err(err) = load_schema_store_with_associations(
                             schema_store,
@@ -154,7 +154,7 @@ impl ConfigManager {
                         )
                         .await
                         {
-                            log::error!("Failed to load schema store: {err}");
+                            log::error!("failed to load schema store: {err}");
                         }
                     }
 
@@ -216,7 +216,7 @@ impl ConfigManager {
             )
             .await
             {
-                log::error!("Failed to load default schema store: {err}");
+                log::error!("failed to load default schema store: {err}");
             }
 
             let config_schema_store = ConfigSchemaStore::new(config, None, schema_store);
@@ -363,7 +363,7 @@ impl ConfigManager {
             load_schema_store_with_associations(&schema_store, &config, None, &associated_schemas)
                 .await
         {
-            log::error!("Failed to load editor config schema store: {err}");
+            log::error!("failed to load editor config schema store: {err}");
         }
 
         let config_schema_store = ConfigSchemaStore::new(config, None, schema_store);

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -66,11 +66,11 @@ pub async fn get_diagnostics_result(
         match matches_file_patterns(&text_document_path, config_path.as_deref(), &config) {
             MatchResult::Matched => {}
             MatchResult::IncludeNotMatched => {
-                log::info!("Skip {text_document_path:?} because it is not in config.files.include");
+                log::info!("skip {text_document_path:?} because it is not in config.files.include");
                 return None;
             }
             MatchResult::ExcludeMatched => {
-                log::info!("Skip {text_document_path:?} because it is in config.files.exclude");
+                log::info!("skip {text_document_path:?} because it is in config.files.exclude");
                 return None;
             }
         }
@@ -96,7 +96,7 @@ pub async fn get_diagnostics_result(
         text_document_path.as_deref(),
         config_path.as_deref(),
     ) else {
-        log::debug!("Linting disabled for {:?} by override", text_document_path);
+        log::debug!("linting disabled for {:?} by override", text_document_path);
         return None;
     };
 

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -160,7 +160,7 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                             }
                                         } else {
                                             log::warn!(
-                                                "Invalid regex pattern property: {}",
+                                                "invalid regex pattern property: {}",
                                                 property_key
                                             );
                                         };

--- a/crates/tombi-lsp/src/handler/associate_schema.rs
+++ b/crates/tombi-lsp/src/handler/associate_schema.rs
@@ -45,7 +45,7 @@ pub async fn handle_associate_schema(backend: &Backend, params: AssociateSchemaP
     log::trace!("{:?}", params);
 
     let Ok(schema_uri) = tombi_schema_store::SchemaUri::from_str(&params.uri) else {
-        log::warn!("Invalid schema URL: {}", params.uri);
+        log::warn!("invalid schema URL: {}", params.uri);
         return;
     };
 
@@ -78,6 +78,6 @@ pub async fn handle_associate_schema(backend: &Backend, params: AssociateSchemaP
     )
     .await
     {
-        log::warn!("Failed to push workspace diagnostics: {err}");
+        log::warn!("failed to push workspace diagnostics: {err}");
     }
 }

--- a/crates/tombi-lsp/src/handler/did_change.rs
+++ b/crates/tombi-lsp/src/handler/did_change.rs
@@ -16,7 +16,7 @@ pub async fn handle_did_change(backend: &Backend, params: DidChangeTextDocumentP
 
     for content_change in content_changes {
         if let Some(range) = content_change.range {
-            log::warn!("Range change is not supported: {:?}", range);
+            log::warn!("range change is not supported: {:?}", range);
         } else {
             latest_text = Some(content_change.text);
         }

--- a/crates/tombi-lsp/src/handler/did_change_configuration.rs
+++ b/crates/tombi-lsp/src/handler/did_change_configuration.rs
@@ -21,14 +21,14 @@ pub async fn handle_did_change_configuration(
     if let Some(tombi_settings) = settings.get("tombi") {
         match serde_json::from_value::<tombi_config::Config>(tombi_settings.clone()) {
             Ok(config) => {
-                log::info!("Updating editor config: {:?}", config);
+                log::info!("updating editor config: {:?}", config);
                 backend.config_manager.update_editor_config(config).await;
             }
             Err(err) => {
-                log::error!("Failed to parse editor config: {}", err);
+                log::error!("failed to parse editor config: {}", err);
             }
         }
     } else {
-        log::debug!("No tombi settings found in didChangeConfiguration");
+        log::debug!("no tombi settings found in didChangeConfiguration");
     }
 }

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -22,7 +22,7 @@ pub async fn handle_did_change_watched_files(
     for change in params.changes {
         let uri: tombi_uri::Uri = change.uri.clone().into();
 
-        log::debug!("Detected {:?} via watcher: {}", change.typ, uri);
+        log::debug!("detected {:?} via watcher: {}", change.typ, uri);
 
         match change.typ {
             FileChangeType::DELETED => {
@@ -85,7 +85,7 @@ pub async fn handle_did_change_watched_files(
                 }
             }
             _ => {
-                log::debug!("Ignored file change type {:?} for URI: {}", change.typ, uri);
+                log::debug!("ignored file change type {:?} for URI: {}", change.typ, uri);
             }
         }
     }

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -79,7 +79,7 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
         backend.spawn_background_task(async move {
             let should_refresh_inlay_hint = cache_warming.await;
             if should_refresh_inlay_hint && let Err(err) = client.inlay_hint_refresh().await {
-                log::debug!("Failed to request warmed inlay hint refresh: {err}");
+                log::debug!("failed to request warmed inlay hint refresh: {err}");
             }
         });
     }

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -61,11 +61,11 @@ pub async fn handle_formatting(
         match matches_file_patterns(&text_document_path, config_path.as_deref(), &config) {
             MatchResult::Matched => {}
             MatchResult::IncludeNotMatched => {
-                log::info!("Skip {text_document_path:?} because it is not in config.files.include");
+                log::info!("skip {text_document_path:?} because it is not in config.files.include");
                 return Ok(None);
             }
             MatchResult::ExcludeMatched => {
-                log::info!("Skip {text_document_path:?} because it is in config.files.exclude");
+                log::info!("skip {text_document_path:?} because it is in config.files.exclude");
                 return Ok(None);
             }
         }
@@ -95,7 +95,7 @@ pub async fn handle_formatting(
         config_path.as_deref(),
     ) else {
         log::debug!(
-            "Formatting disabled for {:?} by override",
+            "formatting disabled for {:?} by override",
             text_document_path
         );
         return Ok(None);
@@ -136,7 +136,7 @@ pub async fn handle_formatting(
             }
         }
         Err(diagnostics) => {
-            log::error!("Failed to format");
+            log::error!("failed to format");
             backend
                 .client
                 .send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -78,12 +78,12 @@ pub async fn handle_hover(
     }
 
     let Some((keys, range)) = get_hover_keys_with_range(&root, position, toml_version).await else {
-        log::debug!("Failed to get hover keys with range");
+        log::debug!("failed to get hover keys with range");
         return Ok(None);
     };
 
     if keys.is_empty() && range.is_none() {
-        log::debug!("Keys and range are empty");
+        log::debug!("keys and range are empty");
         return Ok(None);
     }
 

--- a/crates/tombi-lsp/src/handler/initialized.rs
+++ b/crates/tombi-lsp/src/handler/initialized.rs
@@ -15,16 +15,16 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
 
     let startup_backend = backend.clone();
     backend.spawn_background_task(async move {
-        log::info!("Loading config in background...");
+        log::info!("loading config in background...");
         if let Err(error) = startup_backend.config_manager.load().await {
-            log::warn!("Failed to load config: {error}");
+            log::warn!("failed to load config: {error}");
             return;
         }
 
         let diagnostic_mode = startup_backend.capabilities.read().await.diagnostic_mode;
         match diagnostic_mode {
             DiagnosticMode::Pull => {
-                log::info!("Refreshing pull diagnostics after config load...");
+                log::info!("refreshing pull diagnostics after config load...");
                 startup_backend.refresh_pull_diagnostics().await;
             }
             DiagnosticMode::Push => {
@@ -40,7 +40,7 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
                     startup_backend.push_diagnostics(text_document_uri).await;
                 }
 
-                log::info!("Pushing workspace diagnostics after config load...");
+                log::info!("pushing workspace diagnostics after config load...");
                 if let Err(error) = push_workspace_diagnostics(
                     &startup_backend,
                     &WorkspaceDiagnosticOptions {
@@ -49,15 +49,15 @@ pub async fn handle_initialized(backend: &Backend, params: InitializedParams) {
                 )
                 .await
                 {
-                    log::warn!("Failed to push workspace diagnostics: {error}");
+                    log::warn!("failed to push workspace diagnostics: {error}");
                 }
             }
         }
     });
 
-    log::info!("Registering workspace TOML watchers...");
+    log::info!("registering workspace TOML watchers...");
     if let Err(error) = register_workspace_toml_watcher(backend).await {
-        log::warn!("Failed to register TOML file watchers: {error}");
+        log::warn!("failed to register TOML file watchers: {error}");
     }
 }
 

--- a/crates/tombi-lsp/src/handler/refresh_cache.rs
+++ b/crates/tombi-lsp/src/handler/refresh_cache.rs
@@ -14,15 +14,15 @@ pub async fn handle_refresh_cache(
 
     match backend.config_manager.refresh_cache().await {
         Ok(true) => {
-            log::info!("Cache refreshed");
+            log::info!("cache refreshed");
             Ok(true)
         }
         Ok(false) => {
-            log::info!("No cache to refresh");
+            log::info!("no cache to refresh");
             Ok(false)
         }
         Err(err) => {
-            log::error!("Failed to refresh cache: {err}");
+            log::error!("failed to refresh cache: {err}");
             Err(tower_lsp::jsonrpc::Error {
                 code: tower_lsp::jsonrpc::ErrorCode::InternalError,
 

--- a/crates/tombi-lsp/src/handler/update_config.rs
+++ b/crates/tombi-lsp/src/handler/update_config.rs
@@ -21,12 +21,12 @@ pub async fn handle_update_config(
                 {
                     Ok(_) => {
                         backend.workspace_diagnostics_cache.write().await.reset();
-                        log::info!("Updated config: {}", text_document_uri);
+                        log::info!("updated config: {}", text_document_uri);
                         return Ok(true);
                     }
                     Err(err) => {
                         log::error!(
-                            "Failed to update config for {config_path}: {err}",
+                            "failed to update config for {config_path}: {err}",
                             config_path = config_path.display()
                         );
                     }
@@ -35,7 +35,7 @@ pub async fn handle_update_config(
             Ok(None) => {}
             Err(err) => {
                 log::error!(
-                    "Failed to load config for update for {config_path}: {err}",
+                    "failed to load config for update for {config_path}: {err}",
                     config_path = config_path.display()
                 );
             }

--- a/crates/tombi-lsp/src/handler/update_schema.rs
+++ b/crates/tombi-lsp/src/handler/update_schema.rs
@@ -40,7 +40,7 @@ pub async fn handle_update_schema(
                 )
                 .await
                 {
-                    log::warn!("Failed to push workspace diagnostics: {err}");
+                    log::warn!("failed to push workspace diagnostics: {err}");
                 }
             }
             Ok(is_updated)

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -340,7 +340,7 @@ impl GetHoverContent for tombi_document_tree::Table {
                                             }
                                         } else {
                                             log::warn!(
-                                                "Invalid regex pattern property: {}",
+                                                "invalid regex pattern property: {}",
                                                 property_key
                                             );
                                         };

--- a/crates/tombi-lsp/src/remote_file.rs
+++ b/crates/tombi-lsp/src/remote_file.rs
@@ -141,17 +141,17 @@ async fn fetch_remote_content(url: &Url) -> Result<String, tower_lsp::jsonrpc::E
 
     let client = tombi_schema_store::DefaultHttpClient::new();
     let bytes = client.get_bytes(url.as_str()).await.map_err(|error| {
-        log::error!("Failed to fetch content: {error}");
+        log::error!("failed to fetch content: {error}");
         tower_lsp::jsonrpc::Error::new(tower_lsp::jsonrpc::ErrorCode::InternalError)
     })?;
     let content = String::from_utf8(bytes.to_vec()).map_err(|error| {
-        log::error!("Remote content is not valid UTF-8: {error}");
+        log::error!("remote content is not valid UTF-8: {error}");
         tower_lsp::jsonrpc::Error::new(tower_lsp::jsonrpc::ErrorCode::InternalError)
     })?;
 
     // Check if the content is valid JSON
     tombi_json::ValueNode::from_str(&content).map_err(|e| {
-        log::error!("Failed to parse {url} content: {}", e);
+        log::error!("failed to parse {url} content: {}", e);
         tower_lsp::jsonrpc::Error::new(tower_lsp::jsonrpc::ErrorCode::InternalError)
     })?;
 

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -59,7 +59,7 @@ pub async fn collect_workspace_diagnostic_targets(backend: &Backend) -> Vec<tomb
             && &workspace_config.workspace_folder_path == home_dir
         {
             log::debug!(
-                "Skip diagnostics for workspace folder matching $HOME: {:?}",
+                "skip diagnostics for workspace folder matching $HOME: {:?}",
                 workspace_config.workspace_folder_path
             );
             continue;
@@ -116,7 +116,7 @@ async fn publish_workspace_diagnostics(
 
     if !options.include_open_files && version.is_some() {
         log::debug!(
-            "Skip publishing workspace diagnostics because version is some: {text_document_uri}"
+            "skip publishing workspace diagnostics because version is some: {text_document_uri}"
         );
         return;
     }
@@ -131,14 +131,14 @@ pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_
     let text_document_path = match text_document_uri.to_file_path() {
         Ok(text_document_path) => text_document_path,
         Err(_) => {
-            log::warn!("Watcher event for non-file URI: {text_document_uri}");
+            log::warn!("watcher event for non-file URI: {text_document_uri}");
             return false;
         }
     };
 
     let Ok(content) = tombi_fs::read_to_string_async(&text_document_path).await else {
         log::warn!(
-            "Failed to read file for diagnostics: {:?}",
+            "failed to read file for diagnostics: {:?}",
             text_document_path
         );
         return false;
@@ -153,7 +153,7 @@ pub async fn upsert_document_source(backend: &Backend, text_document_uri: tombi_
         let mut document_sources = backend.document_sources.write().await;
         if let Some(source) = document_sources.get_mut(&text_document_uri) {
             if source.version.is_some() {
-                log::debug!("Skip diagnostics for open document: {text_document_uri}");
+                log::debug!("skip diagnostics for open document: {text_document_uri}");
                 return true;
             }
 

--- a/crates/tombi-lsp/tests/fixtures/issue-1495-subdirectory-glob/README.md
+++ b/crates/tombi-lsp/tests/fixtures/issue-1495-subdirectory-glob/README.md
@@ -22,7 +22,7 @@ The fixture files are valid by default.
 In `crates/tombi-lsp/tests/test_diagnostic.rs`, diagnostics are asserted by opening each file path with injected text `name = false`.
 
 When glob association works correctly, both `product.toml` and `subdir/subproduct.toml` receive the same schema and both produce:
-- `Expected a value of type String, but found Boolean`
+- `expected a value of type String, but found Boolean`
 
 ## Before the Fix
 

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -46,7 +46,7 @@ mod diagnostic {
                 ConfigPath(fixture_path().join("tombi.toml")),
             ) -> Ok([
                 Diagnostic {
-                    message: "Expected a value of type String, but found Boolean",
+                    message: "expected a value of type String, but found Boolean",
                     range: ((0, 7), (0, 12)),
                 }
             ]);
@@ -60,7 +60,7 @@ mod diagnostic {
                 ConfigPath(fixture_path().join("tombi.toml")),
             ) -> Ok([
                 Diagnostic {
-                    message: "Expected a value of type String, but found Boolean",
+                    message: "expected a value of type String, but found Boolean",
                     range: ((0, 7), (0, 12)),
                 }
             ]);
@@ -85,7 +85,7 @@ mod diagnostic {
                 ConfigPath(fixture_path().join(".config/tombi.toml")),
             ) -> Ok([
                 Diagnostic {
-                    message: "Expected a value of type String, but found Boolean",
+                    message: "expected a value of type String, but found Boolean",
                     range: ((0, 7), (0, 12)),
                 }
             ]);
@@ -160,7 +160,7 @@ mod diagnostic {
                 ConfigPath(fixture_path().join("tombi.toml")),
             ) -> Ok([
                 Diagnostic {
-                    message: "The value must be one of [\"x\"], but found \"y\"",
+                    message: "the value must be one of [\"x\"], but found \"y\"",
                     range: ((1, 12), (1, 15)),
                 }
             ]);

--- a/crates/tombi-schema-store/src/schema/array_schema.rs
+++ b/crates/tombi-schema-store/src/schema/array_schema.rs
@@ -292,7 +292,7 @@ impl XTombiArrayValuesOrder {
                 match ArrayValuesOrder::try_from(string.value.as_ref()) {
                     Ok(val) => return Some(XTombiArrayValuesOrder::All(val)),
                     Err(_) => {
-                        log::warn!("Invalid {X_TOMBI_ARRAY_VALUES_ORDER}: {}", string.value);
+                        log::warn!("invalid {X_TOMBI_ARRAY_VALUES_ORDER}: {}", string.value);
                     }
                 }
             }
@@ -310,7 +310,7 @@ impl XTombiArrayValuesOrder {
                                         Some(val) => orders.push(val),
                                         None => {
                                             log::warn!(
-                                                "Invalid {X_TOMBI_ARRAY_VALUES_ORDER} {group_name} group: {}",
+                                                "invalid {X_TOMBI_ARRAY_VALUES_ORDER} {group_name} group: {}",
                                                 group_orders
                                             );
                                         }
@@ -332,7 +332,7 @@ impl XTombiArrayValuesOrder {
                                         Some(val) => orders.push(val),
                                         None => {
                                             log::warn!(
-                                                "Invalid {X_TOMBI_ARRAY_VALUES_ORDER} {group_name} group: {}",
+                                                "invalid {X_TOMBI_ARRAY_VALUES_ORDER} {group_name} group: {}",
                                                 group_orders
                                             );
                                         }
@@ -345,7 +345,7 @@ impl XTombiArrayValuesOrder {
                         }
                         _ => {
                             log::warn!(
-                                "Invalid {X_TOMBI_ARRAY_VALUES_ORDER} group: {}",
+                                "invalid {X_TOMBI_ARRAY_VALUES_ORDER} group: {}",
                                 group_name.value
                             );
                         }

--- a/crates/tombi-schema-store/src/schema/table_schema.rs
+++ b/crates/tombi-schema-store/src/schema/table_schema.rs
@@ -164,11 +164,11 @@ impl TableSchema {
                     if let Ok(v) = ArrayValuesOrderBy::try_from(v) {
                         Some(v)
                     } else {
-                        log::warn!("Invalid {X_TOMBI_ARRAY_VALUES_ORDER_BY}: {v}");
+                        log::warn!("invalid {X_TOMBI_ARRAY_VALUES_ORDER_BY}: {v}");
                         None
                     }
                 } else {
-                    log::warn!("Invalid {X_TOMBI_ARRAY_VALUES_ORDER_BY}: {}", v);
+                    log::warn!("invalid {X_TOMBI_ARRAY_VALUES_ORDER_BY}: {}", v);
                     None
                 }
             });
@@ -617,7 +617,7 @@ impl XTombiTableKeysOrder {
                 match TableKeysOrder::try_from(order.as_str()) {
                     Ok(val) => Some(XTombiTableKeysOrder::All(val)),
                     Err(_) => {
-                        log::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}: {order}");
+                        log::warn!("invalid {X_TOMBI_TABLE_KEYS_ORDER}: {order}");
                         None
                     }
                 }
@@ -627,20 +627,20 @@ impl XTombiTableKeysOrder {
                 for (group_name, order) in &object_node.properties {
                     let Ok(target) = TableKeysOrderGroupKind::try_from(group_name.value.as_str())
                     else {
-                        log::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER} group: {group_name}");
+                        log::warn!("invalid {X_TOMBI_TABLE_KEYS_ORDER} group: {group_name}");
                         return None;
                     };
 
                     let Some(Ok(order)) = order.as_str().map(TableKeysOrder::try_from) else {
                         log::warn!(
-                            "Invalid {X_TOMBI_TABLE_KEYS_ORDER} {group_name} group: {order}"
+                            "invalid {X_TOMBI_TABLE_KEYS_ORDER} {group_name} group: {order}"
                         );
                         return None;
                     };
 
                     if order == TableKeysOrder::Schema && target != TableKeysOrderGroupKind::Keys {
                         log::warn!(
-                            "Invalid {X_TOMBI_TABLE_KEYS_ORDER} {group_name} group: {order}"
+                            "invalid {X_TOMBI_TABLE_KEYS_ORDER} {group_name} group: {order}"
                         );
                         return None;
                     }
@@ -650,7 +650,7 @@ impl XTombiTableKeysOrder {
                 Some(Self::Groups(sort_orders))
             }
             order => {
-                log::warn!("Invalid {X_TOMBI_TABLE_KEYS_ORDER}: {}", order);
+                log::warn!("invalid {X_TOMBI_TABLE_KEYS_ORDER}: {}", order);
                 None
             }
         }

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -210,11 +210,11 @@ impl SchemaStore {
             } {
                 schema_uri
             } else {
-                log::warn!("Invalid schema path: {}", schema.path());
+                log::warn!("invalid schema path: {}", schema.path());
                 return;
             };
 
-            log::debug!("Load schema from config: {}", schema_uri);
+            log::debug!("load schema from config: {}", schema_uri);
 
             self.schemas.write().await.push(crate::Schema {
                 title: None,
@@ -1023,13 +1023,13 @@ impl SchemaStore {
                 },
                 Ok(None) => {
                     log::warn!(
-                        "Failed to find document schema: {}",
+                        "failed to find document schema: {}",
                         matching_schema.schema_uri
                     );
                 }
                 Err(err) => {
                     log::warn!(
-                        "Failed to get document schema for {url}: {err}",
+                        "failed to get document schema for {url}: {err}",
                         url = matching_schema.schema_uri,
                     );
                 }

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -433,7 +433,7 @@ impl SchemaStore {
                 let file = std::fs::File::open(&schema_path)
                     .map_err(|_| crate::Error::SchemaFileReadFailed { schema_path })?;
 
-                log::debug!("fetch schema from file: {}", schema_uri);
+                log::debug!("load schema from file: {}", schema_uri);
 
                 Ok(Some(tombi_json::ValueNode::from_reader(file).map_err(
                     |err| crate::Error::SchemaFileParseFailed {
@@ -511,7 +511,7 @@ impl SchemaStore {
                     });
                 };
 
-                log::debug!("fetch schema from embedded file: {}", schema_uri);
+                log::trace!("load schema from embedded file: {}", schema_uri);
 
                 Ok(Some(tombi_json::ValueNode::from_str(content).map_err(
                     |err| crate::Error::SchemaFileParseFailed {
@@ -1289,7 +1289,7 @@ async fn load_json_schema_from_cache(
     if let Some(schema_cache_content) =
         read_from_cache(Some(schema_cache_path), cache_options).await?
     {
-        log::debug!("load schema from cache: {}", schema_uri);
+        log::trace!("load schema from cache: {}", schema_uri);
 
         return Ok(Some(
             tombi_json::ValueNode::from_str(&schema_cache_content).map_err(|err| {

--- a/crates/tombi-text/src/position.rs
+++ b/crates/tombi-text/src/position.rs
@@ -114,7 +114,7 @@ impl Sub<Position> for Position {
     fn sub(self, rhs: Position) -> Self::Output {
         if rhs > self {
             log::warn!(
-                "Invalid tombi_text::Position: rhs: {:?} > self: {:?}",
+                "invalid tombi_text::Position: rhs: {:?} > self: {:?}",
                 rhs,
                 self
             );

--- a/crates/tombi-text/src/range.rs
+++ b/crates/tombi-text/src/range.rs
@@ -30,7 +30,7 @@ impl Range {
                 end
             } else {
                 log::warn!(
-                    "Invalid tombi_text::Range: start: {:?} > end: {:?}",
+                    "invalid tombi_text::Range: start: {:?} > end: {:?}",
                     start,
                     end
                 );

--- a/crates/tombi-validator/src/diagnostic.rs
+++ b/crates/tombi-validator/src/diagnostic.rs
@@ -7,10 +7,10 @@ use tombi_x_keyword::StringFormat;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DiagnosticKind {
-    #[error("An empty key is discouraged")]
+    #[error("an empty key is discouraged")]
     KeyEmpty,
 
-    #[error("Don't need to use `{rule_name}.disabled = true`. Please remove it.")]
+    #[error("don't need to use `{rule_name}.disabled = true`. Please remove it.")]
     UnusedNoqa { rule_name: &'static str },
 
     /// The entire Table or Array is deprecated
@@ -40,7 +40,7 @@ pub enum DiagnosticKind {
     },
 
     #[error(
-        "In strict mode, {accessors} does not allow \"{key}\" key. \
+        "in strict mode, {accessors} does not allow \"{key}\" key. \
          Please add `\"additionalProperties\": true` to the location where it is defined in {schema_uri}, \
          or add `#:tombi schema.strict = false` as a document comment directive at the top of your document, \
          or set `strict = false` in the matching `schemas[*].strict` / `schema.strict` entry in your `tombi.toml`."
@@ -54,61 +54,61 @@ pub enum DiagnosticKind {
     #[error("\"{key}\" is not allowed")]
     KeyNotAllowed { key: String },
 
-    #[error("Unevaluated property \"{key}\" is not allowed")]
+    #[error("unevaluated property \"{key}\" is not allowed")]
     UnevaluatedPropertyNotAllowed { key: String },
 
-    #[error("Key must match the pattern `{patterns}`")]
+    #[error("key must match the pattern `{patterns}`")]
     KeyPattern { patterns: Patterns },
 
-    #[error("Expected a value of type {expected}, but found {actual}")]
+    #[error("expected a value of type {expected}, but found {actual}")]
     TypeMismatch {
         expected: tombi_schema_store::ValueType,
         actual: tombi_document_tree::ValueType,
     },
 
-    #[error("The value must be const value \"{expected}\", but found \"{actual}\"")]
+    #[error("the value must be const value \"{expected}\", but found \"{actual}\"")]
     Const { expected: String, actual: String },
 
-    #[error("The value must be one of [{}], but found {actual}", .expected.join(", "))]
+    #[error("the value must be one of [{}], but found {actual}", .expected.join(", "))]
     Enum {
         expected: Vec<String>,
         actual: String,
     },
 
-    #[error("The value must be ≤ {maximum}, but found {actual}")]
+    #[error("the value must be ≤ {maximum}, but found {actual}")]
     IntegerMaximum { maximum: i64, actual: i64 },
 
-    #[error("The value must be ≥ {minimum}, but found {actual}")]
+    #[error("the value must be ≥ {minimum}, but found {actual}")]
     IntegerMinimum { minimum: i64, actual: i64 },
 
-    #[error("The value must be < {exclusive_maximum}, but found {actual}")]
+    #[error("the value must be < {exclusive_maximum}, but found {actual}")]
     IntegerExclusiveMaximum { exclusive_maximum: i64, actual: i64 },
 
-    #[error("The value must be > {exclusive_minimum}, but found {actual}")]
+    #[error("the value must be > {exclusive_minimum}, but found {actual}")]
     IntegerExclusiveMinimum { exclusive_minimum: i64, actual: i64 },
 
-    #[error("The value {actual} is not a multiple of {multiple_of}")]
+    #[error("the value {actual} is not a multiple of {multiple_of}")]
     IntegerMultipleOf { multiple_of: i64, actual: i64 },
 
-    #[error("The value must be ≤ {maximum}, but found {actual}")]
+    #[error("the value must be ≤ {maximum}, but found {actual}")]
     FloatMaximum { maximum: f64, actual: f64 },
 
-    #[error("The value must be ≥ {minimum}, but found {actual}")]
+    #[error("the value must be ≥ {minimum}, but found {actual}")]
     FloatMinimum { minimum: f64, actual: f64 },
 
-    #[error("The value must be < {exclusive_maximum}, but found {actual}")]
+    #[error("the value must be < {exclusive_maximum}, but found {actual}")]
     FloatExclusiveMaximum { exclusive_maximum: f64, actual: f64 },
 
-    #[error("The value must be > {exclusive_minimum}, but found {actual}")]
+    #[error("the value must be > {exclusive_minimum}, but found {actual}")]
     FloatExclusiveMinimum { exclusive_minimum: f64, actual: f64 },
 
-    #[error("The value {actual} is not a multiple of {multiple_of}")]
+    #[error("the value {actual} is not a multiple of {multiple_of}")]
     FloatMultipleOf { multiple_of: f64, actual: f64 },
 
-    #[error("The length must be ≤ {maximum}, but found {actual}")]
+    #[error("the length must be ≤ {maximum}, but found {actual}")]
     StringMaxLength { maximum: usize, actual: usize },
 
-    #[error("The length must be ≥ {minimum}, but found {actual}")]
+    #[error("the length must be ≥ {minimum}, but found {actual}")]
     StringMinLength { minimum: usize, actual: usize },
 
     #[error("{actual} is not a valid `{format}` format")]
@@ -120,38 +120,38 @@ pub enum DiagnosticKind {
     #[error("{actual} does not match the pattern `{pattern}`")]
     StringPattern { pattern: String, actual: String },
 
-    #[error("Array must contain at most {max_values} values, but found {actual}")]
+    #[error("array must contain at most {max_values} values, but found {actual}")]
     ArrayMaxValues { max_values: usize, actual: usize },
 
-    #[error("Array must contain at least {min_values} values, but found {actual}")]
+    #[error("array must contain at least {min_values} values, but found {actual}")]
     ArrayMinValues { min_values: usize, actual: usize },
 
-    #[error("Array must contain at least one item matching the `contains` schema")]
+    #[error("array must contain at least one item matching the `contains` schema")]
     ArrayContains,
 
     #[error(
-        "Array must contain at least {min_contains} items matching the `contains` schema, but found {actual}"
+        "array must contain at least {min_contains} items matching the `contains` schema, but found {actual}"
     )]
     ArrayMinContains { min_contains: usize, actual: usize },
 
     #[error(
-        "Array must contain at most {max_contains} items matching the `contains` schema, but found {actual}"
+        "array must contain at most {max_contains} items matching the `contains` schema, but found {actual}"
     )]
     ArrayMaxContains { max_contains: usize, actual: usize },
 
-    #[error("Array values must be unique")]
+    #[error("array values must be unique")]
     ArrayUniqueValues,
 
-    #[error("Additional items are not allowed (tuple schema has {max_items} items)")]
+    #[error("additional items are not allowed (tuple schema has {max_items} items)")]
     ArrayAdditionalItems { max_items: usize },
 
-    #[error("Unevaluated array item at index {index} is not allowed")]
+    #[error("unevaluated array item at index {index} is not allowed")]
     ArrayUnevaluatedItemNotAllowed { index: usize },
 
-    #[error("Table must contain at most {max_keys} keys, but found {actual}")]
+    #[error("table must contain at most {max_keys} keys, but found {actual}")]
     TableMaxKeys { max_keys: usize, actual: usize },
 
-    #[error("Table must contain at least {min_keys} keys, but found {actual}")]
+    #[error("table must contain at least {min_keys} keys, but found {actual}")]
     TableMinKeys { min_keys: usize, actual: usize },
 
     #[error("\"{key}\" is required")]
@@ -166,13 +166,13 @@ pub enum DiagnosticKind {
     #[error("1 of {total_count} schemas must be matched, but no schema candidates were available")]
     OneOfNoMatch { total_count: usize },
 
-    #[error("The schema matches no values")]
+    #[error("the schema matches no values")]
     Nothing,
 
     #[error("\"not\" schema is matched")]
     NotSchemaMatch,
 
-    #[error("When \"{dependent_key}\" is present, \"{required_key}\" is required")]
+    #[error("when \"{dependent_key}\" is present, \"{required_key}\" is required")]
     TableDependencyRequired {
         dependent_key: String,
         required_key: String,

--- a/crates/tombi-validator/src/validate/string.rs
+++ b/crates/tombi-validator/src/validate/string.rs
@@ -590,7 +590,7 @@ pub(crate) fn validate_raw_string<'a>(
 
     if let Some(pattern) = &string_schema.pattern
         && let Ok(regex) =
-            Regex::new(pattern).inspect_err(|_| log::warn!("Invalid regex pattern: {:?}", pattern))
+            Regex::new(pattern).inspect_err(|_| log::warn!("invalid regex pattern: {:?}", pattern))
         && !regex.is_match(value)
     {
         let level = lint_rules

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -246,7 +246,7 @@ async fn validate_table(
                 .collect_vec();
             for pattern_key in pattern_keys {
                 let Ok(pattern) = tombi_regex::Regex::new(&pattern_key) else {
-                    log::warn!("Invalid regex pattern property: {}", pattern_key);
+                    log::warn!("invalid regex pattern property: {}", pattern_key);
                     continue;
                 };
                 if pattern.is_match(accessor_raw_text) {
@@ -1047,7 +1047,7 @@ fn collect_evaluated_properties_from_table_schema<'a>(
             .filter_map(|pattern_key| match tombi_regex::Regex::new(pattern_key) {
                 Ok(pattern) => Some(pattern),
                 Err(_) => {
-                    log::warn!("Invalid regex pattern property: {}", pattern_key);
+                    log::warn!("invalid regex pattern property: {}", pattern_key);
                     None
                 }
             })

--- a/extensions/tombi-extension-pyproject/src/code_action.rs
+++ b/extensions/tombi-extension-pyproject/src/code_action.rs
@@ -135,7 +135,7 @@ pub async fn code_action(
     // Try to find workspace pyproject.toml
     let Ok(pyproject_toml_path) = text_document_uri.to_file_path() else {
         log::warn!(
-            "Failed to convert URI to file path: {:?}",
+            "failed to convert URI to file path: {:?}",
             text_document_uri
         );
         return Ok(None);
@@ -166,7 +166,7 @@ pub async fn code_action(
             find_workspace_pyproject_toml(&pyproject_toml_path, toml_version)
         else {
             log::debug!(
-                "No workspace pyproject.toml found: {:?}",
+                "no workspace pyproject.toml found: {:?}",
                 pyproject_toml_path.display()
             );
             return Ok(None);
@@ -175,7 +175,7 @@ pub async fn code_action(
         // Load workspace text and create line index for workspace document
         let Ok(workspace_text) = tombi_fs::read_to_string(&workspace_path) else {
             log::warn!(
-                "Failed to read workspace pyproject.toml: {:?}",
+                "failed to read workspace pyproject.toml: {:?}",
                 workspace_path.display()
             );
             return Ok(None);
@@ -224,7 +224,7 @@ pub async fn code_action(
             )
         {
             log::debug!(
-                "Providing 'Add to Workspace and Use Workspace Dependency' code action: action={:?}, uri={:?}",
+                "providing 'Add to Workspace and Use Workspace Dependency' code action: action={:?}, uri={:?}",
                 action.title,
                 text_document_uri
             );
@@ -530,7 +530,7 @@ fn add_workspace_dependency_code_action(
     // Generate workspace URI
     let Ok(workspace_uri) = tombi_uri::Uri::from_file_path(workspace_pyproject_toml_path) else {
         log::warn!(
-            "Failed to convert workspace path to URI: {:?}",
+            "failed to convert workspace path to URI: {:?}",
             workspace_pyproject_toml_path.display()
         );
         return None;

--- a/extensions/tombi-extension-pyproject/src/dependency.rs
+++ b/extensions/tombi-extension-pyproject/src/dependency.rs
@@ -29,7 +29,7 @@ pub(crate) fn parse_requirement(dependency: &str) -> Option<Requirement<Verbatim
         Ok(requirement) => Some(requirement),
         Err(e) => {
             log::debug!(
-                "Failed to parse PEP 508 dependency string: dependency={:?}, error={:?}",
+                "failed to parse PEP 508 dependency string: dependency={:?}, error={:?}",
                 dependency,
                 e
             );

--- a/rust/serde_tombi/src/config.rs
+++ b/rust/serde_tombi/src/config.rs
@@ -129,9 +129,9 @@ pub fn load_with_path_and_level(
                 current_dir.join(TOMBI_TOML_FILENAME),
                 current_dir.join(".config").join(TOMBI_TOML_FILENAME),
             ] {
-                log::trace!("Checking config file at {:?}", config_path);
+                log::trace!("checking config file at {:?}", config_path);
                 if tombi_fs::is_file(&config_path) {
-                    log::debug!("Project config found at {:?}", config_path);
+                    log::debug!("project config found at {:?}", config_path);
 
                     match try_from_path(&config_path) {
                         Ok(Some(config)) => {
@@ -149,7 +149,7 @@ pub fn load_with_path_and_level(
             }
 
             let pyproject_toml_path = current_dir.join(PYPROJECT_TOML_FILENAME);
-            log::trace!("Checking pyproject.toml file at {:?}", pyproject_toml_path);
+            log::trace!("checking pyproject.toml file at {:?}", pyproject_toml_path);
             if tombi_fs::is_file(&pyproject_toml_path) {
                 log::debug!(
                     "\"{}\" found at {:?}",
@@ -162,7 +162,7 @@ pub fn load_with_path_and_level(
                         return Ok((config, Some(pyproject_toml_path), ConfigLevel::Project));
                     }
                     None => {
-                        log::debug!("No [tool.tombi] found in {:?}", pyproject_toml_path);
+                        log::debug!("no [tool.tombi] found in {:?}", pyproject_toml_path);
                     }
                 };
             }

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -117,7 +117,7 @@ where
         if FileInputType::from(args.files.as_ref()) == FileInputType::Stdin
             && let Err(error) = std::io::copy(&mut std::io::stdin(), &mut std::io::stdout())
         {
-            log::error!("Failed to copy stdin to stdout: {}", error);
+            log::error!("failed to copy stdin to stdout: {}", error);
         }
     })?;
 
@@ -137,7 +137,7 @@ where
         .enable_all()
         .build()
     else {
-        log::error!("Failed to create tokio runtime");
+        log::error!("failed to create tokio runtime");
         std::process::exit(1);
     };
 
@@ -154,7 +154,7 @@ where
 
         match input {
             FileSearch::Stdin => {
-                log::debug!("Formatting... stdin input");
+                log::debug!("formatting... stdin input");
                 let stdin_path = args.stdin_filename.as_ref().map(std::path::PathBuf::from);
 
                 // Get format options with override support
@@ -163,7 +163,7 @@ where
                     stdin_path.as_deref(),
                     config_path.as_deref(),
                 ) else {
-                    log::debug!("Formatting disabled for stdin by override");
+                    log::debug!("formatting disabled for stdin by override");
                     summary.not_needed_num += 1;
                     return Ok(summary);
                 };
@@ -190,7 +190,7 @@ where
                 for file in files {
                     match file {
                         FileSearchEntry::Found(source_path) => {
-                            log::debug!("Formatting... {:?}", source_path);
+                            log::debug!("formatting... {:?}", source_path);
 
                             // Get format options with override support
                             let Some(format_options) = tombi_glob::get_format_options(
@@ -199,7 +199,7 @@ where
                                 config_path.as_deref(),
                             ) else {
                                 log::debug!(
-                                    "Formatting disabled for {:?} by override",
+                                    "formatting disabled for {:?} by override",
                                     source_path
                                 );
                                 summary.not_needed_num += 1;
@@ -262,7 +262,7 @@ where
                             summary.error_num += 1;
                         }
                         Err(e) => {
-                            log::error!("Task failed {}", e);
+                            log::error!("task failed {}", e);
                             summary.error_num += 1;
                         }
                     }
@@ -315,7 +315,7 @@ where
         Ok(formatted) => {
             let has_diff = source != formatted;
             if has_diff && diff {
-                log::info!("Found format changes in stdin");
+                log::info!("found format changes in stdin");
                 eprint_diff(&source, &formatted);
             }
             if check {
@@ -367,7 +367,7 @@ where
         Ok(formatted) => {
             if source != formatted {
                 if diff {
-                    log::info!("Found format changes in {:?}", source_path);
+                    log::info!("found format changes in {:?}", source_path);
                     eprint_diff(&source, &formatted);
                 }
                 if check {

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -114,7 +114,7 @@ where
         .enable_all()
         .build()
     else {
-        log::error!("Failed to create tokio runtime");
+        log::error!("failed to create tokio runtime");
         std::process::exit(1);
     };
 
@@ -138,7 +138,7 @@ where
                 let Some(lint_options) =
                     tombi_glob::get_lint_options(&config, stdin_path, config_path.as_deref())
                 else {
-                    log::debug!("Linting disabled for stdin by override");
+                    log::debug!("linting disabled for stdin by override");
                     summary.success_num += 1;
                     return Ok(summary);
                 };
@@ -173,7 +173,7 @@ where
                                 Some(source_path.as_ref()),
                                 config_path.as_deref(),
                             ) else {
-                                log::debug!("Linting disabled for {:?} by override", source_path);
+                                log::debug!("linting disabled for {:?} by override", source_path);
                                 summary.success_num += 1;
                                 continue;
                             };
@@ -229,7 +229,7 @@ where
                             }
                         }
                         Err(e) => {
-                            log::error!("Task failed {}", e);
+                            log::error!("task failed {}", e);
                             summary.error_num += 1;
                         }
                     }

--- a/rust/tombi-cli/src/app/command/lsp.rs
+++ b/rust/tombi-cli/src/app/command/lsp.rs
@@ -16,14 +16,14 @@ pub fn run(args: impl Into<Args>) -> Result<(), crate::Error> {
 
     runtime.block_on(async move {
         log::info!(
-            "Tombi Language Server version \"{}\" will start.",
+            "starting Tombi Language Server version \"{}\".",
             env!("CARGO_PKG_VERSION")
         );
 
         let (service, socket) = tombi_lsp::lsp_service(args.common.offline, args.common.no_cache);
         serve(tokio::io::stdin(), tokio::io::stdout(), socket, service).await;
 
-        log::info!("Tombi LSP Server did shut down.");
+        log::info!("stopped Tombi LSP server.");
     });
 
     runtime.shutdown_timeout(std::time::Duration::from_secs(1));


### PR DESCRIPTION
## Summary

- standardize Rust log messages across trace, debug, info, warn, and error levels to start with lowercase text
- standardize error and warning diagnostic messages to start with lowercase text
- refine schema loading log wording and verbosity, and update diagnostic expectations

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --locked --no-fail-fast` (2222 passed)
- `cargo test --workspace --doc --locked`
- `cargo shear`
- `git diff --check`