### PR TITLE
fix(docs): recover from stale client chunks

### DIFF
--- a/docs/src/entry-client.tsx
+++ b/docs/src/entry-client.tsx
@@ -1,6 +1,63 @@
 // @refresh reload
 import { mount, StartClient } from "@solidjs/start/client";
 
+const PRELOAD_ERROR_RELOAD_KEY = "tombi-preload-error-reload-v1";
+const PRELOAD_ERROR_RELOAD_WINDOW_MS = 60_000;
+
+interface PreloadErrorReloadMarker {
+  path: string;
+  createdAt: number;
+}
+
+function parsePreloadErrorReloadMarker(
+  value: string | null,
+): PreloadErrorReloadMarker | undefined {
+  if (!value) return;
+
+  try {
+    const marker = JSON.parse(value) as Record<string, unknown>;
+    if (
+      typeof marker.path === "string" &&
+      typeof marker.createdAt === "number"
+    ) {
+      return {
+        path: marker.path,
+        createdAt: marker.createdAt,
+      };
+    }
+  } catch {
+    return;
+  }
+}
+
+window.addEventListener("vite:preloadError", (event) => {
+  const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  const now = Date.now();
+
+  try {
+    const previousReload = parsePreloadErrorReloadMarker(
+      window.sessionStorage.getItem(PRELOAD_ERROR_RELOAD_KEY),
+    );
+    if (
+      previousReload?.path === path &&
+      now - previousReload.createdAt < PRELOAD_ERROR_RELOAD_WINDOW_MS
+    ) {
+      return;
+    }
+
+    window.sessionStorage.setItem(
+      PRELOAD_ERROR_RELOAD_KEY,
+      JSON.stringify({ path, createdAt: now }),
+    );
+  } catch {
+    // Keep the original error when storage is unavailable rather than risk a reload loop.
+    return;
+  }
+
+  event.preventDefault();
+  window.location.reload();
+});
+
 const app = document.getElementById("app");
 if (!app) throw new Error("Failed to find app element");
 


### PR DESCRIPTION
## Summary

- reload the docs client when Vite reports a stale dynamic-import chunk
- guard reload recovery with session storage to avoid repeated reloads
- preserve the original preload error when recovery cannot be guarded safely

## Testing

- `pnpm --dir docs format:check`
- `pnpm --dir docs lint:check`
- `pnpm --dir docs typecheck`
- `git diff --check`
- `BASE_URL=/tombi PATH=/Users/s23467/.cargo/bin:$PATH pnpm --dir docs build` (46 routes prerendered)
