### PR TITLE
Improve minimal-change guidance for agents

### DIFF
--- a/.claude/agents/review-quality.md
+++ b/.claude/agents/review-quality.md
@@ -16,6 +16,7 @@ PR 作成前ゲートとして呼び出された場合は読み取り専用で�
 - `.claude/rules/rust-workspace-practices.md`
 - `.claude/rules/polyglot-boundaries.md`
 - `.claude/rules/test-macro-policy.md`
+- `.claude/rules/minimal-change.md`
 
 ## 重点観点
 
@@ -23,10 +24,13 @@ PR 作成前ゲートとして呼び出された場合は読み取り専用で�
 - 既存テストや CI surface の取りこぼし
 - source of truth の逆転
 - 既存マクロや既存 workflow から外れた実装
+- 既存 helper / 標準ライブラリ / platform 機能を再実装した重複
+- 現在の要件に不要な abstraction、設定、dependency、将来用 scaffold
 
 ## 出力原則
 
 - findings を重要度順に並べる
 - file / line を可能な限り示す
 - 各 finding には失敗シナリオと根拠を示し、修正は親エージェントに委ねる
+- correctness と安全性を先に確認し、その後に削除・縮小できる差分を示す
 - 問題がなければその旨を明示し、残る検証ギャップだけ短く書く

--- a/.claude/rules/minimal-change.md
+++ b/.claude/rules/minimal-change.md
@@ -1,0 +1,11 @@
+---
+paths: "**/*"
+---
+
+# Minimal Change
+
+- 変更前に対象の実行経路と既存実装を確認し、既存 helper / pattern、標準ライブラリ、platform 機能、導入済み dependency の順に再利用を検討する
+- 新しい abstraction、設定、dependency、将来用 scaffold は、現在の要件で必要な場合だけ追加する
+- bug report は症状として扱い、変更対象の caller と同じ経路を使う箇所を検索して、可能なら共有された根因を一度だけ修正する
+- 最小差分は調査後に選ぶ。trust boundary の validation、data loss を防ぐ error handling、security、accessibility、明示された要件は簡略化しない
+- 非自明な変更には、既存の test macro / test pattern を使った最小の回帰確認を残す

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -17,8 +17,9 @@ description: tombi の差分レビュー時に correctness / 回帰リスク / �
 1. `git diff origin/main...` か対象差分を確認する
 2. 変更された領域の source of truth を特定する
 3. 既存の test macro、workflow、生成手順から外れていないかを確認する
-4. findings を重要度順に整理する
-5. 問題がなければ、未確認の検証範囲だけを残リスクとして記録する
+4. correctness と安全性を確認した後、既存 helper / 標準ライブラリ / platform 機能で置き換えられる実装や、現在の要件に不要な abstraction を確認する
+5. findings を重要度順に整理する
+6. 問題がなければ、未確認の検証範囲だけを残リスクとして記録する
 
 ## 観点
 
@@ -26,3 +27,5 @@ description: tombi の差分レビュー時に correctness / 回帰リスク / �
 - generated artifact の更新漏れ
 - 既存 test macro を無視したテスト実装
 - packaging / workflow への影響漏れ
+- 共有経路ではなく症状ごとに重複した bug fix
+- 未使用の拡張性、新規 dependency、将来用 scaffold による過剰実装


### PR DESCRIPTION
## Summary

- add always-on minimal-change guidance that prefers existing helpers, standard library, native platform features, and installed dependencies
- direct bug fixes toward shared root causes while preserving validation, security, accessibility, and explicit requirements
- extend the normal and pre-PR review paths to identify duplicated or speculative implementation after correctness and safety checks
- keep the existing local review gate without adding Ponytail runtime hooks, mode state, or a separate simplify step

Reference: https://github.com/dietrichgebert/ponytail

## Validation

- `quick_validate.py .claude/skills/review` (`Skill is valid!`)
- parsed YAML frontmatter for all three changed Markdown files
- compared `.claude/rules/minimal-change.md` with its `.codex/rules/` symlink view
- `git diff --cached --check`
- independent read-only `review-quality` subagent review: no actionable findings

Review fingerprint: `254fd09681c14ad374ae7c958d1520eb4019d45b:6b081166810c0418eeb14ead12eccf9d529d2345be62b49f660c7db2dd80c38b`

Remaining gap: the new always-on rule was not startup-tested in live Claude Code and Codex sessions.
