### PR TITLE
fix(lsp): synchronize initial inlay hints

### DIFF
--- a/crates/tombi-lsp/src/backend.rs
+++ b/crates/tombi-lsp/src/backend.rs
@@ -52,6 +52,9 @@ pub struct Backend {
     pub background_tasks: Arc<std::sync::Mutex<Vec<tombi_future::TaskHandle>>>,
     pub document_sources:
         Arc<tokio::sync::RwLock<tombi_hashmap::HashMap<tombi_uri::Uri, DocumentSource>>>,
+    opening_documents: Arc<
+        std::sync::Mutex<tombi_hashmap::HashMap<tombi_uri::Uri, tokio::sync::watch::Sender<bool>>>,
+    >,
     pub config_manager: Arc<ConfigManager>,
     pub workspace_diagnostics_cache: Arc<tokio::sync::RwLock<WorkspaceDiagnosticsCache>>,
 }
@@ -98,8 +101,42 @@ impl Backend {
             })),
             background_tasks: Default::default(),
             document_sources: Default::default(),
+            opening_documents: Default::default(),
             config_manager: Arc::new(ConfigManager::new(options)),
             workspace_diagnostics_cache: Default::default(),
+        }
+    }
+
+    pub(crate) fn begin_document_open(&self, text_document_uri: tombi_uri::Uri) {
+        let (ready, _) = tokio::sync::watch::channel(false);
+        self.opening_documents
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .insert(text_document_uri, ready);
+    }
+
+    pub(crate) fn finish_document_open(&self, text_document_uri: &tombi_uri::Uri) {
+        let ready = self
+            .opening_documents
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(text_document_uri);
+        if let Some(ready) = ready {
+            ready.send_replace(true);
+        }
+    }
+
+    pub(crate) async fn wait_for_document_open(&self, text_document_uri: &tombi_uri::Uri) {
+        let ready = self
+            .opening_documents
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .get(text_document_uri)
+            .cloned();
+
+        if let Some(ready) = ready {
+            let mut ready = ready.subscribe();
+            let _ = ready.wait_for(|ready| *ready).await;
         }
     }
 
@@ -427,25 +464,16 @@ impl tower_lsp::LanguageServer for Backend {
         &self,
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>, tower_lsp::jsonrpc::Error> {
-        let text_document_uri = params.text_document.uri.as_ref();
-        let line_index = {
-            let Ok(document_sources) = self.document_sources.try_read() else {
-                return Ok(None);
-            };
-            let Some(document_source) = document_sources.get(text_document_uri) else {
-                return Ok(None);
-            };
-            document_source.line_index_arc()
+        let Some((hints, line_index)) = handle_inlay_hint(self, params).await? else {
+            return Ok(None);
         };
 
-        handle_inlay_hint(self, params).await.map(|response| {
-            response.map(|hints| {
-                hints
-                    .into_iter()
-                    .map(|hint| hint.into_lsp(line_index.as_ref()))
-                    .collect()
-            })
-        })
+        Ok(Some(
+            hints
+                .into_iter()
+                .map(|hint| hint.into_lsp(line_index.as_ref()))
+                .collect(),
+        ))
     }
 
     async fn folding_range(

--- a/crates/tombi-lsp/src/handler/did_open.rs
+++ b/crates/tombi-lsp/src/handler/did_open.rs
@@ -2,6 +2,18 @@ use tower_lsp::lsp_types::DidOpenTextDocumentParams;
 
 use crate::{backend::Backend, document::DocumentSource};
 
+fn select_cache_warming<T>(
+    cargo_enabled: bool,
+    cargo: impl FnOnce() -> Option<T>,
+    pyproject_enabled: bool,
+    pyproject: impl FnOnce() -> Option<T>,
+) -> Option<T> {
+    cargo_enabled
+        .then(cargo)
+        .flatten()
+        .or_else(|| pyproject_enabled.then(pyproject).flatten())
+}
+
 pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
     log::info!("handle_did_open");
     log::trace!("{:?}", params);
@@ -9,6 +21,7 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
     let DidOpenTextDocumentParams { text_document, .. } = params;
 
     let text_document_uri: tombi_uri::Uri = text_document.uri.into();
+    backend.begin_document_open(text_document_uri.clone());
     let toml_version = backend
         .text_document_toml_version(&text_document_uri, &text_document.text)
         .await;
@@ -33,18 +46,17 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
         .await
         .clear(&text_document_uri);
 
-    let cache_warming: Option<tombi_future::BoxFuture<'static, bool>> = {
-        let config_schema_store = backend
-            .config_manager
-            .config_schema_store_for_uri(&text_document_uri)
-            .await;
-        let offline = config_schema_store.schema_store.offline();
-        let cache_options = config_schema_store.schema_store.cache_options();
+    let config_schema_store = backend
+        .config_manager
+        .config_schema_store_for_uri(&text_document_uri)
+        .await;
+    let offline = config_schema_store.schema_store.offline();
+    let cache_options = config_schema_store.schema_store.cache_options();
 
-        let mut cache_warming = None;
-
-        if config_schema_store.config.cargo_extension_enabled()
-            && let Ok(Some(warming)) = tombi_extension_cargo::did_open(
+    let cache_warming = select_cache_warming(
+        config_schema_store.config.cargo_extension_enabled(),
+        || {
+            tombi_extension_cargo::did_open(
                 &text_document_uri,
                 document_tree.as_ref(),
                 toml_version,
@@ -52,11 +64,10 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
                 cache_options,
                 config_schema_store.config.cargo_extension_features(),
             )
-            .await
-        {
-            cache_warming = Some(warming);
-        } else if config_schema_store.config.pyproject_extension_enabled()
-            && let Ok(Some(warming)) = tombi_extension_pyproject::did_open(
+        },
+        config_schema_store.config.pyproject_extension_enabled(),
+        || {
+            tombi_extension_pyproject::did_open(
                 &text_document_uri,
                 document_tree.as_ref(),
                 toml_version,
@@ -64,23 +75,27 @@ pub async fn handle_did_open(backend: &Backend, params: DidOpenTextDocumentParam
                 cache_options,
                 config_schema_store.config.pyproject_extension_features(),
             )
-            .await
-        {
-            cache_warming = Some(warming);
-        }
-        cache_warming
-    };
+        },
+    );
+    backend.finish_document_open(&text_document_uri);
 
     // Publish diagnostics for the opened document
     backend.push_diagnostics(text_document_uri).await;
 
     if let Some(cache_warming) = cache_warming {
-        let client = backend.client.clone();
-        backend.spawn_background_task(async move {
-            let should_refresh_inlay_hint = cache_warming.await;
-            if should_refresh_inlay_hint && let Err(err) = client.inlay_hint_refresh().await {
-                log::debug!("failed to request warmed inlay hint refresh: {err}");
-            }
-        });
+        backend.spawn_background_task(cache_warming);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_cache_warming;
+
+    #[test]
+    fn cache_warming_falls_back_to_pyproject() {
+        assert_eq!(
+            select_cache_warming(true, || None, true, || Some("pyproject")),
+            Some("pyproject")
+        );
     }
 }

--- a/crates/tombi-lsp/src/handler/inlay_hint.rs
+++ b/crates/tombi-lsp/src/handler/inlay_hint.rs
@@ -1,4 +1,6 @@
-use tombi_text::FromLsp;
+use std::sync::Arc;
+
+use tombi_text::{FromLsp, LineIndex};
 use tower_lsp::lsp_types::InlayHintParams;
 
 use crate::{Backend, config_manager::ConfigSchemaStore};
@@ -6,7 +8,7 @@ use crate::{Backend, config_manager::ConfigSchemaStore};
 pub async fn handle_inlay_hint(
     backend: &Backend,
     params: InlayHintParams,
-) -> Result<Option<Vec<tombi_extension::InlayHint>>, tower_lsp::jsonrpc::Error> {
+) -> Result<Option<(Vec<tombi_extension::InlayHint>, Arc<LineIndex>)>, tower_lsp::jsonrpc::Error> {
     log::info!("handle_inlay_hint");
     log::trace!("{:?}", params);
 
@@ -16,6 +18,7 @@ pub async fn handle_inlay_hint(
         ..
     } = params;
     let text_document_uri = text_document.uri.into();
+    backend.wait_for_document_open(&text_document_uri).await;
 
     let ConfigSchemaStore {
         config,
@@ -26,7 +29,7 @@ pub async fn handle_inlay_hint(
         .config_schema_store_for_uri(&text_document_uri)
         .await;
 
-    let (document_tree, toml_version, visible_range) = {
+    let (document_tree, toml_version, visible_range, line_index) = {
         let Ok(document_sources) = backend.document_sources.try_read() else {
             return Ok(None);
         };
@@ -37,6 +40,7 @@ pub async fn handle_inlay_hint(
             document_source.document_tree(),
             document_source.toml_version,
             tombi_text::Range::from_lsp(range, document_source.line_index()),
+            document_source.line_index_arc(),
         )
     };
 
@@ -52,7 +56,7 @@ pub async fn handle_inlay_hint(
         )
         .await?
     {
-        return Ok(Some(hints));
+        return Ok(Some((hints, line_index)));
     }
 
     if config.pyproject_inlay_hint_enabled()
@@ -65,7 +69,7 @@ pub async fn handle_inlay_hint(
         )
         .await?
     {
-        return Ok(Some(hints));
+        return Ok(Some((hints, line_index)));
     }
 
     Ok(None)

--- a/crates/tombi-lsp/tests/test_inlay_hint.rs
+++ b/crates/tombi-lsp/tests/test_inlay_hint.rs
@@ -126,7 +126,7 @@ async fn collect_inlay_hints_with_backend(
     let toml_file_url =
         Url::from_file_path(&source_path).expect("failed to convert source file path to URL");
 
-    handle_did_open(
+    let did_open = handle_did_open(
         backend,
         DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
@@ -136,18 +136,21 @@ async fn collect_inlay_hints_with_backend(
                 text: toml_text.clone(),
             },
         },
-    )
-    .await;
+    );
 
-    Ok(handle_inlay_hint(
+    let inlay_hint = handle_inlay_hint(
         backend,
         InlayHintParams {
             text_document: TextDocumentIdentifier { uri: toml_file_url },
             range: inlay_hint_range(&toml_text),
             work_done_progress_params: WorkDoneProgressParams::default(),
         },
-    )
-    .await?)
+    );
+
+    // LSP notifications and requests are received in order, but their futures
+    // can overlap after `didOpen` first yields.
+    let (_, result) = tokio::join!(biased; did_open, inlay_hint);
+    Ok(result?.map(|(hints, _)| hints))
 }
 
 async fn collect_inlay_hints(

--- a/extensions/tombi-extension-cargo/src/did_open.rs
+++ b/extensions/tombi-extension-cargo/src/did_open.rs
@@ -32,16 +32,16 @@ struct RegistryDependency {
     default_features_hint: bool,
 }
 
-pub async fn did_open(
+pub fn did_open(
     text_document_uri: &tombi_uri::Uri,
     document_tree: &DocumentTree,
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
     features: Option<&CargoExtensionFeatures>,
-) -> Result<Option<tombi_future::BoxFuture<'static, bool>>, tower_lsp::jsonrpc::Error> {
+) -> Option<tombi_future::BoxFuture<'static, ()>> {
     if !text_document_uri.path().ends_with("Cargo.toml") {
-        return Ok(None);
+        return None;
     }
 
     if !features
@@ -49,15 +49,15 @@ pub async fn did_open(
         .unwrap_or_default()
         .value()
     {
-        return Ok(None);
+        return None;
     }
 
     if warming_disabled(offline, cache_options) {
-        return Ok(None);
+        return None;
     }
 
     let Ok(cargo_toml_path) = text_document_uri.to_file_path() else {
-        return Ok(None);
+        return None;
     };
 
     let document_tree = document_tree.clone();
@@ -72,10 +72,9 @@ pub async fn did_open(
         )
         .await;
         if urls.is_empty() {
-            return false;
+            return;
         }
 
-        let should_refresh_inlay_hint = !urls.awaited.is_empty();
         let awaited_urls = urls.awaited;
         let background_urls = urls.background;
         let background_cache_options = cache_options.clone();
@@ -92,11 +91,9 @@ pub async fn did_open(
                 }
             }
         );
-
-        should_refresh_inlay_hint
     };
 
-    Ok(Some(warm.boxed()))
+    Some(warm.boxed())
 }
 
 async fn warm_urls(
@@ -688,8 +685,8 @@ mod tests {
         assert!(urls.background.is_empty());
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn did_open_ignores_non_cargo_documents() {
+    #[test]
+    fn did_open_ignores_non_cargo_documents() {
         let document_tree = parse_document_tree("");
         let uri = tombi_uri::Uri::from_str("file:///tmp/pyproject.toml").unwrap();
 
@@ -700,10 +697,9 @@ mod tests {
             true,
             None,
             None,
-        )
-        .await;
+        );
 
-        assert!(result.is_ok());
+        assert!(result.is_none());
     }
 
     #[test]

--- a/extensions/tombi-extension-pyproject/src/did_open.rs
+++ b/extensions/tombi-extension-pyproject/src/did_open.rs
@@ -12,16 +12,16 @@ use crate::{
 
 const PREFETCH_CONCURRENCY: usize = 10;
 
-pub async fn did_open(
+pub fn did_open(
     text_document_uri: &tombi_uri::Uri,
     document_tree: &DocumentTree,
     toml_version: TomlVersion,
     offline: bool,
     cache_options: Option<&tombi_cache::Options>,
     features: Option<&PyprojectExtensionFeatures>,
-) -> Result<Option<tombi_future::BoxFuture<'static, bool>>, tower_lsp::jsonrpc::Error> {
+) -> Option<tombi_future::BoxFuture<'static, ()>> {
     if !text_document_uri.path().ends_with("pyproject.toml") {
-        return Ok(None);
+        return None;
     }
 
     if !features
@@ -29,7 +29,7 @@ pub async fn did_open(
         .unwrap_or_default()
         .value()
     {
-        return Ok(None);
+        return None;
     }
 
     if !features
@@ -40,15 +40,15 @@ pub async fn did_open(
         .unwrap_or_default()
         .value()
     {
-        return Ok(None);
+        return None;
     }
 
     if warming_disabled(offline, cache_options) {
-        return Ok(None);
+        return None;
     }
 
     let Ok(pyproject_toml_path) = text_document_uri.to_file_path() else {
-        return Ok(None);
+        return None;
     };
 
     let document_tree = document_tree.clone();
@@ -56,7 +56,7 @@ pub async fn did_open(
     let warm = async move {
         let urls = collect_prefetch_urls(&document_tree, &pyproject_toml_path, toml_version);
         if urls.is_empty() {
-            return false;
+            return;
         }
 
         let cache_options = cache_options.as_ref();
@@ -65,10 +65,9 @@ pub async fn did_open(
                 let _ = warm_remote_json_cache(&url, offline, cache_options).await;
             })
             .await;
-        true
     };
 
-    Ok(Some(warm.boxed()))
+    Some(warm.boxed())
 }
 
 fn warming_disabled(offline: bool, cache_options: Option<&tombi_cache::Options>) -> bool {
@@ -255,8 +254,8 @@ mod tests {
         assert_eq!(urls, vec!["https://pypi.org/pypi/pytest/json".to_string()]);
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn did_open_ignores_non_pyproject_documents() {
+    #[test]
+    fn did_open_ignores_non_pyproject_documents() {
         let document_tree = parse_document_tree("");
         let uri = tombi_uri::Uri::from_str("file:///tmp/Cargo.toml").unwrap();
 
@@ -267,9 +266,8 @@ mod tests {
             true,
             None,
             None,
-        )
-        .await;
+        );
 
-        assert!(result.is_ok());
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- synchronize initial inlay hint requests with `didOpen` document setup
- keep hint positions and LSP conversion on the same document snapshot
- warm Cargo and pyproject metadata in the background without requesting redundant inlay hint refreshes
- preserve pyproject warming fallback when both extensions are enabled

## Testing

- `cargo nextest run` (2223 passed)
- `cargo fmt --all --check`
- `cargo clippy -p tombi-lsp -p tombi-extension-cargo -p tombi-extension-pyproject --all-targets -- -D warnings`
- independent local `review-quality` review: no actionable findings
