### PR TITLE
docs: update Zed extension guidance

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -14,8 +14,7 @@
   "languages": {
     "TOML": {
       "formatter": {
-        "language_server": { "name": "tombi" },
-        "show_edit_predictions": false // https://github.com/tombi-toml/tombi/issues/1556
+        "language_server": { "name": "tombi" }
       }
     }
   }

--- a/docs/src/routes/docs/editors/zed-extension.mdx
+++ b/docs/src/routes/docs/editors/zed-extension.mdx
@@ -1,18 +1,7 @@
-import { Warning } from "~/components/Highlight";
-
 # Zed Extension
 
-<Warning>
-Zed may send `goto type definition` requests on each key press while editing TOML files.
-To avoid unwanted `lsp edit` tabs, set the following in your `tombi.toml`:
-
-```toml
-[lsp]
-goto-type-definition.enabled = false
-```
-
-For context, see [#1556](https://github.com/tombi-toml/tombi/issues/1556).
-</Warning>
+The Tombi extension currently published in Zed's extension registry focuses on Language Server Protocol (LSP) features.
+Syntax highlighting and other syntax-related editor features are provided by the [TOML extension](https://github.com/zed-extensions/toml), which should be installed alongside the Tombi extension.
 
 ## Language Server Binary Priority
 
@@ -78,3 +67,15 @@ You can set offline mode in the Zed settings file.
   }
 }
 ```
+
+## Troubleshooting
+
+Zed v1.1.6 and later include a workaround for background type definition requests that could open unwanted `lsp edit` tabs.
+If you still encounter this behavior, you can temporarily disable Tombi's Go to Type Definition feature in `tombi.toml`:
+
+```toml
+[lsp]
+goto-type-definition.enabled = false
+```
+
+For details and alternative workarounds, see [#1556](https://github.com/tombi-toml/tombi/issues/1556).

--- a/docs/src/routes/docs/installation.mdx
+++ b/docs/src/routes/docs/installation.mdx
@@ -1,6 +1,5 @@
 import CodeTabs from "../../components/CodeTabs";
 import { createSignal } from "solid-js";
-import { Warning } from "~/components/Highlight";
 
 export const [selectedMethod, setSelectedMethod] = createSignal(null);
 
@@ -287,21 +286,9 @@ Cursor, Windsurf, etc.
   url="https://zed.dev/extensions?query=tombi&filter=language-servers"
 />
 
-<Warning>
-If you use Zed's edit predictions, add the following to Zed's settings file (for example, `settings.json`) to disable them for TOML and avoid unwanted `lsp edit` tabs while editing files such as `pyproject.toml` or `Cargo.toml`:
-
-```json
-{
-  "languages": {
-    "TOML": {
-      "show_edit_predictions": false
-    }
-  }
-}
-```
-
-This is the recommended workaround for [#1556](https://github.com/tombi-toml/tombi/issues/1556), where Zed may open `lsp edit` tabs because of background type definition requests. For other Zed-specific configuration tips and separate workarounds, see the [Zed Extension](/docs/editors/zed-extension) page.
-</Warning>
+The Tombi extension currently published in Zed's extension registry focuses on Language Server Protocol (LSP) features.
+For syntax highlighting and other syntax-related editor features, also install the [TOML extension](https://github.com/zed-extensions/toml).
+For Tombi-specific configuration, see the [Zed Extension](/docs/editors/zed-extension) page.
 
 ## Helix
 


### PR DESCRIPTION
## Summary

- replace the prominent Zed `lsp edit` warning with guidance about the current extension split
- point users to the TOML extension for syntax-related editor features
- retain the Tombi fallback under troubleshooting for users who still encounter the Zed behavior
- remove the obsolete edit-predictions workaround from the repository's Zed settings

## Verification

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `BASE_URL=/tombi pnpm --dir docs build`
- `pnpm exec biome format .zed/settings.json`
- `git diff --check`

The production docs build prerendered all 46 routes, including the Zed extension and installation pages.
