### PR TITLE
fix(lexer): reject newline following escaped quote or backslash in basic string

### DIFF
--- a/crates/tombi-lexer/src/lib.rs
+++ b/crates/tombi-lexer/src/lib.rs
@@ -400,6 +400,9 @@ impl Cursor<'_> {
                 }
                 '\\' if matches!(self.peek(1), '"' | '\\') => {
                     self.bump();
+                    if is_line_break(self.peek(1)) {
+                        break;
+                    }
                 }
                 _ if is_line_break(self.peek(1)) => break,
                 _ => (),

--- a/crates/tombi-lexer/tests/test_lex.rs
+++ b/crates/tombi-lexer/tests/test_lex.rs
@@ -4,7 +4,7 @@ use tombi_lexer::{Cursor, ErrorKind::*, Token, tokenize};
 
 macro_rules! test_lex_tokens {
     {#[test]fn $name:ident($source:expr) -> [
-        $(Token($kind:expr, $text:literal),)*
+        $( $item:ident ($kind:expr, $text:expr) ),* $(,)?
     ];} => {
         #[test]
         fn $name() {
@@ -14,29 +14,33 @@ macro_rules! test_lex_tokens {
             let tokens = tokenize(&mut cursor).collect_vec();
             let (expected, _) = [
                 $(
-                    ($kind, $text),
+                    test_lex_tokens!(@item $item($kind, $text)),
                 )*
             ]
             .into_iter()
-            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (kind, text)| {
+            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (result, text)| {
                 let text: &str = text;
                 let end_offset = start_offset + (text.len() as u32);
                 let end_position = start_position + tombi_text::RelativePosition::of(text);
-                acc.push(
-                    Ok(
-                        Token::new(
-                            kind,
-                            (
-                                (start_offset, end_offset).into(),
-                                (start_position, end_position).into()
-                            )
-                        )
-                    )
+                let span_range = (
+                    (start_offset, end_offset).into(),
+                    (start_position, end_position).into(),
                 );
+                acc.push(match result {
+                    Ok(kind) => Ok(Token::new(kind, span_range)),
+                    Err(kind) => Err(tombi_lexer::Error::new(kind, span_range)),
+                });
                 (acc, (end_offset, end_position))
             });
             pretty_assertions::assert_eq!(tokens, expected);
         }
+    };
+
+    (@item Token($kind:expr, $text:expr)) => {
+        (Ok::<tombi_ast_syntax::SyntaxKind, tombi_lexer::ErrorKind>($kind), $text)
+    };
+    (@item Error($kind:expr, $text:expr)) => {
+        (Err::<tombi_ast_syntax::SyntaxKind, tombi_lexer::ErrorKind>($kind), $text)
     };
 }
 
@@ -374,6 +378,24 @@ test_lex_token! {
 test_lex_token! {
     #[test]
     fn basic_string2(r#""Hello, \"Taro\"!""#) -> Ok(Token(BASIC_STRING, (0, 18)));
+}
+
+test_lex_tokens! {
+    #[test]
+    fn invalid_basic_string_newline_after_escaped_quote(concat!("\"", "\\\"", "\nb\"")) -> [
+        Error(InvalidBasicString, concat!("\"", "\\\"")),
+        Token(LINE_BREAK, "\n"),
+        Error(InvalidKey, "b\""),
+    ];
+}
+
+test_lex_tokens! {
+    #[test]
+    fn invalid_basic_string_newline_after_escaped_backslash(concat!("\"x", "\\\\", "\nb\"")) -> [
+        Error(InvalidBasicString, concat!("\"x", "\\\\")),
+        Token(LINE_BREAK, "\n"),
+        Error(InvalidKey, "b\""),
+    ];
 }
 
 test_lex_tokens! {


### PR DESCRIPTION
## Summary

Fixes a lexer bug where a newline directly following an escaped quote or backslash inside a basic string was silently swallowed, so invalid multi-line basic strings lexed — and parsed — with zero errors.

## Cause

In `Cursor::basic_string`, the escape shortcut for `\"` and `\\` consumes two characters with one bump, skipping the lookahead line-break check. The newline after the escaped character was taken as string content, e.g. `a = "\"<LF>b"` produced a valid `BASIC_STRING` token with no error.

## Fix

Re-check for a line break after consuming the escaped character; such inputs now yield `InvalidBasicString`.

## Tests

Two regression tests (escaped quote / escaped backslash followed by a newline). To write them declaratively, `test_lex_tokens!` now accepts `Error(kind, text)` items mixed with `Token(kind, text)`, and `$text` accepts expressions such as `concat!` for inputs with real newlines. Existing invocations are unchanged. If you have any concerns about the way the test macro was changed, please let me know—I'm happy to revise it.