### PR TITLE
fix(lsp): preserve composite schema metadata

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 too-many-arguments-threshold = 20
+large-error-ignored = ["tombi_validator::Invalid"]

--- a/crates/tombi-cache/src/lib.rs
+++ b/crates/tombi-cache/src/lib.rs
@@ -6,25 +6,7 @@ pub const CACHE_INDEX_FILE_NAME: &str = "__index__.json";
 
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn get_tombi_cache_dir_path() -> Option<std::path::PathBuf> {
-    if let Some(tombi_cache_home) = std::env::var_os("TOMBI_CACHE_HOME") {
-        return ensure_cache_dir(std::path::PathBuf::from(tombi_cache_home)).await;
-    }
-
-    if let Some(xdg_cache_home) = std::env::var_os("XDG_CACHE_HOME") {
-        let mut cache_dir_path = std::path::PathBuf::from(xdg_cache_home);
-        cache_dir_path.push("tombi");
-
-        return ensure_cache_dir(cache_dir_path).await;
-    }
-
-    if let Some(home_dir) = dirs::home_dir() {
-        let mut cache_dir_path = home_dir;
-        cache_dir_path.push(".cache");
-        cache_dir_path.push("tombi");
-        return ensure_cache_dir(cache_dir_path).await;
-    }
-
-    None
+    ensure_cache_dir(tombi_cache_dir_path()?).await
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -33,29 +15,74 @@ pub async fn get_tombi_cache_dir_path() -> Option<std::path::PathBuf> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn get_cache_file_path(cache_file_uri: &tombi_uri::Uri) -> Option<std::path::PathBuf> {
-    get_tombi_cache_dir_path().await.map(|mut dir_path| {
-        dir_path.push(cache_file_uri.scheme());
-        if let Some(host) = cache_file_uri.host() {
-            dir_path.push(host.to_string());
-        }
-        if let Some(path_segments) = cache_file_uri.path_segments() {
-            for segment in path_segments {
-                dir_path.push(segment)
-            }
-        }
-        if matches!(cache_file_uri.scheme(), "http" | "https")
-            && !cache_file_uri.path().ends_with(".json")
-        {
-            dir_path.push(CACHE_INDEX_FILE_NAME);
-        }
+fn tombi_cache_dir_path() -> Option<std::path::PathBuf> {
+    if let Some(tombi_cache_home) = std::env::var_os("TOMBI_CACHE_HOME") {
+        return Some(std::path::PathBuf::from(tombi_cache_home));
+    }
 
-        dir_path
-    })
+    if let Some(xdg_cache_home) = std::env::var_os("XDG_CACHE_HOME") {
+        let mut cache_dir_path = std::path::PathBuf::from(xdg_cache_home);
+        cache_dir_path.push("tombi");
+
+        return Some(cache_dir_path);
+    }
+
+    if let Some(home_dir) = dirs::home_dir() {
+        let mut cache_dir_path = home_dir;
+        cache_dir_path.push(".cache");
+        cache_dir_path.push("tombi");
+        return Some(cache_dir_path);
+    }
+
+    None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn get_cache_file_path(cache_file_uri: &tombi_uri::Uri) -> Option<std::path::PathBuf> {
+    Some(cache_file_path(
+        get_tombi_cache_dir_path().await?,
+        cache_file_uri,
+    ))
 }
 
 #[cfg(target_arch = "wasm32")]
 pub async fn get_cache_file_path(_cache_file_uri: &tombi_uri::Uri) -> Option<std::path::PathBuf> {
+    None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn cache_file_path(
+    mut cache_dir_path: std::path::PathBuf,
+    cache_file_uri: &tombi_uri::Uri,
+) -> std::path::PathBuf {
+    cache_dir_path.push(cache_file_uri.scheme());
+    if let Some(host) = cache_file_uri.host() {
+        cache_dir_path.push(host.to_string());
+    }
+    if let Some(path_segments) = cache_file_uri.path_segments() {
+        for segment in path_segments {
+            cache_dir_path.push(segment);
+        }
+    }
+    if matches!(cache_file_uri.scheme(), "http" | "https")
+        && !cache_file_uri.path().ends_with(".json")
+    {
+        cache_dir_path.push(CACHE_INDEX_FILE_NAME);
+    }
+
+    cache_dir_path
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_existing_cache_file_path(cache_file_uri: &tombi_uri::Uri) -> Option<std::path::PathBuf> {
+    let cache_file_path = cache_file_path(tombi_cache_dir_path()?, cache_file_uri);
+    cache_file_path.is_file().then_some(cache_file_path)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn get_existing_cache_file_path(
+    _cache_file_uri: &tombi_uri::Uri,
+) -> Option<std::path::PathBuf> {
     None
 }
 

--- a/crates/tombi-extension/src/completion.rs
+++ b/crates/tombi-extension/src/completion.rs
@@ -2,7 +2,7 @@ mod completion_edit;
 mod completion_hint;
 mod completion_kind;
 
-use std::{ops::Deref, path::Path};
+use std::path::Path;
 
 pub use completion_edit::{CompletionEdit, CompletionTextEdit, InsertReplaceEdit};
 pub use completion_hint::{AddLeadingComma, AddTrailingComma, CommaHint, CompletionHint};
@@ -10,8 +10,6 @@ pub use completion_kind::CompletionKind;
 use tombi_document_tree::dig_accessors;
 use tombi_schema_store::{Accessor, SchemaUri, get_schema_name};
 use tombi_text::{FromLsp, IntoLsp};
-
-use crate::get_tombi_github_uri;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
@@ -510,25 +508,26 @@ impl FromLsp<CompletionContent> for tower_lsp::lsp_types::CompletionItem {
         source: CompletionContent,
         line_index: &tombi_text::LineIndex,
     ) -> tower_lsp::lsp_types::CompletionItem {
-        const SECTION_SEPARATOR: &str = "-----";
-
         let sorted_text = format!("{}_{}", source.priority.as_prefix(), source.label);
+        let omit_detail = source.documentation.is_some()
+            && matches!(
+                &source.priority,
+                CompletionContentPriority::TypeHint
+                    | CompletionContentPriority::TypeHintTrue
+                    | CompletionContentPriority::TypeHintFalse
+            );
 
         let mut schema_text = None;
-        if let Some(schema_uri) = &source.schema_uri {
-            let schema_uri = match get_tombi_github_uri(schema_uri) {
-                Some(schema_uri) => schema_uri,
-                None => schema_uri.deref().clone(),
-            };
-            if let Some(schema_filename) = get_schema_name(&schema_uri) {
-                schema_text = Some(format!("Schema: [{schema_filename}]({schema_uri})\n"));
-            }
+        if let Some(schema_uri) = &source.schema_uri
+            && let Some(schema_filename) = get_schema_name(schema_uri)
+        {
+            schema_text = Some(format!("Schema: [{schema_filename}]({schema_uri})\n"));
         }
         let documentation = match source.documentation {
             Some(documentation) => {
-                let mut documentation = documentation;
+                let mut documentation = documentation.trim_end().to_string();
                 if let Some(schema_text) = schema_text {
-                    documentation.push_str(&format!("\n\n{SECTION_SEPARATOR}\n\n"));
+                    documentation.push_str("\n\n");
                     documentation.push_str(&schema_text);
                 }
                 Some(documentation)
@@ -633,13 +632,17 @@ impl FromLsp<CompletionContent> for tower_lsp::lsp_types::CompletionItem {
             label: source.label,
             label_details,
             kind: Some(source.kind.into()),
-            detail: source.detail.map(|detail| {
-                if let Some(emoji_icon) = source.emoji_icon {
-                    format!("{emoji_icon} {detail}")
-                } else {
-                    detail
-                }
-            }),
+            detail: if omit_detail {
+                None
+            } else {
+                source.detail.map(|detail| {
+                    if let Some(emoji_icon) = source.emoji_icon {
+                        format!("{emoji_icon} {detail}")
+                    } else {
+                        detail
+                    }
+                })
+            },
             documentation: documentation.map(|documentation| {
                 tower_lsp::lsp_types::Documentation::MarkupContent(
                     tower_lsp::lsp_types::MarkupContent {

--- a/crates/tombi-extension/src/completion/completion_kind.rs
+++ b/crates/tombi-extension/src/completion/completion_kind.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum CompletionKind {
     Boolean,

--- a/crates/tombi-extension/src/document_link.rs
+++ b/crates/tombi-extension/src/document_link.rs
@@ -60,3 +60,82 @@ pub fn get_tombi_github_uri(uri: &tombi_uri::Uri) -> Option<tombi_uri::Uri> {
         Some(uri.clone())
     }
 }
+
+pub fn get_schema_link_uri(uri: &tombi_uri::Uri, position: tombi_text::Position) -> tombi_uri::Uri {
+    if uri.scheme() == "tombi" {
+        return get_tombi_github_uri(uri).unwrap_or_else(|| uri.clone());
+    }
+    if !matches!(uri.scheme(), "http" | "https") {
+        return uri.clone();
+    }
+
+    let mut cache_uri = uri.clone();
+    cache_uri.set_fragment(None);
+    let Some(cache_file_path) = tombi_cache::get_existing_cache_file_path(&cache_uri) else {
+        return uri.clone();
+    };
+    let Ok(mut cache_file_uri) = tombi_uri::Uri::from_file_path(cache_file_path) else {
+        return uri.clone();
+    };
+    cache_file_uri.set_fragment(Some(&format!(
+        "L{},{}",
+        position.line + 1,
+        position.column + 1
+    )));
+    cache_file_uri
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use tombi_test_lib::TestCacheHome;
+
+    use super::get_schema_link_uri;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cached_http_schema_links_to_local_position() {
+        let _cache_home = TestCacheHome::new();
+        let schema_uri =
+            tombi_uri::Uri::from_str("https://example.com/cached.schema.json#/properties/value")
+                .unwrap();
+        let mut cache_uri = schema_uri.clone();
+        cache_uri.set_fragment(None);
+        let cache_file_path = tombi_cache::get_cache_file_path(&cache_uri).await.unwrap();
+        tokio::fs::create_dir_all(cache_file_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&cache_file_path, "{}").await.unwrap();
+
+        let link_uri = get_schema_link_uri(&schema_uri, tombi_text::Position::new(2, 4));
+
+        assert_eq!(link_uri.scheme(), "file");
+        assert_eq!(link_uri.fragment(), Some("L3,5"));
+        assert_eq!(link_uri.to_file_path().unwrap(), cache_file_path);
+    }
+
+    #[test]
+    fn uncached_and_unknown_schema_links_are_unchanged() {
+        let _cache_home = TestCacheHome::new();
+        let position = tombi_text::Position::new(2, 4);
+        for schema_uri in [
+            "https://example.com/uncached.schema.json",
+            "tombi://unknown.example/unknown.json",
+        ] {
+            let schema_uri = tombi_uri::Uri::from_str(schema_uri).unwrap();
+            assert_eq!(get_schema_link_uri(&schema_uri, position), schema_uri);
+        }
+    }
+
+    #[test]
+    fn built_in_schema_links_to_github() {
+        let schema_uri =
+            tombi_uri::Uri::from_str("tombi://www.schemastore.org/tombi.json").unwrap();
+
+        let link_uri = get_schema_link_uri(&schema_uri, tombi_text::Position::default());
+
+        assert_eq!(link_uri.scheme(), "https");
+        assert_eq!(link_uri.host_str(), Some("raw.githubusercontent.com"));
+        assert!(link_uri.path().ends_with("/www.schemastore.org/tombi.json"));
+    }
+}

--- a/crates/tombi-fs/src/lib.rs
+++ b/crates/tombi-fs/src/lib.rs
@@ -1,5 +1,24 @@
 use std::path::{Component, Path, PathBuf};
 
+#[derive(Debug)]
+pub struct RunBlockingError {
+    #[cfg(not(target_family = "wasm"))]
+    source: tokio::task::JoinError,
+}
+
+impl std::fmt::Display for RunBlockingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("blocking task failed")
+    }
+}
+
+impl std::error::Error for RunBlockingError {
+    #[cfg(not(target_family = "wasm"))]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 pub fn home_dir() -> Option<PathBuf> {
     dirs::home_dir()
@@ -178,14 +197,16 @@ pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "virtual path not found"))
 }
 
-pub async fn run_blocking<F, R>(function: F) -> Result<R, ()>
+pub async fn run_blocking<F, R>(function: F) -> Result<R, RunBlockingError>
 where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
     #[cfg(not(target_family = "wasm"))]
     {
-        tokio::task::spawn_blocking(function).await.map_err(|_| ())
+        tokio::task::spawn_blocking(function)
+            .await
+            .map_err(|source| RunBlockingError { source })
     }
     #[cfg(target_family = "wasm")]
     {

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "internal_type": {
+      "$ref": "#/$defs/integer",
+      "type": "string"
+    },
+    "internal_const": {
+      "$ref": "#/$defs/integer",
+      "const": "only"
+    },
+    "internal_enum": {
+      "$ref": "#/$defs/integer",
+      "enum": ["only"]
+    },
+    "external_type": {
+      "$ref": "target.schema.json",
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "integer": {
+      "type": "integer"
+    }
+  }
+}

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/target.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/target.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "integer"
+}

--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -40,6 +40,8 @@ mod prefix_items_test_schema;
 mod recursive_anchor_ref_test_schema;
 #[path = "integration/recursive_defs_any_of_test_schema.rs"]
 mod recursive_defs_any_of_test_schema;
+#[path = "integration/ref_sibling_assertions.rs"]
+mod ref_sibling_assertions;
 #[path = "integration/schema_resolution_error.rs"]
 mod schema_resolution_error;
 #[path = "integration/string_format_test_schema.rs"]

--- a/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
@@ -1,0 +1,25 @@
+use tombi_linter::test_lint;
+use tombi_test_lib::project_root_path;
+
+fn schema_path() -> std::path::PathBuf {
+    project_root_path()
+        .join("crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json")
+}
+
+test_lint! {
+    #[test]
+    fn incompatible_type_const_and_enum_reject_values(
+        r#"
+        internal_type = 1
+        internal_const = 1
+        internal_enum = 1
+        external_type = 1
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::Nothing,
+        tombi_validator::DiagnosticKind::Nothing,
+        tombi_validator::DiagnosticKind::Nothing,
+        tombi_validator::DiagnosticKind::Nothing,
+    ])
+}

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -13,15 +13,18 @@ use tombi_config::TomlVersion;
 use tombi_document_tree::{IntoDocumentTreeAndErrors, TryIntoDocumentTree};
 use tombi_extension::CompletionContentPriority;
 use tombi_extension::{
-    CommaHint, CommentContext, CompletionContent, CompletionEdit, CompletionHint,
+    CommaHint, CommentContext, CompletionContent, CompletionEdit, CompletionHint, CompletionKind,
 };
 use tombi_future::Boxable;
 use tombi_rg_tree::{NodeOrToken, TokenAtOffset};
 use tombi_schema_store::{
     Accessor, AccessorKeyKind, AllOfSchema, AnyOfSchema, CompositeSchema, CurrentSchema,
     KeyContext, OneOfSchema, SchemaDefinitions, SchemaStore, SchemaUri, SchemaView,
+    get_schema_name,
 };
 use tombi_syntax::{Direction, SyntaxElement, SyntaxKind, SyntaxNode};
+
+use crate::schema_tooltip::{SchemaTooltip, SchemaTooltipContent};
 
 pub fn get_comment_context(
     root: &tombi_ast::Root,
@@ -246,7 +249,7 @@ pub async fn find_completion_contents(
     schema_context: &tombi_schema_store::SchemaContext<'_>,
     completion_hint: Option<CompletionHint>,
 ) -> Vec<CompletionContent> {
-    match CompletionSource::new(
+    let completion_items = match CompletionSource::new(
         document_tree,
         position,
         keys,
@@ -310,23 +313,8 @@ pub async fn find_completion_contents(
                 .await
         }
         None => Vec::new(),
-    }
-    .into_iter()
-    .fold(
-        tombi_hashmap::IndexMap::new(),
-        |mut acc: tombi_hashmap::IndexMap<_, Vec<_>>, content| {
-            acc.entry(content.label.clone()).or_default().push(content);
-            acc
-        },
-    )
-    .into_iter()
-    .filter_map(|(_, contents)| {
-        contents
-            .into_iter()
-            .sorted_by(|a, b| a.priority.cmp(&b.priority))
-            .next()
-    })
-    .collect()
+    };
+    dedup_completion_contents(completion_items)
 }
 
 pub trait FindCompletionContents {
@@ -342,15 +330,12 @@ pub trait FindCompletionContents {
 }
 
 fn dedup_completion_contents(completion_items: Vec<CompletionContent>) -> Vec<CompletionContent> {
-    let mut deduped_items: tombi_hashmap::IndexMap<String, CompletionContent> =
-        tombi_hashmap::IndexMap::new();
+    let mut deduped_items = tombi_hashmap::IndexMap::with_capacity(completion_items.len());
 
     for item in completion_items {
-        match deduped_items.entry(item.label.clone()) {
+        match deduped_items.entry(completion_content_key(&item)) {
             tombi_hashmap::map::Entry::Occupied(mut entry) => {
-                if item.priority < entry.get().priority {
-                    entry.insert(item);
-                }
+                merge_completion_content(entry.get_mut(), item);
             }
             tombi_hashmap::map::Entry::Vacant(entry) => {
                 entry.insert(item);
@@ -359,6 +344,82 @@ fn dedup_completion_contents(completion_items: Vec<CompletionContent>) -> Vec<Co
     }
 
     deduped_items.into_values().collect()
+}
+
+pub(super) fn dedup_composite_completion_contents(
+    completion_items: Vec<(CompletionContent, Option<SchemaTooltip>)>,
+) -> Vec<CompletionContent> {
+    let mut deduped_items = tombi_hashmap::IndexMap::with_capacity(completion_items.len());
+
+    for (mut item, tooltip) in completion_items {
+        match deduped_items.entry(completion_content_key(&item)) {
+            tombi_hashmap::map::Entry::Occupied(mut entry) => {
+                let (existing, tooltips): &mut (CompletionContent, Vec<SchemaTooltip>) =
+                    entry.get_mut();
+                merge_completion_content(existing, item);
+                if let Some(tooltip) = tooltip {
+                    tooltips.push(tooltip);
+                }
+            }
+            tombi_hashmap::map::Entry::Vacant(entry) => {
+                let tooltips = tooltip.into_iter().collect();
+                item.documentation = None;
+                entry.insert((item, tooltips));
+            }
+        }
+    }
+
+    deduped_items
+        .into_values()
+        .map(|(mut item, tooltips)| {
+            if let Some(tooltip) = SchemaTooltip::composite(tooltips) {
+                item.documentation = Some(tooltip.to_string());
+            }
+            item
+        })
+        .collect()
+}
+
+pub(super) fn take_completion_schema_tooltip(
+    item: &mut CompletionContent,
+    current_schema: &CurrentSchema<'_>,
+) -> Option<SchemaTooltip> {
+    if item.schema_uri.as_ref() == Some(current_schema.schema_uri.as_ref()) {
+        item.schema_uri = Some(
+            tombi_extension::get_schema_link_uri(
+                current_schema.schema_uri.as_ref(),
+                current_schema.schema_view.range().start,
+            )
+            .into(),
+        );
+    }
+    let mut markdown = item.documentation.take().unwrap_or_default();
+    if let Some(schema_uri) = item.schema_uri.take()
+        && let Some(schema_name) = get_schema_name(&schema_uri)
+    {
+        if !markdown.is_empty() && !markdown.ends_with("\n\n") {
+            if markdown.ends_with('\n') {
+                markdown.push('\n');
+            } else {
+                markdown.push_str("\n\n");
+            }
+        }
+        markdown.push_str(&format!("Schema: [{schema_name}]({schema_uri})\n"));
+    }
+
+    (!markdown.is_empty()).then_some(SchemaTooltip::Markdown(markdown))
+}
+
+fn completion_content_key(item: &CompletionContent) -> (String, Option<CompletionKind>) {
+    // Literal candidates with the same label are merged regardless of their literal kind.
+    let non_literal_kind = (!item.kind.is_literal()).then_some(item.kind);
+    (item.label.clone(), non_literal_kind)
+}
+
+fn merge_completion_content(existing: &mut CompletionContent, item: CompletionContent) {
+    if item.priority < existing.priority {
+        *existing = item;
+    }
 }
 
 fn is_generic_literal_type_hint(completion_item: &CompletionContent) -> bool {
@@ -383,6 +444,10 @@ pub(super) async fn merge_adjacent_schema_completion_items(
     any_of_schema: Option<&AnyOfSchema>,
     all_of_schema: Option<&AllOfSchema>,
 ) -> Vec<CompletionContent> {
+    if one_of_schema.is_none() && any_of_schema.is_none() && all_of_schema.is_none() {
+        return base_completion_items;
+    }
+
     let Some(current_schema) = current_schema else {
         return base_completion_items;
     };
@@ -486,7 +551,15 @@ pub(super) async fn merge_adjacent_schema_completion_items(
     completion_items.extend(base_completion_items.into_iter().filter(|completion_item| {
         !has_concrete_adjacent_values || !is_generic_literal_type_hint(completion_item)
     }));
-    dedup_completion_contents(completion_items)
+    dedup_composite_completion_contents(
+        completion_items
+            .into_iter()
+            .map(|mut item| {
+                let tooltip = take_completion_schema_tooltip(&mut item, current_schema);
+                (item, tooltip)
+            })
+            .collect(),
+    )
 }
 
 pub trait CompletionCandidate {
@@ -554,7 +627,7 @@ fn composite_title<'a: 'b, 'b, T: CompositeSchema + Sync + Send>(
     completion_hint: Option<CompletionHint>,
 ) -> tombi_future::BoxFuture<'b, Option<String>> {
     async move {
-        let mut candidates = tombi_hashmap::HashSet::new();
+        let mut candidates = tombi_hashmap::IndexSet::new();
         let schema_visits = tombi_schema_store::SchemaVisits::default();
 
         if let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
@@ -609,7 +682,7 @@ fn composite_description<'a: 'b, 'b, T: CompositeSchema + Sync + Send>(
     completion_hint: Option<CompletionHint>,
 ) -> tombi_future::BoxFuture<'b, Option<String>> {
     async move {
-        let mut candidates = tombi_hashmap::HashSet::new();
+        let mut contents = Vec::new();
         let schema_visits = tombi_schema_store::SchemaVisits::default();
 
         if let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
@@ -628,7 +701,7 @@ fn composite_description<'a: 'b, 'b, T: CompositeSchema + Sync + Send>(
                     continue;
                 }
 
-                if let Some(candidate) = CompletionCandidate::description(
+                let title = CompletionCandidate::title(
                     current_schema.schema_view.as_ref(),
                     &current_schema.schema_uri,
                     &current_schema.definitions,
@@ -636,15 +709,28 @@ fn composite_description<'a: 'b, 'b, T: CompositeSchema + Sync + Send>(
                     schema_store,
                     completion_hint,
                 )
-                .await
-                {
-                    candidates.insert(candidate.to_string());
-                }
+                .await;
+                let description = CompletionCandidate::description(
+                    current_schema.schema_view.as_ref(),
+                    &current_schema.schema_uri,
+                    &current_schema.definitions,
+                    current_schema.strict,
+                    schema_store,
+                    completion_hint,
+                )
+                .await;
+                contents.push(SchemaTooltip::Content(SchemaTooltipContent {
+                    title,
+                    description,
+                    value_type: current_schema.schema_view.value_type().await.to_string(),
+                    constraints: None,
+                    schema: None,
+                }));
             }
         }
 
-        if candidates.len() == 1 {
-            return candidates.into_iter().next();
+        if let Some(tooltip) = SchemaTooltip::composite(contents) {
+            return Some(tooltip.to_string());
         }
 
         composite_schema
@@ -760,6 +846,8 @@ fn tombi_json_value_to_completion_example_item(
 fn tombi_json_value_to_completion_enum_item(
     value: &tombi_json::Value,
     position: tombi_text::Position,
+    detail: Option<String>,
+    documentation: Option<String>,
     schema_uri: Option<&SchemaUri>,
     completion_hint: Option<CompletionHint>,
 ) -> Option<CompletionContent> {
@@ -773,7 +861,12 @@ fn tombi_json_value_to_completion_enum_item(
     let label = value.to_string();
     let edit = CompletionEdit::new_literal(&label, position, completion_hint);
     Some(CompletionContent::new_enum_value(
-        label, None, None, edit, schema_uri, None,
+        label,
+        detail,
+        documentation,
+        edit,
+        schema_uri,
+        None,
     ))
 }
 

--- a/crates/tombi-lsp/src/completion/schema_completion.rs
+++ b/crates/tombi-lsp/src/completion/schema_completion.rs
@@ -2,6 +2,8 @@ use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaView};
 use tombi_x_keyword::StringFormat;
 
+use crate::schema_tooltip::{SchemaTooltip, SchemaTooltipContent};
+
 use super::{
     CompletionContent, CompletionHint, FindCompletionContents,
     merge_adjacent_schema_completion_items, tombi_json_value_to_completion_enum_item,
@@ -9,6 +11,21 @@ use super::{
         find_all_of_completion_items, find_any_of_completion_items, find_one_of_completion_items,
     },
 };
+
+fn set_schema_link_uri(
+    completion_items: &mut [CompletionContent],
+    current_schema: &CurrentSchema<'_>,
+) {
+    let schema_uri = tombi_extension::get_schema_link_uri(
+        current_schema.schema_uri.as_ref(),
+        current_schema.schema_view.range().start,
+    );
+    for item in completion_items {
+        if item.schema_uri.as_ref() == Some(current_schema.schema_uri.as_ref()) {
+            item.schema_uri = Some(schema_uri.clone().into());
+        }
+    }
+}
 
 /// A tag data that indicates that only schema information is used for completion.
 #[derive(Debug)]
@@ -81,24 +98,32 @@ impl FindCompletionContents for SchemaCompletion {
                     .as_deref()
                     .and_then(|schema| schema.finite_literal_candidates())
             {
-                let completion_items = candidates
+                let detail = current_schema.schema_view.title().map(ToString::to_string);
+                let documentation = current_schema
+                    .schema_view
+                    .description()
+                    .map(ToString::to_string);
+                let mut completion_items = candidates
                     .iter()
                     .filter_map(|value| {
                         tombi_json_value_to_completion_enum_item(
                             value,
                             position,
+                            detail.clone(),
+                            documentation.clone(),
                             Some(current_schema.schema_uri.as_ref()),
                             completion_hint,
                         )
                     })
                     .collect::<Vec<_>>();
+                set_schema_link_uri(&mut completion_items, current_schema);
                 return completion_items;
             }
 
             let projected_schema = current_schema.for_completion(schema_context.string_formats());
             let current_schema = projected_schema.as_ref().unwrap_or(current_schema);
 
-            match current_schema.schema_view.as_ref() {
+            let mut completion_items = match current_schema.schema_view.as_ref() {
                 SchemaView::Boolean(boolean_schema) => {
                     boolean_schema
                         .find_completion_contents(
@@ -272,7 +297,41 @@ impl FindCompletionContents for SchemaCompletion {
                     .await
                 }
                 SchemaView::Anything(_) | SchemaView::Nothing(_) | SchemaView::Null => Vec::new(),
+            };
+
+            let needs_documentation = |item: &CompletionContent| {
+                item.documentation.is_none()
+                    && matches!(
+                        item.priority,
+                        tombi_extension::CompletionContentPriority::TypeHint
+                            | tombi_extension::CompletionContentPriority::TypeHintTrue
+                            | tombi_extension::CompletionContentPriority::TypeHintFalse
+                    )
+            };
+
+            if completion_items.iter().any(needs_documentation) {
+                let documentation = SchemaTooltip::Content(SchemaTooltipContent {
+                    title: current_schema.schema_view.title().map(ToString::to_string),
+                    description: current_schema
+                        .schema_view
+                        .description()
+                        .map(ToString::to_string),
+                    value_type: current_schema.schema_view.value_type().await.to_string(),
+                    constraints: None,
+                    schema: None,
+                })
+                .to_string();
+
+                for item in &mut completion_items {
+                    if needs_documentation(item) {
+                        item.documentation = Some(documentation.clone());
+                    }
+                }
             }
+
+            set_schema_link_uri(&mut completion_items, current_schema);
+
+            completion_items
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/completion/value/all_of.rs
+++ b/crates/tombi-lsp/src/completion/value/all_of.rs
@@ -4,6 +4,7 @@ use tombi_schema_store::{Accessor, CurrentSchema};
 
 use crate::completion::{
     CompletionCandidate, CompletionContent, CompletionHint, FindCompletionContents,
+    dedup_composite_completion_contents, take_completion_schema_tooltip,
     tombi_json_value_to_completion_default_item, tombi_json_value_to_completion_example_item,
 };
 
@@ -41,7 +42,7 @@ where
         )
         .await
         else {
-            return completion_items;
+            return Vec::new();
         };
 
         for resolved_schema in &resolved_schemas {
@@ -56,8 +57,13 @@ where
                 )
                 .await;
 
-            completion_items.extend(schema_completions);
+            completion_items.extend(schema_completions.into_iter().map(|mut item| {
+                let tooltip = take_completion_schema_tooltip(&mut item, resolved_schema);
+                (item, tooltip)
+            }));
         }
+
+        let mut completion_items = dedup_composite_completion_contents(completion_items);
 
         let detail = all_of_schema
             .detail(
@@ -78,16 +84,20 @@ where
             )
             .await;
 
-        for completion_item in completion_items.iter_mut() {
-            if completion_item.detail.is_none() {
-                completion_item.detail = detail.clone();
-            }
-            if completion_item.documentation.is_none() {
-                completion_item.documentation = documentation.clone();
+        if keys.is_empty() {
+            for completion_item in completion_items.iter_mut() {
+                if completion_item.detail.is_none() {
+                    completion_item.detail = detail.clone();
+                }
+                if completion_item.documentation.is_none() {
+                    completion_item.documentation = documentation.clone();
+                }
             }
         }
 
-        if let Some(default) = &all_of_schema.default {
+        if keys.is_empty()
+            && let Some(default) = &all_of_schema.default
+        {
             let default_label = default.to_string();
             if let Some(completion_item) = completion_items
                 .iter_mut()
@@ -106,7 +116,9 @@ where
             }
         }
 
-        if let Some(examples) = &all_of_schema.examples {
+        if keys.is_empty()
+            && let Some(examples) = &all_of_schema.examples
+        {
             for example in examples {
                 let example_label = example.to_string();
                 if completion_items

--- a/crates/tombi-lsp/src/completion/value/any_of.rs
+++ b/crates/tombi-lsp/src/completion/value/any_of.rs
@@ -45,6 +45,7 @@ where
         };
 
         let (mut completion_items, narrow_branches) = collect_branch_completions(
+            tombi_validator::Applicator::AnyOf,
             value,
             position,
             keys,
@@ -75,12 +76,14 @@ where
             )
             .await;
 
-        for completion_item in completion_items.iter_mut() {
-            if completion_item.detail.is_none() {
-                completion_item.detail = detail.clone();
-            }
-            if completion_item.documentation.is_none() {
-                completion_item.documentation = documentation.clone();
+        if keys.is_empty() {
+            for completion_item in completion_items.iter_mut() {
+                if completion_item.detail.is_none() {
+                    completion_item.detail = detail.clone();
+                }
+                if completion_item.documentation.is_none() {
+                    completion_item.documentation = documentation.clone();
+                }
             }
         }
 

--- a/crates/tombi-lsp/src/completion/value/array.rs
+++ b/crates/tombi-lsp/src/completion/value/array.rs
@@ -346,7 +346,27 @@ impl FindCompletionContents for tombi_document_tree::Array {
                         )
                         .await
                     }
-                    _ => Vec::new(),
+                    _ => {
+                        let Some(mut projected_schema) = current_schema.for_instance_type(
+                            tombi_schema_store::SchemaType::Array,
+                            schema_context.string_formats(),
+                        ) else {
+                            return Vec::new();
+                        };
+                        if !matches!(projected_schema.schema_view.as_ref(), SchemaView::Array(_)) {
+                            return Vec::new();
+                        }
+                        projected_schema.semantic_schema = None;
+                        self.find_completion_contents(
+                            position,
+                            keys,
+                            accessors,
+                            Some(&projected_schema),
+                            schema_context,
+                            completion_hint,
+                        )
+                        .await
+                    }
                 }
             } else {
                 let mut new_item_index = 0;

--- a/crates/tombi-lsp/src/completion/value/branch_result.rs
+++ b/crates/tombi-lsp/src/completion/value/branch_result.rs
@@ -1,16 +1,26 @@
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaAccessor, SchemaView};
 
-use crate::completion::{CompletionContent, CompletionHint, FindCompletionContents};
+use crate::completion::{
+    CompletionContent, CompletionHint, FindCompletionContents, dedup_composite_completion_contents,
+    take_completion_schema_tooltip,
+};
 
 #[derive(Debug)]
 pub(super) struct BranchCompletionResult {
     pub has_key: bool,
     pub is_valid: bool,
     pub is_recoverable: bool,
-    pub items: Vec<CompletionContent>,
 }
 
 impl BranchCompletionResult {
+    fn should_include(&self, valid_branches: bool, narrow_branches: bool) -> bool {
+        if valid_branches {
+            self.is_valid
+        } else {
+            !narrow_branches || self.has_key
+        }
+    }
+
     fn should_include_in_fallback(&self, valid_branches: bool, narrow_branches: bool) -> bool {
         if valid_branches {
             self.is_valid || self.is_recoverable
@@ -34,6 +44,7 @@ impl BranchCompletionResult {
 /// Returns the collected items and the `narrow_branches` flag for the caller to decide
 /// whether to include composite-level default/examples.
 pub(super) async fn collect_branch_completions<'a, T>(
+    applicator: tombi_validator::Applicator,
     value: &'a T,
     position: tombi_text::Position,
     keys: &'a [tombi_document_tree::Key],
@@ -45,55 +56,37 @@ pub(super) async fn collect_branch_completions<'a, T>(
 where
     T: FindCompletionContents + tombi_validator::Validate + Sync + Send + std::fmt::Debug,
 {
-    let first_key = (keys.len() == 1 && !keys[0].value.is_empty()).then(|| &keys[0].value);
+    let first_key = (keys.len() == 1 && !keys[0].value.is_empty())
+        .then(|| SchemaAccessor::Key(keys[0].value.clone()));
+    let evaluation = tombi_validator::evaluate_applicator(
+        applicator,
+        value,
+        accessors,
+        resolved_schemas,
+        schema_context,
+    )
+    .await;
 
     let mut branch_results = Vec::new();
-    for resolved_schema in resolved_schemas {
-        let branch_has_key = if let Some(ref first_key) = first_key {
+    for (resolved_schema, branch_applicability) in resolved_schemas.iter().zip(&evaluation.branches)
+    {
+        let branch_has_key = if let Some(first_key) = &first_key {
             match resolved_schema.schema_view.as_ref() {
-                SchemaView::Table(table_schema) => table_schema
-                    .properties
-                    .read()
-                    .await
-                    .contains_key(&SchemaAccessor::Key(first_key.to_string())),
+                SchemaView::Table(table_schema) => {
+                    table_schema.properties.read().await.contains_key(first_key)
+                }
                 _ => false,
             }
         } else {
             false
         };
-        let (branch_is_valid, branch_is_recoverable) = match value
-            .validate(accessors, Some(resolved_schema), schema_context)
-            .await
-        {
-            Ok(_) => (true, true),
-            Err(tombi_validator::Invalid {
-                assertion_failed: false,
-                ..
-            }) => (true, true),
-            Err(tombi_validator::Invalid { diagnostics, .. }) => (
-                false,
-                diagnostics
-                    .iter()
-                    .all(|diagnostic| diagnostic.range().contains(position)),
-            ),
-        };
-
-        let schema_completions = value
-            .find_completion_contents(
-                position,
-                keys,
-                accessors,
-                Some(resolved_schema),
-                schema_context,
-                completion_hint,
-            )
-            .await;
+        let branch_is_valid = branch_applicability.is_applicable();
+        let branch_is_recoverable = branch_applicability.is_recoverable_at(position);
 
         branch_results.push(BranchCompletionResult {
             has_key: branch_has_key,
             is_valid: branch_is_valid,
             is_recoverable: branch_is_recoverable,
-            items: schema_completions,
         });
     }
 
@@ -101,13 +94,22 @@ where
     let narrow_branches = branch_results.iter().any(|branch| branch.has_key);
 
     let mut completion_items = Vec::new();
-    for branch in &branch_results {
-        if valid_branches {
-            if branch.is_valid {
-                completion_items.extend(branch.items.iter().cloned());
-            }
-        } else if !narrow_branches || branch.has_key {
-            completion_items.extend(branch.items.iter().cloned());
+    for (resolved_schema, branch) in resolved_schemas.iter().zip(&branch_results) {
+        if branch.should_include(valid_branches, narrow_branches) {
+            let schema_completions = value
+                .find_completion_contents(
+                    position,
+                    keys,
+                    accessors,
+                    Some(resolved_schema),
+                    schema_context,
+                    completion_hint,
+                )
+                .await;
+            completion_items.extend(schema_completions.into_iter().map(|mut item| {
+                let tooltip = take_completion_schema_tooltip(&mut item, resolved_schema);
+                (item, tooltip)
+            }));
         }
     }
 
@@ -115,12 +117,30 @@ where
     // including branches whose validation errors are at the cursor — the user is still
     // typing there, so that branch may become valid.
     if completion_items.is_empty() {
-        completion_items = branch_results
-            .into_iter()
-            .filter(|branch| branch.should_include_in_fallback(valid_branches, narrow_branches))
-            .flat_map(|branch| branch.items)
-            .collect();
+        for (resolved_schema, branch) in resolved_schemas.iter().zip(&branch_results) {
+            if !branch.should_include(valid_branches, narrow_branches)
+                && branch.should_include_in_fallback(valid_branches, narrow_branches)
+            {
+                let schema_completions = value
+                    .find_completion_contents(
+                        position,
+                        keys,
+                        accessors,
+                        Some(resolved_schema),
+                        schema_context,
+                        completion_hint,
+                    )
+                    .await;
+                completion_items.extend(schema_completions.into_iter().map(|mut item| {
+                    let tooltip = take_completion_schema_tooltip(&mut item, resolved_schema);
+                    (item, tooltip)
+                }));
+            }
+        }
     }
 
-    (completion_items, narrow_branches)
+    (
+        dedup_composite_completion_contents(completion_items),
+        narrow_branches,
+    )
 }

--- a/crates/tombi-lsp/src/completion/value/one_of.rs
+++ b/crates/tombi-lsp/src/completion/value/one_of.rs
@@ -45,6 +45,7 @@ where
         };
 
         let (mut completion_items, narrow_branches) = collect_branch_completions(
+            tombi_validator::Applicator::OneOf,
             value,
             position,
             keys,
@@ -75,12 +76,14 @@ where
             )
             .await;
 
-        for completion_item in completion_items.iter_mut() {
-            if completion_item.detail.is_none() {
-                completion_item.detail = detail.clone();
-            }
-            if completion_item.documentation.is_none() {
-                completion_item.documentation = documentation.clone();
+        if keys.is_empty() {
+            for completion_item in completion_items.iter_mut() {
+                if completion_item.detail.is_none() {
+                    completion_item.detail = detail.clone();
+                }
+                if completion_item.documentation.is_none() {
+                    completion_item.documentation = documentation.clone();
+                }
             }
         }
 

--- a/crates/tombi-lsp/src/completion/value/table.rs
+++ b/crates/tombi-lsp/src/completion/value/table.rs
@@ -869,7 +869,27 @@ impl FindCompletionContents for tombi_document_tree::Table {
                         )
                         .await
                     }
-                    _ => Vec::new(),
+                    _ => {
+                        let Some(mut projected_schema) = current_schema.for_instance_type(
+                            tombi_schema_store::SchemaType::Object,
+                            schema_context.string_formats(),
+                        ) else {
+                            return Vec::new();
+                        };
+                        if !matches!(projected_schema.schema_view.as_ref(), SchemaView::Table(_)) {
+                            return Vec::new();
+                        }
+                        projected_schema.semantic_schema = None;
+                        self.find_completion_contents(
+                            position,
+                            keys,
+                            accessors,
+                            Some(&projected_schema),
+                            schema_context,
+                            completion_hint,
+                        )
+                        .await
+                    }
                 }
             } else if let Some(key) = keys.first() {
                 if let Some(value) = self.get(key) {

--- a/crates/tombi-lsp/src/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/goto_type_definition.rs
@@ -23,8 +23,12 @@ pub async fn get_type_definition(
     position: tombi_text::Position,
     keys: &[tombi_document_tree::Key],
     schema_context: &tombi_schema_store::SchemaContext<'_>,
-) -> Option<TypeDefinition> {
-    let source = TypeDefinitionSource::new(document_tree, position, keys, schema_context).await?;
+) -> Vec<TypeDefinition> {
+    let Some(source) =
+        TypeDefinitionSource::new(document_tree, position, keys, schema_context).await
+    else {
+        return Vec::new();
+    };
 
     match source {
         TypeDefinitionSource::Root {
@@ -48,7 +52,10 @@ pub async fn get_type_definition(
             accessors,
             current_schema,
         } => {
-            let (_, value) = tombi_document_tree::dig_accessors(document_tree, &accessors)?;
+            let Some((_, value)) = tombi_document_tree::dig_accessors(document_tree, &accessors)
+            else {
+                return Vec::new();
+            };
             value
                 .get_type_definition(
                     position,
@@ -127,6 +134,18 @@ pub struct TypeDefinition {
     pub range: tombi_text::Range,
 }
 
+pub(crate) fn location_key(
+    schema_uri: &SchemaUri,
+    range: tombi_text::Range,
+) -> (&str, tombi_text::Range) {
+    let uri = schema_uri.as_str();
+    if range == tombi_text::Range::default() {
+        (uri, range)
+    } else {
+        (uri.split_once('#').map_or(uri, |(base, _)| base), range)
+    }
+}
+
 impl TypeDefinition {
     pub fn update_range(
         mut self,
@@ -140,6 +159,17 @@ impl TypeDefinition {
     }
 }
 
+fn prefer_type_definitions(
+    type_definitions: Vec<TypeDefinition>,
+    fallback: Vec<TypeDefinition>,
+) -> Vec<TypeDefinition> {
+    if type_definitions.is_empty() {
+        fallback
+    } else {
+        type_definitions
+    }
+}
+
 pub(super) trait GetTypeDefinition {
     fn get_type_definition<'a: 'b, 'b>(
         &'a self,
@@ -148,7 +178,7 @@ pub(super) trait GetTypeDefinition {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>>;
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>>;
 }
 
 pub(super) async fn adjacent_type_definition<
@@ -168,11 +198,13 @@ pub(super) async fn adjacent_type_definition<
     one_of_schema: Option<&OneOfSchema>,
     any_of_schema: Option<&AnyOfSchema>,
     all_of_schema: Option<&AllOfSchema>,
-) -> Option<TypeDefinition> {
-    let current_schema = current_schema?;
+) -> Vec<TypeDefinition> {
+    let Some(current_schema) = current_schema else {
+        return Vec::new();
+    };
 
     if let Some(one_of_schema) = one_of_schema
-        && let Some(type_definition) = one_of::get_one_of_type_definition(
+        && let type_definitions = one_of::get_one_of_type_definition(
             value,
             position,
             keys,
@@ -184,11 +216,12 @@ pub(super) async fn adjacent_type_definition<
             schema_context,
         )
         .await
+        && !type_definitions.is_empty()
     {
-        return Some(type_definition);
+        return type_definitions;
     }
     if let Some(any_of_schema) = any_of_schema
-        && let Some(type_definition) = any_of::get_any_of_type_definition(
+        && let type_definitions = any_of::get_any_of_type_definition(
             value,
             position,
             keys,
@@ -200,11 +233,12 @@ pub(super) async fn adjacent_type_definition<
             schema_context,
         )
         .await
+        && !type_definitions.is_empty()
     {
-        return Some(type_definition);
+        return type_definitions;
     }
     if let Some(all_of_schema) = all_of_schema
-        && let Some(type_definition) = all_of::get_all_of_type_definition(
+        && let type_definitions = all_of::get_all_of_type_definition(
             value,
             position,
             keys,
@@ -216,11 +250,12 @@ pub(super) async fn adjacent_type_definition<
             schema_context,
         )
         .await
+        && !type_definitions.is_empty()
     {
-        return Some(type_definition);
+        return type_definitions;
     }
 
-    None
+    Vec::new()
 }
 
 pub(super) fn schema_type_definition(
@@ -235,5 +270,35 @@ pub(super) fn schema_type_definition(
         schema_uri,
         schema_accessors: accessors.iter().map(Into::into).collect_vec(),
         range: tombi_text::Range::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::location_key;
+
+    #[test]
+    fn location_key_preserves_fragment_when_range_is_unknown() {
+        let first = tombi_schema_store::SchemaUri::from_str("file:///schema.json#L1").unwrap();
+        let second = tombi_schema_store::SchemaUri::from_str("file:///schema.json#L2").unwrap();
+
+        assert_ne!(
+            location_key(&first, tombi_text::Range::default()),
+            location_key(&second, tombi_text::Range::default()),
+        );
+    }
+
+    #[test]
+    fn location_key_ignores_fragment_when_range_identifies_the_location() {
+        let first = tombi_schema_store::SchemaUri::from_str("file:///schema.json#L1").unwrap();
+        let second = tombi_schema_store::SchemaUri::from_str("file:///schema.json#L2").unwrap();
+        let range = tombi_text::Range::new(
+            tombi_text::Position::new(2, 3),
+            tombi_text::Position::new(2, 8),
+        );
+
+        assert_eq!(location_key(&first, range), location_key(&second, range));
     }
 }

--- a/crates/tombi-lsp/src/goto_type_definition/all_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/all_of.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use tombi_future::Boxable;
 
-use itertools::Itertools;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaUri};
 
 use super::{GetTypeDefinition, TypeDefinition, schema_type_definition};
@@ -16,14 +15,9 @@ pub fn get_all_of_type_definition<'a: 'b, 'b, T>(
     definitions: &'a tombi_schema_store::SchemaDefinitions,
     strict: Option<tombi_schema_type::BoolDefaultTrue>,
     schema_context: &'a tombi_schema_store::SchemaContext,
-) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>>
+) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>>
 where
-    T: GetTypeDefinition
-        + tombi_document_tree::ValueImpl
-        + tombi_validator::Validate
-        + Sync
-        + Send
-        + std::fmt::Debug,
+    T: GetTypeDefinition + tombi_document_tree::ValueImpl + Sync + Send + std::fmt::Debug,
 {
     log::trace!("value: {:?}", value);
     log::trace!("keys: {:?}", keys);
@@ -32,9 +26,8 @@ where
     log::trace!("schema_uri: {:?}", schema_uri);
 
     async move {
-        let mut all_of_type_definition = None;
-
-        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
+        let mut result = Vec::new();
+        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
             &all_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -43,35 +36,32 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await?;
+        .await
+        else {
+            return Vec::new();
+        };
 
         for resolved_schema in &resolved_schemas {
-            if let Some(type_definition) = value
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
+            let navigation_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
+
+            let type_definitions = value
                 .get_type_definition(
                     position,
                     keys,
                     accessors,
-                    Some(resolved_schema),
+                    Some(navigation_schema),
                     schema_context,
                 )
-                .await
-            {
-                if value
-                    .validate(accessors, Some(resolved_schema), schema_context)
-                    .await
-                    .is_err()
-                {
-                    return Some(TypeDefinition {
-                        schema_uri: schema_uri.clone(),
-                        schema_accessors: accessors.iter().map(Into::into).collect_vec(),
-                        range: tombi_text::Range::default(),
-                    });
-                }
-                all_of_type_definition = Some(type_definition);
-            }
+                .await;
+            result.extend(type_definitions);
         }
 
-        all_of_type_definition
+        result
     }
     .boxed()
 }
@@ -84,17 +74,17 @@ impl GetTypeDefinition for tombi_schema_store::AllOfSchema {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             let Some(current_schema) = current_schema else {
                 unreachable!("schema must be provided");
             };
 
-            Some(schema_type_definition(
+            vec![schema_type_definition(
                 current_schema.schema_uri.as_ref(),
                 accessors,
                 self.range,
-            ))
+            )]
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/goto_type_definition/any_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/any_of.rs
@@ -16,7 +16,7 @@ pub fn get_any_of_type_definition<'a: 'b, 'b, T>(
     definitions: &'a tombi_schema_store::SchemaDefinitions,
     strict: Option<tombi_schema_type::BoolDefaultTrue>,
     schema_context: &'a tombi_schema_store::SchemaContext,
-) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>>
+) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>>
 where
     T: GetTypeDefinition
         + tombi_document_tree::ValueImpl
@@ -32,7 +32,7 @@ where
     log::trace!("schema_uri: {:?}", schema_uri);
 
     async move {
-        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
+        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
             &any_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -41,41 +41,59 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await?;
+        .await
+        else {
+            return Vec::new();
+        };
+        let evaluation = tombi_validator::evaluate_applicator(
+            tombi_validator::Applicator::AnyOf,
+            value,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+        )
+        .await;
+        let applicable_count = evaluation.applicable_count();
+        let is_property_key = keys
+            .first()
+            .is_some_and(|key| tombi_document_tree::ValueImpl::range(key).contains(position));
+        let mut result = Vec::new();
 
-        for resolved_schema in &resolved_schemas {
-            if let Some(type_definition) = value
+        for (resolved_schema, branch) in resolved_schemas.iter().zip(&evaluation.branches) {
+            if !(branch.is_applicable() || applicable_count == 0 && is_property_key) {
+                continue;
+            }
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
+            let navigation_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
+
+            let type_definitions = value
                 .get_type_definition(
                     position,
                     keys,
                     accessors,
-                    Some(resolved_schema),
+                    Some(navigation_schema),
                     schema_context,
                 )
-                .await
-                && matches!(
-                    value
-                        .validate(accessors, Some(resolved_schema), schema_context)
-                        .await,
-                    Ok(_)
-                        | Err(tombi_validator::Invalid {
-                            assertion_failed: false,
-                            ..
-                        })
-                )
-            {
-                return Some(type_definition);
-            }
+                .await;
+            result.extend(type_definitions);
+        }
+
+        if !result.is_empty() {
+            return result;
         }
 
         let mut schema_uri = schema_uri.clone();
         schema_uri.set_fragment(Some(&format!("L{}", any_of_schema.range.start.line + 1)));
 
-        Some(TypeDefinition {
+        vec![TypeDefinition {
             schema_uri,
             schema_accessors: accessors.iter().map(Into::into).collect_vec(),
             range: tombi_text::Range::default(),
-        })
+        }]
     }
     .boxed()
 }
@@ -88,17 +106,17 @@ impl GetTypeDefinition for tombi_schema_store::AnyOfSchema {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             let Some(current_schema) = current_schema else {
                 unreachable!("schema must be provided");
             };
 
-            Some(schema_type_definition(
+            vec![schema_type_definition(
                 current_schema.schema_uri.as_ref(),
                 accessors,
                 self.range,
-            ))
+            )]
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/goto_type_definition/comment.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/comment.rs
@@ -17,7 +17,7 @@ use crate::{
 pub async fn get_tombi_document_comment_directive_type_definition(
     root: &tombi_ast::Root,
     position: tombi_text::Position,
-) -> Option<TypeDefinition> {
+) -> Vec<TypeDefinition> {
     if let Some(comment_directive_context) = root
         .tombi_document_comment_directives()
         .collect_vec()
@@ -29,30 +29,34 @@ pub async fn get_tombi_document_comment_directive_type_definition(
         )
         .await
     } else {
-        None
+        Vec::new()
     }
 }
 
 pub async fn get_tombi_value_comment_directive_type_definition(
     comment_directive_context: CommentDirectiveContext<String>,
     schema_uri: SchemaUri,
-) -> Option<TypeDefinition> {
+) -> Vec<TypeDefinition> {
     let CommentDirectiveContext::Content {
         content,
         position_in_content,
         ..
     } = comment_directive_context
     else {
-        return None;
+        return Vec::new();
     };
 
     let toml_version = TOMBI_COMMENT_DIRECTIVE_TOML_VERSION;
     let (root, _) = tombi_parser::parse(&content).into_root_and_errors();
 
-    let (keys, range) = get_hover_keys_with_range(&root, position_in_content, toml_version).await?;
+    let Some((keys, range)) =
+        get_hover_keys_with_range(&root, position_in_content, toml_version).await
+    else {
+        return Vec::new();
+    };
 
     if keys.is_empty() && range.is_none() {
-        return None;
+        return Vec::new();
     }
 
     let document_tree = root.into_document_tree_and_errors(toml_version).tree;

--- a/crates/tombi-lsp/src/goto_type_definition/one_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/one_of.rs
@@ -16,7 +16,7 @@ pub fn get_one_of_type_definition<'a: 'b, 'b, T>(
     definitions: &'a tombi_schema_store::SchemaDefinitions,
     strict: Option<tombi_schema_type::BoolDefaultTrue>,
     schema_context: &'a tombi_schema_store::SchemaContext,
-) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>>
+) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>>
 where
     T: GetTypeDefinition
         + tombi_document_tree::ValueImpl
@@ -32,7 +32,7 @@ where
     log::trace!("schema_uri: {:?}", schema_uri);
 
     async move {
-        let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
+        let Some(resolved_schemas) = tombi_schema_store::resolve_and_collect_schemas(
             &one_of_schema.schemas,
             Cow::Borrowed(schema_uri),
             Cow::Borrowed(definitions),
@@ -41,41 +41,59 @@ where
             &schema_context.schema_visits,
             accessors,
         )
-        .await?;
+        .await
+        else {
+            return Vec::new();
+        };
+        let evaluation = tombi_validator::evaluate_applicator(
+            tombi_validator::Applicator::OneOf,
+            value,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+        )
+        .await;
+        let applicable_count = evaluation.applicable_count();
+        let is_property_key = keys
+            .first()
+            .is_some_and(|key| tombi_document_tree::ValueImpl::range(key).contains(position));
+        let mut result = Vec::new();
 
-        for resolved_schema in &resolved_schemas {
-            if let Some(type_definition) = value
+        for (resolved_schema, branch) in resolved_schemas.iter().zip(&evaluation.branches) {
+            if !(branch.is_applicable() || applicable_count == 0 && is_property_key) {
+                continue;
+            }
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
+            let navigation_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
+
+            let type_definitions = value
                 .get_type_definition(
                     position,
                     keys,
                     accessors,
-                    Some(resolved_schema),
+                    Some(navigation_schema),
                     schema_context,
                 )
-                .await
-                && matches!(
-                    value
-                        .validate(accessors, Some(resolved_schema), schema_context)
-                        .await,
-                    Ok(_)
-                        | Err(tombi_validator::Invalid {
-                            assertion_failed: false,
-                            ..
-                        })
-                )
-            {
-                return Some(type_definition);
-            }
+                .await;
+            result.extend(type_definitions);
+        }
+
+        if !result.is_empty() {
+            return result;
         }
 
         let mut schema_uri = schema_uri.clone();
         schema_uri.set_fragment(Some(&format!("L{}", one_of_schema.range.start.line + 1)));
 
-        Some(TypeDefinition {
+        vec![TypeDefinition {
             schema_uri,
             schema_accessors: accessors.iter().map(Into::into).collect_vec(),
             range: tombi_text::Range::default(),
-        })
+        }]
     }
     .boxed()
 }
@@ -88,17 +106,17 @@ impl GetTypeDefinition for tombi_schema_store::OneOfSchema {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             let Some(current_schema) = current_schema else {
                 unreachable!("schema must be provided");
             };
 
-            Some(schema_type_definition(
+            vec![schema_type_definition(
                 current_schema.schema_uri.as_ref(),
                 accessors,
                 self.range,
-            ))
+            )]
         }
         .boxed()
     }

--- a/crates/tombi-lsp/src/goto_type_definition/type_definition_source.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/type_definition_source.rs
@@ -55,8 +55,7 @@ impl<'a> TypeDefinitionSource<'a> {
 
         if remaining_keys(keys, &accessors).is_empty()
             && matches!(accessors.last(), Some(Accessor::Key(_)))
-            && tombi_document_tree::dig_accessors(document_tree, &accessors)
-                .is_some_and(|(_, value)| value.is_scalar())
+            && tombi_document_tree::dig_accessors(document_tree, &accessors).is_some()
         {
             let parent_accessors = accessors[..accessors.len().saturating_sub(1)].to_vec();
             let (resolved_parent_accessors, resolved_parent_schema) =

--- a/crates/tombi-lsp/src/goto_type_definition/value.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value.rs
@@ -9,7 +9,7 @@ mod offset_date_time;
 mod string;
 mod table;
 
-use super::{GetTypeDefinition, schema_type_definition};
+use super::{GetTypeDefinition, TypeDefinition, schema_type_definition};
 use tombi_future::Boxable;
 
 impl GetTypeDefinition for tombi_document_tree::Value {
@@ -20,7 +20,7 @@ impl GetTypeDefinition for tombi_document_tree::Value {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             if let Some(Ok(current_schema)) = schema_context
                 .get_subschema(accessors, current_schema)
@@ -183,11 +183,11 @@ impl GetTypeDefinition for tombi_document_tree::Value {
                             )
                             .await
                     }
-                    None => None,
+                    None => Vec::new(),
                 },
             };
 
-            if type_definition.is_some() {
+            if !type_definition.is_empty() {
                 return type_definition;
             }
 
@@ -209,7 +209,7 @@ impl GetTypeDefinition for tombi_document_tree::Value {
                     .await;
             }
 
-            None
+            Vec::new()
         }
         .boxed()
     }
@@ -223,7 +223,7 @@ impl GetTypeDefinition for tombi_schema_store::SchemaView {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             match self {
                 Self::Boolean(boolean_schema) => {
@@ -369,14 +369,14 @@ impl GetTypeDefinition for tombi_schema_store::SchemaView {
                         )
                         .await
                 }
-                Self::Anything(schema) => current_schema.map(|current_schema| {
-                    schema_type_definition(
+                Self::Anything(schema) => current_schema.map_or_else(Vec::new, |current_schema| {
+                    vec![schema_type_definition(
                         current_schema.schema_uri.as_ref(),
                         accessors,
                         schema.range,
-                    )
+                    )]
                 }),
-                Self::Nothing(_) | Self::Null => None,
+                Self::Nothing(_) | Self::Null => Vec::new(),
             }
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/array.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/array.rs
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::Array {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -31,13 +31,14 @@ impl GetTypeDefinition for tombi_document_tree::Array {
         async move {
             if let Some((comment_directive_context, schema_uri)) =
                 get_array_comment_directive_content_with_schema_uri(self, position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(Ok(current_schema)) = schema_context
@@ -58,6 +59,28 @@ impl GetTypeDefinition for tombi_document_tree::Array {
             if let Some(current_schema) = current_schema {
                 match current_schema.schema_view.as_ref() {
                     SchemaView::Array(array_schema) => {
+                        if keys.is_empty()
+                            && matches!(
+                                self.kind(),
+                                tombi_document_tree::ArrayKind::ArrayOfTable
+                                    | tombi_document_tree::ArrayKind::ParentArrayOfTable
+                            )
+                            && self.values().iter().any(|value| {
+                                tombi_document_tree::ValueImpl::range(value).start.line
+                                    == position.line
+                            })
+                        {
+                            return array_schema
+                                .get_type_definition(
+                                    position,
+                                    keys,
+                                    accessors,
+                                    Some(current_schema),
+                                    schema_context,
+                                )
+                                .await;
+                        }
+
                         for (index, value) in self.values().iter().enumerate() {
                             if value.contains(position) {
                                 let accessor = Accessor::Index(index);
@@ -85,7 +108,7 @@ impl GetTypeDefinition for tombi_document_tree::Array {
                                         .await;
                                 }
 
-                                if let Some(type_definition) = adjacent_type_definition(
+                                let type_definitions = adjacent_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -96,9 +119,9 @@ impl GetTypeDefinition for tombi_document_tree::Array {
                                     array_schema.any_of.as_deref(),
                                     array_schema.all_of.as_deref(),
                                 )
-                                .await
-                                {
-                                    return Some(type_definition);
+                                .await;
+                                if !type_definitions.is_empty() {
+                                    return type_definitions;
                                 }
 
                                 return value
@@ -191,7 +214,7 @@ impl GetTypeDefinition for tombi_document_tree::Array {
                 }
             }
 
-            None
+            Vec::new()
         }
         .boxed()
     }
@@ -205,17 +228,17 @@ impl GetTypeDefinition for ArraySchema {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
@@ -10,7 +10,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -34,13 +34,14 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
                     BooleanCommonFormatRules,
                     BooleanCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -56,19 +57,21 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            boolean_schema.one_of.as_deref(),
-                            boolean_schema.any_of.as_deref(),
-                            boolean_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                boolean_schema.one_of.as_deref(),
+                                boolean_schema.any_of.as_deref(),
+                                boolean_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -112,10 +115,10 @@ impl GetTypeDefinition for tombi_document_tree::Boolean {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -130,17 +133,17 @@ impl GetTypeDefinition for tombi_schema_store::BooleanSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/float.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/float.rs
@@ -10,7 +10,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::Float {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -34,13 +34,14 @@ impl GetTypeDefinition for tombi_document_tree::Float {
                     FloatCommonFormatRules,
                     FloatCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -56,19 +57,21 @@ impl GetTypeDefinition for tombi_document_tree::Float {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            float_schema.one_of.as_deref(),
-                            float_schema.any_of.as_deref(),
-                            float_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                float_schema.one_of.as_deref(),
+                                float_schema.any_of.as_deref(),
+                                float_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -112,10 +115,10 @@ impl GetTypeDefinition for tombi_document_tree::Float {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -130,17 +133,17 @@ impl GetTypeDefinition for tombi_schema_store::FloatSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
@@ -10,7 +10,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -34,13 +34,14 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                     IntegerCommonFormatRules,
                     IntegerCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -49,7 +50,7 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                         if let Some(r#enum) = &integer_schema.r#enum
                             && !r#enum.contains(&self.value())
                         {
-                            return None;
+                            return Vec::new();
                         }
 
                         let base_type_definition = integer_schema
@@ -62,19 +63,21 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            integer_schema.one_of.as_deref(),
-                            integer_schema.any_of.as_deref(),
-                            integer_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                integer_schema.one_of.as_deref(),
+                                integer_schema.any_of.as_deref(),
+                                integer_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -118,10 +121,10 @@ impl GetTypeDefinition for tombi_document_tree::Integer {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -136,17 +139,17 @@ impl GetTypeDefinition for tombi_schema_store::IntegerSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
@@ -10,7 +10,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -34,13 +34,14 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
                     LocalDateCommonFormatRules,
                     LocalDateCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -56,19 +57,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_date_schema.one_of.as_deref(),
-                            local_date_schema.any_of.as_deref(),
-                            local_date_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_date_schema.one_of.as_deref(),
+                                local_date_schema.any_of.as_deref(),
+                                local_date_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -112,10 +115,10 @@ impl GetTypeDefinition for tombi_document_tree::LocalDate {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -130,17 +133,17 @@ impl GetTypeDefinition for tombi_schema_store::LocalDateSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
@@ -12,7 +12,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -24,7 +24,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -36,13 +36,14 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
                     LocalDateTimeCommonFormatRules,
                     LocalDateTimeCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -58,19 +59,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_date_time_schema.one_of.as_deref(),
-                            local_date_time_schema.any_of.as_deref(),
-                            local_date_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_date_time_schema.one_of.as_deref(),
+                                local_date_time_schema.any_of.as_deref(),
+                                local_date_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -114,10 +117,10 @@ impl GetTypeDefinition for tombi_document_tree::LocalDateTime {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -132,17 +135,17 @@ impl GetTypeDefinition for tombi_schema_store::LocalDateTimeSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
@@ -10,7 +10,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -34,13 +34,14 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
                     LocalTimeCommonFormatRules,
                     LocalTimeCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -56,19 +57,21 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_time_schema.one_of.as_deref(),
-                            local_time_schema.any_of.as_deref(),
-                            local_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_time_schema.one_of.as_deref(),
+                                local_time_schema.any_of.as_deref(),
+                                local_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -112,10 +115,10 @@ impl GetTypeDefinition for tombi_document_tree::LocalTime {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -130,17 +133,17 @@ impl GetTypeDefinition for tombi_schema_store::LocalTimeSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
@@ -12,7 +12,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -24,7 +24,7 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -36,13 +36,14 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
                     OffsetDateTimeCommonFormatRules,
                     OffsetDateTimeCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -58,19 +59,21 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            offset_date_time_schema.one_of.as_deref(),
-                            offset_date_time_schema.any_of.as_deref(),
-                            offset_date_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                offset_date_time_schema.one_of.as_deref(),
+                                offset_date_time_schema.any_of.as_deref(),
+                                offset_date_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -114,10 +117,10 @@ impl GetTypeDefinition for tombi_document_tree::OffsetDateTime {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -132,17 +135,17 @@ impl GetTypeDefinition for tombi_schema_store::OffsetDateTimeSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/string.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/string.rs
@@ -11,7 +11,7 @@ use crate::{
         GetTypeDefinition, TypeDefinition, adjacent_type_definition,
         all_of::get_all_of_type_definition, any_of::get_any_of_type_definition,
         comment::get_tombi_value_comment_directive_type_definition,
-        one_of::get_one_of_type_definition,
+        one_of::get_one_of_type_definition, prefer_type_definitions,
     },
 };
 
@@ -23,7 +23,7 @@ impl GetTypeDefinition for tombi_document_tree::String {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<crate::goto_type_definition::TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -35,13 +35,14 @@ impl GetTypeDefinition for tombi_document_tree::String {
                     StringCommonFormatRules,
                     StringCommonLintRules,
                 >(self.comment_directives(), position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(current_schema) = current_schema {
@@ -57,19 +58,21 @@ impl GetTypeDefinition for tombi_document_tree::String {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            string_schema.one_of.as_deref(),
-                            string_schema.any_of.as_deref(),
-                            string_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                string_schema.one_of.as_deref(),
+                                string_schema.any_of.as_deref(),
+                                string_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OffsetDateTime(offset_date_time_schema)
                         if schema_context.has_string_format(StringFormat::DateTime) =>
@@ -84,19 +87,21 @@ impl GetTypeDefinition for tombi_document_tree::String {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            offset_date_time_schema.one_of.as_deref(),
-                            offset_date_time_schema.any_of.as_deref(),
-                            offset_date_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                offset_date_time_schema.one_of.as_deref(),
+                                offset_date_time_schema.any_of.as_deref(),
+                                offset_date_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::LocalDateTime(local_date_time_schema)
                         if schema_context.has_string_format(StringFormat::DateTimeLocal) =>
@@ -111,19 +116,21 @@ impl GetTypeDefinition for tombi_document_tree::String {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_date_time_schema.one_of.as_deref(),
-                            local_date_time_schema.any_of.as_deref(),
-                            local_date_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_date_time_schema.one_of.as_deref(),
+                                local_date_time_schema.any_of.as_deref(),
+                                local_date_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::LocalDate(local_date_schema)
                         if schema_context.has_string_format(StringFormat::Date) =>
@@ -138,19 +145,21 @@ impl GetTypeDefinition for tombi_document_tree::String {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_date_schema.one_of.as_deref(),
-                            local_date_schema.any_of.as_deref(),
-                            local_date_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_date_schema.one_of.as_deref(),
+                                local_date_schema.any_of.as_deref(),
+                                local_date_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::LocalTime(local_time_schema)
                         if schema_context.has_string_format(StringFormat::TimeLocal) =>
@@ -165,19 +174,21 @@ impl GetTypeDefinition for tombi_document_tree::String {
                             )
                             .await;
 
-                        adjacent_type_definition(
-                            self,
-                            position,
-                            keys,
-                            accessors,
-                            Some(current_schema),
-                            schema_context,
-                            local_time_schema.one_of.as_deref(),
-                            local_time_schema.any_of.as_deref(),
-                            local_time_schema.all_of.as_deref(),
+                        prefer_type_definitions(
+                            adjacent_type_definition(
+                                self,
+                                position,
+                                keys,
+                                accessors,
+                                Some(current_schema),
+                                schema_context,
+                                local_time_schema.one_of.as_deref(),
+                                local_time_schema.any_of.as_deref(),
+                                local_time_schema.all_of.as_deref(),
+                            )
+                            .await,
+                            base_type_definition,
                         )
-                        .await
-                        .or(base_type_definition)
                     }
                     SchemaView::OneOf(one_of_schema) => {
                         get_one_of_type_definition(
@@ -242,10 +253,10 @@ impl GetTypeDefinition for tombi_document_tree::String {
                         )
                         .await
                     }
-                    _ => None,
+                    _ => Vec::new(),
                 }
             } else {
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -260,17 +271,17 @@ impl GetTypeDefinition for tombi_schema_store::StringSchema {
         accessors: &'a [tombi_schema_store::Accessor],
         current_schema: Option<&'a tombi_schema_store::CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -22,7 +22,7 @@ impl GetTypeDefinition for tombi_document_tree::Table {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         log::trace!("self = {:?}", self);
         log::trace!("keys = {:?}", keys);
         log::trace!("accessors = {:?}", accessors);
@@ -31,13 +31,14 @@ impl GetTypeDefinition for tombi_document_tree::Table {
         async move {
             if let Some((comment_directive_context, schema_uri)) =
                 get_table_comment_directive_content_with_schema_uri(self, position, accessors)
-                && let Some(hover_content) = get_tombi_value_comment_directive_type_definition(
+                && let hover_content = get_tombi_value_comment_directive_type_definition(
                     comment_directive_context,
                     schema_uri,
                 )
                 .await
+                && !hover_content.is_empty()
             {
-                return Some(hover_content);
+                return hover_content;
             }
 
             if let Some(Ok(current_schema)) = schema_context
@@ -68,13 +69,13 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     .chain(std::iter::once(accessor))
                                     .collect_vec();
 
-                                if let Some(key_range) = table_schema
-                                    .properties
-                                    .read()
-                                    .await
-                                    .get(&schema_accessor)
-                                    .map(|property_schema| property_schema.key_range)
-                                {
+                                let key_range = {
+                                    let properties = table_schema.properties.read().await;
+                                    properties
+                                        .get(&schema_accessor)
+                                        .map(|property_schema| property_schema.key_range)
+                                };
+                                if let Some(key_range) = key_range {
                                     if let Ok(Some(current_schema)) = table_schema
                                         .resolve_property_schema(
                                             &schema_accessor,
@@ -85,6 +86,26 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         )
                                         .await
                                     {
+                                        if tombi_document_tree::ValueImpl::range(key)
+                                            .contains(position)
+                                        {
+                                            return current_schema
+                                                .schema_view
+                                                .get_type_definition(
+                                                    position,
+                                                    &keys[1..],
+                                                    &accessors,
+                                                    Some(&current_schema),
+                                                    schema_context,
+                                                )
+                                                .await
+                                                .into_iter()
+                                                .map(|type_definition| {
+                                                    type_definition
+                                                        .update_range(&accessors, &key_range)
+                                                })
+                                                .collect();
+                                        }
                                         return value
                                             .get_type_definition(
                                                 position,
@@ -94,9 +115,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                                 schema_context,
                                             )
                                             .await
+                                            .into_iter()
                                             .map(|type_definition| {
                                                 type_definition.update_range(&accessors, &key_range)
-                                            });
+                                            })
+                                            .collect();
                                     }
 
                                     return value
@@ -141,11 +164,13 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                                             schema_context,
                                                         )
                                                         .await
+                                                        .into_iter()
                                                         .map(|type_definition| {
                                                             type_definition.update_range(
                                                                 &accessors, &key_range,
                                                             )
-                                                        });
+                                                        })
+                                                        .collect();
                                                 }
 
                                                 return value
@@ -190,14 +215,16 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                             schema_context,
                                         )
                                         .await
+                                        .into_iter()
                                         .map(|type_definition| {
                                             type_definition
                                                 .update_range(&accessors, schema_key_range)
-                                        });
+                                        })
+                                        .collect();
                                 }
 
                                 if let Some(one_of_schema) = table_schema.one_of.as_deref()
-                                    && let Some(type_definition) = get_one_of_type_definition(
+                                    && let type_definitions = get_one_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -209,11 +236,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
+                                    && !type_definitions.is_empty()
                                 {
-                                    return Some(type_definition);
+                                    return type_definitions;
                                 }
                                 if let Some(any_of_schema) = table_schema.any_of.as_deref()
-                                    && let Some(type_definition) = get_any_of_type_definition(
+                                    && let type_definitions = get_any_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -225,11 +253,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
+                                    && !type_definitions.is_empty()
                                 {
-                                    return Some(type_definition);
+                                    return type_definitions;
                                 }
                                 if let Some(all_of_schema) = table_schema.all_of.as_deref()
-                                    && let Some(type_definition) = get_all_of_type_definition(
+                                    && let type_definitions = get_all_of_type_definition(
                                         self,
                                         position,
                                         keys,
@@ -241,8 +270,9 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                         schema_context,
                                     )
                                     .await
+                                    && !type_definitions.is_empty()
                                 {
-                                    return Some(type_definition);
+                                    return type_definitions;
                                 }
 
                                 if let Some(current_schema) =
@@ -280,14 +310,14 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     key.range().start.line + 1
                                 )));
 
-                                Some(TypeDefinition {
+                                vec![TypeDefinition {
                                     schema_uri,
                                     schema_accessors: accessors
                                         .iter()
                                         .map(Into::into)
                                         .collect_vec(),
                                     range: tombi_text::Range::default(),
-                                })
+                                }]
                             }
                         } else {
                             let type_definition = table_schema
@@ -300,12 +330,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                 )
                                 .await;
 
-                            if type_definition.is_some() {
+                            if !type_definition.is_empty() {
                                 return type_definition;
                             }
 
                             if let Some(one_of_schema) = table_schema.one_of.as_deref()
-                                && let Some(type_definition) = get_one_of_type_definition(
+                                && let type_definitions = get_one_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -317,11 +347,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
+                                && !type_definitions.is_empty()
                             {
-                                return Some(type_definition);
+                                return type_definitions;
                             }
                             if let Some(any_of_schema) = table_schema.any_of.as_deref()
-                                && let Some(type_definition) = get_any_of_type_definition(
+                                && let type_definitions = get_any_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -333,11 +364,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
+                                && !type_definitions.is_empty()
                             {
-                                return Some(type_definition);
+                                return type_definitions;
                             }
                             if let Some(all_of_schema) = table_schema.all_of.as_deref()
-                                && let Some(type_definition) = get_all_of_type_definition(
+                                && let type_definitions = get_all_of_type_definition(
                                     self,
                                     position,
                                     keys,
@@ -349,11 +381,12 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                                     schema_context,
                                 )
                                 .await
+                                && !type_definitions.is_empty()
                             {
-                                return Some(type_definition);
+                                return type_definitions;
                             }
 
-                            None
+                            Vec::new()
                         }
                     }
                     SchemaView::OneOf(one_of_schema) => {
@@ -398,11 +431,11 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                         )
                         .await
                     }
-                    _ => Some(TypeDefinition {
+                    _ => vec![TypeDefinition {
                         schema_uri: current_schema.schema_uri.as_ref().clone(),
                         schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                         range: tombi_text::Range::default(),
-                    }),
+                    }],
                 }
             } else {
                 if let Some(key) = keys.first()
@@ -424,7 +457,7 @@ impl GetTypeDefinition for tombi_document_tree::Table {
                         )
                         .await;
                 }
-                None
+                Vec::new()
             }
         }
         .boxed()
@@ -439,17 +472,17 @@ impl GetTypeDefinition for TableSchema {
         accessors: &'a [Accessor],
         current_schema: Option<&'a CurrentSchema<'a>>,
         _schema_context: &'a tombi_schema_store::SchemaContext,
-    ) -> tombi_future::BoxFuture<'b, Option<TypeDefinition>> {
+    ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
-            current_schema.map(|schema| {
+            current_schema.map_or_else(Vec::new, |schema| {
                 let mut schema_uri = schema.schema_uri.as_ref().clone();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
-                TypeDefinition {
+                vec![TypeDefinition {
                     schema_uri,
                     schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                     range: schema.schema_view.range(),
-                }
+                }]
             })
         }
         .boxed()

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -8,9 +8,32 @@ use crate::{
     config_manager::ConfigSchemaStore,
     goto_type_definition::{
         TypeDefinition, get_tombi_document_comment_directive_type_definition, get_type_definition,
+        location_key,
     },
     handler::hover::get_hover_keys_with_range,
 };
+
+fn type_definition_locations(
+    type_definitions: Vec<TypeDefinition>,
+) -> Vec<tombi_extension::Location> {
+    let mut unique_type_definitions: Vec<TypeDefinition> =
+        Vec::with_capacity(type_definitions.len());
+    for type_definition in type_definitions {
+        if !unique_type_definitions.iter().any(|existing| {
+            location_key(&existing.schema_uri, existing.range)
+                == location_key(&type_definition.schema_uri, type_definition.range)
+        }) {
+            unique_type_definitions.push(type_definition);
+        }
+    }
+    unique_type_definitions
+        .into_iter()
+        .map(|type_definition| tombi_extension::Location {
+            uri: type_definition.schema_uri.into(),
+            range: type_definition.range,
+        })
+        .collect()
+}
 
 pub async fn handle_goto_type_definition(
     backend: &Backend,
@@ -64,13 +87,10 @@ pub async fn handle_goto_type_definition(
 
     let position = position.into_lsp(line_index);
 
-    if let Some(type_definition) =
-        get_tombi_document_comment_directive_type_definition(&root, position).await
-    {
-        return Ok(Some(vec![tombi_extension::Location {
-            uri: type_definition.schema_uri.into(),
-            range: type_definition.range,
-        }]));
+    let type_definitions =
+        get_tombi_document_comment_directive_type_definition(&root, position).await;
+    if !type_definitions.is_empty() {
+        return Ok(Some(type_definition_locations(type_definitions)));
     }
 
     let source_schema = schema_store
@@ -97,22 +117,16 @@ pub async fn handle_goto_type_definition(
         strict,
     );
 
-    Ok(
-        match get_type_definition(
-            &document_source.document_tree(),
-            position,
-            &keys,
-            &schema_context,
-        )
-        .await
-        {
-            Some(TypeDefinition {
-                schema_uri, range, ..
-            }) => Some(vec![tombi_extension::Location {
-                uri: schema_uri.into(),
-                range,
-            }]),
-            _ => Default::default(),
-        },
+    let type_definitions = get_type_definition(
+        &document_source.document_tree(),
+        position,
+        &keys,
+        &schema_context,
     )
+    .await;
+    if type_definitions.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(type_definition_locations(type_definitions)))
+    }
 }

--- a/crates/tombi-lsp/src/hover.rs
+++ b/crates/tombi-lsp/src/hover.rs
@@ -10,13 +10,21 @@ use std::{borrow::Cow, fmt::Debug, ops::Deref};
 
 pub use comment::get_document_comment_directive_hover_content;
 use constraints::ValueConstraints;
+use itertools::Itertools;
 
-use tombi_extension::get_tombi_github_uri;
+use crate::schema_tooltip::{SchemaTooltip, SchemaTooltipContent};
 use tombi_schema_store::{
     Accessor, Accessors, AllOfSchema, AnyOfSchema, CurrentSchema, OneOfSchema, SchemaUri,
     ValueType, get_schema_name,
 };
 use tombi_text::{FromLsp, IntoLsp};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CompositeKind {
+    Any,
+    One,
+    All,
+}
 
 pub async fn get_hover_content(
     tree: &tombi_document_tree::DocumentTree,
@@ -61,25 +69,18 @@ pub(super) trait GetHoverContent {
     ) -> tombi_future::BoxFuture<'b, Option<HoverContent>>;
 }
 
-pub(super) fn project_schema_for_value(
-    value: &impl tombi_document_tree::ValueImpl,
-    schema: &CurrentSchema<'_>,
-    schema_context: &tombi_schema_store::SchemaContext<'_>,
-) -> Option<CurrentSchema<'static>> {
-    if !matches!(
-        schema.schema_view.as_ref(),
-        tombi_schema_store::SchemaView::Anything(_)
-    ) || schema
-        .semantic_schema
-        .as_deref()
-        .is_some_and(tombi_schema_store::SemanticSchema::has_references)
-    {
-        return None;
-    }
-    schema.for_instance_type(
-        tombi_schema_store::SchemaType::from_value_type(value.value_type())?,
-        schema_context.string_formats(),
-    )
+pub(super) fn schema_link_uri(
+    schema_uri: &SchemaUri,
+    schema_range: tombi_text::Range,
+) -> SchemaUri {
+    tombi_extension::get_schema_link_uri(schema_uri, schema_range.start).into()
+}
+
+pub(super) fn current_schema_link_uri(
+    current_schema: Option<&CurrentSchema<'_>>,
+) -> Option<SchemaUri> {
+    current_schema
+        .map(|schema| schema_link_uri(schema.schema_uri.as_ref(), schema.schema_view.range()))
 }
 
 fn merge_optional_vec<T: PartialEq>(
@@ -136,16 +137,110 @@ fn merge_constraints(
     }
 }
 
-fn merge_hover_value_content(
+pub(super) fn merge_hover_value_content(
     mut base: HoverValueContent,
-    adjacent: HoverValueContent,
+    mut adjacent: HoverValueContent,
 ) -> HoverValueContent {
+    base.schema_tooltip = match (base.schema_tooltip.take(), adjacent.schema_tooltip.take()) {
+        (Some(base), Some(adjacent)) => Some(base.combine(adjacent)),
+        (Some(tooltip), None) | (None, Some(tooltip)) => Some(tooltip),
+        (None, None) => None,
+    };
     base.title = base.title.or(adjacent.title);
     base.description = base.description.or(adjacent.description);
     base.constraints = merge_constraints(base.constraints, adjacent.constraints);
     base.schema_uri = base.schema_uri.or(adjacent.schema_uri);
     base.range = base.range.or(adjacent.range);
     base
+}
+
+pub(super) fn first_most_specific_hover_value_content(
+    contents: Vec<HoverValueContent>,
+    applicator: CompositeKind,
+) -> Option<HoverValueContent> {
+    let max_depth = contents
+        .iter()
+        .map(|content| content.accessors.as_ref().len())
+        .max()?;
+    let contents = contents
+        .into_iter()
+        .filter(|content| content.accessors.as_ref().len() == max_depth)
+        .collect_vec();
+    if contents.len() == 1 {
+        return contents.into_iter().next();
+    }
+
+    let value_types = contents
+        .iter()
+        .map(|content| content.value_type.clone())
+        .collect::<tombi_hashmap::IndexSet<_>>();
+    let tooltip_contents = if applicator == CompositeKind::All
+        && contents.iter().any(HoverValueContent::has_tooltip_details)
+    {
+        contents
+            .iter()
+            .filter(|content| content.has_tooltip_details())
+            .collect_vec()
+    } else {
+        contents.iter().collect_vec()
+    };
+
+    if tooltip_contents.len() == 1 {
+        let mut selected = tooltip_contents[0].clone();
+        if value_types.len() > 1 {
+            selected.value_type = ValueType::AllOf(value_types.into_iter().collect());
+        }
+        return Some(selected);
+    }
+
+    let tooltips = tooltip_contents
+        .into_iter()
+        .map(HoverValueContent::schema_tooltip)
+        .collect_vec();
+    let mut selected = None;
+    let mut schema_uri = None;
+    let mut range = None;
+    for mut content in contents {
+        schema_uri = schema_uri.or_else(|| content.schema_uri.take());
+        range = range.or(content.range);
+        selected.get_or_insert(content);
+    }
+
+    let mut selected = selected?;
+    selected.title = None;
+    selected.description = None;
+    selected.constraints = None;
+    selected.schema_uri = schema_uri;
+    selected.range = range;
+    if value_types.len() > 1 {
+        selected.value_type = match applicator {
+            CompositeKind::Any => ValueType::AnyOf(value_types.into_iter().collect()),
+            CompositeKind::One => ValueType::OneOf(value_types.into_iter().collect()),
+            CompositeKind::All => ValueType::AllOf(value_types.into_iter().collect()),
+        };
+    }
+    selected.schema_tooltip = SchemaTooltip::composite(tooltips);
+    Some(selected)
+}
+
+pub(super) fn inherit_matching_nullable_type(composite: &ValueType, value_type: &mut ValueType) {
+    if value_type.is_nullable() {
+        return;
+    }
+    let value_type_simplified = value_type.simplify();
+    let composite_simplified = composite.simplify();
+    let types = match &composite_simplified {
+        ValueType::OneOf(types) | ValueType::AnyOf(types) => types,
+        _ => return,
+    };
+    if types.iter().any(|candidate| {
+        !matches!(candidate, ValueType::Null) && candidate.simplify() == value_type_simplified
+    }) && types
+        .iter()
+        .any(|candidate| matches!(candidate, ValueType::Null))
+    {
+        value_type.set_nullable();
+    }
 }
 
 fn merge_hover_content(
@@ -302,6 +397,47 @@ pub struct HoverValueContent {
     pub constraints: Option<ValueConstraints>,
     pub schema_uri: Option<SchemaUri>,
     pub range: Option<tombi_text::Range>,
+    pub(super) schema_tooltip: Option<SchemaTooltip>,
+}
+
+impl HoverValueContent {
+    fn has_tooltip_details(&self) -> bool {
+        self.title.is_some()
+            || self.description.is_some()
+            || self
+                .constraints
+                .as_ref()
+                .is_some_and(|constraints| constraints != &ValueConstraints::default())
+            || self.schema_uri.is_some()
+            || self.schema_tooltip.is_some()
+    }
+
+    pub(crate) fn schema_tooltip(&self) -> SchemaTooltip {
+        let schema = self.schema_uri.as_ref().and_then(|schema_uri| {
+            get_schema_name(schema_uri).map(|name| format!("Schema: [{name}]({schema_uri})"))
+        });
+        let common = SchemaTooltipContent {
+            title: self.title.clone(),
+            description: self.description.clone(),
+            value_type: self.value_type.to_string(),
+            constraints: self.constraints.as_ref().and_then(|constraints| {
+                let constraints = constraints.to_string();
+                (!constraints.is_empty()).then_some(constraints)
+            }),
+            schema,
+        };
+        match self.schema_tooltip.clone() {
+            Some(tooltip)
+                if common.title.is_some()
+                    || common.description.is_some()
+                    || common.constraints.is_some() =>
+            {
+                tooltip.with_common_content(common)
+            }
+            Some(tooltip) => tooltip,
+            None => SchemaTooltip::Content(common),
+        }
+    }
 }
 
 impl PartialEq for HoverValueContent {
@@ -311,6 +447,7 @@ impl PartialEq for HoverValueContent {
             && self.accessors == other.accessors
             && self.value_type == other.value_type
             && self.constraints == other.constraints
+            && self.schema_tooltip == other.schema_tooltip
             && self.range == other.range
     }
 }
@@ -324,45 +461,15 @@ impl std::hash::Hash for HoverValueContent {
         self.accessors.hash(state);
         self.value_type.hash(state);
         self.constraints.hash(state);
+        self.schema_tooltip.hash(state);
         self.range.hash(state);
     }
 }
 
 impl std::fmt::Display for HoverValueContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const SECTION_SEPARATOR: &str = "-----";
-
-        if let Some(title) = &self.title {
-            writeln!(f, "#### {title}\n")?;
-        }
-
-        if let Some(description) = &self.description {
-            writeln!(f, "{description}\n")?;
-        }
-
-        if self.title.is_some() || self.description.is_some() {
-            writeln!(f, "{SECTION_SEPARATOR}\n")?;
-        }
-
-        if !self.accessors.is_empty() {
-            writeln!(f, "Keys: `{}`\n", self.accessors)?;
-        }
-        writeln!(f, "Value: `{}`\n", self.value_type)?;
-
-        if let Some(constraints) = &self.constraints {
-            writeln!(f, "{constraints}")?;
-        }
-
-        if let Some(schema_uri) = &self
-            .schema_uri
-            .as_ref()
-            .and_then(|url| get_tombi_github_uri(url))
-            && let Some(schema_filename) = get_schema_name(schema_uri)
-        {
-            writeln!(f, "Schema: [{schema_filename}]({schema_uri})\n",)?;
-        }
-
-        Ok(())
+        let keys = (!self.accessors.is_empty()).then(|| self.accessors.to_string());
+        f.write_str(&self.schema_tooltip().render(keys.as_deref()))
     }
 }
 

--- a/crates/tombi-lsp/src/hover/all_of.rs
+++ b/crates/tombi-lsp/src/hover/all_of.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUri};
 
+use super::CompositeKind;
 use crate::{HoverContent, hover::display_value::GetEnum};
 
 use super::{
@@ -31,11 +32,7 @@ where
     log::trace!("schema_uri = {:?}", schema_uri);
 
     async move {
-        let mut title_description_set = tombi_hashmap::HashSet::new();
-        let mut value_type_set = tombi_hashmap::IndexSet::new();
-        let mut constraints = None;
-        let mut enum_values = Vec::new();
-        let mut result_accessors = tombi_schema_store::Accessors::from(accessors.to_vec());
+        let mut hover_value_contents = Vec::new();
 
         let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
             &all_of_schema.schemas,
@@ -49,23 +46,12 @@ where
         .await?;
 
         for resolved_schema in &resolved_schemas {
-            let projected_schema =
-                super::project_schema_for_value(value, resolved_schema, schema_context);
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
             let resolved_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
-            if let Some(values) = resolved_schema
-                .schema_view
-                .as_ref()
-                .get_enum(
-                    &resolved_schema.schema_uri,
-                    &resolved_schema.definitions,
-                    resolved_schema.strict,
-                    schema_context,
-                )
-                .await
-            {
-                enum_values.extend(values);
-            }
-
             if let Some(hover_content) = value
                 .get_hover_content(
                     position,
@@ -77,27 +63,29 @@ where
                 .await
             {
                 match hover_content {
-                    HoverContent::Value(hover_value_content) => {
-                        if hover_value_content.title.is_some()
-                            || hover_value_content.description.is_some()
+                    HoverContent::Value(mut hover_value_content) => {
+                        if hover_value_content
+                            .constraints
+                            .as_ref()
+                            .is_none_or(|constraints| constraints.r#enum.is_none())
+                            && hover_value_content.accessors.as_ref() == accessors
+                            && let Some(enum_values) = resolved_schema
+                                .schema_view
+                                .as_ref()
+                                .get_enum(
+                                    &resolved_schema.schema_uri,
+                                    &resolved_schema.definitions,
+                                    resolved_schema.strict,
+                                    schema_context,
+                                )
+                                .await
                         {
-                            title_description_set.insert((
-                                hover_value_content.title.clone(),
-                                hover_value_content.description.clone(),
-                            ));
+                            hover_value_content
+                                .constraints
+                                .get_or_insert_default()
+                                .r#enum = Some(enum_values);
                         }
-                        value_type_set.insert(hover_value_content.value_type);
-
-                        if let Some(c) = hover_value_content.constraints {
-                            constraints = Some(c);
-                        }
-
-                        // Use the accessors from the successfully resolved schema if they're more specific
-                        if hover_value_content.accessors.as_ref().len()
-                            > result_accessors.as_ref().len()
-                        {
-                            result_accessors = hover_value_content.accessors;
-                        }
+                        hover_value_contents.push(hover_value_content);
                     }
                     HoverContent::Directive(hover_content) => {
                         return Some(HoverContent::Directive(hover_content));
@@ -109,39 +97,41 @@ where
             }
         }
 
-        let (mut title, mut description) = if title_description_set.len() == 1 {
-            title_description_set.into_iter().next().unwrap()
-        } else {
-            (None, None)
-        };
+        let mut hover_value_content = super::first_most_specific_hover_value_content(
+            hover_value_contents,
+            CompositeKind::All,
+        )
+        .unwrap_or_else(|| HoverValueContent {
+            title: None,
+            description: None,
+            accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
+            value_type: value.value_type().into(),
+            constraints: None,
+            schema_uri: Some(super::schema_link_uri(schema_uri, all_of_schema.range)),
+            range: None,
+            schema_tooltip: None,
+        });
+        hover_value_content
+            .schema_uri
+            .get_or_insert_with(|| super::schema_link_uri(schema_uri, all_of_schema.range));
 
-        if title.is_none() && description.is_none() {
-            if let Some(t) = &all_of_schema.title {
-                title = Some(t.clone());
-            }
-            if let Some(d) = &all_of_schema.description {
-                description = Some(d.clone());
-            }
+        if hover_value_content.title.is_none() && hover_value_content.description.is_none() {
+            hover_value_content.title = all_of_schema.title.clone();
+            hover_value_content.description = all_of_schema.description.clone();
         }
 
-        let value_type = if value_type_set.len() == 1 {
-            value_type_set.into_iter().next().unwrap()
-        } else {
-            tombi_schema_store::ValueType::AllOf(value_type_set.into_iter().collect())
-        };
-
-        if result_accessors.as_ref().len() == accessors.len()
+        if hover_value_content.accessors.as_ref().len() == accessors.len()
             && let Some(default) = all_of_schema
                 .default
                 .as_ref()
                 .and_then(|default| DisplayValue::try_from(default).ok())
         {
-            if let Some(constraints) = constraints.as_mut() {
+            if let Some(constraints) = hover_value_content.constraints.as_mut() {
                 if constraints.default.is_none() {
                     constraints.default = Some(default);
                 }
             } else {
-                constraints = Some(ValueConstraints {
+                hover_value_content.constraints = Some(ValueConstraints {
                     default: Some(default),
                     ..Default::default()
                 });
@@ -155,14 +145,13 @@ where
                 .collect_vec();
 
             if !all_of_examples.is_empty() {
-                if let Some(constraints) = constraints.as_mut() {
-                    if let Some(examples) = constraints.examples.as_mut() {
-                        examples.extend(all_of_examples);
-                    } else {
-                        constraints.examples = Some(all_of_examples);
-                    }
+                if let Some(constraints) = hover_value_content.constraints.as_mut() {
+                    constraints.examples = super::merge_optional_vec(
+                        constraints.examples.take(),
+                        Some(all_of_examples),
+                    );
                 } else {
-                    constraints = Some(ValueConstraints {
+                    hover_value_content.constraints = Some(ValueConstraints {
                         examples: Some(all_of_examples),
                         ..Default::default()
                     });
@@ -170,26 +159,7 @@ where
             }
         }
 
-        if !enum_values.is_empty() {
-            if let Some(constraints) = constraints.as_mut() {
-                constraints.r#enum = Some(enum_values);
-            } else {
-                constraints = Some(ValueConstraints {
-                    r#enum: Some(enum_values),
-                    ..Default::default()
-                });
-            }
-        }
-
-        Some(HoverContent::Value(HoverValueContent {
-            title,
-            description,
-            accessors: result_accessors,
-            value_type,
-            constraints,
-            schema_uri: Some(schema_uri.to_owned()),
-            range: None,
-        }))
+        Some(HoverContent::Value(hover_value_content))
     }
     .boxed()
 }
@@ -208,10 +178,6 @@ impl GetHoverContent for tombi_schema_store::AllOfSchema {
                 unreachable!("schema must be provided");
             };
 
-            let mut title_description_set = tombi_hashmap::HashSet::new();
-            let mut value_type_set = tombi_hashmap::IndexSet::new();
-            let mut enum_values = Vec::new();
-
             let resolved_schemas = tombi_schema_store::resolve_and_collect_schemas(
                 &self.schemas,
                 current_schema.schema_uri.clone(),
@@ -223,65 +189,30 @@ impl GetHoverContent for tombi_schema_store::AllOfSchema {
             )
             .await?;
 
-            for resolved_schema in &resolved_schemas {
-                if resolved_schema.schema_view.title().is_some()
-                    || resolved_schema.schema_view.description().is_some()
-                {
-                    title_description_set.insert((
-                        resolved_schema.schema_view.title().map(ToString::to_string),
-                        resolved_schema
-                            .schema_view
-                            .description()
-                            .map(ToString::to_string),
-                    ));
-                }
-                value_type_set.insert(resolved_schema.schema_view.value_type().await);
-
-                if let Some(values) = resolved_schema
+            let value_type = self.value_type().await;
+            let mut contents = Vec::new();
+            for schema in &resolved_schemas {
+                if let Some(HoverContent::Value(content)) = schema
                     .schema_view
-                    .as_ref()
-                    .get_enum(
-                        &resolved_schema.schema_uri,
-                        &resolved_schema.definitions,
-                        resolved_schema.strict,
-                        schema_context,
-                    )
+                    .get_hover_content(_position, _keys, accessors, Some(schema), schema_context)
                     .await
                 {
-                    enum_values.extend(values);
+                    contents.push(content);
                 }
             }
 
-            let (mut title, mut description) = if title_description_set.len() == 1 {
-                title_description_set.into_iter().next().unwrap()
-            } else {
-                (None, None)
-            };
-
-            if title.is_none() && description.is_none() {
-                if let Some(t) = &self.title {
-                    title = Some(t.clone());
-                }
-                if let Some(d) = &self.description {
-                    description = Some(d.clone());
-                }
-            }
-
-            let value_type: tombi_schema_store::ValueType = if value_type_set.len() == 1 {
-                value_type_set.into_iter().next().unwrap()
-            } else {
-                tombi_schema_store::ValueType::AllOf(value_type_set.into_iter().collect())
-            };
-
-            let mut hover_value_content = HoverValueContent {
-                title,
-                description,
-                accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
-                value_type,
-                constraints: None,
-                schema_uri: Some(current_schema.schema_uri.as_ref().to_owned()),
-                range: None,
-            };
+            let mut hover_value_content =
+                super::first_most_specific_hover_value_content(contents, CompositeKind::All)
+                    .unwrap_or_else(|| HoverValueContent {
+                        title: self.title.clone(),
+                        description: self.description.clone(),
+                        accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
+                        value_type,
+                        constraints: None,
+                        schema_uri: super::current_schema_link_uri(Some(current_schema)),
+                        range: None,
+                        schema_tooltip: None,
+                    });
 
             if let Some(default) = self
                 .default
@@ -308,28 +239,16 @@ impl GetHoverContent for tombi_schema_store::AllOfSchema {
 
                 if !all_of_examples.is_empty() {
                     if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                        if let Some(examples) = constraints.examples.as_mut() {
-                            examples.extend(all_of_examples);
-                        } else {
-                            constraints.examples = Some(all_of_examples);
-                        }
+                        constraints.examples = super::merge_optional_vec(
+                            constraints.examples.take(),
+                            Some(all_of_examples),
+                        );
                     } else {
                         hover_value_content.constraints = Some(ValueConstraints {
                             examples: Some(all_of_examples),
                             ..Default::default()
                         });
                     }
-                }
-            }
-
-            if !enum_values.is_empty() {
-                if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                    constraints.r#enum = Some(enum_values);
-                } else {
-                    hover_value_content.constraints = Some(ValueConstraints {
-                        r#enum: Some(enum_values),
-                        ..Default::default()
-                    });
                 }
             }
 

--- a/crates/tombi-lsp/src/hover/any_of.rs
+++ b/crates/tombi-lsp/src/hover/any_of.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext, SchemaUri};
 
+use super::CompositeKind;
 use crate::{HoverContent, hover::display_value::GetEnum};
 
 use super::{
@@ -35,10 +36,7 @@ where
     log::trace!("schema_uri = {:?}", schema_uri);
 
     async move {
-        let mut any_hover_value_contents = vec![];
-        let mut valid_hover_value_contents = vec![];
-        let mut value_type_set = tombi_hashmap::IndexSet::new();
-        let mut enum_values = Vec::new();
+        let mut hover_value_contents = vec![];
         let default = any_of_schema
             .default
             .as_ref()
@@ -54,24 +52,40 @@ where
             accessors,
         )
         .await?;
+        let value_type = any_of_schema.value_type().await;
 
-        for resolved_schema in &resolved_schemas {
-            value_type_set.insert(resolved_schema.schema_view.value_type().await);
-        }
+        let evaluation = tombi_validator::evaluate_applicator(
+            tombi_validator::Applicator::AnyOf,
+            value,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+        )
+        .await;
+        let has_applicable_branch = evaluation
+            .branches
+            .iter()
+            .any(|branch| branch.is_applicable());
 
-        let value_type = if value_type_set.len() == 1 {
-            value_type_set.into_iter().next().unwrap()
-        } else {
-            tombi_schema_store::ValueType::AnyOf(value_type_set.into_iter().collect())
-        };
+        for (resolved_schema, branch_applicability) in
+            resolved_schemas.iter().zip(&evaluation.branches)
+        {
+            if has_applicable_branch && !branch_applicability.is_applicable() {
+                continue;
+            }
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
+            let navigation_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
 
-        for resolved_schema in &resolved_schemas {
             match value
                 .get_hover_content(
                     position,
                     keys,
                     accessors,
-                    Some(resolved_schema),
+                    Some(navigation_schema),
                     schema_context,
                 )
                 .await
@@ -88,46 +102,33 @@ where
                         }
                     }
 
-                    if keys.is_empty() && accessors == hover_value_content.accessors.as_ref() {
+                    if accessors.len() == hover_value_content.accessors.as_ref().len() {
                         hover_value_content.value_type = value_type.clone();
                     }
 
-                    let is_applicable_branch = match value
-                        .validate(accessors, Some(resolved_schema), schema_context)
-                        .await
-                    {
-                        Ok(_) => true,
-                        Err(tombi_validator::Invalid {
-                            assertion_failed, ..
-                        }) => !assertion_failed,
-                    };
-
-                    if is_applicable_branch {
-                        if let Some(values) = hover_value_content
-                            .constraints
+                    if hover_value_content
+                        .constraints
+                        .as_ref()
+                        .is_none_or(|constraints| constraints.r#enum.is_none())
+                        && hover_value_content.accessors.as_ref() == accessors
+                        && let Some(enum_values) = resolved_schema
+                            .schema_view
                             .as_ref()
-                            .and_then(|constraints| constraints.r#enum.as_ref())
-                        {
-                            enum_values.extend(values.iter().cloned());
-                        } else if hover_value_content.accessors.as_ref() == accessors
-                            && let Some(values) = resolved_schema
-                                .schema_view
-                                .as_ref()
-                                .get_enum(
-                                    &resolved_schema.schema_uri,
-                                    &resolved_schema.definitions,
-                                    resolved_schema.strict,
-                                    schema_context,
-                                )
-                                .await
-                        {
-                            enum_values.extend(values);
-                        }
-
-                        valid_hover_value_contents.push(hover_value_content.clone());
+                            .get_enum(
+                                &resolved_schema.schema_uri,
+                                &resolved_schema.definitions,
+                                resolved_schema.strict,
+                                schema_context,
+                            )
+                            .await
+                    {
+                        hover_value_content
+                            .constraints
+                            .get_or_insert_default()
+                            .r#enum = Some(enum_values);
                     }
 
-                    any_hover_value_contents.push(hover_value_content);
+                    hover_value_contents.push(hover_value_content);
                 }
                 Some(HoverContent::Directive(hover_content)) => {
                     return Some(HoverContent::Directive(hover_content));
@@ -141,22 +142,24 @@ where
             };
         }
 
-        let mut hover_value_content =
-            if let Some(hover_value_content) = valid_hover_value_contents.into_iter().next() {
-                hover_value_content
-            } else if let Some(hover_value_content) = any_hover_value_contents.into_iter().next() {
-                hover_value_content
-            } else {
-                HoverValueContent {
-                    title: None,
-                    description: None,
-                    accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
-                    value_type: value.value_type().into(),
-                    constraints: None,
-                    schema_uri: Some(schema_uri.to_owned()),
-                    range: None,
-                }
-            };
+        let mut hover_value_content = super::first_most_specific_hover_value_content(
+            hover_value_contents,
+            CompositeKind::Any,
+        )
+        .unwrap_or_else(|| HoverValueContent {
+            title: any_of_schema.title.clone(),
+            description: any_of_schema.description.clone(),
+            accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
+            value_type: value.value_type().into(),
+            constraints: None,
+            schema_uri: Some(super::schema_link_uri(schema_uri, any_of_schema.range)),
+            range: None,
+            schema_tooltip: None,
+        });
+        super::inherit_matching_nullable_type(&value_type, &mut hover_value_content.value_type);
+        hover_value_content
+            .schema_uri
+            .get_or_insert_with(|| super::schema_link_uri(schema_uri, any_of_schema.range));
 
         if let Some(default) = default {
             if let Some(constraints) = hover_value_content.constraints.as_mut() {
@@ -166,17 +169,6 @@ where
             } else {
                 hover_value_content.constraints = Some(ValueConstraints {
                     default: Some(default),
-                    ..Default::default()
-                });
-            }
-        }
-
-        if !enum_values.is_empty() {
-            if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                constraints.r#enum = Some(enum_values);
-            } else {
-                hover_value_content.constraints = Some(ValueConstraints {
-                    r#enum: Some(enum_values),
                     ..Default::default()
                 });
             }
@@ -201,9 +193,6 @@ impl GetHoverContent for tombi_schema_store::AnyOfSchema {
                 unreachable!("schema must be provided");
             };
 
-            let mut title_description_set = tombi_hashmap::HashSet::new();
-            let mut value_type_set = tombi_hashmap::IndexSet::new();
-            let mut enum_values = Vec::new();
             let default = self
                 .default
                 .as_ref()
@@ -220,66 +209,30 @@ impl GetHoverContent for tombi_schema_store::AnyOfSchema {
             )
             .await?;
 
-            for resolved_schema in &resolved_schemas {
-                if resolved_schema.schema_view.title().is_some()
-                    || resolved_schema.schema_view.description().is_some()
-                {
-                    title_description_set.insert((
-                        resolved_schema.schema_view.title().map(ToString::to_string),
-                        resolved_schema
-                            .schema_view
-                            .description()
-                            .map(ToString::to_string),
-                    ));
-                }
-
-                value_type_set.insert(resolved_schema.schema_view.value_type().await);
-
-                if let Some(values) = resolved_schema
+            let value_type = self.value_type().await;
+            let mut contents = Vec::new();
+            for schema in &resolved_schemas {
+                if let Some(HoverContent::Value(content)) = schema
                     .schema_view
-                    .as_ref()
-                    .get_enum(
-                        &resolved_schema.schema_uri,
-                        &resolved_schema.definitions,
-                        resolved_schema.strict,
-                        schema_context,
-                    )
+                    .get_hover_content(_position, _keys, accessors, Some(schema), schema_context)
                     .await
                 {
-                    enum_values.extend(values);
+                    contents.push(content);
                 }
             }
 
-            let (mut title, mut description) = if title_description_set.len() == 1 {
-                title_description_set.into_iter().next().unwrap()
-            } else {
-                (None, None)
-            };
-
-            if title.is_none() && description.is_none() {
-                if let Some(t) = &self.title {
-                    title = Some(t.clone());
-                }
-                if let Some(d) = &self.description {
-                    description = Some(d.clone());
-                }
-            }
-
-            let value_type: tombi_schema_store::ValueType = if value_type_set.len() == 1 {
-                value_type_set.into_iter().next().unwrap()
-            } else {
-                tombi_schema_store::ValueType::AnyOf(value_type_set.into_iter().collect())
-            };
-
-            let mut hover_value_content = HoverValueContent {
-                title,
-                description,
-                accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
-                value_type,
-                constraints: None,
-                schema_uri: Some(current_schema.schema_uri.as_ref().clone()),
-                range: None,
-            };
+            let mut hover_value_content =
+                super::first_most_specific_hover_value_content(contents, CompositeKind::Any)
+                    .unwrap_or_else(|| HoverValueContent {
+                        title: self.title.clone(),
+                        description: self.description.clone(),
+                        accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
+                        value_type,
+                        constraints: None,
+                        schema_uri: super::current_schema_link_uri(Some(current_schema)),
+                        range: None,
+                        schema_tooltip: None,
+                    });
 
             if let Some(default) = default {
                 if let Some(constraints) = hover_value_content.constraints.as_mut() {
@@ -289,17 +242,6 @@ impl GetHoverContent for tombi_schema_store::AnyOfSchema {
                 } else {
                     hover_value_content.constraints = Some(ValueConstraints {
                         default: Some(default),
-                        ..Default::default()
-                    });
-                }
-            }
-
-            if !enum_values.is_empty() {
-                if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                    constraints.r#enum = Some(enum_values);
-                } else {
-                    hover_value_content.constraints = Some(ValueConstraints {
-                        r#enum: Some(enum_values),
                         ..Default::default()
                     });
                 }

--- a/crates/tombi-lsp/src/hover/constraints.rs
+++ b/crates/tombi-lsp/src/hover/constraints.rs
@@ -26,7 +26,11 @@ where
     }
 
     if let Some(r#enum) = r#enum {
-        enum_values.extend(r#enum.iter().filter_map(convert_fn));
+        for value in r#enum.iter().filter_map(convert_fn) {
+            if !enum_values.contains(&value) {
+                enum_values.push(value);
+            }
+        }
     }
 
     if enum_values.is_empty() {

--- a/crates/tombi-lsp/src/hover/one_of.rs
+++ b/crates/tombi-lsp/src/hover/one_of.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaUri};
 
+use super::CompositeKind;
 use crate::HoverContent;
 
 use super::{
@@ -37,10 +38,8 @@ where
     log::trace!("schema_uri = {:?}", schema_uri);
 
     async move {
-        let mut one_hover_value_contents = tombi_hashmap::HashSet::new();
-        let mut valid_hover_value_contents = tombi_hashmap::HashSet::new();
-        let mut value_type_set = tombi_hashmap::IndexSet::new();
-        let mut enum_domains = Vec::with_capacity(one_of_schema.schemas.read().await.len());
+        let mut one_hover_value_contents = Vec::new();
+        let mut enum_domains = Vec::new();
         let default = one_of_schema
             .default
             .as_ref()
@@ -56,52 +55,72 @@ where
             accessors,
         )
         .await?;
-
         for resolved_schema in &resolved_schemas {
             enum_domains.push(
                 resolved_schema
                     .schema_view
                     .as_ref()
-                    .get_enum(schema_uri, definitions, strict, schema_context)
+                    .get_enum(
+                        &resolved_schema.schema_uri,
+                        &resolved_schema.definitions,
+                        resolved_schema.strict,
+                        schema_context,
+                    )
                     .await,
             );
-
-            value_type_set.insert(resolved_schema.schema_view.value_type().await);
         }
-
+        let value_type = one_of_schema.value_type().await;
         let mut enum_values = tombi_hashmap::IndexSet::new();
         if enum_domains.iter().all(Option::is_some) {
             for domain in enum_domains.iter().flatten() {
                 for candidate in domain {
-                    let match_count = enum_domains
+                    if enum_domains
                         .iter()
                         .flatten()
-                        .filter(|domain| domain.iter().any(|value| value == candidate))
-                        .count();
-                    if match_count == 1 {
+                        .filter(|domain| domain.contains(candidate))
+                        .count()
+                        == 1
+                    {
                         enum_values.insert(candidate.clone());
                     }
                 }
             }
         } else {
-            for domain in enum_domains.into_iter().flatten() {
-                enum_values.extend(domain);
-            }
+            enum_values.extend(enum_domains.into_iter().flatten().flatten());
         }
 
-        let value_type = if value_type_set.len() == 1 {
-            value_type_set.into_iter().next().unwrap()
-        } else {
-            tombi_schema_store::ValueType::OneOf(value_type_set.into_iter().collect())
-        };
+        let evaluation = tombi_validator::evaluate_applicator(
+            tombi_validator::Applicator::OneOf,
+            value,
+            accessors,
+            &resolved_schemas,
+            schema_context,
+        )
+        .await;
+        let has_applicable_branch = evaluation
+            .branches
+            .iter()
+            .any(|branch| branch.is_applicable());
 
-        for resolved_schema in &resolved_schemas {
+        for (resolved_schema, branch_applicability) in
+            resolved_schemas.iter().zip(&evaluation.branches)
+        {
+            if has_applicable_branch && !branch_applicability.is_applicable() {
+                continue;
+            }
+            let projected_schema = crate::schema_resolver::project_schema_for_concrete_value(
+                value,
+                resolved_schema,
+                schema_context,
+            );
+            let navigation_schema = projected_schema.as_ref().unwrap_or(resolved_schema);
+
             match value
                 .get_hover_content(
                     position,
                     keys,
                     accessors,
-                    Some(resolved_schema),
+                    Some(navigation_schema),
                     schema_context,
                 )
                 .await
@@ -118,34 +137,11 @@ where
                         }
                     }
 
-                    if keys.is_empty() && accessors == hover_value_content.accessors.as_ref() {
+                    if accessors.len() == hover_value_content.accessors.as_ref().len() {
                         hover_value_content.value_type = value_type.clone();
                     }
 
-                    if resolved_schema.schema_view.value_type().await
-                        == tombi_schema_store::ValueType::Array
-                        && hover_value_content.value_type != tombi_schema_store::ValueType::Array
-                    {
-                        return Some(HoverContent::Value(hover_value_content));
-                    }
-
-                    match value
-                        .validate(accessors, Some(resolved_schema), schema_context)
-                        .await
-                    {
-                        Ok(_) => {
-                            valid_hover_value_contents.insert(hover_value_content.clone());
-                        }
-                        Err(tombi_validator::Invalid {
-                            assertion_failed: false,
-                            ..
-                        }) => {
-                            valid_hover_value_contents.insert(hover_value_content.clone());
-                        }
-                        _ => {}
-                    }
-
-                    one_hover_value_contents.insert(hover_value_content);
+                    one_hover_value_contents.push(hover_value_content);
                 }
                 Some(HoverContent::Directive(hover_content)) => {
                     return Some(HoverContent::Directive(hover_content));
@@ -159,51 +155,32 @@ where
             }
         }
 
-        let mut hover_value_content = if valid_hover_value_contents.len() == 1 {
-            valid_hover_value_contents
-                .into_iter()
-                .next()
-                .map(|mut hover_content| {
-                    if hover_content.title.is_none() && hover_content.description.is_none() {
-                        if let Some(title) = &one_of_schema.title {
-                            hover_content.title = Some(title.clone());
-                        }
-                        if let Some(description) = &one_of_schema.description {
-                            hover_content.description = Some(description.clone());
-                        }
-                    }
+        if !has_applicable_branch {
+            one_hover_value_contents.retain(|content| content.accessors.as_ref() == accessors);
+        }
 
-                    hover_content
-                })
-        } else if one_hover_value_contents.len() == 1 {
-            one_hover_value_contents
-                .into_iter()
-                .next()
-                .map(|mut hover_content| {
-                    if hover_content.title.is_none() && hover_content.description.is_none() {
-                        if let Some(title) = &one_of_schema.title {
-                            hover_content.title = Some(title.clone());
-                        }
-                        if let Some(description) = &one_of_schema.description {
-                            hover_content.description = Some(description.clone());
-                        }
-                    }
-
-                    hover_content
-                })
-        } else {
+        let mut hover_value_content = super::first_most_specific_hover_value_content(
+            one_hover_value_contents,
+            CompositeKind::One,
+        )
+        .or_else(|| {
             Some(HoverValueContent {
-                title: None,
-                description: None,
+                title: one_of_schema.title.clone(),
+                description: one_of_schema.description.clone(),
                 accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
                 value_type: value.value_type().into(),
                 constraints: None,
-                schema_uri: Some(schema_uri.to_owned()),
+                schema_uri: Some(super::schema_link_uri(schema_uri, one_of_schema.range)),
                 range: None,
+                schema_tooltip: None,
             })
-        };
+        });
 
         if let Some(hover_value_content) = hover_value_content.as_mut() {
+            hover_value_content
+                .schema_uri
+                .get_or_insert_with(|| super::schema_link_uri(schema_uri, one_of_schema.range));
+            super::inherit_matching_nullable_type(&value_type, &mut hover_value_content.value_type);
             if let Some(default) = default {
                 if let Some(constraints) = hover_value_content.constraints.as_mut() {
                     if constraints.default.is_none() {
@@ -216,16 +193,11 @@ where
                     });
                 }
             }
-
             if !enum_values.is_empty() {
-                if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                    constraints.r#enum = Some(enum_values.iter().cloned().collect());
-                } else {
-                    hover_value_content.constraints = Some(ValueConstraints {
-                        r#enum: Some(enum_values.into_iter().collect()),
-                        ..Default::default()
-                    });
-                }
+                hover_value_content
+                    .constraints
+                    .get_or_insert_default()
+                    .r#enum = Some(enum_values.into_iter().collect());
             }
         }
 
@@ -248,9 +220,6 @@ impl GetHoverContent for tombi_schema_store::OneOfSchema {
                 unreachable!("schema must be provided");
             };
 
-            let mut title_description_set = tombi_hashmap::HashSet::new();
-            let mut value_type_set = tombi_hashmap::IndexSet::new();
-            let mut enum_values = Vec::new();
             let default = self
                 .default
                 .as_ref()
@@ -267,65 +236,30 @@ impl GetHoverContent for tombi_schema_store::OneOfSchema {
             )
             .await?;
 
-            for resolved_schema in &resolved_schemas {
-                if resolved_schema.schema_view.title().is_some()
-                    || resolved_schema.schema_view.description().is_some()
-                {
-                    title_description_set.insert((
-                        resolved_schema.schema_view.title().map(ToString::to_string),
-                        resolved_schema
-                            .schema_view
-                            .description()
-                            .map(ToString::to_string),
-                    ));
-                }
-                value_type_set.insert(resolved_schema.schema_view.value_type().await);
-
-                if let Some(values) = resolved_schema
+            let value_type = self.value_type().await;
+            let mut contents = Vec::new();
+            for schema in &resolved_schemas {
+                if let Some(HoverContent::Value(content)) = schema
                     .schema_view
-                    .as_ref()
-                    .get_enum(
-                        &resolved_schema.schema_uri,
-                        &resolved_schema.definitions,
-                        resolved_schema.strict,
-                        schema_context,
-                    )
+                    .get_hover_content(_position, _keys, accessors, Some(schema), schema_context)
                     .await
                 {
-                    enum_values.extend(values);
+                    contents.push(content);
                 }
             }
 
-            let (mut title, mut description) = if title_description_set.len() == 1 {
-                title_description_set.into_iter().next().unwrap()
-            } else {
-                (None, None)
-            };
-
-            if title.is_none() && description.is_none() {
-                if let Some(t) = &self.title {
-                    title = Some(t.clone());
-                }
-                if let Some(d) = &self.description {
-                    description = Some(d.clone());
-                }
-            }
-
-            let value_type: tombi_schema_store::ValueType = if value_type_set.len() == 1 {
-                value_type_set.into_iter().next().unwrap()
-            } else {
-                tombi_schema_store::ValueType::OneOf(value_type_set.into_iter().collect())
-            };
-
-            let mut hover_value_content = HoverValueContent {
-                title,
-                description,
-                accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
-                value_type,
-                constraints: None,
-                schema_uri: Some(current_schema.schema_uri.as_ref().to_owned()),
-                range: None,
-            };
+            let mut hover_value_content =
+                super::first_most_specific_hover_value_content(contents, CompositeKind::One)
+                    .unwrap_or_else(|| HoverValueContent {
+                        title: self.title.clone(),
+                        description: self.description.clone(),
+                        accessors: tombi_schema_store::Accessors::from(accessors.to_vec()),
+                        value_type,
+                        constraints: None,
+                        schema_uri: super::current_schema_link_uri(Some(current_schema)),
+                        range: None,
+                        schema_tooltip: None,
+                    });
 
             if let Some(default) = default {
                 if let Some(constraints) = hover_value_content.constraints.as_mut() {
@@ -335,17 +269,6 @@ impl GetHoverContent for tombi_schema_store::OneOfSchema {
                 } else {
                     hover_value_content.constraints = Some(ValueConstraints {
                         default: Some(default),
-                        ..Default::default()
-                    });
-                }
-            }
-
-            if !enum_values.is_empty() {
-                if let Some(constraints) = hover_value_content.constraints.as_mut() {
-                    constraints.r#enum = Some(enum_values);
-                } else {
-                    hover_value_content.constraints = Some(ValueConstraints {
-                        r#enum: Some(enum_values),
                         ..Default::default()
                     });
                 }

--- a/crates/tombi-lsp/src/hover/value.rs
+++ b/crates/tombi-lsp/src/hover/value.rs
@@ -9,6 +9,7 @@ mod offset_date_time;
 mod string;
 mod table;
 
+use tombi_document_tree::ValueImpl;
 use tombi_future::Boxable;
 use tombi_schema_store::{Accessor, CurrentSchema, SchemaType, SchemaView};
 
@@ -46,32 +47,24 @@ impl GetHoverContent for tombi_document_tree::Value {
                     .await;
             }
 
-            let instance_type = match self {
-                Self::Boolean(_) => Some(SchemaType::Boolean),
-                Self::Integer(_) => Some(SchemaType::Integer),
-                Self::Float(_) => Some(SchemaType::Number),
-                Self::String(_)
-                | Self::OffsetDateTime(_)
-                | Self::LocalDateTime(_)
-                | Self::LocalDate(_)
-                | Self::LocalTime(_) => Some(SchemaType::String),
-                Self::Array(_) => Some(SchemaType::Array),
-                Self::Table(_) => Some(SchemaType::Object),
-                Self::Incomplete { .. } => None,
-            };
+            let instance_type = SchemaType::from_value_type(self.value_type());
             let projected_schema = current_schema.and_then(|schema| {
-                instance_type.and_then(|instance_type| {
-                    schema.for_instance_type(instance_type, schema_context.string_formats())
-                })
+                crate::schema_resolver::project_schema_for_concrete_value(
+                    self,
+                    schema,
+                    schema_context,
+                )
             });
             let current_schema = match current_schema {
                 Some(schema)
                     if schema.semantic_schema.is_some()
-                        && instance_type.is_some()
-                        && !schema
-                            .semantic_schema
-                            .as_deref()
-                            .is_some_and(|semantic| semantic.has_applicators()) =>
+                        && instance_type.is_some_and(|instance_type| {
+                            !schema
+                                .semantic_schema
+                                .as_deref()
+                                .is_some_and(|semantic| semantic.has_applicators())
+                                || schema.has_reference_projection_siblings(instance_type)
+                        }) =>
                 {
                     projected_schema.as_ref()
                 }

--- a/crates/tombi-lsp/src/hover/value/array.rs
+++ b/crates/tombi-lsp/src/hover/value/array.rs
@@ -285,6 +285,7 @@ impl GetHoverContent for tombi_document_tree::Array {
                             constraints: None,
                             schema_uri: None,
                             range: Some(self.range()),
+                            schema_tooltip: None,
                         }));
                     }
                     _ => {}
@@ -318,6 +319,7 @@ impl GetHoverContent for tombi_document_tree::Array {
                 constraints: None,
                 schema_uri: None,
                 range: Some(self.range()),
+                schema_tooltip: None,
             }))
         }
         .boxed()
@@ -379,8 +381,9 @@ impl GetHoverContent for ArraySchema {
                     values_order: self.values_order.clone().map(Into::into),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|cs| cs.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/boolean.rs
+++ b/crates/tombi-lsp/src/hover/value/boolean.rs
@@ -131,6 +131,7 @@ impl GetHoverContent for tombi_document_tree::Boolean {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -166,8 +167,9 @@ impl GetHoverContent for BooleanSchema {
                     }),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/float.rs
+++ b/crates/tombi-lsp/src/hover/value/float.rs
@@ -131,6 +131,7 @@ impl GetHoverContent for tombi_document_tree::Float {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -171,8 +172,9 @@ impl GetHoverContent for FloatSchema {
                     multiple_of: self.multiple_of.map(DisplayValue::Float),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/integer.rs
+++ b/crates/tombi-lsp/src/hover/value/integer.rs
@@ -131,6 +131,7 @@ impl GetHoverContent for tombi_document_tree::Integer {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -171,8 +172,9 @@ impl GetHoverContent for IntegerSchema {
                     multiple_of: self.multiple_of.map(DisplayValue::Integer),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/local_date.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date.rs
@@ -126,6 +126,7 @@ impl GetHoverContent for tombi_document_tree::LocalDate {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -180,9 +181,9 @@ impl GetHoverContent for LocalDateSchema {
                     },
                     ..Default::default()
                 }),
-                schema_uri: current_schema
-                    .map(|current_schema| current_schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_date_time.rs
@@ -128,6 +128,7 @@ impl GetHoverContent for tombi_document_tree::LocalDateTime {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -184,8 +185,9 @@ impl GetHoverContent for LocalDateTimeSchema {
                     },
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/local_time.rs
+++ b/crates/tombi-lsp/src/hover/value/local_time.rs
@@ -126,6 +126,7 @@ impl GetHoverContent for tombi_document_tree::LocalTime {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -180,9 +181,9 @@ impl GetHoverContent for LocalTimeSchema {
                     },
                     ..Default::default()
                 }),
-                schema_uri: current_schema
-                    .map(|current_schema| current_schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/hover/value/offset_date_time.rs
@@ -128,6 +128,7 @@ impl GetHoverContent for tombi_document_tree::OffsetDateTime {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -184,8 +185,9 @@ impl GetHoverContent for OffsetDateTimeSchema {
                     },
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/string.rs
+++ b/crates/tombi-lsp/src/hover/value/string.rs
@@ -308,6 +308,7 @@ impl GetHoverContent for tombi_document_tree::String {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -350,8 +351,9 @@ impl GetHoverContent for StringSchema {
                     pattern: self.pattern.clone(),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/hover/value/table.rs
+++ b/crates/tombi-lsp/src/hover/value/table.rs
@@ -135,10 +135,11 @@ impl GetHoverContent for tombi_document_tree::Table {
                                                     key_patterns,
                                                     ..Default::default()
                                                 }),
-                                                schema_uri: Some(
-                                                    current_schema.schema_uri.as_ref().clone(),
+                                                schema_uri: super::super::current_schema_link_uri(
+                                                    Some(&current_schema),
                                                 ),
                                                 range: None,
+                                                schema_tooltip: None,
                                             }));
                                         }
 
@@ -721,6 +722,7 @@ impl GetHoverContent for tombi_document_tree::Table {
                     constraints: None,
                     schema_uri: None,
                     range: Some(self.range()),
+                    schema_tooltip: None,
                 }))
             }
         }
@@ -788,8 +790,9 @@ impl GetHoverContent for TableSchema {
                     array_values_order_by: self.array_values_order_by.clone(),
                     ..Default::default()
                 }),
-                schema_uri: current_schema.map(|schema| schema.schema_uri.as_ref().clone()),
+                schema_uri: super::super::current_schema_link_uri(current_schema),
                 range: None,
+                schema_tooltip: None,
             }))
         }
         .boxed()

--- a/crates/tombi-lsp/src/lib.rs
+++ b/crates/tombi-lsp/src/lib.rs
@@ -12,6 +12,7 @@ mod location;
 mod references;
 mod remote_file;
 mod schema_resolver;
+mod schema_tooltip;
 mod semantic_tokens;
 mod workspace_config;
 mod workspace_diagnostic;

--- a/crates/tombi-lsp/src/schema_resolver.rs
+++ b/crates/tombi-lsp/src/schema_resolver.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, ops::Deref, sync::Arc};
 
-use tombi_document_tree::{DocumentTree, TableKind, Value, dig_accessors};
+use tombi_document_tree::{DocumentTree, TableKind, Value, ValueImpl, dig_accessors};
 use tombi_future::Boxable;
 use tombi_schema_store::{
     Accessor, ArraySchema, CurrentSchema, ReferableSchemaViews, SchemaAccessor, SchemaContext,
@@ -78,6 +78,19 @@ pub(crate) async fn resolve_table_unevaluated_property_schema(
     resolve_schema_item_owned(schema_item, current_schema, schema_context).await
 }
 
+/// Builds a navigation/presentation view for an observed document value.
+/// The projected type must not be used as evidence that a composite branch applies.
+pub(crate) fn project_schema_for_concrete_value(
+    value: &impl ValueImpl,
+    schema: &CurrentSchema<'_>,
+    schema_context: &SchemaContext<'_>,
+) -> Option<CurrentSchema<'static>> {
+    schema.for_instance_type(
+        tombi_schema_store::SchemaType::from_value_type(value.value_type())?,
+        schema_context.string_formats(),
+    )
+}
+
 pub(crate) async fn resolve_accessors_for_document_or_schema(
     document_tree: &DocumentTree,
     accessors: Vec<Accessor>,
@@ -85,7 +98,7 @@ pub(crate) async fn resolve_accessors_for_document_or_schema(
 ) -> (Vec<Accessor>, Option<CurrentSchema<'static>>) {
     for depth in (0..=accessors.len()).rev() {
         if let Some(current_schema) =
-            resolve_current_schema(&accessors[..depth], schema_context).await
+            resolve_current_schema(document_tree, &accessors[..depth], schema_context).await
         {
             let mut accessors = accessors;
             accessors.truncate(depth);
@@ -140,6 +153,7 @@ fn is_leaf_array_element(value: &Value) -> bool {
 }
 
 async fn resolve_current_schema(
+    document_tree: &DocumentTree,
     accessors: &[Accessor],
     schema_context: &SchemaContext<'_>,
 ) -> Option<CurrentSchema<'static>> {
@@ -153,17 +167,37 @@ async fn resolve_current_schema(
         strict: document_schema.strict,
     };
 
-    resolve_schema_with_accessors(current_schema, accessors, schema_context).await
+    resolve_schema_with_accessors(
+        document_tree,
+        current_schema,
+        Vec::new(),
+        accessors,
+        schema_context,
+    )
+    .await
 }
 
 fn resolve_schema_with_accessors<'a: 'b, 'b>(
+    document_tree: &'a DocumentTree,
     current_schema: CurrentSchema<'static>,
+    resolved_accessors: Vec<Accessor>,
     accessors: &'a [Accessor],
     schema_context: &'a SchemaContext<'a>,
 ) -> tombi_future::BoxFuture<'b, Option<CurrentSchema<'static>>> {
     async move {
         let Some((accessor, remaining_accessors)) = accessors.split_first() else {
-            return Some(current_schema);
+            let projected_schema = if resolved_accessors.is_empty() {
+                project_schema_for_concrete_value(
+                    document_tree.deref(),
+                    &current_schema,
+                    schema_context,
+                )
+            } else {
+                dig_accessors(document_tree, &resolved_accessors).and_then(|(_, value)| {
+                    project_schema_for_concrete_value(value, &current_schema, schema_context)
+                })
+            };
+            return projected_schema.or(Some(current_schema));
         };
 
         let instance_type = match accessor {
@@ -184,9 +218,11 @@ fn resolve_schema_with_accessors<'a: 'b, 'b>(
         };
         if let Some((kind, schemas)) = composite_schemas {
             return resolve_composite_schema_with_accessors(
+                document_tree,
                 kind,
                 &schemas,
                 current_schema,
+                resolved_accessors,
                 accessors,
                 schema_context,
             )
@@ -206,10 +242,17 @@ fn resolve_schema_with_accessors<'a: 'b, 'b>(
                     .await
                     .inspect_err(|err| log::warn!("{err}"))
                     .ok()
-                    .flatten()?
-                    .into_owned();
-                resolve_schema_with_accessors(next_schema, remaining_accessors, schema_context)
-                    .await
+                    .flatten()?;
+                let mut resolved_accessors = resolved_accessors;
+                resolved_accessors.push(accessor.clone());
+                resolve_schema_with_accessors(
+                    document_tree,
+                    next_schema,
+                    resolved_accessors,
+                    remaining_accessors,
+                    schema_context,
+                )
+                .await
             }
             (Accessor::Index(index), SchemaView::Array(array_schema)) => {
                 let next_schema = resolve_array_item_schema(
@@ -218,10 +261,17 @@ fn resolve_schema_with_accessors<'a: 'b, 'b>(
                     &current_schema,
                     schema_context,
                 )
-                .await?
-                .into_owned();
-                resolve_schema_with_accessors(next_schema, remaining_accessors, schema_context)
-                    .await
+                .await?;
+                let mut resolved_accessors = resolved_accessors;
+                resolved_accessors.push(accessor.clone());
+                resolve_schema_with_accessors(
+                    document_tree,
+                    next_schema,
+                    resolved_accessors,
+                    remaining_accessors,
+                    schema_context,
+                )
+                .await
             }
             _ => None,
         }
@@ -230,9 +280,11 @@ fn resolve_schema_with_accessors<'a: 'b, 'b>(
 }
 
 fn resolve_composite_schema_with_accessors<'a: 'b, 'b>(
+    document_tree: &'a DocumentTree,
     kind: CompositeKind,
     schemas: &'a ReferableSchemaViews,
     current_schema: CurrentSchema<'static>,
+    resolved_accessors: Vec<Accessor>,
     accessors: &'a [Accessor],
     schema_context: &'a SchemaContext<'a>,
 ) -> tombi_future::BoxFuture<'b, Option<CurrentSchema<'static>>> {
@@ -248,10 +300,77 @@ fn resolve_composite_schema_with_accessors<'a: 'b, 'b>(
         )
         .await?;
 
-        let mut candidates = Vec::new();
-        for schema in collected {
-            if let Some(resolved) =
-                resolve_schema_with_accessors(schema.into_owned(), accessors, schema_context).await
+        let applicator = match kind {
+            CompositeKind::One => Some(tombi_validator::Applicator::OneOf),
+            CompositeKind::Any => Some(tombi_validator::Applicator::AnyOf),
+            CompositeKind::All => None,
+        };
+        let evaluation = if let Some(applicator) = applicator
+            && resolved_accessors.is_empty()
+        {
+            Some(
+                tombi_validator::evaluate_applicator(
+                    applicator,
+                    document_tree.deref(),
+                    &resolved_accessors,
+                    &collected,
+                    schema_context,
+                )
+                .await,
+            )
+        } else if let Some(applicator) = applicator
+            && let Some((_, value)) = dig_accessors(document_tree, &resolved_accessors)
+        {
+            Some(
+                tombi_validator::evaluate_applicator(
+                    applicator,
+                    value,
+                    &resolved_accessors,
+                    &collected,
+                    schema_context,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+        let applicable_count = evaluation
+            .as_ref()
+            .map(tombi_validator::BranchEvaluationTrace::applicable_count);
+
+        let is_selected = |index| {
+            evaluation.as_ref().is_none_or(|evaluation| {
+                evaluation.includes_in_resolution(index, applicable_count.unwrap_or_default())
+            })
+        };
+        let mut remaining_candidates = (0..collected.len())
+            .filter(|index| is_selected(*index))
+            .count();
+        let mut resolved_accessors = Some(resolved_accessors);
+        let mut candidates = Vec::with_capacity(remaining_candidates);
+        for (index, schema) in collected.into_iter().enumerate() {
+            if !is_selected(index) {
+                continue;
+            }
+            remaining_candidates -= 1;
+            let candidate_accessors = if remaining_candidates == 0 {
+                resolved_accessors
+                    .take()
+                    .expect("resolved accessors must be available for the last candidate")
+            } else {
+                resolved_accessors
+                    .as_ref()
+                    .expect("resolved accessors must remain available while candidates remain")
+                    .clone()
+            };
+            if let Some(resolved) = resolve_schema_with_accessors(
+                document_tree,
+                schema,
+                candidate_accessors,
+                accessors,
+                schema_context,
+            )
+            .await
             {
                 candidates.push(resolved);
             }

--- a/crates/tombi-lsp/src/schema_tooltip.rs
+++ b/crates/tombi-lsp/src/schema_tooltip.rs
@@ -1,0 +1,193 @@
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum SchemaTooltip {
+    Content(SchemaTooltipContent),
+    Markdown(String),
+    Composite(Box<CompositeSchemaTooltip>),
+}
+
+impl SchemaTooltip {
+    pub(crate) fn composite(contents: Vec<SchemaTooltip>) -> Option<Self> {
+        let mut flattened = Vec::with_capacity(contents.len());
+        for content in contents {
+            match content {
+                Self::Composite(composite) => flattened.extend(composite.contents),
+                content => flattened.push(content),
+            }
+        }
+
+        let mut unique_contents = Vec::with_capacity(flattened.len());
+        for content in flattened {
+            if !unique_contents.contains(&content) {
+                unique_contents.push(content);
+            }
+        }
+
+        match unique_contents.len() {
+            0 => None,
+            1 => unique_contents.pop(),
+            _ => Some(Self::Composite(Box::new(CompositeSchemaTooltip {
+                contents: unique_contents,
+            }))),
+        }
+    }
+
+    pub(crate) fn render(&self, keys: Option<&str>) -> String {
+        let mut output = String::new();
+        self.write_markdown(&mut output, keys)
+            .expect("writing Markdown to a String cannot fail");
+        output
+    }
+
+    pub(crate) fn with_common_content(self, common: SchemaTooltipContent) -> Self {
+        Self::Content(common).combine(self)
+    }
+
+    pub(crate) fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Content(common), Self::Content(specific)) => {
+                Self::Content(common.merge(specific))
+            }
+            (Self::Composite(composite), other) => {
+                Self::Composite(Box::new(CompositeSchemaTooltip {
+                    contents: composite
+                        .contents
+                        .into_iter()
+                        .map(|content| content.combine(other.clone()))
+                        .collect(),
+                }))
+            }
+            (content, Self::Composite(composite)) => {
+                Self::Composite(Box::new(CompositeSchemaTooltip {
+                    contents: composite
+                        .contents
+                        .into_iter()
+                        .map(|branch| content.clone().combine(branch))
+                        .collect(),
+                }))
+            }
+            (Self::Markdown(mut left), Self::Markdown(right)) => {
+                if !left.is_empty() && !left.ends_with("\n\n") {
+                    left.push_str("\n\n");
+                }
+                left.push_str(&right);
+                Self::Markdown(left)
+            }
+            (Self::Content(content), Self::Markdown(markdown)) => {
+                Self::Content(content).with_markdown(markdown)
+            }
+            (Self::Markdown(markdown), Self::Content(content)) => {
+                Self::Content(content).with_markdown(markdown)
+            }
+        }
+    }
+
+    fn with_markdown(self, markdown: String) -> Self {
+        match self {
+            Self::Content(content) => {
+                let mut common_markdown = String::new();
+                content
+                    .write_markdown(&mut common_markdown, None)
+                    .expect("writing Markdown to a String cannot fail");
+                common_markdown.push_str(&markdown);
+                Self::Markdown(common_markdown)
+            }
+            content => content,
+        }
+    }
+
+    fn write_markdown(&self, output: &mut String, keys: Option<&str>) -> std::fmt::Result {
+        use std::fmt::Write;
+
+        match self {
+            Self::Content(content) => content.write_markdown(output, keys),
+            Self::Markdown(markdown) => {
+                if let Some(keys) = keys {
+                    writeln!(output, "Keys: `{keys}`\n")?;
+                }
+                output.push_str(markdown);
+                if !markdown.ends_with('\n') {
+                    output.push('\n');
+                }
+                Ok(())
+            }
+            Self::Composite(composite) => {
+                for (index, content) in composite.contents.iter().enumerate() {
+                    if index > 0 {
+                        writeln!(output, "---\n")?;
+                    }
+                    content.write_markdown(output, keys)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaTooltip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.render(None))
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct CompositeSchemaTooltip {
+    contents: Vec<SchemaTooltip>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct SchemaTooltipContent {
+    pub(crate) title: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) value_type: String,
+    pub(crate) constraints: Option<String>,
+    pub(crate) schema: Option<String>,
+}
+
+impl SchemaTooltipContent {
+    fn merge(self, specific: Self) -> Self {
+        Self {
+            title: specific.title.or(self.title),
+            description: merge_text(specific.description, self.description),
+            value_type: specific.value_type,
+            constraints: merge_text(self.constraints, specific.constraints),
+            schema: merge_text(self.schema, specific.schema),
+        }
+    }
+
+    fn write_markdown(&self, output: &mut String, keys: Option<&str>) -> std::fmt::Result {
+        use std::fmt::Write;
+
+        if let Some(title) = &self.title {
+            writeln!(output, "#### {title}\n")?;
+        }
+        if let Some(description) = &self.description {
+            writeln!(output, "{description}\n")?;
+        }
+        if let Some(keys) = keys {
+            writeln!(output, "Keys: `{keys}`\n")?;
+        }
+        writeln!(output, "Value: `{}`\n", self.value_type)?;
+        if let Some(constraints) = &self.constraints {
+            output.push_str(constraints);
+            if !constraints.ends_with('\n') {
+                output.push('\n');
+            }
+        }
+        if let Some(schema) = &self.schema {
+            writeln!(output, "{schema}\n")?;
+        }
+        Ok(())
+    }
+}
+
+fn merge_text(primary: Option<String>, secondary: Option<String>) -> Option<String> {
+    match (primary, secondary) {
+        (Some(primary), Some(secondary)) if primary != secondary => Some(format!(
+            "{}\n\n{}",
+            primary.trim_end(),
+            secondary.trim_start()
+        )),
+        (Some(primary), _) => Some(primary),
+        (None, secondary) => secondary,
+    }
+}

--- a/crates/tombi-lsp/tests/fixtures/composite-array-items.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/composite-array-items.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "all_items": {
+      "type": "array",
+      "allOf": [
+        {
+          "items": { "$ref": "#/$defs/item" }
+        }
+      ]
+    },
+    "one_items": {
+      "type": "array",
+      "oneOf": [
+        {
+          "items": { "$ref": "#/$defs/item" }
+        }
+      ]
+    },
+    "any_items": {
+      "type": "array",
+      "anyOf": [
+        {
+          "items": { "$ref": "#/$defs/item" }
+        }
+      ]
+    },
+    "any_shared": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "value": { "type": "string", "description": "first anyOf value" }
+          }
+        },
+        {
+          "properties": {
+            "value": { "type": "string", "description": "second anyOf value" }
+          }
+        }
+      ]
+    },
+    "any_enum_unconstrained": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "value": { "type": "string", "enum": ["value"] }
+          }
+        },
+        {
+          "properties": {
+            "value": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "any_enum_values": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "value": {
+              "type": "string",
+              "const": "red",
+              "description": "first enum value"
+            }
+          }
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "string",
+              "enum": ["blue", "red"],
+              "description": "second enum value"
+            }
+          }
+        }
+      ]
+    },
+    "any_constraint_alternatives": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "value": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5
+            }
+          }
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            }
+          }
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5
+            }
+          }
+        }
+      ]
+    },
+    "all_shared": {
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "value": { "type": "string", "description": "first allOf value" }
+          }
+        },
+        {
+          "properties": {
+            "value": { "type": "string", "description": "second allOf value" }
+          }
+        }
+      ]
+    },
+    "all_constraints": {
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "first constrained value",
+              "enum": ["aa", "bbb", "cccc"],
+              "minLength": 2
+            }
+          }
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "second constrained value",
+              "enum": ["bbb", "cccc", "ddddd"],
+              "maxLength": 4
+            }
+          }
+        }
+      ]
+    },
+    "one_shared": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "value": { "type": "string", "description": "first oneOf value" }
+          }
+        },
+        {
+          "properties": {
+            "value": { "type": "string", "description": "second oneOf value" }
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "item": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Composite array item name"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/tombi-lsp/tests/fixtures/external-ref-sibling-hover/root.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/external-ref-sibling-hover/root.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "external": {
+      "$ref": "target.schema.json",
+      "title": "Local reference sibling",
+      "description": "Metadata defined next to the external reference.",
+      "minLength": 2
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/fixtures/external-ref-sibling-hover/target.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/external-ref-sibling-hover/target.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "string",
+  "title": "External reference target",
+  "description": "Metadata defined by the external target.",
+  "maxLength": 10
+}

--- a/crates/tombi-lsp/tests/fixtures/one-of-composite-hover.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/one-of-composite-hover.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "scalar": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "title": "Positive branch",
+          "description": "Requires a positive value.",
+          "minimum": 1
+        },
+        {
+          "type": "integer",
+          "title": "Negative branch",
+          "description": "Requires a negative value.",
+          "maximum": -1
+        }
+      ]
+    },
+    "array": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "First array item",
+                "description": "First array item description."
+              }
+            }
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Second array item",
+                "description": "Second array item description."
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -4,12 +4,73 @@ use tombi_test_lib::{
     adjacent_one_of_additional_properties_test_schema_path, adjacent_one_of_hover_test_schema_path,
     dot_config_project_root_fixture_path, exact_index_string_test_schema_path,
     issue_1895_rustfmt_like_schema_path, lsp_consistency_test_schema_path, project_root_path,
-    string_format_test_schema_path, today_local_date, today_local_date_time, today_local_time,
-    today_offset_date_time,
+    ref_sibling_annotations_test_schema_path, string_format_test_schema_path, today_local_date,
+    today_local_date_time, today_local_time, today_offset_date_time,
 };
 
 mod completion_labels {
     use super::*;
+
+    test_completion_labels! {
+        #[tokio::test]
+        async fn cached_remote_schema_completion_link_uses_local_file_position(
+            "value = █",
+            SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: "https://example.com/cached-completion.schema.json".into(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                strict: None,
+                lint: None,
+                format: None,
+                overrides: None,
+            })),
+            CachedResponse::new(
+                "https://example.com/cached-completion.schema.json",
+                r#"{
+  "properties": {
+    "value": {
+      "type": "string"
+    }
+  }
+}"#,
+            ),
+            tombi_lsp::backend::Options {
+                offline: Some(true),
+                no_cache: Some(false),
+            },
+        ) -> Ok([
+            {
+                "label": "\"\"",
+                "documentation": "cached-completion.schema.json#L3,"
+            },
+        ]);
+    }
+
+    test_completion_labels! {
+        #[tokio::test]
+        async fn built_in_schema_completion_link_uses_github(
+            r#"
+            [lint.rules]
+            key-empty = █
+            "#,
+            SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: "tombi://www.schemastore.org/tombi.json".into(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                strict: None,
+                lint: None,
+                format: None,
+                overrides: None,
+            })),
+        ) -> Ok([
+            {
+                "label": "\"warn\"",
+                "documentation": "https://raw.githubusercontent.com/tombi-toml/tombi/main/www.schemastore.org/tombi.json"
+            },
+        ]);
+    }
 
     mod tombi_schema {
         use tombi_test_lib::tombi_schema_path;
@@ -40,6 +101,22 @@ mod completion_labels {
                 "# █",
                 SchemaPath(tombi_schema_path()),
             ) -> Ok([]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn tombi_files_exclude_array_type_hint_uses_property_documentation(
+                r#"
+                [files]
+                exclude = █
+                "#,
+                SchemaPath(tombi_schema_path()),
+            ) -> Ok([
+                {
+                    "label": "[]",
+                    "documentation": "#### File patterns to exclude\n\nThe file match pattern to exclude from formatting and linting.\nSupports glob pattern.\n\nValue: `Array`\n\nSchema:",
+                },
+            ]);
         }
 
         test_completion_labels! {
@@ -1020,6 +1097,20 @@ mod completion_labels {
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
             ) -> Ok(["\"builtin-hook\"", "\"\"", "\"\"\"\"\"\"", "''", "''''''"]);
         }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn adjacent_one_of_reversed_builtin_hook_id_value_completion(
+                r#"
+                [[repos_reversed]]
+                repo = "builtin"
+                hooks = [
+                  { id = █ }
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok(["\"builtin-hook\"", "\"\"", "\"\"\"\"\"\"", "''", "''''''"]);
+        }
     }
 
     mod adjacent_applicators_schema {
@@ -1112,6 +1203,135 @@ mod completion_labels {
                 "#,
                 SchemaPath(adjacent_applicators_test_schema_path()),
             ) -> Ok(["bar", "baz", "foo"]);
+        }
+    }
+
+    mod composite_array_items_schema {
+        use super::*;
+
+        fn schema_path() -> std::path::PathBuf {
+            project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/composite-array-items.schema.json")
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn all_of_item_property_completion(
+                r#"
+                [[all_items]]
+                █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok(["name"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn one_of_item_property_completion(
+                r#"
+                [[one_items]]
+                █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok(["name"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn any_of_item_property_completion(
+                r#"
+                [[any_items]]
+                █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok(["name"]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn any_of_same_property_merges_documentation(
+                r#"
+                [any_shared]
+                █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok([
+                {
+                    "label": "value",
+                    "documentation": "first anyOf value\n\nSchema: [composite-array-items.schema.json](file://",
+                },
+                {
+                    "label": "value",
+                    "documentation": ")\n---\n\nsecond anyOf value",
+                },
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn any_of_const_and_enum_values_merge_documentation(
+                r#"
+                [any_enum_values]
+                value = █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok([
+                {
+                    "label": "\"red\"",
+                    "documentation": "first enum value\n\nSchema: [composite-array-items.schema.json](file://",
+                },
+                {
+                    "label": "\"red\"",
+                    "documentation": ")\n---\n\nsecond enum value",
+                },
+                {
+                    "label": "\"blue\"",
+                    "documentation": "second enum value",
+                },
+            ]);
+        }
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn all_of_enum_completion_intersects_values_and_merges_documentation(
+                r#"
+                [all_constraints]
+                value = █
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok([
+                {
+                    "label": "\"bbb\"",
+                    "documentation": "first constrained value\n\nSchema: [composite-array-items.schema.json](file://",
+                },
+                {
+                    "label": "\"bbb\"",
+                    "documentation": ")\n---\n\nsecond constrained value",
+                },
+                {
+                    "label": "\"cccc\"",
+                    "documentation": "first constrained value\n\nSchema: [composite-array-items.schema.json](file://",
+                },
+                {
+                    "label": "\"cccc\"",
+                    "documentation": ")\n---\n\nsecond constrained value",
+                },
+            ]);
+        }
+    }
+
+    mod ref_sibling_schema {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn ref_target_and_sibling_properties_are_merged(
+                r#"
+                [settings]
+                █
+                "#,
+                SchemaPath(ref_sibling_annotations_test_schema_path()),
+            ) -> Ok(["base", "local"]);
         }
     }
 
@@ -1658,6 +1878,21 @@ mod completion_labels {
                     "documentation": "Date that selects the Workers runtime version.",
                 },
             ]);
+        }
+    }
+
+    mod recursive_schema {
+        use super::*;
+
+        test_completion_labels! {
+            #[tokio::test]
+            async fn recursive_ref_nested_table(
+                r#"
+                [metadata.nested]
+                █
+                "#,
+                SchemaPath(tombi_test_lib::recursive_schema_path()),
+            ) -> Ok(["nested", "tags"]);
         }
     }
 
@@ -2987,6 +3222,7 @@ mod completion_labels {
                 pub struct TestArgs {
                     source_file_path: Option<std::path::PathBuf>,
                     schema_file_path: Option<std::path::PathBuf>,
+                    schema_items: Vec<tombi_config::SchemaItem>,
                     subschemas: Vec<SubSchema>,
                     cached_responses: Vec<CachedResponse>,
                     preselected_labels: Option<Vec<String>>,
@@ -3013,6 +3249,15 @@ mod completion_labels {
                 impl ApplyTestArg for SchemaPath {
                     fn apply(self, args: &mut TestArgs) {
                         args.schema_file_path = Some(self.0);
+                    }
+                }
+
+                #[allow(unused)]
+                struct SchemaItemArg(tombi_config::SchemaItem);
+
+                impl ApplyTestArg for SchemaItemArg {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.schema_items.push(self.0);
                     }
                 }
 
@@ -3076,7 +3321,7 @@ mod completion_labels {
                 let (service, _) =
                     LspService::new(|client| Backend::new(client, &args.backend_options));
                 let backend = service.inner();
-                let mut schema_items = Vec::new();
+                let mut schema_items = args.schema_items.clone();
 
                 if let Some(schema_file_path) = args.schema_file_path.as_ref() {
                     let schema_uri = tombi_schema_store::SchemaUri::from_file_path(schema_file_path)
@@ -3271,14 +3516,19 @@ mod completion_labels {
                     vec![$(($doc_label.to_string(), $documentation.to_string())),*];
 
                 for (expected_label, expected_documentation) in expected_documentation_pairs {
-                    let item = completion_items
+                    let matching_items = completion_items
                         .iter()
-                        .find(|item| item.label == expected_label)
-                        .ok_or_else(|| {
+                        .filter(|item| item.label == expected_label)
+                        .collect_vec();
+                    let [item] = matching_items.as_slice() else {
+                        return Err(
                             format!(
-                                "failed to find completion item {expected_label:?}: {labels:?}"
+                                "expected exactly one completion item {expected_label:?}, found {}: {labels:?}",
+                                matching_items.len()
                             )
-                        })?;
+                            .into(),
+                        );
+                    };
 
                     let documentation = match &item.documentation {
                         Some(tower_lsp::lsp_types::Documentation::String(value)) => {

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -6,6 +6,9 @@ mod goto_type_definition_tests {
         lsp_consistency_test_schema_path,
     };
 
+    struct ExpectedRange(tombi_text::Range);
+    struct ExpectedRanges(Vec<tombi_text::Range>);
+
     mod strict_priority {
         use super::*;
 
@@ -200,6 +203,22 @@ mod goto_type_definition_tests {
                 ]
                 "#,
                 SchemaPath(adjacent_one_of_hover_test_schema_path()),
+                ExpectedRange(((73, 8), (73, 12)).into()),
+            ) -> Ok(adjacent_one_of_hover_test_schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn adjacent_one_of_reversed_builtin_hook_id_value(
+                r#"
+                [[repos_reversed]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+                ExpectedRange(((73, 8), (73, 12)).into()),
             ) -> Ok(adjacent_one_of_hover_test_schema_path());
         );
     }
@@ -255,6 +274,147 @@ mod goto_type_definition_tests {
                 "#,
                 SchemaPath(adjacent_applicators_test_schema_path()),
             ) -> Ok(adjacent_applicators_test_schema_path());
+        );
+    }
+
+    mod lakefile_all_of_schema {
+        use super::*;
+
+        fn schema_path() -> std::path::PathBuf {
+            tombi_test_lib::project_root_path().join("schemas/lakefile-all-of-test.schema.json")
+        }
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn array_of_table_key(
+                r#"
+                name = "lean4-sample"
+
+                [[lean_█lib]]
+                name = "Lean4Sample"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRange(((35, 8), (35, 18)).into()),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn array_of_table_property_key(
+                r#"
+                name = "lean4-sample"
+
+                [[lean_lib]]
+                na█me = "Lean4Sample"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRange(((18, 12), (18, 18)).into()),
+            ) -> Ok(schema_path());
+        );
+    }
+
+    mod composite_array_items_schema {
+        use super::*;
+
+        fn schema_path() -> std::path::PathBuf {
+            tombi_test_lib::project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/composite-array-items.schema.json")
+        }
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn all_of_item_property(
+                r#"
+                [[all_items]]
+                na█me = "value"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRange(((173, 8), (173, 14)).into()),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn one_of_item_property(
+                r#"
+                [[one_items]]
+                na█me = "value"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRange(((173, 8), (173, 14)).into()),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn any_of_item_property(
+                r#"
+                [[any_items]]
+                na█me = "value"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRange(((173, 8), (173, 14)).into()),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn any_of_returns_all_applicable_property_definitions(
+                r#"
+                [any_shared]
+                val█ue = "value"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRanges(vec![
+                    ((33, 12), (33, 19)).into(),
+                    ((38, 12), (38, 19)).into(),
+                ]),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn any_of_returns_all_property_definitions_when_no_branch_matches(
+                r#"
+                [any_shared]
+                val█ue = 42
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRanges(vec![
+                    ((33, 12), (33, 19)).into(),
+                    ((38, 12), (38, 19)).into(),
+                ]),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn one_of_returns_all_property_definitions_when_no_branch_matches(
+                r#"
+                [one_shared]
+                val█ue = 42
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRanges(vec![
+                    ((158, 12), (158, 19)).into(),
+                    ((163, 12), (163, 19)).into(),
+                ]),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn all_of_returns_all_property_definitions(
+                r#"
+                [all_shared]
+                val█ue = "value"
+                "#,
+                SchemaPath(schema_path()),
+                ExpectedRanges(vec![
+                    ((118, 12), (118, 19)).into(),
+                    ((123, 12), (123, 19)).into(),
+                ]),
+            ) -> Ok(schema_path());
         );
     }
 
@@ -314,6 +474,51 @@ mod goto_type_definition_tests {
                     path: exact_index_string_test_schema_path(),
                 },
             ) -> Ok(exact_index_string_test_schema_path());
+        );
+    }
+
+    mod ref_sibling_schema {
+        use super::*;
+
+        fn schema_path() -> std::path::PathBuf {
+            tombi_test_lib::ref_sibling_annotations_test_schema_path()
+        }
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn sibling_property_definition(
+                r#"
+                [settings]
+                loc█al = "value"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok(schema_path());
+        );
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn referenced_property_definition(
+                r#"
+                [settings]
+                bas█e = "value"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok(schema_path());
+        );
+    }
+
+    mod recursive_schema {
+        use super::*;
+
+        test_goto_type_definition!(
+            #[tokio::test]
+            async fn recursive_ref_nested_property(
+                r#"
+                [metadata.nested]
+                ta█gs = []
+                "#,
+                SchemaPath(tombi_test_lib::recursive_schema_path()),
+            ) -> Ok(tombi_test_lib::recursive_schema_path());
         );
     }
 
@@ -676,6 +881,7 @@ mod goto_type_definition_tests {
                     schema_file_path: Option<std::path::PathBuf>,
                     subschemas: Vec<SubSchemaPath>,
                     backend_options: tombi_lsp::backend::Options,
+                    expected_ranges: Option<Vec<tombi_text::Range>>,
                 }
 
                 #[allow(unused)]
@@ -716,6 +922,18 @@ mod goto_type_definition_tests {
                 impl ApplyTestArg for tombi_lsp::backend::Options {
                     fn apply(self, args: &mut TestArgs) {
                         args.backend_options = self;
+                    }
+                }
+
+                impl ApplyTestArg for ExpectedRange {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.expected_ranges = Some(vec![self.0]);
+                    }
+                }
+
+                impl ApplyTestArg for ExpectedRanges {
+                    fn apply(self, args: &mut TestArgs) {
+                        args.expected_ranges = Some(self.0);
                     }
                 }
 
@@ -881,6 +1099,19 @@ mod goto_type_definition_tests {
 
                 match result {
                     Some(definition_links) => {
+                        if let Some(expected_ranges) = args.expected_ranges {
+                            pretty_assertions::assert_eq!(
+                                definition_links.iter().map(|link| link.range).collect_vec(),
+                                expected_ranges,
+                            );
+                        } else {
+                            pretty_assertions::assert_eq!(
+                                definition_links.len(),
+                                1,
+                                "Existing cases must continue to return exactly one definition",
+                            );
+                        }
+                        let expected_count = definition_links.len();
                         let definition_urls = definition_links.into_iter().map(|mut link| {
                                 match link.uri.scheme() {
                                     "file" => link.uri.to_file_path().unwrap().into_path_string(),
@@ -896,7 +1127,7 @@ mod goto_type_definition_tests {
 
                         pretty_assertions::assert_eq!(
                             definition_urls,
-                            vec![expected_path.into_path_string()],
+                            vec![expected_path.into_path_string(); expected_count],
                         );},
                     None => {
                         panic!("No type definition link was returned, but expected path: {:?}", expected_path);

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -84,6 +84,73 @@ async fn write_cached_response(url: &str, body: &str) {
 mod hover_keys_value {
     use super::*;
 
+    test_hover_keys_value!(
+        #[tokio::test]
+        async fn cached_remote_schema_link_uses_local_file_position(
+            r#"
+            value = "█text"
+            "#,
+            UseTestCacheHome,
+            tombi_lsp::backend::Options {
+                offline: Some(true),
+                no_cache: Some(false),
+            },
+            SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: "https://example.com/cached-tooltip.schema.json".into(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                strict: None,
+                lint: None,
+                format: None,
+                overrides: None,
+            })),
+            CachedRemoteJson {
+                url: "https://example.com/cached-tooltip.schema.json",
+                body: r#"{
+  "properties": {
+    "value": {
+      "type": "string"
+    }
+  }
+}"#,
+            },
+        ) -> Ok({
+            "Keys": "value",
+            "Value": "String?",
+            "Hover Contains": [
+                "Schema: [cached-tooltip.schema.json](file://",
+                "cached-tooltip.schema.json#L3,"
+            ]
+        });
+    );
+
+    test_hover_keys_value!(
+        #[tokio::test]
+        async fn built_in_schema_hover_link_uses_github(
+            r#"
+            [lint.rules]
+            key-empty = "█warn"
+            "#,
+            SchemaItemArg(tombi_config::SchemaItem::Root(tombi_config::RootSchema {
+                toml_version: None,
+                path: "tombi://www.schemastore.org/tombi.json".into(),
+                include: vec!["*.toml".into()],
+                exclude: None,
+                strict: None,
+                lint: None,
+                format: None,
+                overrides: None,
+            })),
+        ) -> Ok({
+            "Keys": "lint.rules.key-empty",
+            "Value": "String?",
+            "Hover Contains": [
+                "https://raw.githubusercontent.com/tombi-toml/tombi/main/www.schemastore.org/tombi.json"
+            ]
+        });
+    );
+
     mod strict_priority {
         use super::*;
 
@@ -330,9 +397,27 @@ mod hover_keys_value {
             ) -> Ok({
                 "Keys": "name",
                 "Value": "String?",
+                "Hover Contains": [
+                    "#### Ref Sibling Annotations\n\nString schema used to verify $ref sibling annotations.\n\nKeys: `name`",
+                ],
                 "Title": Some("Ref Sibling Annotations"),
                 "Default": "\"allow\"",
                 "Examples": ["\"warn\"", "\"deny\""]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn ref_sibling_structural_property_is_displayed(
+                r#"
+                [settings]
+                local = "█value"
+                "#,
+                SchemaPath(ref_sibling_annotations_test_schema_path()),
+            ) -> Ok({
+                "Keys": "settings.local",
+                "Value": "String?",
+                "Hover Contains": ["Property declared next to $ref."]
             });
         );
 
@@ -936,6 +1021,24 @@ mod hover_keys_value {
                 "Default": "\"builtin-hook\""
             });
         );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn adjacent_one_of_reversed_hover_prefers_valid_branch_nested_item_schema(
+                r#"
+                [[repos_reversed]]
+                repo = "builtin"
+                hooks = [
+                  { id = "█hook" }
+                ]
+                "#,
+                SchemaPath(adjacent_one_of_hover_test_schema_path()),
+            ) -> Ok({
+                "Keys": "repos_reversed[0].hooks[0].id",
+                "Value": "String",
+                "Default": "\"builtin-hook\""
+            });
+        );
     }
 
     mod any_of_schema {
@@ -1264,6 +1367,238 @@ mod hover_keys_value {
                 "Keys": "ignore",
                 "Value": "(Boolean | Integer | Float | String | LocalDate | LocalDateTime | LocalTime | OffsetDateTime | Array | Table)?",
                 "Description": Some("Annotation-only property schema that should still allow the key.")
+            });
+        );
+    }
+
+    mod composite_array_items_schema {
+        use super::*;
+
+        fn schema_path() -> PathBuf {
+            tombi_test_lib::project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/composite-array-items.schema.json")
+        }
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn all_of_item_property_hover(
+                r#"
+                [[all_items]]
+                name = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "all_items[0].name",
+                "Value": "String?",
+                "Schema": true,
+                "Description": Some("Composite array item name".to_string())
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn one_of_item_property_hover(
+                r#"
+                [[one_items]]
+                name = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "one_items[0].name",
+                "Value": "String?",
+                "Schema": true,
+                "Description": Some("Composite array item name".to_string())
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_item_property_hover(
+                r#"
+                [[any_items]]
+                name = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "any_items[0].name",
+                "Value": "String?",
+                "Schema": true,
+                "Description": Some("Composite array item name".to_string())
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_multiple_valid_branches_separate_metadata(
+                r#"
+                [any_shared]
+                value = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "any_shared.value",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": [
+                    "first anyOf value\n\nKeys: `any_shared.value`\n\nValue: `String?`",
+                    "second anyOf value\n\nKeys: `any_shared.value`\n\nValue: `String?`",
+                    "\n---\n",
+                ],
+                "Hover Counts": [("Keys: `any_shared.value`", 2)]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_with_unconstrained_branch_does_not_claim_enum(
+                r#"
+                [any_enum_unconstrained]
+                value = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "any_enum_unconstrained.value",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": ["Enum Values:", "\n---\n"]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_merges_const_and_enum_values_in_definition_order(
+                r#"
+                [any_enum_values]
+                value = "r█ed"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "any_enum_values.value",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": ["first enum value", "second enum value", "`\"red\"`", "`\"blue\"`", "\n---\n"]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn any_of_deduplicates_identical_branches_in_definition_order(
+                r#"
+                [any_constraint_alternatives]
+                value = 3█
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "any_constraint_alternatives.value",
+                "Value": "Integer?",
+                "Schema": true,
+                "Hover Contains": ["Minimum: `1`", "Maximum: `5`", "Maximum: `6`", "\n---\n"],
+                "Hover Counts": [
+                    ("Minimum: `1`", 2),
+                    ("Maximum: `5`", 1),
+                    ("Maximum: `6`", 1),
+                ]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn all_of_hover_separates_branch_metadata_and_constraints(
+                r#"
+                [all_constraints]
+                value = "b█bb"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "all_constraints.value",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": ["first constrained value", "second constrained value", "Min Length: `2`", "Max Length: `4`", "`\"bbb\"`", "`\"cccc\"`", "\n---\n"]
+            });
+        );
+    }
+
+    mod one_of_composite_hover_schema {
+        use super::*;
+
+        fn schema_path() -> PathBuf {
+            tombi_test_lib::project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/one-of-composite-hover.schema.json")
+        }
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn unmatched_scalar_branches_keep_metadata_and_constraints(
+                r#"
+                scalar = █0
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "scalar",
+                "Value": "Integer?",
+                "Schema": true,
+                "Hover Contains": [
+                    "#### Positive branch",
+                    "Requires a positive value.",
+                    "Minimum: `1`",
+                    "#### Negative branch",
+                    "Requires a negative value.",
+                    "Maximum: `-1`",
+                    "\n---\n",
+                ]
+            });
+        );
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn array_item_branches_keep_all_metadata(
+                r#"
+                array = [{ name = "va█lue" }]
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "array[0].name",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": [
+                    "#### First array item",
+                    "First array item description.",
+                    "#### Second array item",
+                    "Second array item description.",
+                    "\n---\n",
+                ]
+            });
+        );
+    }
+
+    mod external_ref_sibling_hover_schema {
+        use super::*;
+
+        fn schema_path() -> PathBuf {
+            tombi_test_lib::project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/external-ref-sibling-hover/root.schema.json")
+        }
+
+        test_hover_keys_value!(
+            #[tokio::test]
+            async fn semantic_less_composite_keeps_schema_metadata(
+                r#"
+                external = "va█lue"
+                "#,
+                SchemaPath(schema_path()),
+            ) -> Ok({
+                "Keys": "external",
+                "Value": "String?",
+                "Schema": true,
+                "Hover Contains": [
+                    "#### Local reference sibling",
+                    "Metadata defined next to the external reference.",
+                    "Min Length: `2`",
+                    "#### External reference target",
+                    "Metadata defined by the external target.",
+                    "Max Length: `10`",
+                    "\n---\n",
+                ]
             });
         );
     }
@@ -2141,6 +2476,7 @@ mod hover_keys_value {
             $(, "Values Order": $values_order:expr)?
             $(, "Disabled Values Order": $disabled_values_order:expr)?
             $(, "Hover Contains": [$($hover_contains:expr),* $(,)?])?
+            $(, "Hover Counts": [$(($hover_count_text:expr, $hover_count:expr)),* $(,)?])?
             $(, "Title": $title:expr)?
             $(, "Description": $description:expr)?
             $(, "Enum": [$($enum_values:expr),* $(,)?])?
@@ -2561,6 +2897,18 @@ mod hover_keys_value {
                     )*
                 )?
                 $(
+                    let rendered_hover = hover_content.to_string();
+                    $(
+                        pretty_assertions::assert_eq!(
+                            rendered_hover.matches($hover_count_text).count(),
+                            $hover_count,
+                            "Rendered hover occurrence count differs for {:?}\nrendered: {}",
+                            $hover_count_text,
+                            rendered_hover,
+                        );
+                    )*
+                )?
+                $(
                     let expected_title = $title;
                     pretty_assertions::assert_eq!(
                         hover_content.title.as_deref(),
@@ -2577,7 +2925,7 @@ mod hover_keys_value {
                     );
                 )?
                 $(
-                    let expected_enum = vec![$($enum_values),*];
+                    let expected_enum: Vec<&str> = vec![$($enum_values),*];
                     pretty_assertions::assert_eq!(
                         hover_content
                             .constraints

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -91,10 +91,31 @@ impl<'a> CurrentSchema<'a> {
         if !semantic_schema.accepts_instance_type(instance_type) {
             return None;
         }
+        if self.schema_view.matches_instance_type(instance_type)
+            && !self.requires_instance_projection(instance_type)
+        {
+            return Some(self.clone().into_owned());
+        }
         Some(self.with_projected_view(
             semantic_schema,
             semantic_schema.schema_view_for_type(instance_type, string_formats),
         ))
+    }
+
+    /// Returns whether the current presentation view omits constraints that
+    /// become relevant for this instance type.
+    pub fn requires_instance_projection(&self, instance_type: super::SchemaType) -> bool {
+        self.semantic_schema.as_deref().is_some_and(|semantic| {
+            semantic.accepts_instance_type(instance_type)
+                && (!self.schema_view.matches_instance_type(instance_type)
+                    || semantic.root_reference_has_projection_siblings(instance_type))
+        })
+    }
+
+    pub fn has_reference_projection_siblings(&self, instance_type: super::SchemaType) -> bool {
+        self.semantic_schema
+            .as_deref()
+            .is_some_and(|semantic| semantic.root_reference_has_projection_siblings(instance_type))
     }
 
     pub fn for_completion(
@@ -167,18 +188,25 @@ impl Referable<SchemaView> {
             (None, None, None) => (None, None),
         };
         let referable = if let (Some(kind), Some(reference)) = (reference_kind, reference_value) {
+            // Draft 7 treats a `$ref` object as a reference only. Newer drafts allow
+            // assertion and applicator siblings to participate in evaluation.
+            let supports_ref_siblings = dialect != Some(crate::JsonSchemaDialect::Draft07);
+            let semantic_schema = supports_ref_siblings
+                .then(|| Arc::new(super::SemanticSchema::from_object_node(object, dialect)))
+                .filter(|schema| has_reference_projection_siblings(schema));
             Some(Referable::Ref {
                 reference: reference.to_string(),
                 kind,
-                semantic_schema: Some(Arc::new(super::SemanticSchema::from_object_node(
-                    object, dialect,
-                ))),
+                semantic_schema,
+                // Keep annotation siblings for compatibility with existing Draft 7
+                // schemas. They do not affect validation, unlike assertion and
+                // applicator siblings, which remain disabled above.
                 title: object
                     .get("title")
-                    .and_then(|title| title.as_str().map(|s| s.to_string())),
+                    .and_then(|title| title.as_str().map(ToString::to_string)),
                 description: object
                     .get("description")
-                    .and_then(|description| description.as_str().map(|s| s.to_string())),
+                    .and_then(|description| description.as_str().map(ToString::to_string)),
                 default: object.get("default").cloned().map(Into::into),
                 examples: object
                     .get("examples")
@@ -462,6 +490,60 @@ impl Referable<SchemaView> {
                     )
                     .await?
                     {
+                        if ref_semantic_schema
+                            .as_deref()
+                            .is_some_and(has_reference_projection_siblings)
+                        {
+                            let source_schema_uri = schema_uri.as_ref().clone();
+                            let source_definitions = definitions.clone().into_owned();
+                            let local_semantic = ref_semantic_schema
+                                .clone()
+                                .expect("reference siblings have semantic schema");
+                            let range = local_semantic.range();
+                            let schemas = vec![
+                                Referable::Resolved {
+                                    schema_uri: Some(source_schema_uri),
+                                    value: Arc::new(SchemaView::Anything(super::AnythingSchema {
+                                        title: None,
+                                        description: None,
+                                        range,
+                                    })),
+                                    semantic_schema: Some(local_semantic),
+                                },
+                                Referable::Resolved {
+                                    schema_uri: Some(
+                                        resolved_reference.schema_uri.as_ref().clone(),
+                                    ),
+                                    value: resolved_reference.schema_view.clone(),
+                                    semantic_schema: resolved_reference.semantic_schema.clone(),
+                                },
+                            ];
+                            *self = Referable::Resolved {
+                                schema_uri: None,
+                                value: Arc::new(SchemaView::AllOf(super::AllOfSchema {
+                                    title: title.clone(),
+                                    description: description.clone(),
+                                    range,
+                                    schemas: Arc::new(tokio::sync::RwLock::new(schemas)),
+                                    default: default.clone(),
+                                    examples: examples.clone(),
+                                    deprecation: deprecation.clone(),
+                                    ..Default::default()
+                                })),
+                                semantic_schema: None,
+                            };
+
+                            return self
+                                .resolve_with_dynamic_scope(
+                                    schema_uri,
+                                    Cow::Owned(source_definitions),
+                                    strict,
+                                    schema_store,
+                                    dynamic_scope,
+                                )
+                                .await;
+                        }
+
                         let mut resolved_value = resolved_reference.schema_view.clone();
                         if title.is_some() || description.is_some() {
                             let schema_view = Arc::make_mut(&mut resolved_value);
@@ -668,6 +750,22 @@ fn combine_ref_semantics(
         (Some(schema), None) | (None, Some(schema)) => Some(schema),
         (None, None) => None,
     }
+}
+
+fn has_reference_projection_siblings(schema: &super::SemanticSchema) -> bool {
+    use super::SchemaType;
+
+    [
+        SchemaType::Null,
+        SchemaType::Boolean,
+        SchemaType::Object,
+        SchemaType::Array,
+        SchemaType::Number,
+        SchemaType::String,
+        SchemaType::Integer,
+    ]
+    .into_iter()
+    .any(|instance_type| schema.root_reference_has_projection_siblings(instance_type))
 }
 
 fn apply_ref_semantics(
@@ -1230,6 +1328,45 @@ mod test {
     };
 
     #[test]
+    fn ref_assertion_siblings_follow_dialect() {
+        let schema = tombi_json::ValueNode::from_str(
+            r##"{"$ref":"#/$defs/value","type":"string","minLength":3}"##,
+        )
+        .unwrap();
+        let object = schema.as_object().unwrap();
+
+        let draft_7 = Referable::new(
+            object,
+            None,
+            Some(crate::JsonSchemaDialect::Draft07),
+            None,
+            None,
+        );
+        std::assert_matches!(
+            draft_7,
+            Some(Referable::Ref {
+                semantic_schema: None,
+                ..
+            })
+        );
+
+        let draft_2020_12 = Referable::new(
+            object,
+            None,
+            Some(crate::JsonSchemaDialect::Draft2020_12),
+            None,
+            None,
+        );
+        std::assert_matches!(
+            draft_2020_12,
+            Some(Referable::Ref {
+                semantic_schema: Some(_),
+                ..
+            })
+        );
+    }
+
+    #[test]
     fn test_json_pointer_percent_decode() {
         use tombi_json::ValueNode;
 
@@ -1349,7 +1486,10 @@ mod test {
         };
 
         let value_type = referable.value_type().await;
-        std::assert_matches!(value_type, crate::ValueType::AnyOf(types) if types.is_empty());
+        std::assert_matches!(
+            value_type,
+            crate::ValueType::AnyOf(types) if types.is_empty()
+        );
     }
 
     #[tokio::test]
@@ -1542,13 +1682,105 @@ mod test {
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[tokio::test]
+    async fn external_ref_sibling_keeps_source_and_target_contexts() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "tombi_ref_sibling_context_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let main_path = temp_dir.join("main.json");
+        let target_path = temp_dir.join("target.json");
+        std::fs::write(
+            &main_path,
+            r##"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$defs": {
+                    "local": { "type": "string" },
+                    "combined": {
+                        "$ref": "./target.json#/$defs/base",
+                        "properties": {
+                            "local": { "$ref": "#/$defs/local" }
+                        }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+        std::fs::write(
+            &target_path,
+            r##"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$defs": {
+                    "base": {
+                        "type": "object",
+                        "properties": { "remote": { "type": "integer" } }
+                    }
+                }
+            }"##,
+        )
+        .unwrap();
+
+        let source_uri = tombi_uri::SchemaUri::from_file_path(&main_path).unwrap();
+        let target_uri = tombi_uri::SchemaUri::from_file_path(&target_path).unwrap();
+        let schema_store = SchemaStore::new();
+        let document_schema = schema_store
+            .try_get_document_schema(&source_uri)
+            .await
+            .unwrap()
+            .unwrap();
+        let definitions = document_schema.definitions.clone();
+        let mut referable = {
+            let defs = definitions.read().await;
+            defs.get("#/$defs/combined").cloned().unwrap()
+        };
+
+        let resolved = referable
+            .resolve(
+                Cow::Owned(source_uri.clone()),
+                Cow::Owned(definitions),
+                None,
+                &schema_store,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let SchemaView::AllOf(all_of) = resolved.schema_view.as_ref() else {
+            panic!("external $ref with structural siblings must resolve as allOf");
+        };
+        let branches = all_of.schemas.read().await;
+
+        std::assert_matches!(
+            branches.as_slice(),
+            [
+                Referable::Resolved {
+                    schema_uri: Some(local_uri),
+                    ..
+                },
+                Referable::Resolved {
+                    schema_uri: Some(remote_uri),
+                    ..
+                }
+            ] if local_uri == &source_uri && remote_uri == &target_uri
+        );
+        drop(branches);
+        std::fs::remove_dir_all(temp_dir).unwrap();
+    }
+
     #[test]
     fn test_parse_dynamic_anchor_reference() {
         let local = parse_dynamic_anchor_reference("#rootDyn");
         assert_eq!(local, Some((None, "#rootDyn".to_string())));
 
         let remote = parse_dynamic_anchor_reference("https://example.com/schema.json#rootDyn");
-        std::assert_matches!(remote, Some((Some(_), anchor)) if anchor == "#rootDyn");
+        std::assert_matches!(
+            remote,
+            Some((Some(_), anchor)) if anchor == "#rootDyn"
+        );
 
         assert!(parse_dynamic_anchor_reference("#/defs/x").is_none());
     }

--- a/crates/tombi-schema-store/src/schema/schema_view.rs
+++ b/crates/tombi-schema-store/src/schema/schema_view.rs
@@ -35,6 +35,33 @@ pub enum SchemaView {
 }
 
 impl SchemaView {
+    /// Whether this view declares a type that the given instance type satisfies.
+    ///
+    /// Composite and unconstrained views (`oneOf`/`anyOf`/`allOf`/`Anything`/
+    /// `Nothing`) declare no type of their own, so they never match here;
+    /// callers decide how to treat them.
+    pub fn matches_instance_type(&self, instance_type: super::SchemaType) -> bool {
+        use super::SchemaType;
+
+        matches!(
+            (self, instance_type),
+            (Self::Null, SchemaType::Null)
+                | (Self::Boolean(_), SchemaType::Boolean)
+                | (Self::Integer(_), SchemaType::Integer)
+                | (Self::Float(_), SchemaType::Number | SchemaType::Integer)
+                | (Self::Array(_), SchemaType::Array)
+                | (Self::Table(_), SchemaType::Object)
+                | (
+                    Self::String(_)
+                        | Self::LocalDate(_)
+                        | Self::LocalDateTime(_)
+                        | Self::LocalTime(_)
+                        | Self::OffsetDateTime(_),
+                    SchemaType::String,
+                )
+        )
+    }
+
     pub fn adjacent_applicators(
         &self,
     ) -> (

--- a/crates/tombi-schema-store/src/schema/semantic_schema.rs
+++ b/crates/tombi-schema-store/src/schema/semantic_schema.rs
@@ -506,6 +506,33 @@ impl SemanticSchema {
         }
     }
 
+    /// Returns whether a node-local reference also has semantic siblings that
+    /// must participate in the typed projection. Reference annotations are
+    /// already applied to the resolved view and therefore do not count here.
+    pub(crate) fn root_reference_has_projection_siblings(&self, instance_type: SchemaType) -> bool {
+        match self {
+            Self::Boolean(_) => false,
+            Self::Composite(composite) => composite
+                .schemas
+                .iter()
+                .any(|schema| schema.root_reference_has_projection_siblings(instance_type)),
+            Self::Object(object) => {
+                object.references.primary().is_some()
+                    && (object.type_assertion.is_some()
+                        || object.assertions.const_value.is_some()
+                        || object.assertions.enum_values.is_some()
+                        || self.has_direct_constraints_for_type(instance_type)
+                        || !object.applicators.all_of.is_empty()
+                        || !object.applicators.any_of.is_empty()
+                        || !object.applicators.one_of.is_empty()
+                        || object.applicators.not.is_some()
+                        || object.applicators.if_schema.is_some()
+                        || object.applicators.then_schema.is_some()
+                        || object.applicators.else_schema.is_some())
+            }
+        }
+    }
+
     /// Returns values that satisfy exactly one `oneOf` branch when every branch
     /// has a finite `const`/`enum` domain. Keeping the domains per branch until
     /// this point avoids incorrectly suggesting a value shared by two branches.
@@ -1247,10 +1274,10 @@ mod tests {
             Some(0)
         );
         assert_eq!(schema.constraints.string.min_length.unwrap().value, 1);
-        assert!(matches!(
+        std::assert_matches!(
             schema.constraints.object.unevaluated_properties.as_deref(),
             Some(SemanticSchema::Boolean(Spanned { value: false, .. }))
-        ));
+        );
     }
 
     #[test]
@@ -1279,10 +1306,10 @@ mod tests {
         };
         assert_eq!(number.minimum, Some(10.0));
 
-        assert!(matches!(
+        std::assert_matches!(
             schema.schema_view_for_type(SchemaType::String, None),
             Some(SchemaView::String(_))
-        ));
+        );
         let SchemaView::Table(object) = schema
             .schema_view_for_type(SchemaType::Object, None)
             .unwrap()
@@ -1295,6 +1322,24 @@ mod tests {
                 .blocking_read()
                 .contains_key(&crate::SchemaAccessor::Key("name".into()))
         );
+    }
+
+    #[test]
+    fn root_reference_projection_requires_structural_siblings() {
+        let root_reference =
+            SemanticSchema::Object(Box::new(parse(r##"{"$ref":"#/$defs/item"}"##)));
+        let nested_reference =
+            SemanticSchema::Object(Box::new(parse(r##"{"items":{"$ref":"#/$defs/item"}}"##)));
+
+        assert!(root_reference.has_references());
+        assert!(!root_reference.root_reference_has_projection_siblings(SchemaType::Object));
+        assert!(nested_reference.has_references());
+        assert!(!nested_reference.root_reference_has_projection_siblings(SchemaType::Array));
+
+        let sibling_reference = SemanticSchema::Object(Box::new(parse(
+            r##"{"$ref":"#/$defs/item","properties":{"local":{"type":"string"}}}"##,
+        )));
+        assert!(sibling_reference.root_reference_has_projection_siblings(SchemaType::Object));
     }
 
     #[test]
@@ -1343,17 +1388,17 @@ mod tests {
             }"#,
         );
 
-        assert!(matches!(
+        std::assert_matches!(
             schema.constraints.object.unevaluated_properties.as_deref(),
             Some(SemanticSchema::Boolean(Spanned { value: false, .. }))
-        ));
+        );
         let SemanticSchema::Object(branch) = &schema.applicators.one_of[0] else {
             panic!("branch must be an object schema");
         };
-        assert!(matches!(
+        std::assert_matches!(
             branch.constraints.object.unevaluated_properties.as_deref(),
             Some(SemanticSchema::Boolean(Spanned { value: true, .. }))
-        ));
+        );
     }
 
     #[test]

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -770,6 +770,8 @@ impl SchemaStore {
         Ok(Some(source_schema))
     }
 
+    // Preserve the existing tuple error API without boxing every failure.
+    #[allow(clippy::result_large_err)]
     pub async fn resolve_source_schema_from_ast(
         &self,
         root: &tombi_ast::Root,

--- a/crates/tombi-validator/src/branch_evaluation.rs
+++ b/crates/tombi-validator/src/branch_evaluation.rs
@@ -1,0 +1,166 @@
+use tombi_future::Boxable;
+use tombi_schema_store::{Accessor, CurrentSchema, SchemaContext};
+
+use crate::Validate;
+
+#[derive(Debug)]
+pub enum BranchApplicability {
+    Applicable,
+    Rejected {
+        diagnostic_ranges: Vec<tombi_text::Range>,
+    },
+}
+
+impl BranchApplicability {
+    pub fn is_applicable(&self) -> bool {
+        matches!(self, Self::Applicable)
+    }
+
+    pub fn is_recoverable_at(&self, position: tombi_text::Position) -> bool {
+        match self {
+            Self::Applicable => true,
+            Self::Rejected { diagnostic_ranges } => {
+                !diagnostic_ranges.is_empty()
+                    && diagnostic_ranges
+                        .iter()
+                        .all(|range| range.contains(position))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Applicator {
+    OneOf,
+    AnyOf,
+}
+
+#[derive(Debug)]
+pub struct BranchEvaluationTrace {
+    pub applicator: Applicator,
+    pub branches: Vec<BranchApplicability>,
+}
+
+impl BranchEvaluationTrace {
+    pub fn applicable_count(&self) -> usize {
+        self.branches
+            .iter()
+            .filter(|branch| branch.is_applicable())
+            .count()
+    }
+
+    /// Branches retained while resolving a path. Ambiguous or incomplete input
+    /// keeps every candidate so callers do not invent an order-dependent winner.
+    pub fn includes_in_resolution(&self, index: usize, applicable_count: usize) -> bool {
+        match self.applicator {
+            Applicator::OneOf if applicable_count == 1 => self.branches[index].is_applicable(),
+            Applicator::AnyOf if applicable_count > 0 => self.branches[index].is_applicable(),
+            Applicator::OneOf | Applicator::AnyOf => true,
+        }
+    }
+}
+
+pub fn evaluate_applicator<'a: 'b, 'b, T>(
+    applicator: Applicator,
+    value: &'a T,
+    accessors: &'a [Accessor],
+    schemas: &'a [CurrentSchema<'a>],
+    schema_context: &'a SchemaContext<'a>,
+) -> tombi_future::BoxFuture<'b, BranchEvaluationTrace>
+where
+    T: Validate + Sync + Send + std::fmt::Debug,
+{
+    async move {
+        let mut evaluations = Vec::with_capacity(schemas.len());
+        for schema in schemas {
+            let applicability = match value
+                .validate(accessors, Some(schema), schema_context)
+                .await
+            {
+                Ok(_) => BranchApplicability::Applicable,
+                Err(invalid) if !invalid.assertion_failed => BranchApplicability::Applicable,
+                Err(invalid) => BranchApplicability::Rejected {
+                    diagnostic_ranges: invalid
+                        .diagnostics
+                        .into_iter()
+                        .map(|diagnostic| diagnostic.range())
+                        .collect(),
+                },
+            };
+            evaluations.push(applicability);
+        }
+        BranchEvaluationTrace {
+            applicator,
+            branches: evaluations,
+        }
+    }
+    .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn applicable_trace(applicator: Applicator, count: usize) -> BranchEvaluationTrace {
+        BranchEvaluationTrace {
+            applicator,
+            branches: (0..count)
+                .map(|_| BranchApplicability::Applicable)
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn one_of_keeps_all_candidates_when_multiple_branches_apply() {
+        let trace = applicable_trace(Applicator::OneOf, 2);
+        let count = trace.applicable_count();
+        assert!(trace.includes_in_resolution(0, count));
+        assert!(trace.includes_in_resolution(1, count));
+    }
+
+    #[test]
+    fn one_of_selects_its_only_applicable_branch() {
+        let trace = BranchEvaluationTrace {
+            applicator: Applicator::OneOf,
+            branches: vec![
+                BranchApplicability::Rejected {
+                    diagnostic_ranges: Vec::new(),
+                },
+                BranchApplicability::Applicable,
+                BranchApplicability::Rejected {
+                    diagnostic_ranges: Vec::new(),
+                },
+            ],
+        };
+        let count = trace.applicable_count();
+        assert!(!trace.includes_in_resolution(0, count));
+        assert!(trace.includes_in_resolution(1, count));
+        assert!(!trace.includes_in_resolution(2, count));
+    }
+
+    #[test]
+    fn any_of_preserves_every_applicable_branch() {
+        let trace = BranchEvaluationTrace {
+            applicator: Applicator::AnyOf,
+            branches: vec![
+                BranchApplicability::Applicable,
+                BranchApplicability::Rejected {
+                    diagnostic_ranges: Vec::new(),
+                },
+                BranchApplicability::Applicable,
+            ],
+        };
+        let count = trace.applicable_count();
+        assert!(trace.includes_in_resolution(0, count));
+        assert!(!trace.includes_in_resolution(1, count));
+        assert!(trace.includes_in_resolution(2, count));
+    }
+
+    #[test]
+    fn rejected_branch_without_diagnostics_is_not_recoverable() {
+        let applicability = BranchApplicability::Rejected {
+            diagnostic_ranges: Vec::new(),
+        };
+        assert!(!applicability.is_recoverable_at(Default::default()));
+    }
+}

--- a/crates/tombi-validator/src/lib.rs
+++ b/crates/tombi-validator/src/lib.rs
@@ -1,3 +1,4 @@
+mod branch_evaluation;
 pub mod comment_directive;
 mod convert;
 mod diagnostic;
@@ -6,6 +7,9 @@ mod match_evidence;
 mod valid;
 mod validate;
 
+pub use branch_evaluation::{
+    Applicator, BranchApplicability, BranchEvaluationTrace, evaluate_applicator,
+};
 pub use comment_directive::get_tombi_value_comment_directive_and_diagnostics;
 pub use diagnostic::{Diagnostic, DiagnosticKind};
 pub use invalid::Invalid;

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -179,11 +179,27 @@ pub fn project_current_schema_for_value(
         tombi_schema_store::SchemaView::Anything(_) | tombi_schema_store::SchemaView::Nothing(_)
             if is_boolean_schema
     );
-    if matches_instance {
+    let instance_type = tombi_schema_store::SchemaType::from_value_type(value.value_type())?;
+    if current_schema.has_reference_projection_siblings(instance_type)
+        && let Some(semantic_schema) = current_schema
+            .semantic_schema
+            .as_deref()
+            .filter(|schema| !schema.accepts_instance_type(instance_type))
+    {
+        return Some(tombi_schema_store::CurrentSchema {
+            schema_view: std::sync::Arc::new(tombi_schema_store::SchemaView::Nothing(
+                semantic_schema.range(),
+            )),
+            semantic_schema: None,
+            schema_uri: Cow::Owned(current_schema.schema_uri.as_ref().clone()),
+            definitions: Cow::Owned(current_schema.definitions.as_ref().clone()),
+            strict: current_schema.strict,
+        });
+    }
+    if matches_instance && !current_schema.requires_instance_projection(instance_type) {
         return None;
     }
 
-    let instance_type = tombi_schema_store::SchemaType::from_value_type(value.value_type())?;
     if matches!(
         current_schema.schema_view.as_ref(),
         tombi_schema_store::SchemaView::OneOf(_)
@@ -199,7 +215,12 @@ pub fn project_current_schema_for_value(
     {
         return None;
     }
-    current_schema.for_instance_type(instance_type, schema_context.string_formats())
+    let mut projected_schema =
+        current_schema.for_instance_type(instance_type, schema_context.string_formats())?;
+    // This node has already been materialized for the observed value. Nested
+    // schemas retain their own semantic sources when they are resolved.
+    projected_schema.semantic_schema = None;
+    Some(projected_schema)
 }
 
 fn resolve_deprecated_lint_level(

--- a/schemas/adjacent-one-of-hover-test.schema.json
+++ b/schemas/adjacent-one-of-hover-test.schema.json
@@ -7,6 +7,12 @@
       "items": {
         "$ref": "#/definitions/Repo"
       }
+    },
+    "repos_reversed": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RepoReversed"
+      }
     }
   },
   "required": ["repos"],
@@ -71,6 +77,17 @@
         }
       },
       "required": ["id"]
+    },
+    "RepoReversed": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/BuiltinRepo"
+        },
+        {
+          "$ref": "#/definitions/RemoteRepo"
+        }
+      ]
     }
   }
 }

--- a/schemas/lakefile-all-of-test.schema.json
+++ b/schemas/lakefile-all-of-test.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "definitions": {
+    "baseConfig": {
+      "properties": {
+        "buildType": {
+          "type": "string"
+        }
+      }
+    },
+    "leanLibConfig": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/baseConfig"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/baseConfig"
+    },
+    {
+      "properties": {
+        "lean_lib": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/leanLibConfig"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/ref-sibling-annotations-test.schema.json
+++ b/schemas/ref-sibling-annotations-test.schema.json
@@ -6,6 +6,16 @@
       "$ref": "#/$defs/name",
       "default": "allow",
       "examples": ["warn", "deny"]
+    },
+    "settings": {
+      "$ref": "#/$defs/baseSettings",
+      "properties": {
+        "local": {
+          "type": "string",
+          "description": "Property declared next to $ref."
+        }
+      },
+      "additionalProperties": true
     }
   },
   "$defs": {
@@ -13,6 +23,15 @@
       "type": "string",
       "title": "Ref Sibling Annotations",
       "description": "String schema used to verify $ref sibling annotations."
+    },
+    "baseSettings": {
+      "type": "object",
+      "properties": {
+        "base": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- preserve every applicable JSON Schema definition for goto-type-definition across `anyOf`, `oneOf`, and `allOf`
- share composite schema tooltips between hover and completion while keeping distinct metadata and constraints separated
- preserve `$ref` sibling semantics and source locations, including cached local and built-in schema links
- keep branch evaluation consistent across validation and LSP features

## Validation

- `cargo nextest run` — 2276 passed
- `cargo fmt --all --check`
- `cargo clippy -p tombi-cache -p tombi-extension -p tombi-linter -p tombi-lsp -p tombi-schema-store -p tombi-validator --all-targets -- -D warnings`
- independent review-quality agents reviewed each final fingerprint; all findings were fixed and the final review had no actionable findings
