### PR TITLE
Replace Copilot PR review with local subagent review

### DIFF
--- a/.claude/agents/review-quality.md
+++ b/.claude/agents/review-quality.md
@@ -1,6 +1,6 @@
 ---
 name: review-quality
-description: 差分レビュー時に correctness、回帰、検証不足、保守性を優先して点検する
+description: PR 作成前の差分を読み取り専用で独立レビューし、correctness、回帰、検証不足、保守性を優先して点検する
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
@@ -8,6 +8,8 @@ model: sonnet
 # Review Quality
 
 差分レビューでは、要約より先に問題点を列挙する。
+
+PR 作成前ゲートとして呼び出された場合は読み取り専用で動作し、ファイル、index、working tree、GitHub の状態を変更しない。
 
 ## 開始前に読むべきルール
 
@@ -26,4 +28,5 @@ model: sonnet
 
 - findings を重要度順に並べる
 - file / line を可能な限り示す
+- 各 finding には失敗シナリオと根拠を示し、修正は親エージェントに委ねる
 - 問題がなければその旨を明示し、残る検証ギャップだけ短く書く

--- a/.claude/skills/codex/github-pr-flow/SKILL.md
+++ b/.claude/skills/codex/github-pr-flow/SKILL.md
@@ -1,108 +1,106 @@
 ---
 name: github-pr-flow
-description: "Codex 専用。必要に応じて `github-pr-create`（または user-global `my-github-pr-create`）で PR を作成し、その後 `gh` で Copilot review を依頼し、統一 skill `github-pr-resolve` に待機と対応を委譲する。PR 作成手順そのものは PR-create skill を source of truth として利用する。トリガー: 'github-pr-flow', 'PR作成してCopilotレビュー依頼', 'PR作成からレビュー対応まで', '/github-pr-flow'"
-metadata:
-  short-description: PR作成からCopilot依頼、即時引き継ぎまで
+description: "現在のローカル差分を検証し、Codex または Claude Code の review-quality サブエージェントによる独立レビューを PR 作成前に完了してから、commit、push、GitHub PR 作成、CI と既存 review thread の対応まで進める。トリガー: 'github-pr-flow'、'PR作成からレビュー対応まで'、'ローカルレビューしてPR作成'、'/github-pr-flow'"
 ---
 
 # GitHub PR Flow
 
-現在のローカル差分をもとに、必要なら別 Skill で PR を作成し、その後の Copilot レビュー依頼を `gh pr edit --add-reviewer @copilot` で行い、待機とレビュー対応を統一 Skill [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) に委譲する Codex 専用 Skill。途中で simplify 系の別 Skill は実行しない。
+現在の変更をローカルで独立レビューしてから PR を作成し、作成後の CI と既存 review thread を [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) で処理する。GitHub 上の AI reviewer にはレビューを依頼しない。
 
-## Use This Skill When
-
-- 現在の差分から PR 作成と Copilot レビュー依頼をまとめて進めたい
-- 現在の差分で新規 PR を作り、その直後に Copilot へレビュー依頼したい
-- Copilot にレビュー依頼した後、そのまま待機と対応まで続けて進めたい
-- すべての review thread を解決した状態で PR を引き渡す
-
-## Do Not Use This Skill When
-
-- 新規 PR を作るだけでよい → `github-pr-create` または user-global `my-github-pr-create`
-- Copilot review を使わずに PR URL を返せば十分
-- 既存 PR の review 対応だけをしたい → [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md)
-
-## Preconditions
+## 前提
 
 - `gh auth status` が成功する
 - push 権限がある
-- このリポジトリの `AGENTS.md` と対象領域の追加ルールを確認済み
-- `gh --version` で `gh >= 2.89.0` を満たしている
-- `@copilot` reviewer の可否確認は `gh pr edit <PR番号またはURL> --add-reviewer @copilot` を実行し、未対応ならその正確なエラー内容を確認できる
-- 対象リポジトリが `github.com` 上にある（GitHub Enterprise Server の `@copilot` reviewer は未対応）
+- リポジトリと変更対象領域の `AGENTS.md` / `.claude/rules/` を確認済みである
+- Codex または Claude Code のサブエージェント機能を利用できる
 - 非対話コマンドを使う
 
-## Workflow
+## ワークフロー
 
-### 1. 必要なら PR 作成 skill で PR URL 取得まで完了する
+### 1. PR に含める差分を確定する
 
-PR 作成そのものは別 skill に従う。優先順位:
+1. `git fetch origin main` を実行し、必要なら `origin/main` を取り込む
+2. `git rev-parse origin/main` の出力を review base OID として記録する
+3. [`../../workspace-check/SKILL.md`](../../workspace-check/SKILL.md) で変更面を分類し、必要なローカル検証を選択・実行して、実行済み項目と残るギャップを記録する
+4. PR に含めるファイルだけを stage する
+5. `git diff --cached --check` と `git status --short` で、意図しない差分や未追跡ファイルがないことを確認する
+6. `git diff --cached --binary origin/main | shasum -a 256` の出力を patch hash として記録し、`<review-base-oid>:<patch-hash>` を review fingerprint とする
 
-1. リポジトリ内に `github-pr-create` skill が存在すればそれを使う
-2. 無ければ user-global の `my-github-pr-create` を使う
-3. どちらも使えない場合は手動で:
-   - ブランチ命名（`<type>/<purpose-kebab>`）
-   - `git fetch origin main` と取り込み
-   - 必要な検証（tombi: `cargo fmt --all`、Rust 変更時は `cargo clippy --workspace --all-targets --locked -- -D warnings`、`cargo nextest run --workspace --locked --no-fail-fast`、`cargo test --workspace --doc --locked`）
-   - commit / `git push -u origin <branch>`
-   - `gh pr create --base main --head <branch> --title ... --body ... --label ...`
+差分が空なら PR を作成しない。未追跡ファイルは stage されるまでレビュー対象に含まれないため、必ず先に対象を確定する。
 
-PR URL がまだ無い場合は、この Skill の中で PR 作成まで進めてから戻る。
+### 2. ローカルの独立サブエージェントにレビューを依頼する
 
-この Step では PR 作成に必要な処理だけを行い、simplify 系の別 Skill を前処理として挟まない。
+実行中のハーネスに応じて、Codex または Claude Code のサブエージェント機能で `review-quality` エージェントを起動する。親エージェント自身の自己レビューだけで代替しない。
 
-### 2. `gh` で Copilot にレビュー依頼する
+サブエージェントには次を渡す。
 
-1. 対象 PR を PR 番号、PR URL、または head branch で特定する
-2. `gh pr edit <PR番号|URL|ブランチ名> --add-reviewer @copilot` を実行する
-3. reviewer 追加に成功したら、そのまま統一 Skill に委譲する
+- base: `origin/main`
+- review base OID
+- review fingerprint
+- 対象: `git diff --cached origin/main` と変更ファイルの関連実装・テスト
+- 実行済み検証と結果
+- 読み取り専用でレビューし、ファイルを変更しないこと
+- correctness、回帰、検証不足、source of truth の不整合を優先し、finding は file / line と根拠を付けること
 
-依頼できた場合:
+実装方針の正当化や期待する結論を先に教えない。サブエージェントが独立に差分と周辺コードを確認できる情報だけを渡す。
 
-- 以後の待機と review 対応は統一 Skill に委譲する
-- reviewer UI 確認のために browser を開かない
+### 3. finding を解消し、同じ差分を再確認する
 
-依頼できない場合:
+- actionable finding がなければ、review fingerprint が変わっていないことを確認して Step 4 へ進む
+- actionable finding があれば親エージェントが修正し、対象検証、stage、fingerprint 採取をやり直す
+- fingerprint が変わった場合、以前のレビュー結果を再利用せず、新しいサブエージェントで Step 2 をやり直す
+- 仕様判断が必要で解消できない finding は、PR を作成せずユーザーに確認する
 
-- `gh --version` が `2.89.0` 未満なら、先に `gh` を更新する。Homebrew 管理なら `brew upgrade gh` を使う
-- `gh auth status` が失敗する場合は認証を修復してから再試行する
-- `gh pr edit ... --add-reviewer @copilot` が機能未提供、権限不足、または Copilot code review 未有効を示す場合は、その正確なエラー内容をユーザーへ報告して止まる
-- 通常フローとして browser 操作へフォールバックしない。ユーザーが明示的に UI での手動依頼を選んだ場合だけ案内する
+レビュー結果が空、失敗、権限不足、タイムアウトなどで有効な判定を得られない場合も fail closed とし、PR を作成しない。
 
-### 3. 統一 Skill に直ちに委譲する
+### 4. PR を作成する
 
-Copilot へのレビュー依頼が終わったら、この Skill では待たずに統一 Skill [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) を使う。
+PR 作成そのものは次の優先順位で既存 skill に従う。
 
-- 入力は PR URL または PR番号を使う
-- Copilot review が未着なら最大 15 分ポーリングして待つ処理も、その Skill の責務とする
-- 採用 / 不採用 / 既対応の判断、必要な修正、CI 修正、全返信、thread resolve はその Skill の責務とする
-- この Skill 側では review 対応ロジックを重複実装しない
+1. リポジトリ内の `github-pr-create`
+2. user-global の `my-github-pr-create`
+3. どちらも使えない場合は、次の manual fallback を使う
 
-### 4. 最終状態を整理して終了する
+manual fallback では、現在 branch が `main` または detached HEAD でないことを確認する。該当する場合は `<type>/<purpose-kebab>` 形式の topic branch を作成してから commit する。push 先は現在の GitHub アカウントが書き込める明示的な remote とし、base repository の保護された `main` へ直接 push しない。
 
+```bash
+git commit -m '<type>: <summary>'
+git push -u <writable-remote> HEAD:refs/heads/<topic-branch>
+gh pr create \
+  --repo tombi-toml/tombi \
+  --base main \
+  --head '<owner>:<topic-branch>' \
+  --title '<title>' \
+  --body-file <body-file> \
+  --label '<label>'
+```
+
+`<writable-remote>` の URL と `<owner>` が同じ fork を指すこと、push 後の remote OID が local HEAD と一致することを確認する。引数なしの対話的な `gh pr create` は使わない。
+
+commit 直前に `git fetch origin main` を再実行し、`origin/main` の OID と staged patch hash が承認済み review fingerprint と一致することを確認する。commit 後は `git diff --binary origin/main HEAD | shasum -a 256` で同じ tree 差分であることに加え、`git status --porcelain` が空であることを確認する。commit hook、formatter、base drift のいずれかで fingerprint が変わるか未commit差分が残った場合は、Step 1 から検証とレビューをやり直す。
+
+`gh pr create` の直前にも `git ls-remote origin refs/heads/main` で remote base OID を直接確認する。承認済み review base OID と異なる場合は PR を作成せず、`origin/main` を更新して Step 1 からやり直す。
+
+PR 作成時は branch、検証結果、commit、PR URL、必要な label を記録する。GitHub 上の AI reviewer 追加コマンドは実行しない。
+
+### 5. 作成後の状態を確認する
+
+PR URL、承認済み review base OID、review fingerprint、commit 後の exact head OID を入力として [`../../github-pr-resolve/SKILL.md`](../../github-pr-resolve/SKILL.md) を使う。委譲先は現在の remote base、local / remote / PR head、full PR diff が渡された証拠と一致する場合だけ、そのレビュー結果を引き継ぐ。
+
+- CI の失敗を調査・修正する
+- 既に投稿された AI / 人間の review thread があれば通常どおり対応する
+- review request の追加や AI reviewer の応答待ちは行わない
 - PR はマージしない
-- PR URL、head branch、最終未解決 thread 数、残タスクの有無を記録する
-- 呼び出し元が連続フロー skill の場合、merge 待機と最終 merge 実行は呼び出し元の責務として継続する
-- merge や deploy などの最終判断は、この Skill 単体では扱わない
 
-## Notes
+PR 作成後の `main` 取り込み、CI 修正、review 対応などで head tree を変える場合は、push 前に新しい full PR diff を Step 1〜3 と同じ検証・fingerprint・独立サブエージェントレビューへ通す。以前の review fingerprint は再利用しない。
 
-- 使い分け:
-  - 新規 PR 作成だけなら `github-pr-create` / `my-github-pr-create`
-  - PR 作成後に Copilot review 依頼と thread 解決まで求められたら `github-pr-flow`
-- `github-pr-flow` は PR 作成機能も持つが、その手順は PR-create skill をそのまま利用する
-- Copilot レビュー依頼は `gh pr edit --add-reviewer @copilot` を通常フローとする
-- `gh --version` が `2.89.0` 未満なら先に更新し、未対応時は実コマンドのエラー内容で判断する
-- `@copilot` reviewer は `github.com` でのみ使う。GHES は対象外
-- review 対応は統一 Skill に集約し、`github-pr-flow` 側に重複手順を書かない
-- reviewer 追加や Copilot レビュー依頼のために browser を開かない
-- 連続フロー skill から呼ばれた場合でも、この Skill 自体は merge しない。呼び出し元は未マージを理由に終了せず、待機と merge を続ける
+最終 handoff 前に remote base OID を再取得する。base または head tree が最後に承認された fingerprint から変わっていれば、最新の組み合わせで検証と独立レビューをやり直す。その後、現在の head、CI、reviews、comments、全ページの review threads、mergeability を同じ状態で取り直す。
 
-## Output Checklist
+## 出力
 
-- 利用した PR-create skill 名と PR 作成時の必須項目（branch、検証、commit、PR URL、label）
-- Copilot レビュー依頼の成否
-- 返信した thread 数
-- 修正不要として解決した thread 数
-- 最終未解決 thread 数
-- PR は未マージのまま引き渡したこと
+- 利用したローカル review subagent
+- 承認済み review base OID、review fingerprint、finding の有無
+- 実行した検証
+- branch、commit、PR URL、label
+- 対応した thread 数と最終未解決 thread 数
+- PR を未マージで引き渡したこと

--- a/.claude/skills/codex/github-pr-flow/agents/openai.yaml
+++ b/.claude/skills/codex/github-pr-flow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "github-pr-flow"
-  short_description: "Create a PR, request Copilot review, then hand off to the unified review workflow"
-  default_prompt: "Use $github-pr-flow to create a PR from current changes, request Copilot review with `gh pr edit --add-reviewer @copilot`, and then use $github-pr-resolve for waiting, CI fixes, and review-thread resolution before stopping short of merge. Do not run any simplify skill as part of this flow."
+  short_description: "Run a local subagent review before creating a PR"
+  default_prompt: "Use $github-pr-flow to validate the current changes, obtain an independent local subagent review, create the PR, and handle CI and existing review threads without requesting an AI reviewer on GitHub."

--- a/.claude/skills/github-pr-resolve/SKILL.md
+++ b/.claude/skills/github-pr-resolve/SKILL.md
@@ -1,106 +1,60 @@
 ---
 name: github-pr-resolve
-description: "GitHub の PR URL / PR番号から、PR の head branch を checkout し、最新の main を取り込み、CI の失敗ジョブ確認・修正、AI / 人間を問わずレビューコメントと review thread を取得し、妥当な指摘の修正、不要または既対応の説明、必要な返信と resolve まで行う。tombi の Rust / cargo / pnpm / uv 運用に合わせて進める。トリガー: PR URL、'レビュー対応', 'AIレビュー対応', 'Copilotレビューをさばく', '人間レビュー対応', '会話を解決', 'CIも直して', '/pr-fix-review'"
-metadata:
-  short-description: PRのCI修正とレビュー解決
+description: "GitHub の PR URL / PR番号から head branch を checkout し、最新の main を取り込み、CI の失敗を修正し、AI / 人間を問わず既存の review comment と review thread を取得して、妥当な指摘の修正、不要または既対応の説明、返信、resolve まで行う。tombi の Rust / cargo / pnpm / uv 運用に合わせる。トリガー: PR URL、'レビュー対応'、'AIレビュー対応'、'人間レビュー対応'、'会話を解決'、'CIも直して'、'/pr-fix-review'"
 ---
 
 # GitHub PR Resolve
 
-tombi リポジトリで、GitHub PR の CI 修正とレビュー会話の解決を最後まで進めるための統一スキル。AI reviewer と人間レビュアーを分けず、同じフローで扱う。
-
-## 役割
-
-- この Skill は PR 単位のオーケストレーションを担当する
-- CI run / job の詳細解析が必要なときだけ [`references/ci-run-job-debug.md`](references/ci-run-job-debug.md) を補助的に読む
-- この Skill から checkout / `origin/main` の merge / push / reply / resolve まで進める
-- AI reviewer と人間レビュアーの thread / summary / top-level comment をまとめて処理する
-
-## 使う場面
-
-- PR URL / PR番号を起点に対応する
-- GitHub Actions の失敗を直す
-- AI / 人間を問わず review thread に返信して resolve する
-- Copilot review を待ってから対応を始める
-- 「妥当なら修正、不要なら理由を返す」を一連で処理する
+tombi の GitHub PR に既に存在する CI 失敗とレビュー会話を解決する。AI reviewer と人間レビュアーを同じ基準で扱う。この Skill から reviewer を追加せず、未着レビューを待つためのポーリングもしない。
 
 ## 前提
 
 - `gh auth status` が成功する
-- `gh` と `jq` の両方がインストール済み（review request 判定や thread 解析で `jq` を必須にする。macOS なら `brew install jq`、Debian/Ubuntu なら `apt-get install jq`）
+- `gh` と `jq` がインストール済みである
 - PR の head branch に push できる
-- 返信前に、必要なローカル検証を終える
-- thread は無言で resolve しない。必ず返信してから resolve する
-- コード変更時は、このリポジトリの `AGENTS.md` と対象サブディレクトリの `AGENTS.md` / `.claude/rules/` に従う
-- submodule / 認証まわりで詰まっても `git config --global` / `git config --local` / `git config --system` で Git 設定を書き換えて回避しない。PAT や `url.*.insteadOf` を Git 設定へ保存するのも禁止する
+- 返信前に必要なローカル検証を終える
+- thread は必ず返信してから resolve する
+- コード変更時は `AGENTS.md` と対象領域の `.claude/rules/` に従う
+- 認証回避のために Git の global / local / system config を書き換えたり、PAT や `url.*.insteadOf` を保存したりしない
 
-## 基本フロー
+## ワークフロー
 
-### 1. PR を開いて branch を合わせ、Copilot review request の有無を確認する
+### 1. PR と branch を確認する
 
 ```bash
 gh pr checkout <pr-url-or-number>
-gh pr view <pr-url-or-number> --json number,title,url,headRefName,baseRefName,reviewDecision
+gh pr view <pr-url-or-number> --json number,title,url,headRefName,headRefOid,headRepository,headRepositoryOwner,baseRefName,reviewDecision,comments,reviews
 gh pr checks <pr-url-or-number> --json name,state,bucket,link,workflow
 ```
 
-- 変更範囲の把握が必要なら `gh pr view <pr> --json files`
-- 既存の issue comment / review summary も見るなら `gh pr view <pr> --json comments,reviews`
-- Copilot にレビュー依頼を出しているかは、review request を最初に確認する
+必要なら `gh pr view <pr> --json files` で変更範囲も確認する。review request の追加や AI reviewer の応答待ちは行わず、現在取得できる CI、reviews、comments、threads を処理する。
 
-```bash
-gh api graphql \
-  -f owner=tombi-toml \
-  -f repo=tombi \
-  -F number=<number> \
-  -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      reviewRequests(first: 100) {
-        nodes {
-          requestedReviewer {
-            __typename
-            ... on Bot { login }
-            ... on User { login }
-            ... on Team { slug name }
-          }
-        }
-      }
-    }
-  }
-}' |
-  jq '
-    [
-      .data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
-      | .login? // .slug? // empty
-      | ascii_downcase
-    ]
-    | any(test("copilot"))
-  '
-```
+この Skill は `main` base 専用である。取得した `baseRefName` が `main` 以外なら、`origin/main` を merge せず未対応 base として停止し、ユーザーへ報告する。
 
-- `true` なら「Copilot review request が pending」とみなして Step 4 の待機判定に使う
-- `false` なら、この PR では Copilot review request は確認できていないので、Copilot review 待ちのためのポーリングはしない
+fork PR では `origin` を head remote とみなさない。`headRepository.nameWithOwner`、`headRepositoryOwner.login`、`headRefName` から `https://github.com/<owner>/<repo>.git` の head ref を特定し、`git ls-remote <head-repository-url> refs/heads/<headRefName>` を PR の `headRefOid` と比較する。push 権限または head repository を特定できなければ変更を push せず報告する。
 
 ### 2. 最新の `main` を取り込む
-
-checkout 後、head branch に最新の `origin/main` が入っているかを確認する。未取り込みなら、CI 修正や review 対応の前に merge して競合を解消する。
 
 ```bash
 git fetch origin main
 git merge-base --is-ancestor origin/main HEAD || git merge origin/main --no-edit
 ```
 
-- `git merge-base --is-ancestor origin/main HEAD` が成功したら、最新の `origin/main` は取り込み済みなので何もしない
-- merge が必要だった場合は、この段階で競合を解消してから次へ進む
-- merge 後は、影響を受けるローカル検証をやり直してから CI 原因調査や review 返信に進む
+merge が必要なら競合を解消し、影響を受けるローカル検証をやり直してから進む。
 
-### 3. CI の失敗を処理する
+### 3. 現在の full PR diff のレビュー証拠を確立する
 
-- `gh pr checks <pr> --json ...` で `bucket == "fail"` を優先する
-- failed check の `link` から run ID を取り、ログを確認する
-- job の rerun が必要なときは、URL の `jobs/<number>` ではなく `databaseId` を使う
+処理開始時に、コード変更の有無にかかわらず、現在の PR head に対応する review base OID、patch hash、review fingerprint、exact head OID を確立する。
+
+`github-pr-flow` などの呼び出し元から承認済み review base OID、review fingerprint、exact head OID が渡された場合は、remote base、local HEAD、remote head、PR head、`git diff --binary origin/main HEAD` の hash を再取得する。すべて一致する場合だけレビュー結果を引き継ぐ。
+
+証拠が渡されていない standalone 実行、または1項目でも一致しない場合は、現在の full PR diff に必要なローカル検証を実行し、`<review-base-oid>:<patch-hash>` を fingerprint として記録してから、Codex または Claude Code の `review-quality` サブエージェントへ読み取り専用レビューを依頼する。actionable finding があれば修正フローへ進み、有効な判定を得られなければ fail closed とする。
+
+### 4. CI の失敗を処理する
+
+- `gh pr checks <pr> --json ...` の `bucket == "fail"` を優先する
+- failed check の `link` から run ID を取り、推測せず job log を確認する
+- job の rerun には URL の `jobs/<number>` ではなく `databaseId` を使う
 
 ```bash
 gh run view <run-id> --json jobs
@@ -109,138 +63,26 @@ gh run view <run-id> --log-failed
 gh run view <run-id> --job <job-database-id> --log
 ```
 
-- 深掘りが必要なら [`references/ci-run-job-debug.md`](references/ci-run-job-debug.md) を読む
-- 修正中は失敗していたジョブ相当のローカル検証を優先する
-- Rust 変更時の主な検証コマンド（tombi の CI と整合）:
+詳細解析が必要なら [`references/ci-run-job-debug.md`](references/ci-run-job-debug.md) を読む。修正中は失敗ジョブ相当の最小検証を優先し、変更面に応じて次を追加する。
 
-```bash
-cargo build --verbose --locked
-cargo nextest run --workspace --locked --no-fail-fast
-cargo test --workspace --doc --locked
-cargo shear
-```
+- Rust: `cargo build --verbose --locked`、`cargo nextest run --workspace --locked --no-fail-fast`、`cargo test --workspace --doc --locked`、`cargo shear`
+- format / lint: `cargo fmt --all --check`、`cargo clippy --workspace --all-targets --locked -- -D warnings`
+- editor / docs / blog: `pnpm format`、`pnpm lint`
+- Python packaging: `uv run pytest`、`uv run ruff check`、必要なら `maturin build`
+- toml-test: 対象を絞った `cargo nextest run -p toml-test ...`
 
-- 必要に応じて `cargo fmt --all --check` と `cargo clippy --workspace --all-targets --locked -- -D warnings` も実行する（CI には含まれないが、warning は放置しない方針）
-- editor / docs (`editors/`、`docs/`、`blog/`) の変更時: `pnpm format`、`pnpm lint`
-- Python packaging 変更時: `uv run pytest`、`uv run ruff check`、必要なら `maturin build`
-- toml-test 関連の変更時: `cargo nextest run -p toml-test ...` など対象 crate に絞った実行
-
-push 後の再確認:
+push 後は CI を再確認する。
 
 ```bash
 gh run rerun <run-id> --failed
-gh pr checks <pr-url-or-number> --watch --fail-fast
+gh pr checks <pr-url-or-number> --watch --interval 10
 ```
 
-### 4. Copilot review request が pending で、まだコメント未着なら最大 15 分待つ
+新規 PR も含め、check suite がまだ現れていない場合は開始を待って再取得する。`bucket == "pending"` が1件でもあれば terminal になるまで待ち、`fail` または `cancel` があれば原因を処理する。全対象 check が同じ head で `pass` または意図された `skipping` になったことを確認するまで handoff しない。待機が環境の上限に達した場合は未完了として報告し、成功扱いにしない。
 
-Step 1 で Copilot review request が `true` だった場合だけ、Copilot から review / thread / top-level comment が投稿済みかを確認する。Copilot review request 自体が無いなら待たずに進む。request があり、かつ Copilot からの反応がまだ 1 件も無い場合は、`gh` で最大 15 分ポーリングして待つ。
+### 5. 全ページの review thread を取得する
 
-```bash
-# 最大待機回数と間隔を決める（15 秒 × 60 回 = 最大 15 分）
-max_attempts=60
-interval=15
-attempt=0
-
-while true; do
-  attempt=$((attempt + 1))
-
-  echo "[copilot-wait] $(date -u "+%Y-%m-%dT%H:%M:%SZ") (${attempt}/${max_attempts}) Copilot review を確認中..."
-
-  copilot_requested=$(
-    gh api graphql \
-      -f owner=tombi-toml \
-      -f repo=tombi \
-      -F number=<pr-number> \
-      -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      reviewRequests(first: 100) {
-        nodes {
-          requestedReviewer {
-            __typename
-            ... on Bot { login }
-            ... on User { login }
-            ... on Team { slug name }
-          }
-        }
-      }
-    }
-  }
-}' |
-      jq '
-        [
-          .data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer
-          | .login? // .slug? // empty
-          | ascii_downcase
-        ]
-        | any(test("copilot"))
-      '
-  )
-
-  if [ "$copilot_requested" != "true" ]; then
-    echo "[copilot-wait] Copilot review request は pending ではありません。待機を終了します。"
-    break
-  fi
-
-  copilot_has_feedback=$(
-    gh pr view <pr-url-or-number> --json reviews,comments |
-      jq '
-        [
-          (.reviews[]? | .author.login),
-          (.comments[]? | .author.login)
-        ]
-        | flatten
-        | map(select(. != null) | ascii_downcase)
-        | any(test("copilot"))
-      '
-  )
-
-  copilot_has_thread=$(
-    gh api graphql \
-      -f query='...reviewThreads...' \
-      -F owner=tombi-toml \
-      -F repo=tombi \
-      -F number=<pr-number> |
-      jq '
-        [
-          .. | objects | select(has("author")) | .author.login?
-        ]
-        | map(select(. != null) | ascii_downcase)
-        | any(test("copilot"))
-      '
-  )
-
-  if [ "$copilot_has_feedback" = "true" ] || [ "$copilot_has_thread" = "true" ]; then
-    echo "[copilot-wait] Copilot からの review / comment / thread を検知したため待機を終了します。"
-    break
-  fi
-
-  if [ "$attempt" -ge "$max_attempts" ]; then
-    echo "[copilot-wait] 最大待機回数 (${max_attempts}) に到達しました。"
-    echo "[copilot-wait] 現時点で Copilot からの review / comment / thread は確認できていません。"
-    break
-  fi
-
-  if [ $((attempt % 5)) -eq 0 ]; then
-    echo "[copilot-wait] まだ Copilot からの review / comment はありません。引き続き待機します..."
-  fi
-
-  sleep "$interval"
-done
-```
-
-- `reviews[].author.login`、thread comment の `author.login`、top-level comment を見て Copilot からの最初の反応が付いたかを確認する
-- pending の Copilot review request が無い PR では待たない
-- Copilot からの反応が見えたらポーリングを止め、通常の review 対応フローに進む
-- ポーリング中に review request が取り消された / 消化済みで pending ではなくなった場合も待機を止める
-- 待機は `gh` だけで行い、review 確認のために browser を開かない
-- 15 分待っても返ってこない場合は、その時点の状態と確認時刻をユーザーに報告する
-
-### 5. unresolved review thread を取る
-
-`gh pr view --json reviews,comments` では thread 単位の resolve 状態が取れない。review thread は GraphQL で取得する。
+`gh pr view --json reviews,comments` では thread 単位の resolve 状態が取れないため、GraphQL の `reviewThreads` を使う。
 
 ```bash
 gh api graphql \
@@ -248,15 +90,13 @@ gh api graphql \
   -f repo=tombi \
   -F number=<number> \
   -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
+query($owner: String!, $repo: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       id
-      reviewThreads(first: 100) {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
+      reviewThreads(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -265,7 +105,9 @@ query($owner: String!, $repo: String!, $number: Int!) {
           viewerCanResolve
           path
           line
-          comments(first: 20) {
+          comments(first: 100) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               body
@@ -282,24 +124,70 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }'
 ```
 
-- `isResolved == false` の thread を順に処理する
-- `pageInfo.hasNextPage == true` なら追加ページも取って、未処理 thread を残さない
-- `isOutdated == true` でも、指摘の意図が残っていれば無視しない
-- top-level PR comment は resolve できないため、必要なら `gh pr comment` で別途返信する
-- `viewerCanResolve == false` の thread は返信までは行い、権限不足をユーザーに報告する
-- AI reviewer / 人間レビュアーを分けず、対象にした unresolved thread を残さない
+- 初回は `after` を省略し、`pageInfo.hasNextPage == true` なら `-f after='<endCursor>'` を追加して次ページを取得する。`hasNextPage == false` になるまで繰り返す
+- 各 thread の `comments.pageInfo.hasNextPage == true` なら、thread ID と comments cursor を使う次の query を `hasNextPage == false` まで繰り返す
+- 各 GraphQL 応答の `.errors` が空であること、`endCursor` が非空かつ前ページから進行すること、ページ継続中に空 nodes が返らないこと、thread / comment ID が重複しないことを確認する
+- `reviewThreads.totalCount` と取得した unique thread ID 数、および各 `comments.totalCount` と取得した unique comment ID 数が一致しなければ fail closed とする
+- 実行環境のページ上限へ達した場合は完全取得とみなさず、未完了として報告する
+- `isResolved == false` の thread を処理する
+- `isOutdated == true` でも指摘の意図が残るなら無視しない
+- top-level comment は必要に応じて `gh pr comment` で返信する
+- `viewerCanResolve == false` なら返信まで行い、権限不足を報告する
 
-### 6. 指摘の扱いを決める
+```bash
+gh api graphql \
+  -F threadId='<thread-id>' \
+  -f after='<comments-endCursor>' \
+  -f query='
+query($threadId: ID!, $after: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          body
+          publishedAt
+          url
+          author { login }
+          pullRequestReview { id state url }
+        }
+      }
+    }
+  }
+}'
+```
 
-- 妥当: 修正し、必要なテストを通し、push してから返信する
-- 不要: 修正しない。コードや仕様に基づく理由を返信する
-- 既対応: 対応した commit / file / test を示して返信する
+### 6. 指摘を判定する
 
-対象は AI reviewer と人間レビュアーの両方を含む。技術判断で完結するものは自分で決めて進める。曖昧な仕様判断だけユーザー確認を検討する。
+- 妥当: 修正し、必要なテストと次のローカルレビューゲートを通し、push してから返信する
+- 不要: コードまたは仕様に基づく理由を返信する
+- 既対応: 対応した commit、file、test を示して返信する
+
+AI reviewer と人間レビュアーを区別せず、技術判断で完結するものは進める。曖昧な仕様判断だけユーザー確認を検討する。
+
+#### コード変更を push する前のローカルレビューゲート
+
+`main` の取り込み、CI 修正、review 対応などで head tree を変える場合は、次を push 前に実行する。
+
+1. `git fetch origin main` を実行する
+2. `git merge-base --is-ancestor origin/main HEAD || git merge origin/main --no-edit` で最新の `origin/main` を必ず取り込む
+3. merge 後の tree に対して必要なローカル検証を完了し、PR に含める変更だけを stage する
+4. `git rev-parse origin/main` を review base OID として記録する
+5. `git diff --cached --binary origin/main | shasum -a 256` を patch hash とし、`<review-base-oid>:<patch-hash>` を review fingerprint として記録する
+6. Codex または Claude Code の `review-quality` サブエージェントに、full PR diff、fingerprint、検証結果を渡して読み取り専用レビューを依頼する
+7. actionable finding があれば修正・検証・stage・fingerprint・独立レビューをやり直す
+8. finding がなくても、commit 直前に remote base OID と staged full PR diff が承認済み fingerprint と一致することを確認する
+9. commit 後に `git diff --binary origin/main HEAD | shasum -a 256` が同じ tree 差分を示し、`git status --porcelain` が空であることを確認してから push する
+
+base OID、commit hook、formatter などで head tree が変われば以前のレビュー結果を失効させ、検証と独立レビューをやり直す。サブエージェントから有効な判定を得られない場合も commit / push しない。
+
+push は Step 1 で特定した head repository の `<headRefName>` を明示的な対象にする。push 後は同じ repository URL を `git ls-remote` し、その OID と local HEAD、PR の `headRefOid` が一致するまで確認する。
 
 ### 7. thread に返信して resolve する
 
-返信は review thread に付ける。top-level の PR comment で代用しない。
+返信は top-level comment ではなく対象 review thread に付ける。
 
 ```bash
 gh api graphql \
@@ -308,10 +196,7 @@ gh api graphql \
   -f query='
 mutation($threadId: ID!, $body: String!) {
   addPullRequestReviewThreadReply(
-    input: {
-      pullRequestReviewThreadId: $threadId
-      body: $body
-    }
+    input: { pullRequestReviewThreadId: $threadId, body: $body }
   ) {
     comment { url }
   }
@@ -329,46 +214,22 @@ mutation($threadId: ID!) {
 }'
 ```
 
-- `pullRequestReviewThreadId` と `resolveReviewThread.input.threadId` は別名に見えても、どちらも thread ID を使う
-- 返信後に resolve し、無言 resolve はしない
+返信後に resolve する。top-level comment には `gh pr comment <pr> --body-file <file>` で返信する。
 
-top-level PR comment への返信:
+## 返信内容
 
-```bash
-gh pr comment <pr-url-or-number> --body-file /tmp/pr-comment-reply.md
-```
-
-## 返信の基準
-
-### 修正したとき
-
-- 何を変えたか
-- どこで変えたか
-- 何で確認したか
-
-例:
-
-```text
-対応しました。`crates/tombi-formatter/src/...rs` の分岐を修正し、`cargo nextest run -p tombi-formatter --locked` と `cargo clippy --workspace --all-targets --locked -- -D warnings` で確認しています。
-```
-
-### 修正不要のとき
-
-- なぜ不要か
-- 既存コード / 仕様 / テストのどれが根拠か
-- 必要なら代替案
-
-例:
-
-```text
-この件は現状のままとしました。ここは TOML の `...` 仕様に合わせた分岐で、`crates/tombi-formatter/tests/...` でも同じ前提を固定しています。今回の PR では変更対象にしません。
-```
+修正した場合は、変更内容、変更箇所、確認コマンドを書く。修正しない場合は、不要と判断した理由と根拠となるコード、仕様、テストを書く。
 
 ## 完了条件
 
-- 必要なコード修正が push 済み
-- 失敗していた CI の原因を潰している
-- 対象にした unresolved review thread すべてに返信済み
-- resolve 可能な thread はすべて resolve 済み
-- top-level comment / review summary があれば、必要な説明を PR comment で返している
-- ユーザーには、修正内容・実行した検証・未解決事項の有無だけを短く報告する
+- 必要なコード修正が push 済みである
+- 失敗していた CI の原因を解消している
+- check suite が開始済みで、pending / failed / cancelled check がなく、全対象 check が同じ exact head で pass または意図された skipping になっている
+- 対象にした unresolved thread すべてに返信済みである
+- resolve 可能な thread はすべて resolve 済みである
+- top-level comment / review summary に必要な説明を返している
+- handoff 直前に remote `main` の OID、local HEAD、remote head、PR head、承認済み review fingerprint を再取得している
+- remote base OID と承認済み review base OID が一致し、local / remote / PR head が同一で、current full PR diff の hash が承認済み patch hash と一致している
+- base または head tree が変わっていれば、最新の組み合わせで merge、検証、fingerprint、独立レビューをやり直している
+- 同じ exact head / base で CI、reviews、comments、全ページの threads、mergeability を再取得している
+- 修正内容、検証、未解決事項だけを短く報告する


### PR DESCRIPTION
## Summary

- remove GitHub Copilot reviewer requests and response polling from the agent harness
- require an independent local Codex or Claude Code subagent review before PR creation
- invalidate review evidence on base or head drift and re-review post-PR fixes before push
- keep existing human and AI review-thread handling without requesting a paid GitHub reviewer

## Validation

- `quick_validate.py .claude/skills/codex/github-pr-flow`
- `quick_validate.py .claude/skills/github-pr-resolve`
- `rg --hidden -n -i "copilot|add-reviewer|@copilot|copilot-wait" .claude .codex` (no matches)
- `git diff --check`
- independent `review-quality` subagent review (no actionable findings on the final fingerprint)

Review fingerprint: `dafac891b8439279760a8b8cfe7b06c725cf1478:6f85bd133708a767775e0919f554478ff1462ecf167349c08bb55a080f6c353a`
