### PR TITLE
fix(playground): reload config before formatting

### DIFF
--- a/docs/src/routes/docs/language-server/command.mdx
+++ b/docs/src/routes/docs/language-server/command.mdx
@@ -196,12 +196,10 @@ Update the configuration file. This command reloads the configuration from disk 
 #### Request
 
 ```typescript
-interface UpdateConfigParams {
-  textDocument: TextDocumentIdentifier;
-}
+type UpdateConfigParams = TextDocumentIdentifier;
 ```
 
-The `textDocument` should point to a Tombi configuration file (e.g., `tombi.toml`).
+The identifier should point to a Tombi configuration file (e.g., `tombi.toml`).
 
 #### Response
 
@@ -216,7 +214,7 @@ Returns `true` if the configuration was updated successfully, `false` otherwise.
 ```typescript
 // Update the configuration file
 const updated = await client.sendRequest("tombi/updateConfig", {
-  textDocument: { uri: "file:///path/to/project/tombi.toml" }
+  uri: "file:///path/to/project/tombi.toml"
 });
 
 if (updated) {

--- a/docs/src/utils/tombi-lsp.ts
+++ b/docs/src/utils/tombi-lsp.ts
@@ -56,6 +56,11 @@ interface PendingRequest {
 }
 
 const WORKSPACE_URI = "file:///workspace";
+const TOMBI_CONFIG_FILENAMES = new Set([
+  ".tombi.toml",
+  "pyproject.toml",
+  "tombi.toml",
+]);
 
 function baseUrl(): string {
   return import.meta.env.SERVER_BASE_URL.endsWith("/")
@@ -229,6 +234,13 @@ export class TombiLspClient {
   }
 
   async format(path: string): Promise<LspTextEdit[]> {
+    const filename = path.slice(path.lastIndexOf("/") + 1);
+    if (TOMBI_CONFIG_FILENAMES.has(filename)) {
+      await this.request<boolean>("tombi/updateConfig", {
+        uri: workspaceFileUri(path),
+      });
+    }
+
     return (
       (await this.request<LspTextEdit[] | null>("textDocument/formatting", {
         options: { insertSpaces: true, tabSize: 2 },

--- a/rust/tombi-wasm/tests/lsp-smoke.mjs
+++ b/rust/tombi-wasm/tests/lsp-smoke.mjs
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import init, {
   ServerConfig,
   serve,
+  set_workspace_file,
   set_workspace_files,
 } from "../../../typescript/@tombi-toml/wasm-lsp/dist/tombi_lsp_wasm.js";
 
@@ -413,6 +414,59 @@ assert.equal(completionResponse?.error, undefined);
 assert.ok(
   (completionResponse?.result?.items ?? completionResponse?.result ?? []).length > 0,
   `WASM LSP completion should return candidates: ${JSON.stringify(completionResponse)}`,
+);
+
+const updatedConfig = `toml-version = "v1.1.0"
+
+[format.rules]
+group-blank-lines-limit = 5
+
+
+
+line-width = 100
+`;
+set_workspace_file("file:///workspace/tombi.toml", updatedConfig);
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "textDocument/didChange",
+    params: {
+      contentChanges: [{ text: updatedConfig }],
+      textDocument: { uri: "file:///workspace/tombi.toml", version: 2 },
+    },
+  }),
+);
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    id: 8,
+    method: "tombi/updateConfig",
+    params: { uri: "file:///workspace/tombi.toml" },
+  }),
+);
+
+const updateConfigResponse = await waitForResponse(8);
+assert.equal(updateConfigResponse?.error, undefined);
+assert.equal(updateConfigResponse?.result, true);
+
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    id: 9,
+    method: "textDocument/formatting",
+    params: {
+      options: { insertSpaces: true, tabSize: 2 },
+      textDocument: { uri: "file:///workspace/tombi.toml" },
+    },
+  }),
+);
+
+const configFormattingResponse = await waitForResponse(9);
+assert.equal(configFormattingResponse?.error, undefined);
+assert.equal(
+  configFormattingResponse?.result,
+  null,
+  "formatting tombi.toml should use its reloaded group-blank-lines-limit",
 );
 
 input.close();


### PR DESCRIPTION
## Summary

- reload an edited Tombi configuration before formatting it in the Playground
- send the `tombi/updateConfig` request using the server's actual `TextDocumentIdentifier` shape
- cover reloading `group-blank-lines-limit` before formatting `tombi.toml` and correct the command documentation

## Tests

- `cargo fmt --all -- --check`
- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `pnpm --dir typescript/@tombi-toml/wasm-lsp test`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --check`