### PR TITLE
fix(docs): respect base URL for JSX links

### DIFF
--- a/docs/src/remark/base-url.ts
+++ b/docs/src/remark/base-url.ts
@@ -23,13 +23,14 @@ export function remarkBaseUrl() {
       node.url = processUrl(node.url);
     });
 
-    // Process URLs in images
+    // Process URLs in JSX links and images
     visit(tree, "mdxJsxFlowElement", (node: MdxJsxFlowElement) => {
-      if (node.name === "img") {
+      const urlAttribute = node.name === "a" ? "href" : "src";
+      if (node.name === "a" || node.name === "img") {
         for (const attr of node.attributes) {
           if (
             attr.type === "mdxJsxAttribute" &&
-            attr.name === "src" &&
+            attr.name === urlAttribute &&
             typeof attr.value === "string"
           ) {
             attr.value = processUrl(attr.value);


### PR DESCRIPTION
## Summary

- apply the configured docs base URL to root-relative links in JSX anchors
- keep the WASM Playground button working when the docs are deployed under `/tombi`
- reuse the existing URL transformation used by Markdown links and JSX images

## Verification

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`
- confirmed the prerendered WASM docs link is `href="/tombi/playground"`