### PR TITLE
perf(json): optimize lexer and parser hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,7 +3006,6 @@ name = "tombi-json"
 version = "0.0.0-dev"
 dependencies = [
  "itertools 0.14.0",
- "memchr",
  "pretty_assertions",
  "serde",
  "thiserror 2.0.12",
@@ -3026,7 +3025,6 @@ dependencies = [
  "pretty_assertions",
  "textwrap",
  "tombi-json-syntax",
- "tombi-regex",
  "tombi-test-lib",
  "tombi-text",
 ]

--- a/crates/tombi-json-lexer/Cargo.toml
+++ b/crates/tombi-json-lexer/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 [dependencies]
 memchr.workspace = true
 tombi-json-syntax = { path = "../tombi-json-syntax" }
-tombi-regex.workspace = true
 tombi-text.workspace = true
 
 [dev-dependencies]

--- a/crates/tombi-json-lexer/src/cursor.rs
+++ b/crates/tombi-json-lexer/src/cursor.rs
@@ -39,20 +39,6 @@ impl<'a> Cursor<'a> {
             .unwrap_or(EOF_CHAR)
     }
 
-    pub fn peek_with_current_while(&self, mut predicate: impl FnMut(char) -> bool) -> String {
-        let iter = self.chars.clone();
-        let mut s = String::new();
-        s.push(self.current_char);
-        for c in iter {
-            if predicate(c) {
-                s.push(c);
-            } else {
-                break;
-            }
-        }
-        s
-    }
-
     /// Checks if the character at the current position is expected.
     pub fn matches(&self, expected: &str) -> bool {
         let mut iter = expected.chars();

--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -11,20 +11,6 @@ pub use lexed::Lexed;
 pub use token::Token;
 use tombi_json_syntax::{SyntaxKind, T};
 
-macro_rules! regex {
-    ($($var:ident = $re:expr);+;) => {
-        $(
-            static $var: std::sync::LazyLock<tombi_regex::Regex> =
-                std::sync::LazyLock::new(|| tombi_regex::Regex::new($re).unwrap());
-        )+
-    };
-}
-
-regex!(
-    REGEX_INTEGER_DEC = r"^-?(:?[1-9](:?[0-9])*|0)$";
-    REGEX_FLOAT = r"^-?[0-9]+(:?(:?\.[0-9]+)?[eE][+-]?[0-9]+|\.[0-9]+)$";
-);
-
 pub fn lex(source: &str) -> Lexed {
     let mut lexed = Lexed::default();
     let mut last_offset = tombi_text::Offset::default();
@@ -158,18 +144,9 @@ impl Cursor<'_> {
     }
 
     fn number(&mut self) -> Result<Token, crate::Error> {
-        let line = self.peek_with_current_while(|c| !is_token_separator(c));
-
-        if let Some(m) = REGEX_FLOAT.find(&line) {
-            debug_assert!(m.start() == 0);
-            if m.end() > 1 {
-                self.eat_n(m.end() - 1);
-            }
-            return Ok(Token::new(SyntaxKind::NUMBER, self.pop_span_range()));
-        } else if let Some(m) = REGEX_INTEGER_DEC.find(&line) {
-            debug_assert!(m.start() == 0);
-            if m.end() > 1 {
-                self.eat_n(m.end() - 1);
+        if let Some(len) = json_number_len(self.current(), self.remaining()) {
+            if len > 1 {
+                self.eat_ascii_bytes(len - 1);
             }
             return Ok(Token::new(SyntaxKind::NUMBER, self.pop_span_range()));
         }
@@ -183,6 +160,7 @@ impl Cursor<'_> {
         debug_assert!(self.current() == '"');
 
         let mut first_error: Option<ErrorKind> = None;
+        let mut contains_escape = false;
         self.eat_long_ascii_string_content();
         while let Some(c) = self.bump() {
             match c {
@@ -191,42 +169,45 @@ impl Cursor<'_> {
                         return Err(crate::Error::new(error_kind, self.pop_span_range()));
                     }
 
-                    return Ok(Token::new(SyntaxKind::STRING, self.pop_span_range()));
+                    return Ok(Token::new_string(contains_escape, self.pop_span_range()));
                 }
                 '\u{0000}'..='\u{001F}' if first_error.is_none() => {
                     first_error = Some(InvalidString);
                 }
-                '\\' => match self.bump() {
-                    Some(escape_char) => match escape_char {
-                        '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' => {}
-                        'u' => {
-                            let mut valid_unicode = true;
-                            for _i in 0..4 {
-                                match self.bump() {
-                                    Some(hex_char) if hex_char.is_ascii_hexdigit() => {}
-                                    _ => {
-                                        valid_unicode = false;
-                                        break;
+                '\\' => {
+                    contains_escape = true;
+                    match self.bump() {
+                        Some(escape_char) => match escape_char {
+                            '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' => {}
+                            'u' => {
+                                let mut valid_unicode = true;
+                                for _i in 0..4 {
+                                    match self.bump() {
+                                        Some(hex_char) if hex_char.is_ascii_hexdigit() => {}
+                                        _ => {
+                                            valid_unicode = false;
+                                            break;
+                                        }
                                     }
                                 }
-                            }
 
-                            if !valid_unicode && first_error.is_none() {
-                                first_error = Some(InvalidString);
+                                if !valid_unicode && first_error.is_none() {
+                                    first_error = Some(InvalidString);
+                                }
                             }
-                        }
-                        _ => {
+                            _ => {
+                                if first_error.is_none() {
+                                    first_error = Some(InvalidString);
+                                }
+                            }
+                        },
+                        None => {
                             if first_error.is_none() {
                                 first_error = Some(InvalidString);
                             }
                         }
-                    },
-                    None => {
-                        if first_error.is_none() {
-                            first_error = Some(InvalidString);
-                        }
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -237,14 +218,76 @@ impl Cursor<'_> {
     #[inline]
     fn eat_long_ascii_string_content(&mut self) {
         let remaining = self.remaining().as_bytes();
-        if !scanner::is_long_string_content(remaining) {
+        if remaining.len() < scanner::MIN_SIMD_INPUT_LEN {
             return;
         }
 
-        let len = scanner::ascii_before_quote_or_escape(remaining);
-        if len > 0 {
+        let len = scanner::ordinary_ascii_prefix(remaining);
+        if len >= scanner::MIN_SIMD_INPUT_LEN {
             self.eat_ascii_bytes(len);
         }
+    }
+}
+
+#[inline]
+fn json_number_len(first: char, remaining: &str) -> Option<usize> {
+    let bytes = remaining.as_bytes();
+    let mut index = 0;
+
+    let integer_first = if first == '-' {
+        let digit = *bytes.get(index)?;
+        index += 1;
+        digit
+    } else {
+        first as u8
+    };
+
+    if !integer_first.is_ascii_digit() {
+        return None;
+    }
+
+    let mut integer_len = 1;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+        integer_len += 1;
+    }
+
+    let mut has_fraction_or_exponent = false;
+    if bytes.get(index) == Some(&b'.') {
+        has_fraction_or_exponent = true;
+        index += 1;
+        if !bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            return None;
+        }
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+    }
+
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        has_fraction_or_exponent = true;
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        if !bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            return None;
+        }
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+    }
+
+    // Keep compatibility with the previous regexes: leading zeroes are
+    // rejected for integers but were accepted for fractions and exponents.
+    if integer_first == b'0' && integer_len > 1 && !has_fraction_or_exponent {
+        return None;
+    }
+
+    match remaining[index..].chars().next() {
+        None => Some(index + 1),
+        Some(next) if is_token_separator(next) => Some(index + 1),
+        Some(_) => None,
     }
 }
 

--- a/crates/tombi-json-lexer/src/scanner.rs
+++ b/crates/tombi-json-lexer/src/scanner.rs
@@ -1,8 +1,4 @@
-//! SIMD-dispatched scanners for long ASCII JSON string content.
-//!
-//! Escape handling and validation stay scalar. This scanner only skips an
-//! ordinary ASCII prefix; `memchr` selects vector implementations at runtime
-//! where the target supports them.
+//! SIMD scanner for ordinary JSON string bytes.
 
 pub(crate) const MIN_SIMD_INPUT_LEN: usize = 32;
 
@@ -12,19 +8,79 @@ fn is_ordinary_ascii_string_byte(byte: u8) -> bool {
 }
 
 #[inline]
-pub(crate) fn is_long_string_content(bytes: &[u8]) -> bool {
-    bytes
-        .get(..MIN_SIMD_INPUT_LEN)
-        .is_some_and(|prefix| prefix.iter().copied().all(is_ordinary_ascii_string_byte))
+pub(crate) fn ordinary_ascii_prefix(bytes: &[u8]) -> usize {
+    if bytes.len() < MIN_SIMD_INPUT_LEN {
+        return bytes
+            .iter()
+            .position(|&byte| !is_ordinary_ascii_string_byte(byte))
+            .unwrap_or(bytes.len());
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: AArch64 always provides NEON. The scanner only performs
+    // unaligned reads within `bytes` and uses the mask to locate a boundary.
+    unsafe {
+        ordinary_ascii_prefix_neon(bytes)
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let prefix = &bytes[..MIN_SIMD_INPUT_LEN];
+        if let Some(index) = prefix
+            .iter()
+            .position(|&byte| !is_ordinary_ascii_string_byte(byte))
+        {
+            return index;
+        }
+
+        let end = memchr::memchr2(b'"', b'\\', bytes).unwrap_or(bytes.len());
+        bytes[..end]
+            .iter()
+            .position(|&byte| !is_ordinary_ascii_string_byte(byte))
+            .unwrap_or(end)
+    }
 }
 
-#[inline]
-pub(crate) fn ascii_before_quote_or_escape(bytes: &[u8]) -> usize {
-    let end = memchr::memchr2(b'"', b'\\', bytes).unwrap_or(bytes.len());
-    let prefix = &bytes[..end];
-    prefix
-        .iter()
-        .copied()
-        .position(|byte| !is_ordinary_ascii_string_byte(byte))
-        .unwrap_or(end)
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn ordinary_ascii_prefix_neon(bytes: &[u8]) -> usize {
+    use core::arch::aarch64::*;
+
+    let quote = vdupq_n_u8(b'"');
+    let escape = vdupq_n_u8(b'\\');
+    let control_limit = vdupq_n_u8(0x20);
+    let non_ascii_limit = vdupq_n_u8(0x80);
+    let mut offset = 0;
+
+    while offset + 16 <= bytes.len() {
+        // SAFETY: The loop condition guarantees that 16 bytes are available.
+        let chunk = unsafe { vld1q_u8(bytes.as_ptr().add(offset)) };
+        let quote_mask = vceqq_u8(chunk, quote);
+        let escape_mask = vceqq_u8(chunk, escape);
+        let control_mask = vcltq_u8(chunk, control_limit);
+        let non_ascii_mask = vcgeq_u8(chunk, non_ascii_limit);
+        let special_mask = vorrq_u8(
+            vorrq_u8(quote_mask, escape_mask),
+            vorrq_u8(control_mask, non_ascii_mask),
+        );
+
+        if vmaxvq_u8(special_mask) != 0 {
+            let mut lanes = [0u8; 16];
+            // SAFETY: `lanes` has exactly 16 writable bytes.
+            unsafe { vst1q_u8(lanes.as_mut_ptr(), special_mask) };
+            return offset
+                + lanes
+                    .iter()
+                    .position(|&lane| lane != 0)
+                    .expect("a non-zero SIMD mask must contain a non-zero lane");
+        }
+
+        offset += 16;
+    }
+
+    offset
+        + bytes[offset..]
+            .iter()
+            .position(|&byte| !is_ordinary_ascii_string_byte(byte))
+            .unwrap_or(bytes.len() - offset)
 }

--- a/crates/tombi-json-lexer/src/token.rs
+++ b/crates/tombi-json-lexer/src/token.rs
@@ -3,18 +3,37 @@ use tombi_json_syntax::SyntaxKind;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Token {
     kind: SyntaxKind,
+    contains_escape: bool,
     span: tombi_text::Span,
     range: tombi_text::Range,
 }
 
 impl Token {
     pub fn new(kind: SyntaxKind, (span, range): (tombi_text::Span, tombi_text::Range)) -> Self {
-        Self { kind, span, range }
+        Self {
+            kind,
+            contains_escape: false,
+            span,
+            range,
+        }
+    }
+
+    pub fn new_string(
+        contains_escape: bool,
+        (span, range): (tombi_text::Span, tombi_text::Range),
+    ) -> Self {
+        Self {
+            kind: SyntaxKind::STRING,
+            contains_escape,
+            span,
+            range,
+        }
     }
 
     pub const fn eof() -> Self {
         Self {
             kind: SyntaxKind::EOF,
+            contains_escape: false,
             span: tombi_text::Span::MAX,
             range: tombi_text::Range::MAX,
         }
@@ -31,6 +50,11 @@ impl Token {
     }
 
     #[inline]
+    pub fn contains_escape(&self) -> bool {
+        self.contains_escape
+    }
+
+    #[inline]
     pub fn span(&self) -> tombi_text::Span {
         self.span
     }
@@ -43,6 +67,10 @@ impl Token {
 
 impl std::fmt::Debug for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?} @{} @{}", self.kind, self.span, self.range)
+        write!(
+            f,
+            "{:?} @{} @{} (contains_escape: {})",
+            self.kind, self.span, self.range, self.contains_escape
+        )
     }
 }

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -25,17 +25,16 @@ macro_rules! test_tokens {
                 let text: &str = text;
                 let end_offset = start_offset + (text.len() as u32);
                 let end_position = start_position + tombi_text::RelativePosition::of(text);
-                acc.push(
-                    Ok(
-                        Token::new(
-                            kind,
-                            (
-                                (start_offset, end_offset).into(),
-                                (start_position, end_position).into()
-                            )
-                        )
-                    )
+                let span_range = (
+                    (start_offset, end_offset).into(),
+                    (start_position, end_position).into()
                 );
+                let token = if kind == STRING {
+                    Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
+                } else {
+                    Token::new(kind, span_range)
+                };
+                acc.push(Ok(token));
                 (acc, (end_offset, end_position))
             });
             pretty_assertions::assert_eq!(tokens, expected);
@@ -56,7 +55,15 @@ macro_rules! test_token {
             pretty_assertions::assert_eq!(
                 tokens,
                 [
-                    Ok(
+                    Ok(if $kind == STRING {
+                        Token::new_string(
+                            source.as_bytes().contains(&b'\\'),
+                            (
+                                ($start_offset, $end_offset).into(),
+                                (start_position, end_position).into()
+                            )
+                        )
+                    } else {
                         Token::new(
                             $kind,
                             (
@@ -64,7 +71,7 @@ macro_rules! test_token {
                                 (start_position, end_position).into()
                             )
                         )
-                    )
+                    })
                 ]
             );
         }
@@ -464,6 +471,184 @@ test_token! {
 test_token! {
     #[test]
     fn error_number_trailing_decimal("10.") -> Err(Token(ErrorKind::InvalidNumber, (0, 3)));
+}
+
+test_token! {
+    #[test]
+    fn error_number_missing_exponent("1e") -> Err(Token(ErrorKind::InvalidNumber, (0, 2)));
+}
+
+test_token! {
+    #[test]
+    fn error_number_missing_signed_exponent("1e+") -> Err(Token(ErrorKind::InvalidNumber, (0, 3)));
+}
+
+test_token! {
+    #[test]
+    fn error_number_negative_leading_zero("-01") -> Err(Token(ErrorKind::InvalidNumber, (0, 3)));
+}
+
+test_token! {
+    #[test]
+    fn number_leading_zero_fraction_compatibility("01.2") -> Ok(Token(NUMBER, (0, 4)));
+}
+
+test_token! {
+    #[test]
+    fn number_leading_zero_exponent_compatibility("01e2") -> Ok(Token(NUMBER, (0, 4)));
+}
+
+test_token! {
+    #[test]
+    fn number_negative_leading_zero_fraction_compatibility("-01.2")
+        -> Ok(Token(NUMBER, (0, 5)));
+}
+
+test_token! {
+    #[test]
+    fn number_multiple_leading_zero_exponent_compatibility("00e1")
+        -> Ok(Token(NUMBER, (0, 4)));
+}
+
+test_token! {
+    #[test]
+    fn error_number_invalid_suffix("1.2x") -> Err(Token(ErrorKind::InvalidNumber, (0, 4)));
+}
+
+test_tokens! {
+    #[test]
+    fn numbers_followed_by_separators("[1,2] 3\n4") -> [
+        Token(BRACKET_START, "["),
+        Token(NUMBER, "1"),
+        Token(COMMA, ","),
+        Token(NUMBER, "2"),
+        Token(BRACKET_END, "]"),
+        Token(WHITESPACE, " "),
+        Token(NUMBER, "3"),
+        Token(LINE_BREAK, "\n"),
+        Token(NUMBER, "4"),
+    ];
+}
+
+// Exercise both sides of the 16-byte SIMD lane and 32-byte admission boundaries.
+test_token! {
+    #[test]
+    fn string_quote_at_15_bytes(concat!("\"", "aaaaaaaaaaaaaaa", "\""))
+        -> Ok(Token(STRING, (0, 17)));
+}
+
+test_token! {
+    #[test]
+    fn string_quote_at_16_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "\""))
+        -> Ok(Token(STRING, (0, 18)));
+}
+
+test_token! {
+    #[test]
+    fn string_quote_at_31_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaa", "\""))
+        -> Ok(Token(STRING, (0, 33)));
+}
+
+test_token! {
+    #[test]
+    fn string_quote_at_32_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaa", "\""))
+        -> Ok(Token(STRING, (0, 34)));
+}
+
+test_token! {
+    #[test]
+    fn string_quote_at_33_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", "\""))
+        -> Ok(Token(STRING, (0, 35)));
+}
+
+test_token! {
+    #[test]
+    fn string_escape_at_15_bytes(concat!("\"", "aaaaaaaaaaaaaaa", "\\n", "tail\""))
+        -> Ok(Token(STRING, (0, 23)));
+}
+
+test_token! {
+    #[test]
+    fn string_escape_at_16_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "\\n", "tail\""))
+        -> Ok(Token(STRING, (0, 24)));
+}
+
+test_token! {
+    #[test]
+    fn string_escape_at_31_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaa", "\\n", "tail\""))
+        -> Ok(Token(STRING, (0, 39)));
+}
+
+test_token! {
+    #[test]
+    fn string_escape_at_32_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaa", "\\n", "tail\""))
+        -> Ok(Token(STRING, (0, 40)));
+}
+
+test_token! {
+    #[test]
+    fn string_escape_at_33_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", "\\n", "tail\""))
+        -> Ok(Token(STRING, (0, 41)));
+}
+
+test_token! {
+    #[test]
+    fn string_unicode_at_15_bytes(concat!("\"", "aaaaaaaaaaaaaaa", "🦅tail\""))
+        -> Ok(Token(STRING, (0, 25)));
+}
+
+test_token! {
+    #[test]
+    fn string_unicode_at_16_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "🦅tail\""))
+        -> Ok(Token(STRING, (0, 26)));
+}
+
+test_token! {
+    #[test]
+    fn string_unicode_at_31_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaa", "🦅tail\""))
+        -> Ok(Token(STRING, (0, 41)));
+}
+
+test_token! {
+    #[test]
+    fn string_unicode_at_32_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaa", "🦅tail\""))
+        -> Ok(Token(STRING, (0, 42)));
+}
+
+test_token! {
+    #[test]
+    fn string_unicode_at_33_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", "🦅tail\""))
+        -> Ok(Token(STRING, (0, 43)));
+}
+
+test_token! {
+    #[test]
+    fn error_string_control_at_15_bytes(concat!("\"", "aaaaaaaaaaaaaaa", "\u{0001}\""))
+        -> Err(Token(ErrorKind::InvalidString, (0, 18)));
+}
+
+test_token! {
+    #[test]
+    fn error_string_control_at_16_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "\u{0001}\""))
+        -> Err(Token(ErrorKind::InvalidString, (0, 19)));
+}
+
+test_token! {
+    #[test]
+    fn error_string_control_at_31_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaa", "\u{0001}\""))
+        -> Err(Token(ErrorKind::InvalidString, (0, 34)));
+}
+
+test_token! {
+    #[test]
+    fn error_string_control_at_32_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaa", "\u{0001}\""))
+        -> Err(Token(ErrorKind::InvalidString, (0, 35)));
+}
+
+test_token! {
+    #[test]
+    fn error_string_control_at_33_bytes(concat!("\"", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", "\u{0001}\""))
+        -> Err(Token(ErrorKind::InvalidString, (0, 36)));
 }
 
 test_tokens! {

--- a/crates/tombi-json/Cargo.toml
+++ b/crates/tombi-json/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 
 [dependencies]
 itertools.workspace = true
-memchr.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tombi-hashmap.workspace = true

--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -71,6 +71,7 @@ impl<'a> Parser<'a> {
             Some(token) if token.kind() == SyntaxKind::STRING => {
                 let span = token.span();
                 let range = token.range();
+                let contains_escape = token.contains_escape();
                 // Get the string and advance the position
                 let raw_str = &self.source[span.start.into()..span.end.into()];
                 self.advance();
@@ -78,7 +79,7 @@ impl<'a> Parser<'a> {
                 // Remove the quotation marks
                 let content = &raw_str[1..raw_str.len() - 1];
 
-                if memchr::memchr(b'\\', content.as_bytes()).is_none() {
+                if !contains_escape {
                     return Ok(StringNode {
                         value: content.to_owned(),
                         range,
@@ -344,10 +345,12 @@ impl<'a> Parser<'a> {
 
             let key = self.parse_string()?;
 
-            // Check for duplicate keys
-            if properties.contains_key(&key) {
-                return Err(Error::DuplicateKey(key.value));
-            }
+            let vacant_entry = match properties.as_inner_mut().entry(key) {
+                tombi_hashmap::map::Entry::Occupied(entry) => {
+                    return Err(Error::DuplicateKey(entry.key().value.clone()));
+                }
+                tombi_hashmap::map::Entry::Vacant(entry) => entry,
+            };
 
             // Expect colon
             self.expect(T![:])?;
@@ -355,8 +358,8 @@ impl<'a> Parser<'a> {
             // Parse value
             let value = self.parse_value(depth + 1)?;
 
-            // Store key and value
-            properties.insert(key, value);
+            // Store key and value without hashing the key a second time.
+            vacant_entry.insert(value);
 
             // Check for comma or closing brace
             match self.peek_kind() {


### PR DESCRIPTION
## Summary

- replace regex-based JSON number lexing with an allocation-free byte scanner while preserving the previous accepted language
- scan long ordinary ASCII strings with AArch64 NEON and retain the existing scalar/memchr fallback elsewhere
- carry escape metadata from the lexer into the parser and avoid rescanning unescaped strings
- use the map entry API to avoid hashing object keys twice
- cover number compatibility and 15/16/31/32/33-byte string scanner boundaries with the existing declarative lexer test macros

## Performance

Parse-only release AB/BA benchmarks against `70b90cf9ff7b7437b3eab51a86ffa7fc5d8afe5a` on Apple M2 Max used 31 paired samples per case, alternating order, with about 30 ms per side. Repeated forward/reverse measurements showed stable improvements for the primary synthetic workloads:

- tiny JSON: 18.6–21.9% faster
- long strings: 83.5–84.0% faster
- numeric-heavy: 72.8–75.1% faster
- object-heavy: 36.3–38.8% faster

Short strings, Unicode, escaped strings, and the representative Cargo/Tombi/pyproject schemas showed order-sensitive results in the final exact-tree reruns, so this PR makes no improvement claim for those workloads. Non-AArch64 fallback performance was not measured; its build paths were checked separately.

## Validation

- `cargo fmt --all --check`
- `cargo test -p tombi-json-lexer -p tombi-json --locked` (107 tests)
- `cargo test -p tombi-schema-store --locked` (75 tests; pre-existing dead-code warnings)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- `cargo check -p tombi-json --target wasm32-unknown-unknown --locked`
- `cargo check -p tombi-json --target x86_64-pc-windows-msvc --locked`
- `cargo check -p tombi-json --target x86_64-unknown-illumos --locked`
- `git diff --cached --check`

## Review

- independent read-only pre-PR review: no actionable findings
- reviewed fingerprint: `70b90cf9ff7b7437b3eab51a86ffa7fc5d8afe5a:a8e8d7882b580db5cf7089c2355f567904b5281eb9acd38333ad3dafa4bc6c1e`
- residual risk: non-AArch64 runtime performance remains unmeasured
