### PR TITLE
fix(linter): suppress false strict warnings for ref siblings

### DIFF
--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
@@ -17,11 +17,27 @@
     "external_type": {
       "$ref": "target.schema.json",
       "type": "string"
+    },
+    "settings": {
+      "$ref": "#/$defs/settings",
+      "type": "object"
     }
   },
   "$defs": {
     "integer": {
       "type": "integer"
+    },
+    "settings": {
+      "type": "object",
+      "properties": {
+        "minimum_release_age_excludes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "unevaluatedProperties": false
     }
   }
 }

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
@@ -60,6 +60,46 @@
         }
       },
       "unevaluatedProperties": false
+    },
+    "ref_with_unevaluated_items": {
+      "$ref": "#/$defs/prefix_item",
+      "unevaluatedItems": false
+    },
+    "ref_creates_array_evaluation_scope": {
+      "$ref": "#/$defs/closed_array",
+      "prefixItems": [
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "failed_all_of_with_unevaluated_items": {
+      "allOf": [
+        {
+          "prefixItems": [
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        {
+          "minItems": 5
+        }
+      ],
+      "unevaluatedItems": false
+    },
+    "failed_conditional_with_unevaluated_items": {
+      "if": {
+        "prefixItems": [
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "then": {
+        "minItems": 5
+      },
+      "unevaluatedItems": false
     }
   },
   "$defs": {
@@ -86,6 +126,16 @@
           "type": "string"
         }
       }
+    },
+    "prefix_item": {
+      "prefixItems": [
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "closed_array": {
+      "unevaluatedItems": false
     },
     "settings": {
       "type": "object",

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/root.schema.json
@@ -21,11 +21,71 @@
     "settings": {
       "$ref": "#/$defs/settings",
       "type": "object"
+    },
+    "ref_with_max_items": {
+      "$ref": "#/$defs/array",
+      "maxItems": 2
+    },
+    "ref_creates_evaluation_scope": {
+      "$ref": "#/$defs/closed",
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    },
+    "ref_with_unevaluated_properties": {
+      "$ref": "#/$defs/bar_property",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "external_ref_with_unevaluated_properties": {
+      "$ref": "target.schema.json#/$defs/bar_property",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "dynamic_ref_with_unevaluated_properties": {
+      "$dynamicRef": "#dynamicBarProperty",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false
     }
   },
   "$defs": {
     "integer": {
       "type": "integer"
+    },
+    "array": {
+      "type": "array"
+    },
+    "closed": {
+      "unevaluatedProperties": false
+    },
+    "bar_property": {
+      "properties": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "dynamic_bar_property": {
+      "$dynamicAnchor": "dynamicBarProperty",
+      "properties": {
+        "bar": {
+          "type": "string"
+        }
+      }
     },
     "settings": {
       "type": "object",

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/target.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-assertions/target.schema.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "integer"
+  "type": "integer",
+  "$defs": {
+    "bar_property": {
+      "properties": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-object-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-object-assertions/root.schema.json
@@ -18,6 +18,10 @@
       "$ref": "#/$defs/required_table",
       "type": "object"
     },
+    "nested_sibling": {
+      "$ref": "#/$defs/nested_table",
+      "type": "object"
+    },
     "closed_sibling": {
       "$ref": "#/$defs/open_table",
       "type": "object",
@@ -71,6 +75,22 @@
         }
       },
       "required": ["required_known"]
+    },
+    "nested_table": {
+      "type": "object",
+      "properties": {
+        "known": {
+          "type": "boolean"
+        },
+        "child": {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/crates/tombi-linter/tests/fixtures/ref-sibling-object-assertions/root.schema.json
+++ b/crates/tombi-linter/tests/fixtures/ref-sibling-object-assertions/root.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "type_sibling": {
+      "$ref": "#/$defs/open_table",
+      "type": "object"
+    },
+    "type_sibling_closed_target": {
+      "$ref": "#/$defs/closed_table",
+      "type": "object"
+    },
+    "type_sibling_unevaluated_target": {
+      "$ref": "#/$defs/unevaluated_table",
+      "type": "object"
+    },
+    "type_sibling_required_target": {
+      "$ref": "#/$defs/required_table",
+      "type": "object"
+    },
+    "closed_sibling": {
+      "$ref": "#/$defs/open_table",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "closed_sibling_closed_target": {
+      "$ref": "#/$defs/closed_table",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "closed_sibling_without_type": {
+      "$ref": "#/$defs/open_table",
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "open_table": {
+      "type": "object",
+      "properties": {
+        "known": {
+          "type": "boolean"
+        }
+      }
+    },
+    "closed_table": {
+      "type": "object",
+      "properties": {
+        "known": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "unevaluated_table": {
+      "type": "object",
+      "properties": {
+        "known": {
+          "type": "boolean"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "required_table": {
+      "type": "object",
+      "properties": {
+        "known": {
+          "type": "boolean"
+        },
+        "required_known": {
+          "type": "boolean"
+        }
+      },
+      "required": ["required_known"]
+    }
+  }
+}

--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -42,6 +42,8 @@ mod recursive_anchor_ref_test_schema;
 mod recursive_defs_any_of_test_schema;
 #[path = "integration/ref_sibling_assertions.rs"]
 mod ref_sibling_assertions;
+#[path = "integration/ref_sibling_object_assertions.rs"]
+mod ref_sibling_object_assertions;
 #[path = "integration/schema_resolution_error.rs"]
 mod schema_resolution_error;
 #[path = "integration/string_format_test_schema.rs"]

--- a/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
@@ -166,3 +166,83 @@ test_lint! {
         },
     ])
 }
+
+test_lint! {
+    #[test]
+    fn ref_annotations_contribute_to_sibling_unevaluated_items(
+        r#"
+        ref_with_unevaluated_items = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn ref_sibling_unevaluated_items_rejects_unknown_item(
+        r#"
+        ref_with_unevaluated_items = [1, 2]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 1,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn ref_target_has_its_own_array_evaluation_scope(
+        r#"
+        ref_creates_array_evaluation_scope = [1]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 0,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn failed_all_of_does_not_contribute_to_unevaluated_items(
+        r#"
+        failed_all_of_with_unevaluated_items = [1, 2]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 0,
+        },
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 1,
+        },
+        tombi_validator::DiagnosticKind::ArrayMinValues {
+            min_values: 5,
+            actual: 2,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn failed_conditional_does_not_contribute_to_unevaluated_items(
+        r#"
+        failed_conditional_with_unevaluated_items = [1, 2]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::ArrayMinValues {
+            min_values: 5,
+            actual: 2,
+        },
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 0,
+        },
+        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
+            index: 1,
+        },
+    ])
+}

--- a/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
@@ -49,3 +49,120 @@ test_lint! {
         },
     ])
 }
+
+test_lint! {
+    #[test]
+    fn ref_applies_alongside_array_constraint(
+        r#"
+        ref_with_max_items = [1, 2, 3]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::ArrayMaxValues {
+            max_values: 2,
+            actual: 3,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn ref_target_has_its_own_evaluation_scope(
+        r#"
+        [ref_creates_evaluation_scope]
+        prop1 = "match"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "prop1".to_string(),
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn ref_annotations_contribute_to_sibling_unevaluated_properties(
+        r#"
+        [ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn ref_sibling_unevaluated_properties_rejects_unknown_property(
+        r#"
+        [ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        baz = "baz"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "baz".to_string(),
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn external_ref_annotations_contribute_to_sibling_unevaluated_properties(
+        r#"
+        [external_ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn external_ref_sibling_unevaluated_properties_rejects_unknown_property(
+        r#"
+        [external_ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        baz = "baz"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "baz".to_string(),
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn dynamic_ref_annotations_contribute_to_sibling_unevaluated_properties(
+        r#"
+        [dynamic_ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn dynamic_ref_sibling_unevaluated_properties_rejects_unknown_property(
+        r#"
+        [dynamic_ref_with_unevaluated_properties]
+        foo = "foo"
+        bar = "bar"
+        baz = "baz"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "baz".to_string(),
+        },
+    ])
+}

--- a/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
@@ -23,3 +23,29 @@ test_lint! {
         tombi_validator::DiagnosticKind::Nothing,
     ])
 }
+
+test_lint! {
+    #[test]
+    fn ref_sibling_type_allows_properties_declared_by_target_in_strict_mode(
+        r#"
+        [settings]
+        minimum_release_age_excludes = ["github:kjanat/actionlint"]
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn ref_sibling_type_still_rejects_undeclared_properties(
+        r#"
+        [settings]
+        unknown = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "unknown".to_string(),
+        },
+    ])
+}

--- a/crates/tombi-linter/tests/integration/ref_sibling_object_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_object_assertions.rs
@@ -1,11 +1,11 @@
 //! `$ref` with sibling object assertions (regression guards for issue #2151).
 //!
-//! Tombi projects a `$ref` that carries assertion siblings into an internal
-//! `allOf` of the sibling-only schema and the reference target. The sibling-only
-//! branch declares no `properties`, so strict mode must not close it on its own.
-//! An explicit `additionalProperties: false` sibling, on the other hand, does
-//! close the table for every key, because `additionalProperties` only sees the
-//! `properties` of the schema object it appears in.
+//! A sibling `type` assertion is already represented by the resolved schema
+//! view, so it does not require rebuilding that view as a projected `allOf`.
+//! Other assertion siblings still need their own annotation scope. In
+//! particular, an explicit `additionalProperties: false` sibling closes the
+//! table for every key because it only sees `properties` from the schema object
+//! in which it appears.
 
 use tombi_diagnostic::Level;
 use tombi_linter::test_lint;
@@ -36,6 +36,38 @@ test_lint! {
         "#,
         SchemaPath(schema_path()),
     ) -> Diagnostics([
+        { code: "table-strict-additional-keys", level: Level::WARNING },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_keeps_warning_for_unknown_key_next_to_failing_key(
+        r#"
+        [type_sibling]
+        known = "not boolean"
+        unknown = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "type-mismatch", level: Level::ERROR },
+        { code: "table-strict-additional-keys", level: Level::WARNING },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_keeps_warning_in_nested_table_when_parent_key_fails(
+        r#"
+        [nested_sibling]
+        known = "not boolean"
+
+        [nested_sibling.child]
+        unknown_child = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "type-mismatch", level: Level::ERROR },
         { code: "table-strict-additional-keys", level: Level::WARNING },
     ])
 }

--- a/crates/tombi-linter/tests/integration/ref_sibling_object_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_object_assertions.rs
@@ -1,0 +1,154 @@
+//! `$ref` with sibling object assertions (regression guards for issue #2151).
+//!
+//! Tombi projects a `$ref` that carries assertion siblings into an internal
+//! `allOf` of the sibling-only schema and the reference target. The sibling-only
+//! branch declares no `properties`, so strict mode must not close it on its own.
+//! An explicit `additionalProperties: false` sibling, on the other hand, does
+//! close the table for every key, because `additionalProperties` only sees the
+//! `properties` of the schema object it appears in.
+
+use tombi_diagnostic::Level;
+use tombi_linter::test_lint;
+use tombi_test_lib::project_root_path;
+
+fn schema_path() -> std::path::PathBuf {
+    project_root_path()
+        .join("crates/tombi-linter/tests/fixtures/ref-sibling-object-assertions/root.schema.json")
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_accepts_referenced_key(
+        r#"
+        [type_sibling]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_warns_unknown_key_in_strict_mode(
+        r#"
+        [type_sibling]
+        unknown = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "table-strict-additional-keys", level: Level::WARNING },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_type_mismatch_does_not_warn_for_referenced_key(
+        r#"
+        [type_sibling]
+        known = "not boolean"
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "type-mismatch", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_required_failure_does_not_warn_for_referenced_key(
+        r#"
+        [type_sibling_required_target]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "table-key-required", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_with_closed_target_accepts_referenced_key(
+        r#"
+        [type_sibling_closed_target]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_with_closed_target_rejects_unknown_key(
+        r#"
+        [type_sibling_closed_target]
+        unknown = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "key-not-allowed", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_with_unevaluated_target_accepts_referenced_key(
+        r#"
+        [type_sibling_unevaluated_target]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn type_sibling_with_unevaluated_target_rejects_unknown_key(
+        r#"
+        [type_sibling_unevaluated_target]
+        unknown = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "unevaluated-property-not-allowed", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn closed_sibling_rejects_every_key(
+        r#"
+        [closed_sibling]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "key-not-allowed", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn closed_sibling_with_closed_target_rejects_every_key(
+        r#"
+        [closed_sibling_closed_target]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "key-not-allowed", level: Level::ERROR },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn closed_sibling_without_type_rejects_every_key(
+        r#"
+        [closed_sibling_without_type]
+        known = true
+        "#,
+        SchemaPath(schema_path()),
+    ) -> Diagnostics([
+        { code: "key-not-allowed", level: Level::ERROR },
+    ])
+}

--- a/crates/tombi-schema-store/src/schema/all_of_schema.rs
+++ b/crates/tombi-schema-store/src/schema/all_of_schema.rs
@@ -19,6 +19,7 @@ pub struct AllOfSchema {
     pub keys_order: Option<TableKeysOrder>,
     pub not: Option<Box<NotSchema>>,
     pub if_then_else: Option<Box<IfThenElseSchema>>,
+    pub reference_siblings: bool,
 }
 
 impl AllOfSchema {
@@ -89,6 +90,7 @@ impl AllOfSchema {
                 dynamic_anchor_collector,
             )
             .map(Box::new),
+            reference_siblings: false,
         }
     }
 

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -528,6 +528,7 @@ impl Referable<SchemaView> {
                                     default: default.clone(),
                                     examples: examples.clone(),
                                     deprecation: deprecation.clone(),
+                                    reference_siblings: true,
                                     ..Default::default()
                                 })),
                                 semantic_schema: None,
@@ -743,7 +744,7 @@ fn combine_ref_semantics(
 ) -> Option<Arc<super::SemanticSchema>> {
     match (local, target) {
         (Some(local), Some(target)) => Some(Arc::new(super::SemanticSchema::composite(
-            super::SemanticCompositeKind::AllOf,
+            super::SemanticCompositeKind::Reference,
             vec![local.as_ref().clone(), target.as_ref().clone()],
             local.range(),
         ))),

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -102,13 +102,13 @@ impl<'a> CurrentSchema<'a> {
         ))
     }
 
-    /// Returns whether the current presentation view omits constraints that
-    /// become relevant for this instance type.
+    /// Returns whether the current view omits constraints for this instance type.
+    /// A compatible `$ref` sibling `type` is already represented by the resolved view.
     pub fn requires_instance_projection(&self, instance_type: super::SchemaType) -> bool {
         self.semantic_schema.as_deref().is_some_and(|semantic| {
             semantic.accepts_instance_type(instance_type)
                 && (!self.schema_view.matches_instance_type(instance_type)
-                    || semantic.root_reference_has_projection_siblings(instance_type))
+                    || semantic.root_reference_requires_instance_projection(instance_type))
         })
     }
 

--- a/crates/tombi-schema-store/src/schema/schema_view.rs
+++ b/crates/tombi-schema-store/src/schema/schema_view.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, str::FromStr, sync::Arc};
 
 use futures::future::join_all;
 use tombi_future::{BoxFuture, Boxable};
@@ -8,7 +8,7 @@ use tombi_x_keyword::{StringFormat, TomlDateTimeType};
 use super::{
     AllOfSchema, AnchorCollector, AnyOfSchema, ArraySchema, BooleanSchema, Deprecation,
     DynamicAnchorCollector, FindSchemaCandidates, FloatSchema, IntegerSchema, LocalDateSchema,
-    LocalDateTimeSchema, LocalTimeSchema, OffsetDateTimeSchema, OneOfSchema, SchemaUri,
+    LocalDateTimeSchema, LocalTimeSchema, OffsetDateTimeSchema, OneOfSchema, Referable, SchemaUri,
     StringSchema, TableSchema,
 };
 use crate::{Accessor, SchemaDefinitions, SchemaStore, schema::any_schema::AnythingSchema};
@@ -99,6 +99,59 @@ impl SchemaView {
             | Self::Anything(_)
             | Self::Nothing(_) => (None, None, None, None),
         }
+    }
+
+    pub fn with_reference_targets(mut self, targets: Vec<Referable<SchemaView>>) -> Self {
+        fn attach(slot: &mut Option<Box<AllOfSchema>>, mut targets: Vec<Referable<SchemaView>>) {
+            if let Some(existing) = slot.take() {
+                targets.insert(
+                    0,
+                    Referable::Resolved {
+                        schema_uri: None,
+                        value: Arc::new(SchemaView::AllOf(*existing)),
+                        semantic_schema: None,
+                    },
+                );
+            }
+            *slot = Some(Box::new(AllOfSchema {
+                schemas: Arc::new(tokio::sync::RwLock::new(targets)),
+                ..Default::default()
+            }));
+        }
+
+        let all_of = match &mut self {
+            Self::Boolean(schema) => Some(&mut schema.all_of),
+            Self::Integer(schema) => Some(&mut schema.all_of),
+            Self::Float(schema) => Some(&mut schema.all_of),
+            Self::String(schema) => Some(&mut schema.all_of),
+            Self::LocalDate(schema) => Some(&mut schema.all_of),
+            Self::LocalDateTime(schema) => Some(&mut schema.all_of),
+            Self::LocalTime(schema) => Some(&mut schema.all_of),
+            Self::OffsetDateTime(schema) => Some(&mut schema.all_of),
+            Self::Array(schema) => Some(&mut schema.all_of),
+            Self::Table(schema) => Some(&mut schema.all_of),
+            Self::OneOf(_)
+            | Self::AnyOf(_)
+            | Self::AllOf(_)
+            | Self::Null
+            | Self::Anything(_)
+            | Self::Nothing(_) => None,
+        };
+        if let Some(all_of) = all_of {
+            attach(all_of, targets);
+            return self;
+        }
+
+        let mut schemas = vec![Referable::Resolved {
+            schema_uri: None,
+            value: Arc::new(self),
+            semantic_schema: None,
+        }];
+        schemas.extend(targets);
+        Self::AllOf(AllOfSchema {
+            schemas: Arc::new(tokio::sync::RwLock::new(schemas)),
+            ..Default::default()
+        })
     }
 
     pub(crate) fn new_single(
@@ -915,5 +968,47 @@ impl FindSchemaCandidates for SchemaView {
             .await
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{AllOfSchema, AnyOfSchema, Referable, SchemaView, StringSchema};
+
+    fn string_target() -> Referable<SchemaView> {
+        Referable::Resolved {
+            schema_uri: None,
+            value: Arc::new(SchemaView::String(StringSchema::default())),
+            semantic_schema: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn reference_targets_attach_to_typed_schema() {
+        let schema = SchemaView::String(StringSchema::default())
+            .with_reference_targets(vec![string_target()]);
+
+        let SchemaView::String(schema) = schema else {
+            panic!("expected string schema");
+        };
+        assert_eq!(schema.all_of.unwrap().schemas.read().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reference_targets_wrap_composite_schema() {
+        let schema =
+            SchemaView::AnyOf(AnyOfSchema::default()).with_reference_targets(vec![string_target()]);
+
+        let SchemaView::AllOf(AllOfSchema { schemas, .. }) = schema else {
+            panic!("expected allOf schema");
+        };
+        let schemas = schemas.read().await;
+        assert_eq!(schemas.len(), 2);
+        assert!(matches!(
+            &schemas[0],
+            Referable::Resolved { value, .. } if matches!(value.as_ref(), SchemaView::AnyOf(_))
+        ));
     }
 }

--- a/crates/tombi-schema-store/src/schema/semantic_schema.rs
+++ b/crates/tombi-schema-store/src/schema/semantic_schema.rs
@@ -510,12 +510,18 @@ impl SemanticSchema {
         }
     }
 
-    /// Includes `type`, which validation uses to reject incompatible instances.
+    /// Returns whether validation must preserve a root `$ref`'s sibling
+    /// assertions in a projection. This includes a sibling `type`: validation
+    /// still needs it to reject instances whose type is incompatible with the
+    /// referenced schema.
     pub(crate) fn root_reference_has_projection_siblings(&self, instance_type: SchemaType) -> bool {
         self.root_reference_has_projection_siblings_inner(instance_type, true)
     }
 
-    /// Excludes `type`, which alone does not require rebuilding the resolved view.
+    /// Returns whether the resolved view must be rebuilt as an instance-specific
+    /// projection. Unlike validation, this excludes a sibling `type` because the
+    /// resolved view already represents that type; only the other assertion
+    /// siblings require a separate projection and annotation scope.
     pub(crate) fn root_reference_requires_instance_projection(
         &self,
         instance_type: SchemaType,

--- a/crates/tombi-schema-store/src/schema/semantic_schema.rs
+++ b/crates/tombi-schema-store/src/schema/semantic_schema.rs
@@ -506,19 +506,35 @@ impl SemanticSchema {
         }
     }
 
-    /// Returns whether a node-local reference also has semantic siblings that
-    /// must participate in the typed projection. Reference annotations are
-    /// already applied to the resolved view and therefore do not count here.
+    /// Includes `type`, which validation uses to reject incompatible instances.
     pub(crate) fn root_reference_has_projection_siblings(&self, instance_type: SchemaType) -> bool {
+        self.root_reference_has_projection_siblings_inner(instance_type, true)
+    }
+
+    /// Excludes `type`, which alone does not require rebuilding the resolved view.
+    pub(crate) fn root_reference_requires_instance_projection(
+        &self,
+        instance_type: SchemaType,
+    ) -> bool {
+        self.root_reference_has_projection_siblings_inner(instance_type, false)
+    }
+
+    fn root_reference_has_projection_siblings_inner(
+        &self,
+        instance_type: SchemaType,
+        include_type_assertion: bool,
+    ) -> bool {
         match self {
             Self::Boolean(_) => false,
-            Self::Composite(composite) => composite
-                .schemas
-                .iter()
-                .any(|schema| schema.root_reference_has_projection_siblings(instance_type)),
+            Self::Composite(composite) => composite.schemas.iter().any(|schema| {
+                schema.root_reference_has_projection_siblings_inner(
+                    instance_type,
+                    include_type_assertion,
+                )
+            }),
             Self::Object(object) => {
                 object.references.primary().is_some()
-                    && (object.type_assertion.is_some()
+                    && ((include_type_assertion && object.type_assertion.is_some())
                         || object.assertions.const_value.is_some()
                         || object.assertions.enum_values.is_some()
                         || self.has_direct_constraints_for_type(instance_type)

--- a/crates/tombi-schema-store/src/schema/semantic_schema.rs
+++ b/crates/tombi-schema-store/src/schema/semantic_schema.rs
@@ -81,6 +81,7 @@ pub enum SemanticCompositeKind {
     OneOf,
     AnyOf,
     AllOf,
+    Reference,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -189,7 +190,7 @@ impl SemanticSchema {
                             .any(|schema| schema.accepts_instance_type(instance_type)))
             }
             Self::Composite(composite) => match composite.kind {
-                SemanticCompositeKind::AllOf => composite
+                SemanticCompositeKind::AllOf | SemanticCompositeKind::Reference => composite
                     .schemas
                     .iter()
                     .all(|schema| schema.accepts_instance_type(instance_type)),
@@ -302,10 +303,13 @@ impl SemanticSchema {
                     schemas,
                     ..Default::default()
                 }),
-                SemanticCompositeKind::AllOf => super::SchemaView::AllOf(super::AllOfSchema {
-                    schemas,
-                    ..Default::default()
-                }),
+                SemanticCompositeKind::AllOf | SemanticCompositeKind::Reference => {
+                    super::SchemaView::AllOf(super::AllOfSchema {
+                        schemas,
+                        reference_siblings: composite.kind == SemanticCompositeKind::Reference,
+                        ..Default::default()
+                    })
+                }
             });
         }
         let Self::Object(object) = self else {
@@ -672,7 +676,7 @@ impl SemanticSchema {
                     .schemas
                     .iter()
                     .any(|schema| schema.accepts_literal(value)),
-                SemanticCompositeKind::AllOf => composite
+                SemanticCompositeKind::AllOf | SemanticCompositeKind::Reference => composite
                     .schemas
                     .iter()
                     .all(|schema| schema.accepts_literal(value)),
@@ -689,7 +693,9 @@ impl SemanticCompositeSchema {
             .map(SemanticSchema::finite_literal_candidates)
             .collect::<Vec<_>>();
         let mut candidates = match self.kind {
-            SemanticCompositeKind::AllOf => domains.iter().find_map(Clone::clone)?,
+            SemanticCompositeKind::AllOf | SemanticCompositeKind::Reference => {
+                domains.iter().find_map(Clone::clone)?
+            }
             SemanticCompositeKind::AnyOf | SemanticCompositeKind::OneOf => {
                 if domains.iter().any(Option::is_none) {
                     return None;
@@ -718,7 +724,7 @@ impl SemanticCompositeSchema {
                 .schemas
                 .iter()
                 .any(|schema| schema.accepts_literal(value)),
-            SemanticCompositeKind::AllOf => self
+            SemanticCompositeKind::AllOf | SemanticCompositeKind::Reference => self
                 .schemas
                 .iter()
                 .all(|schema| schema.accepts_literal(value)),

--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -52,9 +52,8 @@ where
             crate::validate::schema_resolution_diagnostic(&err, value.range(), common_rules)
         }));
 
-        for resolved_schema in &resolved_schemas {
-            match value
-                .validate(accessors, Some(resolved_schema), schema_context)
+        if all_of_schema.reference_siblings {
+            match validate_reference_siblings(value, accessors, &resolved_schemas, schema_context)
                 .await
             {
                 Ok(result) => evaluated_locations.merge_from(result),
@@ -65,6 +64,23 @@ where
                     assertion_failed |= error.assertion_failed;
                     total_diagnostics.extend(error.diagnostics);
                     match_evidence.merge_from(*error.match_evidence);
+                }
+            }
+        } else {
+            for resolved_schema in &resolved_schemas {
+                match value
+                    .validate(accessors, Some(resolved_schema), schema_context)
+                    .await
+                {
+                    Ok(result) => evaluated_locations.merge_from(result),
+                    Err(error) => {
+                        if !error.assertion_failed {
+                            evaluated_locations.merge_from(error.local_evaluated_locations.clone());
+                        }
+                        assertion_failed |= error.assertion_failed;
+                        total_diagnostics.extend(error.diagnostics);
+                        match_evidence.merge_from(*error.match_evidence);
+                    }
                 }
             }
         }
@@ -132,6 +148,56 @@ where
                 local_evaluated_locations: evaluated_locations,
             })
         }
+    }
+    .boxed()
+}
+
+fn validate_reference_siblings<'a: 'b, 'b, T>(
+    value: &'a T,
+    accessors: &'a [tombi_schema_store::Accessor],
+    schemas: &'a [CurrentSchema<'a>],
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> BoxFuture<'b, Result<crate::Valid, crate::Invalid>>
+where
+    T: Validate + ValueImpl + Sync + Send + Debug,
+{
+    async move {
+        let Some((local, targets)) = schemas.split_first() else {
+            return Ok(crate::Valid::new());
+        };
+        let Some(instance_type) =
+            tombi_schema_store::SchemaType::from_value_type(value.value_type())
+        else {
+            return value.validate(accessors, Some(local), schema_context).await;
+        };
+        let Some(local) = local.for_instance_type(instance_type, schema_context.string_formats())
+        else {
+            return value.validate(accessors, Some(local), schema_context).await;
+        };
+        let targets = targets
+            .iter()
+            .map(|target| tombi_schema_store::Referable::Resolved {
+                schema_uri: Some(target.schema_uri.as_ref().clone()),
+                value: target.schema_view.clone(),
+                semantic_schema: target.semantic_schema.clone(),
+            })
+            .collect();
+        let current_schema = CurrentSchema {
+            schema_view: std::sync::Arc::new(
+                local
+                    .schema_view
+                    .as_ref()
+                    .clone()
+                    .with_reference_targets(targets),
+            ),
+            semantic_schema: None,
+            schema_uri: local.schema_uri,
+            definitions: local.definitions,
+            strict: local.strict,
+        };
+        value
+            .validate(accessors, Some(&current_schema), schema_context)
+            .await
     }
     .boxed()
 }

--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -121,6 +121,11 @@ where
             }
         }
 
+        if assertion_failed && schema_context.strict(Some(current_schema)) {
+            total_diagnostics
+                .retain(|diagnostic| diagnostic.code() != "table-strict-additional-keys");
+        }
+
         if total_diagnostics.is_empty() && !assertion_failed {
             Ok(evaluated_locations)
         } else {

--- a/crates/tombi-validator/src/validate/all_of.rs
+++ b/crates/tombi-validator/src/validate/all_of.rs
@@ -121,11 +121,6 @@ where
             }
         }
 
-        if assertion_failed && schema_context.strict(Some(current_schema)) {
-            total_diagnostics
-                .retain(|diagnostic| diagnostic.code() != "table-strict-additional-keys");
-        }
-
         if total_diagnostics.is_empty() && !assertion_failed {
             Ok(evaluated_locations)
         } else {

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -141,8 +141,8 @@ async fn validate_array(
     let has_unevaluated_items = array_schema.unevaluated_items_schema.is_some()
         || array_schema.unevaluated_items == Some(false);
 
-    if let Some(if_then_else_schema) = array_schema.if_then_else.as_ref()
-        && let Err(error) = validate_if_then_else(
+    if let Some(if_then_else_schema) = array_schema.if_then_else.as_ref() {
+        match validate_if_then_else(
             array_value,
             accessors,
             if_then_else_schema,
@@ -151,13 +151,50 @@ async fn validate_array(
             common_rules,
         )
         .await
-    {
-        assertion_failed |= error.assertion_failed;
-        validation_result
-            .match_evidence
-            .merge_from(*error.match_evidence);
-        validation_result.merge_from(error.local_evaluated_locations);
-        total_diagnostics.extend(error.diagnostics);
+        {
+            Ok(result) => validation_result.merge_from(result),
+            Err(error) => {
+                assertion_failed |= error.assertion_failed;
+                validation_result
+                    .match_evidence
+                    .merge_from(*error.match_evidence);
+                if !error.assertion_failed {
+                    validation_result.merge_from(error.local_evaluated_locations);
+                }
+                total_diagnostics.extend(error.diagnostics);
+            }
+        }
+    }
+
+    let adjacent_result = validate_adjacent_applicators(
+        array_value,
+        accessors,
+        array_schema.one_of.as_deref(),
+        array_schema.any_of.as_deref(),
+        array_schema.all_of.as_deref(),
+        array_schema.not.as_deref(),
+        current_schema,
+        schema_context,
+        comment_directives,
+        lint_rules.map(|rules| &rules.common),
+    )
+    .await;
+    let adjacent_evaluated = match &adjacent_result {
+        Ok(result) => Some(result),
+        Err(error) if !error.assertion_failed => Some(&error.local_evaluated_locations),
+        Err(_) => None,
+    };
+    if let Some(adjacent_evaluated) = adjacent_evaluated {
+        for index in &adjacent_evaluated.indices {
+            if let Some(evaluated) = evaluated.get_mut(*index) {
+                *evaluated = true;
+            }
+        }
+    }
+    for index in &validation_result.indices {
+        if let Some(evaluated) = evaluated.get_mut(*index) {
+            *evaluated = true;
+        }
     }
 
     if let Some(prefix_items) = &array_schema.prefix_items {
@@ -731,22 +768,7 @@ async fn validate_array(
         })
     };
 
-    merge_validation_results(
-        base_result,
-        validate_adjacent_applicators(
-            array_value,
-            accessors,
-            array_schema.one_of.as_deref(),
-            array_schema.any_of.as_deref(),
-            array_schema.all_of.as_deref(),
-            array_schema.not.as_deref(),
-            current_schema,
-            schema_context,
-            comment_directives,
-            lint_rules.map(|rules| &rules.common),
-        )
-        .await,
-    )
+    merge_validation_results(base_result, adjacent_result)
 }
 
 async fn validate_array_without_schema(

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -92,39 +92,21 @@ impl Validate for tombi_document_tree_syntax::Table {
                         )
                         .await
                     }
-                    SchemaView::AllOf(all_of_schema) => {
-                        let declared_locations = if schema_context.strict(Some(current_schema)) {
-                            collect_all_of_declared_properties(
-                                self,
-                                accessors,
-                                all_of_schema,
-                                current_schema,
-                                schema_context,
-                            )
-                            .await
-                        } else {
-                            crate::Valid::new()
-                        };
-                        validate_all_of(
-                            self,
-                            accessors,
-                            all_of_schema,
-                            current_schema,
-                            schema_context,
-                            self.comment_directives()
-                                .map(|directives| directives.cloned().collect_vec())
-                                .as_deref(),
-                            lint_rules.as_ref().map(|rules| &rules.common),
-                        )
-                        .await
-                        .or_else(|error| {
-                            filter_evaluated_table_strict_additional_diagnostics(
-                                self,
-                                &declared_locations,
-                                error,
-                            )
-                        })
-                    }
+                    SchemaView::AllOf(all_of_schema) => validate_all_of(
+                        self,
+                        accessors,
+                        all_of_schema,
+                        current_schema,
+                        schema_context,
+                        self.comment_directives()
+                            .map(|directives| directives.cloned().collect_vec())
+                            .as_deref(),
+                        lint_rules.as_ref().map(|rules| &rules.common),
+                    )
+                    .await
+                    .or_else(|error| {
+                        filter_evaluated_table_strict_additional_diagnostics(self, error)
+                    }),
                     SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
@@ -155,42 +137,23 @@ impl Validate for tombi_document_tree_syntax::Table {
 #[allow(clippy::result_large_err)]
 fn filter_evaluated_table_strict_additional_diagnostics(
     table: &tombi_document_tree_syntax::Table,
-    declared_locations: &crate::Valid,
     mut error: crate::Invalid,
 ) -> Result<crate::Valid, crate::Invalid> {
-    // An allOf branch can report a key as additional even when another branch
-    // declares it (even if that branch fails another assertion) or rejects it
-    // with an explicit closure keyword. Keep strict warnings only when no branch
-    // has reached either conclusion for the key.
-    let mut concluded_ranges = table
+    let evaluated_ranges = table
         .key_values()
         .iter()
         .filter(|(key, _)| {
-            declared_locations.properties.contains(key.value())
-                || error
-                    .local_evaluated_locations
-                    .properties
-                    .contains(key.value())
+            error
+                .local_evaluated_locations
+                .properties
+                .contains(key.value())
         })
         .map(|(key, value)| key.range() + value.range())
         .collect::<HashSet<_>>();
 
-    concluded_ranges.extend(
-        error
-            .diagnostics
-            .iter()
-            .filter(|diagnostic| {
-                matches!(
-                    diagnostic.code(),
-                    "key-not-allowed" | "unevaluated-property-not-allowed"
-                )
-            })
-            .map(|diagnostic| diagnostic.range()),
-    );
-
     error.diagnostics.retain(|diagnostic| {
         diagnostic.code() != "table-strict-additional-keys"
-            || !concluded_ranges.contains(&diagnostic.range())
+            || !evaluated_ranges.contains(&diagnostic.range())
     });
 
     if error.diagnostics.is_empty() && !error.assertion_failed {
@@ -198,55 +161,6 @@ fn filter_evaluated_table_strict_additional_diagnostics(
     } else {
         Err(error)
     }
-}
-
-fn collect_all_of_declared_properties<'a>(
-    table: &'a tombi_document_tree_syntax::Table,
-    accessors: &'a [Accessor],
-    all_of_schema: &'a tombi_schema_store::AllOfSchema,
-    current_schema: &'a CurrentSchema<'a>,
-    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-) -> BoxFuture<'a, crate::Valid> {
-    async move {
-        let mut result = crate::Valid::new();
-        let Some(schemas) = tombi_schema_store::resolve_and_collect_schemas(
-            &all_of_schema.schemas,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            current_schema.strict,
-            schema_context.store,
-            &schema_context.schema_visits,
-            accessors,
-        )
-        .await
-        else {
-            return result;
-        };
-        let mut visited_schema_values = HashSet::new();
-
-        for schema in schemas {
-            let schema = schema
-                .for_instance_type(
-                    tombi_schema_store::SchemaType::Object,
-                    schema_context.string_formats(),
-                )
-                .unwrap_or(schema);
-            result.merge_from(
-                collect_evaluated_properties_from_schema_view(
-                    table,
-                    accessors,
-                    schema.schema_view.as_ref(),
-                    &schema,
-                    schema_context,
-                    &mut visited_schema_values,
-                )
-                .await,
-            );
-        }
-
-        result
-    }
-    .boxed()
 }
 
 async fn validate_table(

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -92,21 +92,20 @@ impl Validate for tombi_document_tree_syntax::Table {
                         )
                         .await
                     }
-                    SchemaView::AllOf(all_of_schema) => validate_all_of(
-                        self,
-                        accessors,
-                        all_of_schema,
-                        current_schema,
-                        schema_context,
-                        self.comment_directives()
-                            .map(|directives| directives.cloned().collect_vec())
-                            .as_deref(),
-                        lint_rules.as_ref().map(|rules| &rules.common),
-                    )
-                    .await
-                    .or_else(|error| {
-                        filter_evaluated_table_strict_additional_diagnostics(self, error)
-                    }),
+                    SchemaView::AllOf(all_of_schema) => {
+                        validate_all_of(
+                            self,
+                            accessors,
+                            all_of_schema,
+                            current_schema,
+                            schema_context,
+                            self.comment_directives()
+                                .map(|directives| directives.cloned().collect_vec())
+                                .as_deref(),
+                            lint_rules.as_ref().map(|rules| &rules.common),
+                        )
+                        .await
+                    }
                     SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
                     SchemaView::Nothing(_) => handle_nothing_schema(self),
@@ -131,35 +130,6 @@ impl Validate for tombi_document_tree_syntax::Table {
             crate::validate::with_lint_diagnostics(result, lint_rules_diagnostics)
         }
         .boxed()
-    }
-}
-
-#[allow(clippy::result_large_err)]
-fn filter_evaluated_table_strict_additional_diagnostics(
-    table: &tombi_document_tree_syntax::Table,
-    mut error: crate::Invalid,
-) -> Result<crate::Valid, crate::Invalid> {
-    let evaluated_ranges = table
-        .key_values()
-        .iter()
-        .filter(|(key, _)| {
-            error
-                .local_evaluated_locations
-                .properties
-                .contains(key.value())
-        })
-        .map(|(key, value)| key.range() + value.range())
-        .collect::<HashSet<_>>();
-
-    error.diagnostics.retain(|diagnostic| {
-        diagnostic.code() != "table-strict-additional-keys"
-            || !evaluated_ranges.contains(&diagnostic.range())
-    });
-
-    if error.diagnostics.is_empty() && !error.assertion_failed {
-        Ok(error.local_evaluated_locations)
-    } else {
-        Err(error)
     }
 }
 

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -93,6 +93,18 @@ impl Validate for tombi_document_tree_syntax::Table {
                         .await
                     }
                     SchemaView::AllOf(all_of_schema) => {
+                        let declared_locations = if schema_context.strict(Some(current_schema)) {
+                            collect_all_of_declared_properties(
+                                self,
+                                accessors,
+                                all_of_schema,
+                                current_schema,
+                                schema_context,
+                            )
+                            .await
+                        } else {
+                            crate::Valid::new()
+                        };
                         validate_all_of(
                             self,
                             accessors,
@@ -105,6 +117,13 @@ impl Validate for tombi_document_tree_syntax::Table {
                             lint_rules.as_ref().map(|rules| &rules.common),
                         )
                         .await
+                        .or_else(|error| {
+                            filter_evaluated_table_strict_additional_diagnostics(
+                                self,
+                                &declared_locations,
+                                error,
+                            )
+                        })
                     }
                     SchemaView::Null => handle_nothing_schema(self),
                     SchemaView::Anything(_) => handle_anything_schema(self),
@@ -131,6 +150,103 @@ impl Validate for tombi_document_tree_syntax::Table {
         }
         .boxed()
     }
+}
+
+#[allow(clippy::result_large_err)]
+fn filter_evaluated_table_strict_additional_diagnostics(
+    table: &tombi_document_tree_syntax::Table,
+    declared_locations: &crate::Valid,
+    mut error: crate::Invalid,
+) -> Result<crate::Valid, crate::Invalid> {
+    // An allOf branch can report a key as additional even when another branch
+    // declares it (even if that branch fails another assertion) or rejects it
+    // with an explicit closure keyword. Keep strict warnings only when no branch
+    // has reached either conclusion for the key.
+    let mut concluded_ranges = table
+        .key_values()
+        .iter()
+        .filter(|(key, _)| {
+            declared_locations.properties.contains(key.value())
+                || error
+                    .local_evaluated_locations
+                    .properties
+                    .contains(key.value())
+        })
+        .map(|(key, value)| key.range() + value.range())
+        .collect::<HashSet<_>>();
+
+    concluded_ranges.extend(
+        error
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                matches!(
+                    diagnostic.code(),
+                    "key-not-allowed" | "unevaluated-property-not-allowed"
+                )
+            })
+            .map(|diagnostic| diagnostic.range()),
+    );
+
+    error.diagnostics.retain(|diagnostic| {
+        diagnostic.code() != "table-strict-additional-keys"
+            || !concluded_ranges.contains(&diagnostic.range())
+    });
+
+    if error.diagnostics.is_empty() && !error.assertion_failed {
+        Ok(error.local_evaluated_locations)
+    } else {
+        Err(error)
+    }
+}
+
+fn collect_all_of_declared_properties<'a>(
+    table: &'a tombi_document_tree_syntax::Table,
+    accessors: &'a [Accessor],
+    all_of_schema: &'a tombi_schema_store::AllOfSchema,
+    current_schema: &'a CurrentSchema<'a>,
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> BoxFuture<'a, crate::Valid> {
+    async move {
+        let mut result = crate::Valid::new();
+        let Some(schemas) = tombi_schema_store::resolve_and_collect_schemas(
+            &all_of_schema.schemas,
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            current_schema.strict,
+            schema_context.store,
+            &schema_context.schema_visits,
+            accessors,
+        )
+        .await
+        else {
+            return result;
+        };
+        let mut visited_schema_values = HashSet::new();
+
+        for schema in schemas {
+            let schema = schema
+                .for_instance_type(
+                    tombi_schema_store::SchemaType::Object,
+                    schema_context.string_formats(),
+                )
+                .unwrap_or(schema);
+            result.merge_from(
+                collect_evaluated_properties_from_schema_view(
+                    table,
+                    accessors,
+                    schema.schema_view.as_ref(),
+                    &schema,
+                    schema_context,
+                    &mut visited_schema_values,
+                )
+                .await,
+            );
+        }
+
+        result
+    }
+    .boxed()
 }
 
 async fn validate_table(


### PR DESCRIPTION
## Summary

Replaces the diagnostic-filtering approach this PR originally took with the root cause fix from #2153, and keeps the regression coverage from both PRs.

- revert the post-hoc `table-strict-additional-keys` filtering added in the first two commits
- keep `$ref` target properties when a sibling `type` triggers instance projection (cherry-picked from #2153)
- evaluate `$ref` / `$dynamicRef` siblings in the local schema scope so `unevaluatedProperties` and `unevaluatedItems` can consume target annotations (cherry-picked from #2153)
- collect array annotations before applying `unevaluatedItems` and ignore annotations from failed applicators (cherry-picked from #2153)
- add regression coverage for `$ref` object assertion siblings, including strict warnings that must survive next to a failing key
- expand the doc comments on the two ref-sibling projection predicates

## Why the approach changed

The first two commits filtered the `table-strict-additional-keys` diagnostics after they were produced. That treated the symptom, and it had two problems:

- the blanket `retain` in `validate_all_of` dropped every strict warning in the `allOf` subtree as soon as any key failed an assertion, silencing legitimate warnings for unrelated keys and for nested tables
- the same root cause also breaks `unevaluatedProperties` / `unevaluatedItems` next to `$ref`, which diagnostic filtering cannot reach at all

@kjanat's #2153 fixes the root cause instead. A sibling `type` no longer forces the resolved view to be rebuilt from the local node alone (which dropped the `$ref` target's `properties`), and real assertion siblings are represented as `SemanticCompositeKind::Reference` so the target's annotations land in the local evaluation scope. With that, the false strict warnings are never produced in the first place, and no diagnostic suppression is needed.

Cross-checking both approaches on a common base (`0f086fc04`), with each PR's tests ported to the other:

| | this PR's tests (13) | #2153's tests (16) |
| --- | --- | --- |
| original filtering approach | 13 pass | 8 pass, **8 fail** |
| #2153 root cause fix | 13 pass | 16 pass |

The 8 failures are the `unevaluatedProperties` / `unevaluatedItems` annotation-scope cases for `$ref`, `$dynamicRef` and external refs.

The three fix commits are cherry-picked from #2153 with authorship preserved. The `.gitignore` change from #2153 is not included — the LSP tests writing tempfiles into the workspace root is worth fixing on its own rather than ignoring the artifacts.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p tombi-linter --test integration ref_sibling` — 29 passed

Fixes #2151
Supersedes #2153
