### PR TITLE
perf(docs): make playground usable while Monaco loads

### DIFF
--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -1125,13 +1125,31 @@ export default function Playground() {
                 classList={{
                   "is-loading": editorLoading() || Boolean(editorError()),
                 }}
-                ref={editorContainer}
               >
+                <div
+                  class="playground-monaco-editor"
+                  ref={editorContainer}
+                  style={{
+                    visibility:
+                      editorLoading() || editorError() ? "hidden" : undefined,
+                  }}
+                />
                 <Show when={editorLoading()}>
-                  <div class="playground-editor-loading">
+                  <textarea
+                    class="playground-editor-fallback"
+                    aria-label="TOML editor"
+                    value={activeEntry()?.text ?? ""}
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck={false}
+                    onInput={(event) =>
+                      updateActiveFile(event.currentTarget.value)
+                    }
+                  />
+                  <output class="playground-editor-loading" aria-live="polite">
                     <TbLoader2 class="playground-spinner" aria-hidden="true" />
-                    Loading editor…
-                  </div>
+                    Loading enhanced editor…
+                  </output>
                 </Show>
                 <Show when={editorError()}>
                   {(message) => (

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -1146,10 +1146,6 @@ export default function Playground() {
                       updateActiveFile(event.currentTarget.value)
                     }
                   />
-                  <output class="playground-editor-loading" aria-live="polite">
-                    <TbLoader2 class="playground-spinner" aria-hidden="true" />
-                    Loading enhanced editor…
-                  </output>
                 </Show>
                 <Show when={editorError()}>
                   {(message) => (

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -200,7 +200,10 @@ export default function Playground() {
     return flattened;
   });
 
-  const isPlaygroundReady = createMemo(() => isMounted() && !editorLoading());
+  const isPlaygroundVisible = createMemo(() => isMounted());
+  const isPlaygroundBusy = createMemo(
+    () => editorLoading() || runState() === "loading",
+  );
 
   const setFailure = (message: string) => {
     setRunState("error");
@@ -934,14 +937,14 @@ export default function Playground() {
 
       <div
         class="playground-shell"
-        aria-busy={!isPlaygroundReady()}
+        aria-busy={isPlaygroundBusy()}
         style={{ position: "relative", padding: "2.5rem 0 4rem" }}
       >
         <section
           class="playground-workspace"
           aria-label="Tombi WASM LSP playground"
-          aria-hidden={!isPlaygroundReady()}
-          style={{ display: isPlaygroundReady() ? undefined : "none" }}
+          aria-hidden={!isPlaygroundVisible()}
+          style={{ display: isPlaygroundVisible() ? undefined : "none" }}
         >
           <div class="playground-toolbar">
             <div class="playground-runtime-label">
@@ -1194,7 +1197,7 @@ export default function Playground() {
           </section>
         </section>
 
-        <Show when={!isPlaygroundReady()}>
+        <Show when={!isPlaygroundVisible()}>
           <output
             class="playground-workspace playground-initial-loading"
             aria-live="polite"

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -165,7 +165,7 @@ export default function Playground() {
   const [treeContextMenu, setTreeContextMenu] = createSignal<TreeContextMenu>();
   const [runState, setRunState] = createSignal<RunState>("loading");
   const [statusMessage, setStatusMessage] = createSignal(
-    "Starting the Tombi WebAssembly language server…",
+    "Downloading tombi-wasm-lsp…",
   );
   const models = new Map<string, MonacoEditor.ITextModel>();
   let diagnosticSequence = 0;
@@ -200,9 +200,7 @@ export default function Playground() {
     return flattened;
   });
 
-  const isPlaygroundReady = createMemo(
-    () => isMounted() && !editorLoading() && runState() !== "loading",
-  );
+  const isPlaygroundReady = createMemo(() => isMounted() && !editorLoading());
 
   const setFailure = (message: string) => {
     setRunState("error");
@@ -758,7 +756,9 @@ export default function Playground() {
     })();
   });
 
-  onMount(() => {
+  createEffect(() => {
+    if (editorLoading() || editorError()) return;
+
     let disposed = false;
     let client: TombiLspClient | undefined;
     onCleanup(() => {

--- a/docs/src/routes/playground/index.tsx
+++ b/docs/src/routes/playground/index.tsx
@@ -756,9 +756,7 @@ export default function Playground() {
     })();
   });
 
-  createEffect(() => {
-    if (editorLoading() || editorError()) return;
-
+  onMount(() => {
     let disposed = false;
     let client: TombiLspClient | undefined;
     onCleanup(() => {

--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -3,6 +3,7 @@
   --playground-muted: #667085;
   --playground-panel: #ffffff;
   --playground-editor: #f8fafc;
+  --playground-text: #101828;
   position: relative;
   padding: 2.5rem 0 4rem;
 }
@@ -396,6 +397,7 @@
 .playground-editor-fallback {
   position: absolute;
   inset: 0;
+  z-index: 1;
   width: 100%;
   height: 100%;
   resize: none;
@@ -409,23 +411,6 @@
   font-size: 0.875rem;
   line-height: 1.5;
   tab-size: 2;
-}
-
-.playground-editor-loading {
-  position: absolute;
-  right: 1rem;
-  bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  border: 1px solid var(--playground-border);
-  border-radius: 0.45rem;
-  padding: 0.4rem 0.55rem;
-  background: var(--playground-panel);
-  color: var(--playground-muted);
-  font-size: 0.85rem;
-  font-weight: 650;
-  pointer-events: none;
 }
 
 .playground-editor-error {
@@ -564,6 +549,7 @@
   --playground-muted: #98a2b3;
   --playground-panel: #202b3a;
   --playground-editor: #182230;
+  --playground-text: #f2f4f7;
 }
 
 :root.dark .playground-workspace {

--- a/docs/src/styles/playground.css
+++ b/docs/src/styles/playground.css
@@ -385,14 +385,55 @@
 }
 
 .playground-editor.is-loading {
-  display: grid;
-  place-items: center;
+  overflow: hidden;
 }
 
-.playground-editor-loading,
-.playground-editor-error {
+.playground-monaco-editor {
+  width: 100%;
+  height: 100%;
+}
+
+.playground-editor-fallback {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: 0;
+  padding: 1rem 4rem 1rem 1rem;
+  outline: 0;
+  background: var(--playground-editor);
+  color: var(--playground-text);
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  tab-size: 2;
+}
+
+.playground-editor-loading {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
   display: flex;
   align-items: center;
+  gap: 0.55rem;
+  border: 1px solid var(--playground-border);
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.55rem;
+  background: var(--playground-panel);
+  color: var(--playground-muted);
+  font-size: 0.85rem;
+  font-weight: 650;
+  pointer-events: none;
+}
+
+.playground-editor-error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 0.55rem;
   color: var(--playground-muted);
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary

- start loading Monaco and `tombi-wasm-lsp` in parallel
- reveal the Playground shell and Explorer immediately after hydration
- provide an editable plain-text `tombi.toml` fallback while Monaco loads
- preserve fallback edits when switching to the enhanced Monaco editor
- report `Downloading tombi-wasm-lsp…` in the status bar until the LSP is ready

## Motivation

The deployed `tombi_lsp_wasm_bg.wasm` is about 10.5 MB, while Monaco also loads a substantial module graph in development. Waiting for Monaco prevented editing even though the workspace source was already available. The lightweight textarea makes the Playground usable immediately, then hands the same workspace state to Monaco when it finishes loading.

## Verification

- `cargo fmt --all --check`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `git diff --check`
- `BASE_URL=/tombi PATH=/Users/s23467/.cargo/bin:$PATH pnpm --dir docs build`