### PR TITLE
fix(deps): update nanoid to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   linkify-it: 5.0.2
   markdown-it: 14.2.0
   minimatch: 10.2.5
+  nanoid: 3.3.18
   nitropack: 2.13.4
   postcss: 8.5.23
   qs: 6.15.2
@@ -3339,8 +3340,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8435,7 +8436,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -8775,7 +8776,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ overrides:
   linkify-it: 5.0.2
   markdown-it: 14.2.0
   minimatch: 10.2.5
+  nanoid: 3.3.18
   nitropack: 2.13.4
   postcss: 8.5.23
   qs: 6.15.2


### PR DESCRIPTION
## Summary

- override nanoid to 3.3.18
- update the pnpm lockfile to use the patched version through postcss

## Context

OSV Scanner run https://github.com/tombi-toml/tombi/actions/runs/31778719950 failed because nanoid 3.3.17 is affected by GHSA-2v37-7h3g-55p8. Version 3.3.18 contains the fix.

## Verification

- cargo fmt --all -- --check
- pnpm install --lockfile-only --frozen-lockfile
- OSV Scanner v2.3.8 repository scan
- git diff --check
