### PR TITLE
perf(json): accelerate long string parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ name = "tombi-json"
 version = "0.0.0-dev"
 dependencies = [
  "itertools 0.14.0",
+ "memchr",
  "pretty_assertions",
  "serde",
  "thiserror 2.0.12",
@@ -3021,6 +3022,7 @@ name = "tombi-json-lexer"
 version = "0.0.0-dev"
 dependencies = [
  "itertools 0.14.0",
+ "memchr",
  "pretty_assertions",
  "textwrap",
  "tombi-json-syntax",

--- a/crates/tombi-json-lexer/Cargo.toml
+++ b/crates/tombi-json-lexer/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+memchr.workspace = true
 tombi-json-syntax = { path = "../tombi-json-syntax" }
 tombi-regex.workspace = true
 tombi-text.workspace = true

--- a/crates/tombi-json-lexer/src/cursor.rs
+++ b/crates/tombi-json-lexer/src/cursor.rs
@@ -72,6 +72,27 @@ impl<'a> Cursor<'a> {
         self.chars.as_str().is_empty()
     }
 
+    #[inline]
+    pub(crate) fn remaining(&self) -> &str {
+        self.chars.as_str()
+    }
+
+    /// Consumes an ASCII prefix without decoding one character at a time.
+    /// SIMD scanners call this after locating a token boundary.
+    pub(crate) fn eat_ascii_bytes(&mut self, len: usize) {
+        debug_assert!(len > 0);
+        let remaining = self.chars.as_str();
+        let prefix = &remaining.as_bytes()[..len];
+        debug_assert!(prefix.is_ascii());
+        let current_char = prefix[len - 1] as char;
+        let rest = &remaining[len..];
+
+        self.current_offset += tombi_text::Offset::new(len as u32);
+        self.current_position += tombi_text::RelativePosition::from((0, len as u32));
+        self.current_char = current_char;
+        self.chars = rest.chars();
+    }
+
     /// Moves to the next character.
     pub(crate) fn bump(&mut self) -> Option<char> {
         if let Some(c) = self.chars.next() {

--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -1,6 +1,7 @@
 mod cursor;
 mod error;
 mod lexed;
+mod scanner;
 mod token;
 
 use cursor::Cursor;
@@ -182,6 +183,7 @@ impl Cursor<'_> {
         debug_assert!(self.current() == '"');
 
         let mut first_error: Option<ErrorKind> = None;
+        self.eat_long_ascii_string_content();
         while let Some(c) = self.bump() {
             match c {
                 _ if c == '"' => {
@@ -230,6 +232,19 @@ impl Cursor<'_> {
         }
 
         Err(crate::Error::new(InvalidString, self.pop_span_range()))
+    }
+
+    #[inline]
+    fn eat_long_ascii_string_content(&mut self) {
+        let remaining = self.remaining().as_bytes();
+        if !scanner::is_long_string_content(remaining) {
+            return;
+        }
+
+        let len = scanner::ascii_before_quote_or_escape(remaining);
+        if len > 0 {
+            self.eat_ascii_bytes(len);
+        }
     }
 }
 

--- a/crates/tombi-json-lexer/src/scanner.rs
+++ b/crates/tombi-json-lexer/src/scanner.rs
@@ -1,0 +1,30 @@
+//! SIMD-dispatched scanners for long ASCII JSON string content.
+//!
+//! Escape handling and validation stay scalar. This scanner only skips an
+//! ordinary ASCII prefix; `memchr` selects vector implementations at runtime
+//! where the target supports them.
+
+pub(crate) const MIN_SIMD_INPUT_LEN: usize = 32;
+
+#[inline]
+fn is_ordinary_ascii_string_byte(byte: u8) -> bool {
+    matches!(byte, 0x20..=0x7f) && !matches!(byte, b'"' | b'\\')
+}
+
+#[inline]
+pub(crate) fn is_long_string_content(bytes: &[u8]) -> bool {
+    bytes
+        .get(..MIN_SIMD_INPUT_LEN)
+        .is_some_and(|prefix| prefix.iter().copied().all(is_ordinary_ascii_string_byte))
+}
+
+#[inline]
+pub(crate) fn ascii_before_quote_or_escape(bytes: &[u8]) -> usize {
+    let end = memchr::memchr2(b'"', b'\\', bytes).unwrap_or(bytes.len());
+    let prefix = &bytes[..end];
+    prefix
+        .iter()
+        .copied()
+        .position(|byte| !is_ordinary_ascii_string_byte(byte))
+        .unwrap_or(end)
+}

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -304,6 +304,45 @@ test_token! {
     fn string_with_unicode(r#""\u00A9""#) -> Ok(Token(STRING, (0, 8)));
 }
 
+test_token! {
+    #[test]
+    fn string_long_ascii(
+        r#""abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ""#
+    ) -> Ok(Token(
+        STRING,
+        (
+            0,
+            r#""abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ""#.len() as u32
+        )
+    ));
+}
+
+test_token! {
+    #[test]
+    fn string_long_ascii_before_escape(
+        r#""abcdefghijklmnopqrstuvwxyz0123456789\"tail""#
+    ) -> Ok(Token(
+        STRING,
+        (
+            0,
+            r#""abcdefghijklmnopqrstuvwxyz0123456789\"tail""#.len() as u32
+        )
+    ));
+}
+
+test_token! {
+    #[test]
+    fn string_long_ascii_before_unicode(
+        r#""abcdefghijklmnopqrstuvwxyz0123456789🦅tail""#
+    ) -> Ok(Token(
+        STRING,
+        (
+            0,
+            r#""abcdefghijklmnopqrstuvwxyz0123456789🦅tail""#.len() as u32
+        )
+    ));
+}
+
 // Tests for single tokens - Other primitives
 test_token! {
     #[test]
@@ -381,6 +420,19 @@ test_tokens! {
 test_token! {
     #[test]
     fn error_unescaped_control_char("\"\u{0001}\"") -> Err(Token(ErrorKind::InvalidString, (0, 3)));
+}
+
+test_token! {
+    #[test]
+    fn error_long_ascii_before_unescaped_control_char(
+        "\"abcdefghijklmnopqrstuvwxyz0123456789\u{0001}\""
+    ) -> Err(Token(
+        ErrorKind::InvalidString,
+        (
+            0,
+            "\"abcdefghijklmnopqrstuvwxyz0123456789\u{0001}\"".len() as u32
+        )
+    ));
 }
 
 test_token! {

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 itertools.workspace = true
+memchr.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tombi-hashmap.workspace = true

--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -78,6 +78,13 @@ impl<'a> Parser<'a> {
                 // Remove the quotation marks
                 let content = &raw_str[1..raw_str.len() - 1];
 
+                if memchr::memchr(b'\\', content.as_bytes()).is_none() {
+                    return Ok(StringNode {
+                        value: content.to_owned(),
+                        range,
+                    });
+                }
+
                 // Process the string including escape sequences
                 let mut processed = String::with_capacity(content.len());
                 let mut chars = content.chars().peekable();
@@ -493,6 +500,24 @@ mod tests {
         assert!(value_node.is_string());
         pretty_assertions::assert_eq!(value_node.as_str(), Some("hello"));
     }
+
+    test_json_parser!(
+        long_unescaped_string_uses_copy_path,
+        r#""abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ""#,
+        |result| {
+            result.as_ref().ok().and_then(ValueNode::as_str)
+                == Some("abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        }
+    );
+
+    test_json_parser!(
+        escaped_string_preserves_decode_path,
+        r#""abcdefghijklmnopqrstuvwxyz0123456789\nend""#,
+        |result| {
+            result.as_ref().ok().and_then(ValueNode::as_str)
+                == Some("abcdefghijklmnopqrstuvwxyz0123456789\nend")
+        }
+    );
 
     #[test]
     fn test_parse_array() {


### PR DESCRIPTION
## Summary

- add a SIMD-dispatched fast path for long ordinary ASCII JSON string content in the lexer
- avoid per-character decoding when parsed JSON strings contain no escapes
- cover long, escaped, Unicode, control-byte, and boundary cases with existing declarative test macros

## Performance

Parse-only AB/BA benchmarks on Apple M2 Max showed stable improvements for representative schemas with long strings:

- Cargo schema: 1.5–5.3% faster
- Tombi schema: 5.4–12.1% faster
- pyproject schema: 13.5–18.3% faster
- short-string schema: neutral/noise (-1.1% to +3.5%)

Escape-heavy results were order-sensitive, so this PR makes no performance claim for that workload.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p tombi-json-lexer -p tombi-json`
- `cargo clippy --locked -p tombi-json-lexer -p tombi-json --all-targets -- -D warnings`
- `cargo test --locked -p tombi-schema-store`
- `cargo check --workspace --all-targets --locked`
- `cargo check --locked --target wasm32-unknown-unknown -p tombi-json-lexer -p tombi-json`
- `git diff --check`

## Review

- independent read-only pre-PR review: no findings
- reviewed fingerprint: `3cb9d5a5c3b6b418bc8f681afefc1e3c8cdadd26:e9e0aae445bdc192647dc678afa66d9dbeab3e324c243747ba4989d28d82c346`
