### PR TITLE
fix(docs): prevent Safari table text inflation

### DIFF
--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -191,6 +191,8 @@ main {
 /* Table Styles */
 .mdx-content .mdx-table-shell {
   position: relative;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .mdx-content .mdx-table-sticky-head {


### PR DESCRIPTION
## Summary

- prevent mobile Safari from inflating text in horizontally scrollable documentation tables
- apply text-size adjustment to the shared table shell so both the original table and cloned sticky header inherit it

## Testing

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `git diff --cached --check`

## Validation gap

- not visually tested on a physical iOS Safari device
