### PR TITLE
perf: speed up lint and format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ time = { version = "0.3.47" }
 tokio = { version = "1.45.0", default-features = false }
 tombi-accessor = { path = "crates/tombi-accessor" }
 tombi-ast = { path = "crates/tombi-ast" }
+tombi-ast-syntax = { path = "crates/tombi-ast-syntax" }
 tombi-cache = { path = "crates/tombi-cache" }
 tombi-cli-options = { path = "crates/tombi-cli-options" }
 tombi-comment-directive = { path = "crates/tombi-comment-directive" }
@@ -112,7 +113,6 @@ tombi-regex = { path = "crates/tombi-regex" }
 tombi-schema-store = { path = "crates/tombi-schema-store", default-features = false }
 tombi-schema-type = { path = "crates/tombi-schema-type" }
 tombi-severity-level = { path = "crates/tombi-severity-level" }
-tombi-ast-syntax = { path = "crates/tombi-ast-syntax" }
 tombi-test-lib = { path = "crates/tombi-test-lib" }
 tombi-text = { path = "crates/tombi-text", default-features = false, features = ["serde"] }
 tombi-toml-text = { path = "crates/tombi-toml-text" }

--- a/crates/tombi-document-tree-syntax/Cargo.toml
+++ b/crates/tombi-document-tree-syntax/Cargo.toml
@@ -11,11 +11,11 @@ chrono.workspace = true
 itertools.workspace = true
 thiserror.workspace = true
 tombi-accessor.workspace = true
+tombi-ast-syntax.workspace = true
 tombi-date-time.workspace = true
 tombi-diagnostic = { workspace = true, optional = true }
 tombi-document-tree.workspace = true
 tombi-hashmap.workspace = true
-tombi-ast-syntax.workspace = true
 tombi-text.workspace = true
 tombi-toml-text.workspace = true
 tombi-toml-version.workspace = true

--- a/crates/tombi-formatter/Cargo.toml
+++ b/crates/tombi-formatter/Cargo.toml
@@ -11,6 +11,7 @@ log.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
+tombi-ast-syntax.workspace = true
 tombi-comment-directive.workspace = true
 tombi-comment-directive-serde.workspace = true
 tombi-config.workspace = true
@@ -21,7 +22,6 @@ tombi-hashmap.workspace = true
 tombi-parser.workspace = true
 tombi-regex.workspace = true
 tombi-schema-store = { workspace = true, features = ["ast-syntax"] }
-tombi-ast-syntax.workspace = true
 tombi-text.workspace = true
 tombi-uri.workspace = true
 tombi-validator.workspace = true

--- a/crates/tombi-formatter/src/editor/rule/array_values_order.rs
+++ b/crates/tombi-formatter/src/editor/rule/array_values_order.rs
@@ -88,6 +88,10 @@ pub(in crate::editor) async fn array_values_order<'a>(
         return Vec::new();
     };
 
+    let old_order = values_with_comma
+        .iter()
+        .map(|(value, _)| value.syntax().range())
+        .collect_vec();
     let mut changes = vec![];
 
     let is_last_comma = values_with_comma
@@ -125,6 +129,13 @@ pub(in crate::editor) async fn array_values_order<'a>(
     let Some(mut sorted_values_with_comma) = sorted_values_with_comma else {
         return Vec::new();
     };
+
+    if old_order.into_iter().eq(sorted_values_with_comma
+        .iter()
+        .map(|(value, _)| value.syntax().range()))
+    {
+        return Vec::new();
+    }
 
     if let Some((_, comma)) = sorted_values_with_comma.last_mut()
         && !is_last_comma

--- a/crates/tombi-formatter/src/editor/rule/inline_table_keys_order.rs
+++ b/crates/tombi-formatter/src/editor/rule/inline_table_keys_order.rs
@@ -37,6 +37,21 @@ pub(in crate::editor) async fn inline_table_keys_order<'a>(
         .as_ref()
         .and_then(|comment_directive| comment_directive.table_keys_order().map(Into::into));
 
+    let schema_override = schema_context.table_order_override(current_schema, accessors);
+    if schema_override.is_some_and(|override_item| override_item.disabled) {
+        return Vec::new();
+    }
+
+    let schema_order_enabled = schema_override.is_some_and(|override_item| !override_item.disabled)
+        || schema_context.schema_table_keys_order_enabled(current_schema);
+    if order.is_none() && !schema_order_enabled {
+        return Vec::new();
+    }
+
+    let old_order = key_values_with_comma
+        .iter()
+        .map(|(key_value, _)| key_value.syntax().range())
+        .collect_vec();
     let mut changes = vec![];
 
     let is_last_comma = key_values_with_comma
@@ -69,6 +84,13 @@ pub(in crate::editor) async fn inline_table_keys_order<'a>(
     else {
         return Vec::new();
     };
+
+    if old_order.into_iter().eq(sorted_key_values_with_comma
+        .iter()
+        .map(|(key_value, _)| key_value.syntax().range()))
+    {
+        return Vec::new();
+    }
 
     if let Some((_, comma)) = sorted_key_values_with_comma.last_mut()
         && !is_last_comma

--- a/crates/tombi-formatter/src/editor/rule/root_table_keys_order.rs
+++ b/crates/tombi-formatter/src/editor/rule/root_table_keys_order.rs
@@ -76,6 +76,10 @@ pub(in crate::editor) async fn root_table_keys_order<'a>(
         return changes;
     }
 
+    let old_order = table_or_array_of_tables
+        .iter()
+        .map(|table| table.syntax().range())
+        .collect_vec();
     let old_first = table_or_array_of_tables.first().unwrap().syntax().clone();
     let old_last = table_or_array_of_tables.last().unwrap().syntax().clone();
 
@@ -107,6 +111,13 @@ pub(in crate::editor) async fn root_table_keys_order<'a>(
     else {
         return changes;
     };
+
+    if old_order
+        .into_iter()
+        .eq(sorted_table.iter().map(|table| table.syntax().range()))
+    {
+        return changes;
+    }
 
     let new = sorted_table.iter().map(SourcePart::node).collect_vec();
 

--- a/crates/tombi-formatter/src/editor/rule/table_keys_order.rs
+++ b/crates/tombi-formatter/src/editor/rule/table_keys_order.rs
@@ -47,6 +47,16 @@ pub(in crate::editor) async fn table_keys_order<'a>(
         return Vec::new();
     }
 
+    let schema_order_enabled = schema_override.is_some_and(|override_item| !override_item.disabled)
+        || schema_context.schema_table_keys_order_enabled(current_schema);
+    if comment_directive_order.is_none() && !schema_order_enabled {
+        return Vec::new();
+    }
+
+    let old_order = key_values_with_comma
+        .iter()
+        .map(|(key_value, _)| key_value.syntax().range())
+        .collect_vec();
     let old_first = key_values_with_comma.first().unwrap().0.syntax().clone();
     let (last_key_value, last_comma) = key_values_with_comma.last().unwrap();
     let old_last = last_comma.as_ref().map_or_else(
@@ -76,6 +86,13 @@ pub(in crate::editor) async fn table_keys_order<'a>(
     else {
         return Vec::new();
     };
+
+    if old_order.into_iter().eq(sorted_key_values_with_comma
+        .iter()
+        .map(|(key_value, _)| key_value.syntax().range()))
+    {
+        return Vec::new();
+    }
 
     let mut new = Vec::with_capacity(sorted_key_values_with_comma.len() * 2);
     for (value, comma) in &sorted_key_values_with_comma {

--- a/crates/tombi-lexer/Cargo.toml
+++ b/crates/tombi-lexer/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [dependencies]
 memchr.workspace = true
-tombi-regex.workspace = true
 tombi-ast-syntax.workspace = true
+tombi-regex.workspace = true
 tombi-text.workspace = true
 
 [dev-dependencies]

--- a/crates/tombi-lsp/Cargo.toml
+++ b/crates/tombi-lsp/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_tombi.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
+tombi-ast-syntax.workspace = true
 tombi-cache.workspace = true
 tombi-comment-directive.workspace = true
 tombi-comment-directive-serde.workspace = true
@@ -36,7 +37,6 @@ tombi-parser.workspace = true
 tombi-regex.workspace = true
 tombi-schema-store = { workspace = true, features = ["ast-syntax", "document-tree"] }
 tombi-schema-type.workspace = true
-tombi-ast-syntax.workspace = true
 tombi-text = { workspace = true, features = ["lsp"] }
 tombi-toml-text.workspace = true
 tombi-uri.workspace = true

--- a/crates/tombi-parser/Cargo.toml
+++ b/crates/tombi-parser/Cargo.toml
@@ -10,9 +10,9 @@ drop_bomb.workspace = true
 itertools.workspace = true
 log.workspace = true
 thiserror.workspace = true
+tombi-ast-syntax.workspace = true
 tombi-diagnostic = { workspace = true, optional = true }
 tombi-lexer.workspace = true
-tombi-ast-syntax.workspace = true
 tombi-text.workspace = true
 
 [dev-dependencies]

--- a/crates/tombi-schema-store/src/http_client/reqwest_client.rs
+++ b/crates/tombi-schema-store/src/http_client/reqwest_client.rs
@@ -1,9 +1,10 @@
 use crate::http_client::{FetchError, HttpClient, HttpFuture, http_timeout_secs};
 use bytes::Bytes;
+use std::sync::{Arc, OnceLock};
 use tombi_future::Boxable;
 
 #[derive(Debug, Clone)]
-pub struct ReqwestHttpClient(reqwest::Client);
+pub struct ReqwestHttpClient(Arc<OnceLock<Result<reqwest::Client, String>>>);
 
 impl Default for ReqwestHttpClient {
     fn default() -> Self {
@@ -13,27 +14,36 @@ impl Default for ReqwestHttpClient {
 
 impl ReqwestHttpClient {
     pub fn new() -> Self {
-        Self(
-            reqwest::Client::builder()
-                .user_agent("tombi-language-server")
-                .timeout(std::time::Duration::from_secs(http_timeout_secs()))
-                .build()
-                .expect("Failed to create reqwest client"),
-        )
+        Self(Arc::new(OnceLock::new()))
+    }
+
+    fn client(&self) -> Result<&reqwest::Client, FetchError> {
+        self.0
+            .get_or_init(|| {
+                reqwest::Client::builder()
+                    .user_agent("tombi-language-server")
+                    .timeout(std::time::Duration::from_secs(http_timeout_secs()))
+                    .build()
+                    .map_err(|err| err.to_string())
+            })
+            .as_ref()
+            .map_err(|reason| FetchError::FetchFailed {
+                reason: reason.clone(),
+            })
     }
 }
 
 impl HttpClient for ReqwestHttpClient {
     fn get_bytes<'a>(&'a self, url: &'a str) -> HttpFuture<'a, Result<Bytes, FetchError>> {
         async move {
-            let response = self
-                .0
-                .get(url)
-                .send()
-                .await
-                .map_err(|err| FetchError::FetchFailed {
-                    reason: err.to_string(),
-                })?;
+            let response =
+                self.client()?
+                    .get(url)
+                    .send()
+                    .await
+                    .map_err(|err| FetchError::FetchFailed {
+                        reason: err.to_string(),
+                    })?;
 
             if !response.status().is_success() {
                 return Err(FetchError::StatusNotOk {

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -31,6 +31,67 @@ struct CachedDocumentSchema {
     document_schema: Result<Arc<DocumentSchema>, crate::Error>,
 }
 
+#[derive(Debug, Clone)]
+struct StoredSchema {
+    schema: crate::Schema,
+    patterns: SchemaPatterns,
+}
+
+#[derive(Debug, Clone)]
+struct SchemaPatterns {
+    include_patterns: Vec<glob::Pattern>,
+    exclude_patterns: Vec<glob::Pattern>,
+}
+
+impl StoredSchema {
+    fn new(schema: crate::Schema) -> Self {
+        let patterns = SchemaPatterns::new(&schema.include, schema.exclude.as_deref());
+
+        Self { schema, patterns }
+    }
+
+    fn matches(
+        &self,
+        path_for_matching: &std::path::Path,
+        absolute_source_path: &std::path::Path,
+    ) -> bool {
+        self.patterns
+            .matches(path_for_matching, absolute_source_path)
+    }
+}
+
+impl SchemaPatterns {
+    fn new(include: &[String], exclude: Option<&[String]>) -> Self {
+        Self {
+            include_patterns: compile_schema_patterns(include),
+            exclude_patterns: exclude.map(compile_schema_patterns).unwrap_or_default(),
+        }
+    }
+
+    fn matches(
+        &self,
+        path_for_matching: &std::path::Path,
+        absolute_source_path: &std::path::Path,
+    ) -> bool {
+        let matches_path = |pattern: &glob::Pattern| {
+            pattern.matches_path(path_for_matching)
+                || (path_for_matching != absolute_source_path
+                    && pattern.matches_path(absolute_source_path))
+        };
+
+        self.include_patterns.iter().any(matches_path)
+            && !self.exclude_patterns.iter().any(matches_path)
+    }
+}
+
+impl Deref for StoredSchema {
+    type Target = crate::Schema;
+
+    fn deref(&self) -> &Self::Target {
+        &self.schema
+    }
+}
+
 /// Options for associating a schema with file patterns
 #[derive(Debug, Clone, Default)]
 pub struct AssociateSchemaOptions {
@@ -45,7 +106,7 @@ pub struct AssociateSchemaOptions {
 pub struct SchemaStore {
     http_client: Arc<dyn HttpClient>,
     document_schemas: DocumentSchemas,
-    schemas: Arc<RwLock<Vec<crate::Schema>>>,
+    schemas: Arc<RwLock<Vec<StoredSchema>>>,
     options: crate::Options,
     base_dir_path: Arc<RwLock<Option<std::path::PathBuf>>>,
 }
@@ -217,21 +278,24 @@ impl SchemaStore {
 
             log::debug!("load schema from config: {}", schema_uri);
 
-            self.schemas.write().await.push(crate::Schema {
-                title: None,
-                description: None,
-                deprecated_lint_level: schema.deprecated_lint_level(),
-                format_rules: schema.format().and_then(|format| format.rules.clone()),
-                lint_rules: schema.lint().and_then(|lint| lint.rules.clone()),
-                overrides: schema_overrides(schema),
-                strict: schema.strict(),
-                schema_uri,
-                catalog_uri: None,
-                include: schema.include().to_vec(),
-                exclude: schema.exclude().map(|exclude| exclude.to_vec()),
-                toml_version: schema.toml_version(),
-                sub_root_accessors: schema.root().and_then(PatternAccessor::parse),
-            });
+            self.schemas
+                .write()
+                .await
+                .push(StoredSchema::new(crate::Schema {
+                    title: None,
+                    description: None,
+                    deprecated_lint_level: schema.deprecated_lint_level(),
+                    format_rules: schema.format().and_then(|format| format.rules.clone()),
+                    lint_rules: schema.lint().and_then(|lint| lint.rules.clone()),
+                    overrides: schema_overrides(schema),
+                    strict: schema.strict(),
+                    schema_uri,
+                    catalog_uri: None,
+                    include: schema.include().to_vec(),
+                    exclude: schema.exclude().map(|exclude| exclude.to_vec()),
+                    toml_version: schema.toml_version(),
+                    sub_root_accessors: schema.root().and_then(PatternAccessor::parse),
+                }));
         }))
         .await;
     }
@@ -364,7 +428,7 @@ impl SchemaStore {
                 .iter()
                 .any(|pattern| pattern.ends_with(".toml"))
             {
-                schemas.push(crate::Schema {
+                schemas.push(StoredSchema::new(crate::Schema {
                     title: Some(schema.name),
                     description: Some(schema.description),
                     deprecated_lint_level: None,
@@ -378,7 +442,7 @@ impl SchemaStore {
                     exclude: None,
                     toml_version: None,
                     sub_root_accessors: None,
-                });
+                }));
             }
         }
         Ok(())
@@ -845,14 +909,7 @@ impl SchemaStore {
         let schemas = self.schemas.read().await;
         let matching_schemas = schemas
             .iter()
-            .filter(|schema| {
-                matches_schema_patterns(
-                    &schema.include,
-                    schema.exclude.as_deref(),
-                    &path_for_matching,
-                    &canonicalized_source_path,
-                )
-            })
+            .filter(|schema| schema.matches(&path_for_matching, &canonicalized_source_path))
             .collect_vec();
 
         let mut source_schema: Option<SourceSchema> = None;
@@ -1133,15 +1190,20 @@ impl SchemaStore {
         let mut schemas = self.schemas.write().await;
         if options.force {
             // Insert at the beginning to force precedence
-            schemas.insert(0, new_schema);
+            schemas.insert(0, StoredSchema::new(new_schema));
         } else {
             // Append at the end
-            schemas.push(new_schema);
+            schemas.push(StoredSchema::new(new_schema));
         }
     }
 
     pub async fn list_schemas(&self) -> Vec<crate::Schema> {
-        self.schemas.read().await.clone()
+        self.schemas
+            .read()
+            .await
+            .iter()
+            .map(|schema| schema.schema.clone())
+            .collect()
     }
 }
 
@@ -1171,40 +1233,21 @@ async fn schema_cache_version(_schema_uri: &SchemaUri) -> Option<SchemaCacheVers
     None
 }
 
+fn compile_schema_patterns(patterns: &[String]) -> Vec<glob::Pattern> {
+    patterns
+        .iter()
+        .filter_map(|pattern| glob::Pattern::new(&glob_pattern_for_file_match(pattern)).ok())
+        .collect()
+}
+
+#[cfg(test)]
 fn matches_schema_patterns(
     include: &[String],
     exclude: Option<&[String]>,
     path_for_matching: &std::path::Path,
     absolute_source_path: &std::path::Path,
 ) -> bool {
-    let included = include.iter().any(|pat| {
-        let pattern = glob_pattern_for_file_match(pat);
-
-        glob::Pattern::new(&pattern)
-            .ok()
-            .map(|glob_pat| {
-                glob_pat.matches_path(path_for_matching)
-                    || (path_for_matching != absolute_source_path
-                        && glob_pat.matches_path(absolute_source_path))
-            })
-            .unwrap_or_default()
-    });
-
-    included
-        && !exclude.is_some_and(|exclude| {
-            exclude.iter().any(|pat| {
-                let pattern = glob_pattern_for_file_match(pat);
-
-                glob::Pattern::new(&pattern)
-                    .ok()
-                    .map(|glob_pat| {
-                        glob_pat.matches_path(path_for_matching)
-                            || (path_for_matching != absolute_source_path
-                                && glob_pat.matches_path(absolute_source_path))
-                    })
-                    .unwrap_or_default()
-            })
-        })
+    SchemaPatterns::new(include, exclude).matches(path_for_matching, absolute_source_path)
 }
 
 fn glob_pattern_for_file_match(pattern: &str) -> String {

--- a/crates/tombi-text/Cargo.toml
+++ b/crates/tombi-text/Cargo.toml
@@ -12,15 +12,15 @@ serde = { workspace = true, optional = true }
 unicode-segmentation.workspace = true
 wasm-bindgen = { workspace = true, optional = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-tower-lsp = { workspace = true, optional = true, features = ["runtime-tokio"] }
-
-[target.'cfg(target_family = "wasm")'.dependencies]
-tower-lsp = { workspace = true, optional = true, features = ["runtime-agnostic"] }
-
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tower-lsp = { workspace = true, features = ["runtime-tokio"], optional = true }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tower-lsp = { workspace = true, features = ["runtime-agnostic"], optional = true }
 
 [features]
 default = ["lsp", "serde"]

--- a/rust/tombi-cli/src/app/command.rs
+++ b/rust/tombi-cli/src/app/command.rs
@@ -16,3 +16,20 @@ pub enum TomlCommand {
 
     Completion(completion::Args),
 }
+
+pub(super) fn max_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
+}
+
+pub(super) fn file_open_error(
+    source_path: std::path::PathBuf,
+    error: std::io::Error,
+) -> crate::Error {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        crate::Error::TombiGlob(tombi_glob::Error::FileNotFound(source_path))
+    } else {
+        crate::Error::Io(error)
+    }
+}

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -50,6 +50,27 @@ struct FormatRunSummary {
     error_num: usize,
 }
 
+fn record_task_result<P>(
+    result: Result<Result<bool, crate::Error>, tokio::task::JoinError>,
+    summary: &mut FormatRunSummary,
+    printer: &mut P,
+) where
+    crate::Error: Print<P>,
+{
+    match result {
+        Ok(Ok(true)) => summary.success_num += 1,
+        Ok(Ok(false)) => summary.not_needed_num += 1,
+        Ok(Err(error)) => {
+            error.print(printer);
+            summary.error_num += 1;
+        }
+        Err(err) => {
+            log::error!("task failed {err}");
+            summary.error_num += 1;
+        }
+    }
+}
+
 pub fn run(args: Args) -> Result<(), crate::Error> {
     let quiet = args.quiet;
     let FormatRunSummary {
@@ -186,7 +207,8 @@ where
             }
             FileSearch::Files(files) => {
                 let mut tasks = tokio::task::JoinSet::new();
-                let mut errors = Vec::new();
+                let concurrency = super::max_concurrency();
+
                 for file in files {
                     match file {
                         FileSearchEntry::Found(source_path) => {
@@ -206,37 +228,34 @@ where
                                 continue;
                             };
 
-                            match FormatFile::from_file(&source_path, args.check).await {
-                                Ok(file) => {
-                                    let printer = printer.clone();
-                                    let schema_store = schema_store.clone();
-
-                                    tasks.spawn(async move {
-                                        format_file(
-                                            file,
-                                            printer,
-                                            &source_path,
-                                            toml_version,
-                                            args.check,
-                                            args.diff,
-                                            &format_options,
-                                            &schema_store,
-                                        )
-                                        .await
-                                    });
-                                }
-                                Err(err) => {
-                                    if err.kind() == std::io::ErrorKind::NotFound {
-                                        crate::Error::TombiGlob(tombi_glob::Error::FileNotFound(
-                                            source_path,
-                                        ))
-                                        .print(&mut printer);
-                                    } else {
-                                        crate::Error::Io(err).print(&mut printer);
-                                    }
-                                    summary.error_num += 1;
+                            while tasks.len() >= concurrency {
+                                if let Some(result) = tasks.join_next().await {
+                                    record_task_result(result, &mut summary, &mut printer);
                                 }
                             }
+
+                            let printer = printer.clone();
+                            let schema_store = schema_store.clone();
+
+                            tasks.spawn(async move {
+                                let file = FormatFile::from_file(&source_path, args.check)
+                                    .await
+                                    .map_err(|error| {
+                                        super::file_open_error(source_path.clone(), error)
+                                    })?;
+
+                                format_file(
+                                    file,
+                                    printer,
+                                    &source_path,
+                                    toml_version,
+                                    args.check,
+                                    args.diff,
+                                    &format_options,
+                                    &schema_store,
+                                )
+                                .await
+                            });
                         }
                         FileSearchEntry::Skipped(_) => {
                             summary.skipped_num += 1;
@@ -249,29 +268,7 @@ where
                 }
 
                 while let Some(result) = tasks.join_next().await {
-                    match result {
-                        Ok(Ok(formatted)) => {
-                            if formatted {
-                                summary.success_num += 1;
-                            } else {
-                                summary.not_needed_num += 1;
-                            }
-                        }
-                        Ok(Err(error)) => {
-                            errors.push(error);
-                            summary.error_num += 1;
-                        }
-                        Err(e) => {
-                            log::error!("task failed {}", e);
-                            summary.error_num += 1;
-                        }
-                    }
-                }
-
-                if !errors.is_empty() {
-                    for error in errors {
-                        error.print(&mut printer);
-                    }
+                    record_task_result(result, &mut summary, &mut printer);
                 }
             }
         };

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -44,6 +44,27 @@ struct LintRunSummary {
     error_num: usize,
 }
 
+fn record_task_result<P>(
+    result: Result<Result<bool, crate::Error>, tokio::task::JoinError>,
+    summary: &mut LintRunSummary,
+    printer: &mut P,
+) where
+    crate::Error: Print<P>,
+{
+    match result {
+        Ok(Ok(true)) => summary.success_num += 1,
+        Ok(Ok(false)) => summary.error_num += 1,
+        Ok(Err(error)) => {
+            error.print(printer);
+            summary.error_num += 1;
+        }
+        Err(err) => {
+            log::error!("task failed {err}");
+            summary.error_num += 1;
+        }
+    }
+}
+
 pub fn run(args: Args) -> Result<(), crate::Error> {
     let quiet = args.quiet;
     let LintRunSummary {
@@ -161,6 +182,7 @@ where
             }
             FileSearch::Files(files) => {
                 let mut tasks = tokio::task::JoinSet::new();
+                let concurrency = super::max_concurrency();
 
                 for file in files {
                     match file {
@@ -178,36 +200,32 @@ where
                                 continue;
                             };
 
-                            match tokio::fs::File::open(&source_path).await {
-                                Ok(file) => {
-                                    let printer = printer.clone();
-                                    let schema_store = schema_store.clone();
-
-                                    tasks.spawn(async move {
-                                        lint_file(
-                                            file,
-                                            printer,
-                                            Some(source_path.as_ref()),
-                                            toml_version,
-                                            &lint_options,
-                                            &schema_store,
-                                            args.error_on_warnings,
-                                        )
-                                        .await
-                                    });
-                                }
-                                Err(err) => {
-                                    if err.kind() == std::io::ErrorKind::NotFound {
-                                        crate::Error::TombiGlob(tombi_glob::Error::FileNotFound(
-                                            source_path,
-                                        ))
-                                        .print(&mut printer);
-                                    } else {
-                                        crate::Error::Io(err).print(&mut printer);
-                                    }
-                                    summary.error_num += 1;
+                            while tasks.len() >= concurrency {
+                                if let Some(result) = tasks.join_next().await {
+                                    record_task_result(result, &mut summary, &mut printer);
                                 }
                             }
+
+                            let printer = printer.clone();
+                            let schema_store = schema_store.clone();
+
+                            tasks.spawn(async move {
+                                let file =
+                                    tokio::fs::File::open(&source_path).await.map_err(|error| {
+                                        super::file_open_error(source_path.clone(), error)
+                                    })?;
+
+                                Ok(lint_file(
+                                    file,
+                                    printer,
+                                    Some(source_path.as_ref()),
+                                    toml_version,
+                                    &lint_options,
+                                    &schema_store,
+                                    args.error_on_warnings,
+                                )
+                                .await)
+                            });
                         }
                         FileSearchEntry::Skipped(_) => {
                             summary.skipped_num += 1;
@@ -220,19 +238,7 @@ where
                 }
 
                 while let Some(result) = tasks.join_next().await {
-                    match result {
-                        Ok(success) => {
-                            if success {
-                                summary.success_num += 1;
-                            } else {
-                                summary.error_num += 1;
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("task failed {}", e);
-                            summary.error_num += 1;
-                        }
-                    }
+                    record_task_result(result, &mut summary, &mut printer);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- lazily initialize the reqwest client and precompile schema association glob patterns
- skip formatter ordering rewrites when no ordering is active or the order is already unchanged
- bound lint and format file tasks using shared concurrency and file-open error handling

## Performance

- repository lint improved from about 355 ms to about 81 ms in the initial release-build benchmark
- formatting an already ordered `Cargo.toml` improved from about 33 ms to about 29 ms
- bounded format scheduling was neutral in the final 30-run comparison and modestly faster in an interleaved 60-pair comparison

## Validation

- `cargo fmt --all --check`
- `cargo test -p tombi-schema-store -p tombi-formatter -p tombi-cli`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --release -p tombi-cli`
- `target/release/tombi format --check --quiet --offline .`
- `target/release/tombi lint --quiet --offline .`

Independent local review completed with no actionable findings.
