### PR TITLE
fix(validator): scope conditional annotations

### DIFF
--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -56,6 +56,8 @@ mod tuple_items_test_schema;
 mod unevaluated_items_test_schema;
 #[path = "integration/unevaluated_properties_branch_additional_test_schema.rs"]
 mod unevaluated_properties_branch_additional_test_schema;
+#[path = "integration/unevaluated_properties_if_then_test_schema.rs"]
+mod unevaluated_properties_if_then_test_schema;
 #[path = "integration/unevaluated_properties_test_schema.rs"]
 mod unevaluated_properties_test_schema;
 #[path = "integration/union_best_match.rs"]

--- a/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
@@ -1,0 +1,79 @@
+use tombi_linter::test_lint;
+use tombi_test_lib::unevaluated_properties_if_then_test_schema_path;
+
+test_lint! {
+    #[test]
+    fn test_then_branch_annotations_apply_when_then_succeeds(
+        r#"
+        #:tombi schema.strict = false
+        [then_branch]
+        kind = "a"
+        value = 1
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_then_branch_annotations_dropped_when_then_fails(
+        r#"
+        #:tombi schema.strict = false
+        [then_branch]
+        kind = "a"
+        value = 1
+        extra = true
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "kind".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "value".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "extra".to_string(),
+        },
+        tombi_validator::DiagnosticKind::TableMaxKeys {
+            max_keys: 2,
+            actual: 3,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_else_branch_annotations_apply_when_else_succeeds(
+        r#"
+        #:tombi schema.strict = false
+        [else_branch]
+        other = 1
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_else_branch_annotations_dropped_when_else_fails(
+        r#"
+        #:tombi schema.strict = false
+        [else_branch]
+        other = 1
+        extra = 2
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "other".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "extra".to_string(),
+        },
+        tombi_validator::DiagnosticKind::TableMaxKeys {
+            max_keys: 1,
+            actual: 2,
+        },
+    ])
+}

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -224,6 +224,12 @@ pub fn unevaluated_properties_branch_additional_test_schema_path() -> PathBuf {
         .join("unevaluated-properties-branch-additional-test.schema.json")
 }
 
+pub fn unevaluated_properties_if_then_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("unevaluated-properties-if-then-test.schema.json")
+}
+
 pub fn lsp_consistency_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -964,7 +964,9 @@ async fn validate_table(
     {
         assertion_failed |= error.assertion_failed;
         match_evidence.merge_from(*error.match_evidence);
-        evaluated_locations.merge_from(error.local_evaluated_locations);
+        if !error.assertion_failed {
+            evaluated_locations.merge_from(error.local_evaluated_locations);
+        }
         total_diagnostics.extend(error.diagnostics);
     }
 
@@ -1361,6 +1363,44 @@ fn collect_evaluated_properties_from_schema_view<'a>(
     .boxed()
 }
 
+fn collect_evaluated_properties_from_applied_branch<'a>(
+    table_value: &'a tombi_document_tree_syntax::Table,
+    accessors: &'a [tombi_schema_store::Accessor],
+    schema_item: &'a tombi_schema_store::SchemaItem,
+    current_schema: &'a CurrentSchema<'a>,
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> BoxFuture<'a, Option<crate::Valid>> {
+    async move {
+        let Ok(Some(branch_current_schema)) = tombi_schema_store::resolve_schema_item(
+            schema_item,
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            current_schema.strict,
+            schema_context.store,
+        )
+        .await
+        .inspect_err(|err| log::warn!("{err}")) else {
+            return Some(crate::Valid::new());
+        };
+        let branch_current_schema = branch_current_schema
+            .for_instance_type(
+                tombi_schema_store::SchemaType::Object,
+                schema_context.string_formats(),
+            )
+            .unwrap_or(branch_current_schema);
+
+        match table_value
+            .validate(accessors, Some(&branch_current_schema), schema_context)
+            .await
+        {
+            Ok(evaluated_locations) => Some(evaluated_locations),
+            Err(error) if !error.assertion_failed => Some(error.local_evaluated_locations),
+            Err(_) => None,
+        }
+    }
+    .boxed()
+}
+
 fn collect_evaluated_properties_from_if_then_else_schema<'a>(
     table_value: &'a tombi_document_tree_syntax::Table,
     accessors: &'a [tombi_schema_store::Accessor],
@@ -1404,29 +1444,30 @@ fn collect_evaluated_properties_from_if_then_else_schema<'a>(
             .await;
 
             if let Some(then_schema) = &if_then_else_schema.then_schema {
-                result.merge_from(
-                    collect_evaluated_properties_from_schema_item(
-                        table_value,
-                        accessors,
-                        then_schema,
-                        current_schema,
-                        schema_context,
-                        visited_schema_values,
-                    )
-                    .await,
-                );
+                let Some(then_evaluated) = collect_evaluated_properties_from_applied_branch(
+                    table_value,
+                    accessors,
+                    then_schema,
+                    current_schema,
+                    schema_context,
+                )
+                .await
+                else {
+                    return crate::Valid::new();
+                };
+                result.merge_from(then_evaluated);
             }
             result
         } else if let Some(else_schema) = &if_then_else_schema.else_schema {
-            collect_evaluated_properties_from_schema_item(
+            collect_evaluated_properties_from_applied_branch(
                 table_value,
                 accessors,
                 else_schema,
                 current_schema,
                 schema_context,
-                visited_schema_values,
             )
             .await
+            .unwrap_or_default()
         } else {
             crate::Valid::new()
         }

--- a/schemas/unevaluated-properties-if-then-test.schema.json
+++ b/schemas/unevaluated-properties-if-then-test.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UnevaluatedPropertiesIfThenTest",
+  "type": "object",
+  "properties": {
+    "then_branch": {
+      "type": "object",
+      "if": {
+        "properties": { "kind": { "type": "string" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "kind": { "type": "string" },
+          "value": { "type": "integer" }
+        },
+        "maxProperties": 2
+      },
+      "unevaluatedProperties": false
+    },
+    "else_branch": {
+      "type": "object",
+      "if": {
+        "properties": { "kind": { "type": "string" } },
+        "required": ["kind"]
+      },
+      "else": {
+        "properties": {
+          "other": { "type": "integer" }
+        },
+        "maxProperties": 1
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- discard annotations from the entire `if`/`then`/`else` applicator when its selected branch fails
- prevent failed conditionals from suppressing sibling `unevaluatedProperties` diagnostics
- preserve annotations from successful conditionals and non-assertion lint diagnostics
- reuse the branch validation result instead of walking its schema again
- add regression coverage for successful and failing `then` and `else` branches

## Validation

```sh
cargo nextest run -p tombi-validator -p tombi-linter # 484 passed
cargo test -p tombi-linter --test integration unevaluated_properties_if_then_test_schema:: # 4 passed
```

Related to #2151
Related to #2152
