### PR TITLE
perf: reduce stdin runtime overhead

### DIFF
--- a/rust/tombi-cli/src/app/command.rs
+++ b/rust/tombi-cli/src/app/command.rs
@@ -23,6 +23,15 @@ pub(super) fn max_concurrency() -> usize {
         .unwrap_or(1)
 }
 
+pub(super) fn runtime(single_threaded: bool) -> std::io::Result<tokio::runtime::Runtime> {
+    let mut builder = if single_threaded {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+    };
+    builder.enable_all().build()
+}
+
 pub(super) fn file_open_error(
     source_path: std::path::PathBuf,
     error: std::io::Error,

--- a/rust/tombi-cli/src/app/command/format.rs
+++ b/rust/tombi-cli/src/app/command/format.rs
@@ -154,9 +154,8 @@ where
             }),
         });
 
-    let Ok(runtime) = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
+    let Ok(runtime) =
+        super::runtime(FileInputType::from(args.files.as_ref()) == FileInputType::Stdin)
     else {
         log::error!("failed to create tokio runtime");
         std::process::exit(1);

--- a/rust/tombi-cli/src/app/command/lint.rs
+++ b/rust/tombi-cli/src/app/command/lint.rs
@@ -1,7 +1,7 @@
 use tokio::io::AsyncReadExt;
 use tombi_config::{LintOptions, TomlVersion};
 use tombi_diagnostic::{Diagnostic, Print};
-use tombi_glob::{FileSearch, FileSearchEntry};
+use tombi_glob::{FileInputType, FileSearch, FileSearchEntry};
 
 use crate::app::CommonArgs;
 
@@ -131,9 +131,8 @@ where
             }),
         });
 
-    let Ok(runtime) = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
+    let Ok(runtime) =
+        super::runtime(FileInputType::from(args.files.as_ref()) == FileInputType::Stdin)
     else {
         log::error!("failed to create tokio runtime");
         std::process::exit(1);


### PR DESCRIPTION
## Summary

- use Tokio's current-thread runtime when `format` or `lint` reads from stdin
- retain the multi-thread runtime for file and project inputs
- share runtime construction between the two commands

Stdin supplies only one input, so worker creation and multi-thread scheduler overhead cannot provide file-level parallelism there.

## Benchmark

Compared the release build against `origin/main` (`363537888d4b7b253e33d93463475896cd3f4508`) with a 5.6 KiB TOML document on stdin, `--offline --quiet`, no project config, `hyperfine --warmup 10 --runs 50`, and both AB/BA command orders.

Mean system CPU time decreased consistently:

| command | AB | BA |
| --- | ---: | ---: |
| `format` | 4.52 ms -> 3.04 ms (-33%) | 4.37 ms -> 3.22 ms (-26%) |
| `lint` | 4.76 ms -> 3.53 ms (-26%) | 4.59 ms -> 3.38 ms (-26%) |

Wall-clock results were noisy and order-sensitive: `format` ranged from 13% faster to 8% slower, while `lint` ranged from 14% faster to effectively unchanged. This PR therefore treats reduced runtime/scheduler overhead, rather than a stable wall-clock speedup, as the measured result.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tombi-cli`
- `cargo clippy -p tombi-cli --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo build --release -p tombi-cli`
- compared stdin formatter output with the `origin/main` baseline
- ran stdin lint smoke tests against baseline and current builds

The remaining test gap is the stdin path with a remote schema; the runtime selection itself does not change schema loading behavior.
