### PR TITLE
test(lexer): cover CRLF after basic string escape and simplify test macro

### DIFF
--- a/crates/tombi-lexer/tests/test_lex.rs
+++ b/crates/tombi-lexer/tests/test_lex.rs
@@ -4,7 +4,7 @@ use tombi_lexer::{Cursor, ErrorKind::*, Token, tokenize};
 
 macro_rules! test_lex_tokens {
     {#[test]fn $name:ident($source:expr) -> [
-        $( $item:ident ($kind:expr, $text:expr) ),* $(,)?
+        $($item:ident($kind:expr, $text:literal),)*
     ];} => {
         #[test]
         fn $name() {
@@ -36,10 +36,10 @@ macro_rules! test_lex_tokens {
         }
     };
 
-    (@item Token($kind:expr, $text:expr)) => {
+    (@item Token($kind:expr, $text:literal)) => {
         (Ok::<tombi_ast_syntax::SyntaxKind, tombi_lexer::ErrorKind>($kind), $text)
     };
-    (@item Error($kind:expr, $text:expr)) => {
+    (@item Error($kind:expr, $text:literal)) => {
         (Err::<tombi_ast_syntax::SyntaxKind, tombi_lexer::ErrorKind>($kind), $text)
     };
 }
@@ -382,8 +382,8 @@ test_lex_token! {
 
 test_lex_tokens! {
     #[test]
-    fn invalid_basic_string_newline_after_escaped_quote(concat!("\"", "\\\"", "\nb\"")) -> [
-        Error(InvalidBasicString, concat!("\"", "\\\"")),
+    fn invalid_basic_string_newline_after_escaped_quote("\"\\\"\nb\"") -> [
+        Error(InvalidBasicString, "\"\\\""),
         Token(LINE_BREAK, "\n"),
         Error(InvalidKey, "b\""),
     ];
@@ -391,9 +391,27 @@ test_lex_tokens! {
 
 test_lex_tokens! {
     #[test]
-    fn invalid_basic_string_newline_after_escaped_backslash(concat!("\"x", "\\\\", "\nb\"")) -> [
-        Error(InvalidBasicString, concat!("\"x", "\\\\")),
+    fn invalid_basic_string_crlf_after_escaped_quote("\"\\\"\r\nb\"") -> [
+        Error(InvalidBasicString, "\"\\\""),
+        Token(LINE_BREAK, "\r\n"),
+        Error(InvalidKey, "b\""),
+    ];
+}
+
+test_lex_tokens! {
+    #[test]
+    fn invalid_basic_string_newline_after_escaped_backslash("\"x\\\\\nb\"") -> [
+        Error(InvalidBasicString, "\"x\\\\"),
         Token(LINE_BREAK, "\n"),
+        Error(InvalidKey, "b\""),
+    ];
+}
+
+test_lex_tokens! {
+    #[test]
+    fn invalid_basic_string_crlf_after_escaped_backslash("\"x\\\\\r\nb\"") -> [
+        Error(InvalidBasicString, "\"x\\\\"),
+        Token(LINE_BREAK, "\r\n"),
         Error(InvalidKey, "b\""),
     ];
 }


### PR DESCRIPTION
## Summary

Follow-up to #2149, addressing two points raised in review.

## 1. Add CRLF regression tests

#2149 changed the tokenization of CRLF input as well as LF. For `a = "\"<CRLF>b"`:

| | `InvalidBasicString` | `LINE_BREAK` |
|---|---|---|
| before | span 4..8 (absorbs the `\r`) | span 8..9 (`\n` only) |
| after | span 4..7 | span 7..9 (`\r\n`) |

A `LINE_BREAK` covering only `\n` would mislead `Cursor::line_ending` detection, so add CRLF cases for both escape shapes (escaped quote and escaped backslash) to pin those token boundaries.

## 2. Revert the `$text:expr` widening in `test_lex_tokens!`

#2149 widened `$text:literal` to `$text:expr` so the new tests could use `concat!` to embed real line breaks. But Rust string literals already express line breaks directly, as the existing `Token(LINE_BREAK, "\n")` cases show (`test_lex.rs:111,119`, and many others).

Going back to `literal`:

- drops the `concat!` wrappers, so the new cases read like the rest of the file
- restores the original repetition syntax `$(...,)*` (the change to `),* $(,)?` is no longer needed)

The substantive part of the macro extension — `$item:ident` plus the `@item` rules that allow `Token` and `Error` to be mixed — is kept as is.

## Tests

`cargo test -p tombi-lexer` → 102 passed. `cargo fmt --all` and `cargo clippy -p tombi-lexer --tests` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)