### PR TITLE
fix(validator): scope conditional and dependency annotations

### DIFF
--- a/crates/tombi-linter/tests/integration.rs
+++ b/crates/tombi-linter/tests/integration.rs
@@ -56,6 +56,8 @@ mod tuple_items_test_schema;
 mod unevaluated_items_test_schema;
 #[path = "integration/unevaluated_properties_branch_additional_test_schema.rs"]
 mod unevaluated_properties_branch_additional_test_schema;
+#[path = "integration/unevaluated_properties_if_then_test_schema.rs"]
+mod unevaluated_properties_if_then_test_schema;
 #[path = "integration/unevaluated_properties_test_schema.rs"]
 mod unevaluated_properties_test_schema;
 #[path = "integration/union_best_match.rs"]

--- a/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
+++ b/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
@@ -1120,6 +1120,9 @@ mod draft2019_09_unevaluated_properties {
         fn schema() -> JsonValue {
             serde_json::json!({
                 "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "properties": {
+                    "foo": {"type": "string"}
+                },
                 "dependentSchemas": {
                     "foo": {
                         "properties": {
@@ -1200,6 +1203,12 @@ mod draft2019_09_unevaluated_properties {
             ) -> Err([
                 tombi_validator::Diagnostic::new(
                     tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "foo".to_string()
+                    },
+                    ((0, 0), (0, 15))
+                ),
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
                         key: "bar".to_string()
                     },
                     ((1, 0), (1, 10))
@@ -1210,6 +1219,39 @@ mod draft2019_09_unevaluated_properties {
                         actual: 2,
                     },
                     ((0, 0), (2, 0))
+                ),
+            ]);
+        );
+
+        fn dependent_required_schema() -> JsonValue {
+            serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "dependentRequired": {
+                    "foo": ["bar"]
+                },
+                "unevaluatedProperties": false
+            })
+        }
+
+        suite_test!(
+            #[tokio::test] async fn dependent_required_does_not_mark_properties_as_evaluated(
+                r#"
+                foo = "trigger"
+                bar = "ok"
+                "#,
+                JsonSchema(dependent_required_schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "foo".to_string()
+                    },
+                    ((0, 0), (0, 15))
+                ),
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "bar".to_string()
+                    },
+                    ((1, 0), (1, 10))
                 ),
             ]);
         );

--- a/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
+++ b/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
@@ -1177,6 +1177,37 @@ mod draft2019_09_unevaluated_properties {
             ]);
         );
 
+        fn trigger_key_only_schema() -> JsonValue {
+            serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "dependentSchemas": {
+                    "foo": {
+                        "properties": {
+                            "bar": {"type": "string"}
+                        }
+                    }
+                },
+                "unevaluatedProperties": false
+            })
+        }
+
+        suite_test!(
+            #[tokio::test] async fn successful_dependency_does_not_annotate_trigger_key(
+                r#"
+                foo = "x"
+                bar = "y"
+                "#,
+                JsonSchema(trigger_key_only_schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "foo".to_string()
+                    },
+                    ((0, 0), (0, 9))
+                ),
+            ]);
+        );
+
         fn failing_schema() -> JsonValue {
             serde_json::json!({
                 "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
+++ b/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
@@ -1157,6 +1157,62 @@ mod draft2019_09_unevaluated_properties {
                 ),
             ]);
         );
+
+        suite_test!(
+            #[tokio::test] async fn dependency_annotations_are_not_collected_without_trigger(
+                r#"
+                bar = "ok"
+                "#,
+                JsonSchema(schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "bar".to_string()
+                    },
+                    ((0, 0), (0, 10))
+                ),
+            ]);
+        );
+
+        fn failing_schema() -> JsonValue {
+            serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2019-09/schema",
+                "dependentSchemas": {
+                    "foo": {
+                        "properties": {
+                            "foo": {"type": "string"},
+                            "bar": {"type": "string"}
+                        },
+                        "maxProperties": 1
+                    }
+                },
+                "unevaluatedProperties": false
+            })
+        }
+
+        suite_test!(
+            #[tokio::test] async fn failed_dependency_annotations_are_not_collected(
+                r#"
+                foo = "trigger"
+                bar = "ok"
+                "#,
+                JsonSchema(failing_schema()),
+            ) -> Err([
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+                        key: "bar".to_string()
+                    },
+                    ((1, 0), (1, 10))
+                ),
+                tombi_validator::Diagnostic::new(
+                    tombi_validator::DiagnosticKind::TableMaxKeys {
+                        max_keys: 1,
+                        actual: 2,
+                    },
+                    ((0, 0), (2, 0))
+                ),
+            ]);
+        );
     }
 
     mod any_of_evaluated_properties {

--- a/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
+++ b/crates/tombi-linter/tests/integration/ref_sibling_assertions.rs
@@ -228,7 +228,7 @@ test_lint! {
 
 test_lint! {
     #[test]
-    fn failed_conditional_does_not_contribute_to_unevaluated_items(
+    fn failed_then_keeps_successful_if_annotations_for_unevaluated_items(
         r#"
         failed_conditional_with_unevaluated_items = [1, 2]
         "#,
@@ -237,9 +237,6 @@ test_lint! {
         tombi_validator::DiagnosticKind::ArrayMinValues {
             min_values: 5,
             actual: 2,
-        },
-        tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
-            index: 0,
         },
         tombi_validator::DiagnosticKind::ArrayUnevaluatedItemNotAllowed {
             index: 1,

--- a/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
@@ -16,7 +16,7 @@ test_lint! {
 
 test_lint! {
     #[test]
-    fn test_then_branch_annotations_dropped_when_then_fails(
+    fn test_failed_then_keeps_successful_if_annotations(
         r#"
         #:tombi schema.strict = false
         [then_branch]
@@ -26,9 +26,6 @@ test_lint! {
         "#,
         SchemaPath(unevaluated_properties_if_then_test_schema_path()),
     ) -> Err([
-        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
-            key: "kind".to_string(),
-        },
         tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
             key: "value".to_string(),
         },

--- a/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
+++ b/crates/tombi-linter/tests/integration/unevaluated_properties_if_then_test_schema.rs
@@ -1,0 +1,79 @@
+use tombi_linter::test_lint;
+use tombi_test_lib::unevaluated_properties_if_then_test_schema_path;
+
+test_lint! {
+    #[test]
+    fn test_then_branch_annotations_apply_when_then_succeeds(
+        r#"
+        #:tombi schema.strict = false
+        [then_branch]
+        kind = "a"
+        value = 1
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_then_branch_annotations_dropped_when_then_fails(
+        r#"
+        #:tombi schema.strict = false
+        [then_branch]
+        kind = "a"
+        value = 1
+        extra = true
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "kind".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "value".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "extra".to_string(),
+        },
+        tombi_validator::DiagnosticKind::TableMaxKeys {
+            max_keys: 2,
+            actual: 3,
+        },
+    ])
+}
+
+test_lint! {
+    #[test]
+    fn test_else_branch_annotations_apply_when_else_succeeds(
+        r#"
+        #:tombi schema.strict = false
+        [else_branch]
+        other = 1
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Ok(_)
+}
+
+test_lint! {
+    #[test]
+    fn test_else_branch_annotations_dropped_when_else_fails(
+        r#"
+        #:tombi schema.strict = false
+        [else_branch]
+        other = 1
+        extra = 2
+        "#,
+        SchemaPath(unevaluated_properties_if_then_test_schema_path()),
+    ) -> Err([
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "other".to_string(),
+        },
+        tombi_validator::DiagnosticKind::UnevaluatedPropertyNotAllowed {
+            key: "extra".to_string(),
+        },
+        tombi_validator::DiagnosticKind::TableMaxKeys {
+            max_keys: 1,
+            actual: 2,
+        },
+    ])
+}

--- a/crates/tombi-test-lib/src/path.rs
+++ b/crates/tombi-test-lib/src/path.rs
@@ -224,6 +224,12 @@ pub fn unevaluated_properties_branch_additional_test_schema_path() -> PathBuf {
         .join("unevaluated-properties-branch-additional-test.schema.json")
 }
 
+pub fn unevaluated_properties_if_then_test_schema_path() -> PathBuf {
+    project_root_path()
+        .join("schemas")
+        .join("unevaluated-properties-if-then-test.schema.json")
+}
+
 pub fn lsp_consistency_test_schema_path() -> PathBuf {
     project_root_path()
         .join("schemas")

--- a/crates/tombi-validator/src/valid.rs
+++ b/crates/tombi-validator/src/valid.rs
@@ -18,6 +18,27 @@ impl Valid {
         self.match_evidence.merge_from(*other.match_evidence);
     }
 
+    /// Merges the annotations a subschema produced into `self` and returns
+    /// whatever failure is left for the caller to report.
+    ///
+    /// Annotations of a subschema whose assertions failed are discarded,
+    /// because a failing subschema contributes nothing to
+    /// `unevaluatedProperties` / `unevaluatedItems`.
+    pub fn merge_result(&mut self, result: Result<Self, crate::Invalid>) -> Option<crate::Invalid> {
+        match result {
+            Ok(local_evaluated_locations) => {
+                self.merge_from(local_evaluated_locations);
+                None
+            }
+            Err(mut error) => {
+                if !error.assertion_failed {
+                    self.merge_from(std::mem::take(&mut error.local_evaluated_locations));
+                }
+                Some(error)
+            }
+        }
+    }
+
     #[inline]
     pub fn mark_property(&mut self, key: impl Into<String>) {
         self.properties.insert(key.into());

--- a/crates/tombi-validator/src/valid.rs
+++ b/crates/tombi-validator/src/valid.rs
@@ -18,25 +18,40 @@ impl Valid {
         self.match_evidence.merge_from(*other.match_evidence);
     }
 
-    /// Merges the annotations a subschema produced into `self` and returns
-    /// whatever failure is left for the caller to report.
+    /// Merges the annotations a validation result carries into `self` and
+    /// returns whatever failure is left for the caller to report.
     ///
-    /// Annotations of a subschema whose assertions failed are discarded,
-    /// because a failing subschema contributes nothing to
-    /// `unevaluatedProperties` / `unevaluatedItems`.
-    pub fn merge_result(&mut self, result: Result<Self, crate::Invalid>) -> Option<crate::Invalid> {
+    /// The caller is responsible for having dropped the annotations of any
+    /// subschema whose own assertions failed. Use this when the result is the
+    /// merged output of several subschemas that already applied that rule
+    /// individually — as `validate_if_then_else` does — so that a failing
+    /// branch does not take its successful siblings' annotations with it.
+    pub(crate) fn merge_result_keeping_annotations(
+        &mut self,
+        result: Result<Self, crate::Invalid>,
+    ) -> Option<crate::Invalid> {
         match result {
             Ok(local_evaluated_locations) => {
                 self.merge_from(local_evaluated_locations);
                 None
             }
             Err(mut error) => {
-                if !error.assertion_failed {
-                    self.merge_from(std::mem::take(&mut error.local_evaluated_locations));
-                }
+                self.merge_from(std::mem::take(&mut error.local_evaluated_locations));
                 Some(error)
             }
         }
+    }
+
+    /// Merges the annotations a single subschema produced into `self`, dropping
+    /// them when that subschema failed its own assertions, and returns whatever
+    /// failure is left for the caller to report.
+    pub(crate) fn merge_result(
+        &mut self,
+        mut result: Result<Self, crate::Invalid>,
+    ) -> Option<crate::Invalid> {
+        crate::validate::discard_failed_annotations(&mut result);
+
+        self.merge_result_keeping_annotations(result)
     }
 
     #[inline]

--- a/crates/tombi-validator/src/validate.rs
+++ b/crates/tombi-validator/src/validate.rs
@@ -474,6 +474,23 @@ pub(crate) fn schema_resolution_diagnostic(
     .then(|| error.to_warning_diagnostic(range))
 }
 
+/// Drops the annotations a subschema produced when its own assertions failed —
+/// such a subschema contributes nothing to `unevaluatedProperties` /
+/// `unevaluatedItems`. Annotations its successful siblings produced are
+/// untouched, so a parent applicator must apply this per subschema result
+/// rather than to the merged result of the whole applicator.
+///
+/// This resets the whole `local_evaluated_locations`, including the match
+/// evidence nested in it; callers that need the failure's own match evidence
+/// read it from `Invalid::match_evidence`.
+pub(crate) fn discard_failed_annotations(result: &mut Result<crate::Valid, crate::Invalid>) {
+    if let Err(error) = result
+        && error.assertion_failed
+    {
+        error.local_evaluated_locations = crate::Valid::new();
+    }
+}
+
 pub(crate) fn is_assertion_success(result: &Result<crate::Valid, crate::Invalid>) -> bool {
     match result {
         Ok(_) => true,

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -152,7 +152,7 @@ async fn validate_array(
         )
         .await;
 
-        if let Some(error) = validation_result.merge_result(result) {
+        if let Some(error) = validation_result.merge_result_keeping_annotations(result) {
             assertion_failed |= error.assertion_failed;
             validation_result
                 .match_evidence

--- a/crates/tombi-validator/src/validate/array.rs
+++ b/crates/tombi-validator/src/validate/array.rs
@@ -142,7 +142,7 @@ async fn validate_array(
         || array_schema.unevaluated_items == Some(false);
 
     if let Some(if_then_else_schema) = array_schema.if_then_else.as_ref() {
-        match validate_if_then_else(
+        let result = validate_if_then_else(
             array_value,
             accessors,
             if_then_else_schema,
@@ -150,19 +150,14 @@ async fn validate_array(
             schema_context,
             common_rules,
         )
-        .await
-        {
-            Ok(result) => validation_result.merge_from(result),
-            Err(error) => {
-                assertion_failed |= error.assertion_failed;
-                validation_result
-                    .match_evidence
-                    .merge_from(*error.match_evidence);
-                if !error.assertion_failed {
-                    validation_result.merge_from(error.local_evaluated_locations);
-                }
-                total_diagnostics.extend(error.diagnostics);
-            }
+        .await;
+
+        if let Some(error) = validation_result.merge_result(result) {
+            assertion_failed |= error.assertion_failed;
+            validation_result
+                .match_evidence
+                .merge_from(*error.match_evidence);
+            total_diagnostics.extend(error.diagnostics);
         }
     }
 

--- a/crates/tombi-validator/src/validate/if_then_else.rs
+++ b/crates/tombi-validator/src/validate/if_then_else.rs
@@ -5,7 +5,7 @@ use tombi_document_tree_syntax::ValueImpl;
 use tombi_schema_store::CurrentSchema;
 
 use crate::Validate;
-use crate::validate::{is_assertion_success, merge_validation_results};
+use crate::validate::{discard_failed_annotations, is_assertion_success, merge_validation_results};
 
 pub async fn validate_if_then_else<T>(
     value: &T,
@@ -18,10 +18,14 @@ pub async fn validate_if_then_else<T>(
 where
     T: Validate + ValueImpl + Sync + Send,
 {
+    // A failed `if`, `then` or `else` subschema drops its own annotations, but
+    // the ones its successful siblings produced survive, so the rule is applied
+    // per subschema result rather than to the merged result.
     #[allow(clippy::result_large_err)]
     let merge_if_result =
-        |branch_result: Result<crate::Valid, crate::Invalid>,
+        |mut branch_result: Result<crate::Valid, crate::Invalid>,
          if_result: Result<crate::Valid, crate::Invalid>| {
+            discard_failed_annotations(&mut branch_result);
             match if_result {
                 Ok(evaluated_locations) => {
                     merge_validation_results(Ok(evaluated_locations), branch_result)
@@ -106,9 +110,10 @@ where
             .await
             {
                 Ok(Some(else_current_schema)) => {
-                    return value
+                    let branch_result = value
                         .validate(accessors, Some(&else_current_schema), schema_context)
                         .await;
+                    return merge_if_result(branch_result, if_result);
                 }
                 Err(err) => {
                     if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
@@ -116,7 +121,7 @@ where
                         value.range(),
                         common_rules,
                     ) {
-                        return Err(vec![diagnostic].into());
+                        return merge_if_result(Err(vec![diagnostic].into()), if_result);
                     }
                 }
                 Ok(None) => {}

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use tombi_accessor::MarkdownSchemaAccessors;
 use tombi_comment_directive::value::TableCommonLintRules;
 use tombi_future::{BoxFuture, Boxable};
+use tombi_hashmap::HashMap;
 use tombi_schema_store::{Accessor, CompositeSchema, CurrentSchema, SchemaAccessor, SchemaView};
 use tombi_severity_level::{SeverityLevel, SeverityLevelDefaultError};
 
@@ -12,13 +13,101 @@ use crate::{
     validate::{
         filter_table_strict_additional_diagnostics, handle_anything_schema, handle_deprecated,
         handle_deprecated_value, handle_nothing_schema, handle_unused_noqa,
-        if_then_else::validate_if_then_else, is_assertion_success, merge_validation_results,
+        if_then_else::validate_if_then_else, merge_validation_results,
         validate_adjacent_applicators,
     },
 };
 
 use super::{Validate, validate_all_of, validate_any_of, validate_one_of};
 use crate::diagnostic::Patterns;
+
+/// A dependency schema is an additional constraint layered on top of the parent
+/// table schema. Running strict mode here against the partial dependency schema
+/// causes false-positive additional key diagnostics for valid keys defined by
+/// the parent schema.
+fn dependency_schema_context<'a>(
+    schema_context: &tombi_schema_store::SchemaContext<'a>,
+) -> tombi_schema_store::SchemaContext<'a> {
+    tombi_schema_store::SchemaContext {
+        toml_version: schema_context.toml_version,
+        root_schema: schema_context.root_schema,
+        sub_schema_link_map: schema_context.sub_schema_link_map,
+        deprecated_lint_level: schema_context.deprecated_lint_level,
+        schema_format_rules: schema_context.schema_format_rules,
+        schema_lint_rules: schema_context.schema_lint_rules,
+        schema_overrides: schema_context.schema_overrides,
+        schema_visits: schema_context.schema_visits.clone(),
+        store: schema_context.store,
+        strict: Some(false.into()),
+    }
+}
+
+/// Validates every dependent schema whose trigger key is present, merging the
+/// annotations it produced into `evaluated_locations`.
+///
+/// `unevaluatedProperties` is decided while walking the keys, so these have to
+/// run before that walk; the failures they leave behind are returned so the
+/// caller can report them where the owning keyword is diagnosed, keeping the
+/// diagnostic order the keyword would have produced on its own. Only the
+/// diagnostics and `assertion_failed` of a returned failure are reported; its
+/// `match_evidence` does not propagate out of a dependent schema.
+async fn validate_dependent_schemas<'a>(
+    entries: &[(&'a str, &'a tombi_schema_store::SchemaItem)],
+    table_value: &tombi_document_tree_syntax::Table,
+    accessors: &[tombi_schema_store::Accessor],
+    keys: &[&str],
+    current_schema: &CurrentSchema<'_>,
+    schema_context: &tombi_schema_store::SchemaContext<'_>,
+    common_rules: Option<&tombi_comment_directive::value::CommonLintRules>,
+    evaluated_locations: &mut crate::Valid,
+) -> HashMap<&'a str, crate::Invalid> {
+    let dependency_context = dependency_schema_context(schema_context);
+    let mut failures = HashMap::new();
+
+    for (dependent_key, schema_item) in entries {
+        if !keys.contains(dependent_key) {
+            continue;
+        }
+
+        match tombi_schema_store::resolve_schema_item(
+            schema_item,
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            current_schema.strict,
+            schema_context.store,
+        )
+        .await
+        {
+            Ok(Some(dependent_schema)) => {
+                let result = table_value
+                    .validate(accessors, Some(&dependent_schema), &dependency_context)
+                    .await;
+
+                if let Some(error) = evaluated_locations.merge_result(result) {
+                    failures.insert(*dependent_key, error);
+                }
+            }
+            Ok(None) => {}
+            Err(err) => {
+                if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
+                    &err,
+                    table_value.range(),
+                    common_rules,
+                ) {
+                    failures.insert(
+                        *dependent_key,
+                        crate::Invalid {
+                            diagnostics: vec![diagnostic],
+                            ..Default::default()
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    failures
+}
 
 impl Validate for tombi_document_tree_syntax::Table {
     fn validate<'a: 'b, 'b>(
@@ -144,6 +233,7 @@ async fn validate_table(
     let mut assertion_failed = false;
     let mut total_diagnostics = vec![];
     let common_rules = table_rules.map(|rules| &rules.common);
+    let keys = table_value.keys().map(|key| key.value()).collect_vec();
     let mut evaluated_locations = collect_evaluated_properties_from_table_schema(
         table_value,
         accessors,
@@ -152,6 +242,64 @@ async fn validate_table(
         schema_context,
     )
     .await;
+
+    let mut dependency_schema_failures = HashMap::new();
+    if let Some(dependencies) = &table_schema.dependencies {
+        let entries = dependencies
+            .iter()
+            .filter_map(|(key, dependency)| match dependency {
+                tombi_schema_store::Dependency::Schema(schema_item) => {
+                    Some((key.as_str(), schema_item))
+                }
+                tombi_schema_store::Dependency::Property(_) => None,
+            })
+            .collect_vec();
+        dependency_schema_failures = validate_dependent_schemas(
+            &entries,
+            table_value,
+            accessors,
+            &keys,
+            current_schema,
+            schema_context,
+            common_rules,
+            &mut evaluated_locations,
+        )
+        .await;
+    }
+
+    let mut dependent_schema_failures = HashMap::new();
+    if let Some(dependent_schemas) = &table_schema.dependent_schemas {
+        let entries = dependent_schemas
+            .iter()
+            .map(|(key, schema_item)| (key.as_str(), schema_item))
+            .collect_vec();
+        dependent_schema_failures = validate_dependent_schemas(
+            &entries,
+            table_value,
+            accessors,
+            &keys,
+            current_schema,
+            schema_context,
+            common_rules,
+            &mut evaluated_locations,
+        )
+        .await;
+    }
+
+    let if_then_else_error = if let Some(if_then_else_schema) = &table_schema.if_then_else {
+        let result = validate_if_then_else(
+            table_value,
+            accessors,
+            if_then_else_schema,
+            current_schema,
+            schema_context,
+            common_rules,
+        )
+        .await;
+        evaluated_locations.merge_result(result)
+    } else {
+        None
+    };
     let evaluated_properties = &evaluated_locations.properties;
 
     for (key, value) in table_value.key_values() {
@@ -528,8 +676,6 @@ async fn validate_table(
         }
     }
 
-    let keys = table_value.keys().map(|key| key.value()).collect_vec();
-
     if let Some(required) = &table_schema.required {
         for required_key in required {
             if !keys.contains(&required_key.as_str()) {
@@ -649,12 +795,12 @@ async fn validate_table(
 
     if let Some(dependencies) = &table_schema.dependencies {
         for (dependent_key, dependency) in dependencies {
-            if !keys.contains(&dependent_key.as_str()) {
-                continue;
-            }
-
             match dependency {
                 tombi_schema_store::Dependency::Property(required_keys) => {
+                    if !keys.contains(&dependent_key.as_str()) {
+                        continue;
+                    }
+
                     for required_key in required_keys {
                         if !keys.contains(&required_key.as_str()) {
                             assertion_failed = true;
@@ -672,56 +818,11 @@ async fn validate_table(
                         }
                     }
                 }
-                tombi_schema_store::Dependency::Schema(schema_item) => {
-                    match tombi_schema_store::resolve_schema_item(
-                        schema_item,
-                        current_schema.schema_uri.clone(),
-                        current_schema.definitions.clone(),
-                        current_schema.strict,
-                        schema_context.store,
-                    )
-                    .await
+                tombi_schema_store::Dependency::Schema(_) => {
+                    if let Some(failure) = dependency_schema_failures.remove(dependent_key.as_str())
                     {
-                        Ok(Some(dep_schema)) => {
-                            // A dependency schema is an additional constraint layered on top of
-                            // the parent table schema. Running strict mode here against the
-                            // partial dependency schema causes false-positive additional key
-                            // diagnostics for valid keys defined by the parent schema.
-                            let dependency_schema_context = tombi_schema_store::SchemaContext {
-                                toml_version: schema_context.toml_version,
-                                root_schema: schema_context.root_schema,
-                                sub_schema_link_map: schema_context.sub_schema_link_map,
-                                deprecated_lint_level: schema_context.deprecated_lint_level,
-                                schema_format_rules: schema_context.schema_format_rules,
-                                schema_lint_rules: schema_context.schema_lint_rules,
-                                schema_overrides: schema_context.schema_overrides,
-                                schema_visits: schema_context.schema_visits.clone(),
-                                store: schema_context.store,
-                                strict: Some(false.into()),
-                            };
-
-                            if let Err(crate::Invalid {
-                                assertion_failed: child_assertion_failed,
-                                diagnostics,
-                                ..
-                            }) = table_value
-                                .validate(accessors, Some(&dep_schema), &dependency_schema_context)
-                                .await
-                            {
-                                assertion_failed |= child_assertion_failed;
-                                total_diagnostics.extend(diagnostics);
-                            }
-                        }
-                        Ok(None) => {}
-                        Err(err) => {
-                            if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
-                                &err,
-                                table_value.range(),
-                                common_rules,
-                            ) {
-                                total_diagnostics.push(diagnostic);
-                            }
-                        }
+                        assertion_failed |= failure.assertion_failed;
+                        total_diagnostics.extend(failure.diagnostics);
                     }
                 }
             }
@@ -754,57 +855,12 @@ async fn validate_table(
     }
 
     if let Some(dependent_schemas) = &table_schema.dependent_schemas {
-        for (dependent_key, schema_item) in dependent_schemas {
-            if !keys.contains(&dependent_key.as_str()) {
-                continue;
-            }
-
-            match tombi_schema_store::resolve_schema_item(
-                schema_item,
-                current_schema.schema_uri.clone(),
-                current_schema.definitions.clone(),
-                current_schema.strict,
-                schema_context.store,
-            )
-            .await
-            {
-                Ok(Some(dep_schema)) => {
-                    // See the rationale in the `Dependency::Schema` branch above.
-                    let dependency_schema_context = tombi_schema_store::SchemaContext {
-                        toml_version: schema_context.toml_version,
-                        root_schema: schema_context.root_schema,
-                        sub_schema_link_map: schema_context.sub_schema_link_map,
-                        deprecated_lint_level: schema_context.deprecated_lint_level,
-                        schema_format_rules: schema_context.schema_format_rules,
-                        schema_lint_rules: schema_context.schema_lint_rules,
-                        schema_overrides: schema_context.schema_overrides,
-                        schema_visits: schema_context.schema_visits.clone(),
-                        store: schema_context.store,
-                        strict: Some(false.into()),
-                    };
-
-                    if let Err(crate::Invalid {
-                        assertion_failed: child_assertion_failed,
-                        diagnostics,
-                        ..
-                    }) = table_value
-                        .validate(accessors, Some(&dep_schema), &dependency_schema_context)
-                        .await
-                    {
-                        assertion_failed |= child_assertion_failed;
-                        total_diagnostics.extend(diagnostics);
-                    }
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    if let Some(diagnostic) = crate::validate::schema_resolution_diagnostic(
-                        &err,
-                        table_value.range(),
-                        common_rules,
-                    ) {
-                        total_diagnostics.push(diagnostic);
-                    }
-                }
+        // Walk the schema's own (insertion-ordered) map rather than draining the
+        // failures, so diagnostics keep the order the keywords are declared in.
+        for dependent_key in dependent_schemas.keys() {
+            if let Some(error) = dependent_schema_failures.remove(dependent_key.as_str()) {
+                assertion_failed |= error.assertion_failed;
+                total_diagnostics.extend(error.diagnostics);
             }
         }
     }
@@ -946,22 +1002,9 @@ async fn validate_table(
         );
     }
 
-    if let Some(if_then_else_schema) = table_schema.if_then_else.as_ref()
-        && let Err(error) = validate_if_then_else(
-            table_value,
-            accessors,
-            if_then_else_schema,
-            current_schema,
-            schema_context,
-            common_rules,
-        )
-        .await
-    {
+    if let Some(error) = if_then_else_error {
         assertion_failed |= error.assertion_failed;
         match_evidence.merge_from(*error.match_evidence);
-        if !error.assertion_failed {
-            evaluated_locations.merge_from(error.local_evaluated_locations);
-        }
         total_diagnostics.extend(error.diagnostics);
     }
 
@@ -1008,8 +1051,6 @@ fn collect_evaluated_properties_from_table_schema<'a>(
 ) -> BoxFuture<'a, crate::Valid> {
     async move {
         let mut result = crate::Valid::new();
-        let mut dependent_schema_items = Vec::new();
-
         let property_keys = table_schema
             .properties
             .read()
@@ -1077,81 +1118,6 @@ fn collect_evaluated_properties_from_table_schema<'a>(
             }
         }
 
-        if let Some(dependencies) = &table_schema.dependencies {
-            for (dependent_key, dependency) in dependencies {
-                if let tombi_schema_store::Dependency::Schema(schema_item) = dependency {
-                    dependent_schema_items.push((dependent_key, schema_item));
-                }
-            }
-        }
-
-        if let Some(dependent_schemas) = &table_schema.dependent_schemas {
-            for (dependent_key, schema_item) in dependent_schemas {
-                dependent_schema_items.push((dependent_key, schema_item));
-            }
-        }
-
-        if !dependent_schema_items.is_empty() {
-            let dependency_schema_context = tombi_schema_store::SchemaContext {
-                toml_version: schema_context.toml_version,
-                root_schema: schema_context.root_schema,
-                sub_schema_link_map: schema_context.sub_schema_link_map,
-                deprecated_lint_level: schema_context.deprecated_lint_level,
-                schema_format_rules: schema_context.schema_format_rules,
-                schema_lint_rules: schema_context.schema_lint_rules,
-                schema_overrides: schema_context.schema_overrides,
-                schema_visits: schema_context.schema_visits.clone(),
-                store: schema_context.store,
-                strict: Some(false.into()),
-            };
-            let comment_directives = table_value
-                .comment_directives()
-                .map(|directives| directives.cloned().collect_vec());
-
-            for (dependent_key, schema_item) in dependent_schema_items {
-                if !table_value.keys().any(|key| key.value() == dependent_key) {
-                    continue;
-                }
-
-                let Ok(Some(schema)) = tombi_schema_store::resolve_schema_item(
-                    schema_item,
-                    current_schema.schema_uri.clone(),
-                    current_schema.definitions.clone(),
-                    current_schema.strict,
-                    schema_context.store,
-                )
-                .await
-                .inspect_err(|err| log::warn!("{err}")) else {
-                    continue;
-                };
-                let schema = schema
-                    .for_instance_type(
-                        tombi_schema_store::SchemaType::Object,
-                        schema_context.string_formats(),
-                    )
-                    .unwrap_or(schema);
-                let Some(validation_result) = crate::validate::validate_resolved_schema(
-                    table_value,
-                    accessors,
-                    &schema,
-                    &dependency_schema_context,
-                    comment_directives.as_deref(),
-                    None,
-                )
-                .await
-                else {
-                    continue;
-                };
-
-                if is_assertion_success(&validation_result) {
-                    match validation_result {
-                        Ok(evaluated_locations) => result.merge_from(evaluated_locations),
-                        Err(error) => result.merge_from(error.local_evaluated_locations),
-                    }
-                }
-            }
-        }
-
         if let Some(one_of_schema) = &table_schema.one_of {
             result.merge_from(
                 collect_evaluated_properties_from_referable_schemas(
@@ -1187,25 +1153,6 @@ fn collect_evaluated_properties_from_table_schema<'a>(
                 )
                 .await,
             );
-        }
-
-        if let Some(if_then_else_schema) = &table_schema.if_then_else {
-            let validation_result = validate_if_then_else(
-                table_value,
-                accessors,
-                if_then_else_schema,
-                current_schema,
-                schema_context,
-                None,
-            )
-            .await;
-
-            if is_assertion_success(&validation_result) {
-                match validation_result {
-                    Ok(evaluated_locations) => result.merge_from(evaluated_locations),
-                    Err(error) => result.merge_from(error.local_evaluated_locations),
-                }
-            }
         }
 
         // An `unevaluatedProperties: true` subschema succeeds for every
@@ -1247,16 +1194,17 @@ fn collect_evaluated_properties_from_referable_schemas<'a>(
             return result;
         };
 
+        let comment_directives = table_value
+            .comment_directives()
+            .map(|directives| directives.cloned().collect_vec());
+
         for schema in &schemas {
             let Some(validation_result) = crate::validate::validate_resolved_schema(
                 table_value,
                 accessors,
                 schema,
                 schema_context,
-                table_value
-                    .comment_directives()
-                    .map(|directives| directives.cloned().collect_vec())
-                    .as_deref(),
+                comment_directives.as_deref(),
                 None,
             )
             .await

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -964,7 +964,9 @@ async fn validate_table(
     {
         assertion_failed |= error.assertion_failed;
         match_evidence.merge_from(*error.match_evidence);
-        evaluated_locations.merge_from(error.local_evaluated_locations);
+        if !error.assertion_failed {
+            evaluated_locations.merge_from(error.local_evaluated_locations);
+        }
         total_diagnostics.extend(error.diagnostics);
     }
 
@@ -1361,6 +1363,44 @@ fn collect_evaluated_properties_from_schema_view<'a>(
     .boxed()
 }
 
+fn collect_evaluated_properties_from_applied_branch<'a>(
+    table_value: &'a tombi_document_tree_syntax::Table,
+    accessors: &'a [tombi_schema_store::Accessor],
+    schema_item: &'a tombi_schema_store::SchemaItem,
+    current_schema: &'a CurrentSchema<'a>,
+    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
+) -> BoxFuture<'a, Option<crate::Valid>> {
+    async move {
+        let Ok(Some(branch_current_schema)) = tombi_schema_store::resolve_schema_item(
+            schema_item,
+            current_schema.schema_uri.clone(),
+            current_schema.definitions.clone(),
+            current_schema.strict,
+            schema_context.store,
+        )
+        .await
+        .inspect_err(|err| log::warn!("{err}")) else {
+            return Some(crate::Valid::new());
+        };
+        let branch_current_schema = branch_current_schema
+            .for_instance_type(
+                tombi_schema_store::SchemaType::Object,
+                schema_context.string_formats(),
+            )
+            .unwrap_or(branch_current_schema);
+
+        match table_value
+            .validate(accessors, Some(&branch_current_schema), schema_context)
+            .await
+        {
+            Ok(evaluated_locations) => Some(evaluated_locations),
+            Err(error) if !error.assertion_failed => Some(error.local_evaluated_locations),
+            Err(_) => None,
+        }
+    }
+    .boxed()
+}
+
 fn collect_evaluated_properties_from_if_then_else_schema<'a>(
     table_value: &'a tombi_document_tree_syntax::Table,
     accessors: &'a [tombi_schema_store::Accessor],
@@ -1404,29 +1444,30 @@ fn collect_evaluated_properties_from_if_then_else_schema<'a>(
             .await;
 
             if let Some(then_schema) = &if_then_else_schema.then_schema {
-                result.merge_from(
-                    collect_evaluated_properties_from_schema_item(
-                        table_value,
-                        accessors,
-                        then_schema,
-                        current_schema,
-                        schema_context,
-                        visited_schema_values,
-                    )
-                    .await,
-                );
+                let Some(then_evaluated) = collect_evaluated_properties_from_applied_branch(
+                    table_value,
+                    accessors,
+                    then_schema,
+                    current_schema,
+                    schema_context,
+                )
+                .await
+                else {
+                    return crate::Valid::new();
+                };
+                result.merge_from(then_evaluated);
             }
             result
         } else if let Some(else_schema) = &if_then_else_schema.else_schema {
-            collect_evaluated_properties_from_schema_item(
+            collect_evaluated_properties_from_applied_branch(
                 table_value,
                 accessors,
                 else_schema,
                 current_schema,
                 schema_context,
-                visited_schema_values,
             )
             .await
+            .unwrap_or_default()
         } else {
             crate::Valid::new()
         }

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -2,7 +2,6 @@ use itertools::Itertools;
 use tombi_accessor::MarkdownSchemaAccessors;
 use tombi_comment_directive::value::TableCommonLintRules;
 use tombi_future::{BoxFuture, Boxable};
-use tombi_hashmap::HashSet;
 use tombi_schema_store::{Accessor, CompositeSchema, CurrentSchema, SchemaAccessor, SchemaView};
 use tombi_severity_level::{SeverityLevel, SeverityLevelDefaultError};
 
@@ -145,18 +144,14 @@ async fn validate_table(
     let mut assertion_failed = false;
     let mut total_diagnostics = vec![];
     let common_rules = table_rules.map(|rules| &rules.common);
-    let mut evaluated_locations = {
-        let mut visited_schema_values = HashSet::new();
-        collect_evaluated_properties_from_table_schema(
-            table_value,
-            accessors,
-            table_schema,
-            current_schema,
-            schema_context,
-            &mut visited_schema_values,
-        )
-        .await
-    };
+    let mut evaluated_locations = collect_evaluated_properties_from_table_schema(
+        table_value,
+        accessors,
+        table_schema,
+        current_schema,
+        schema_context,
+    )
+    .await;
     let evaluated_properties = &evaluated_locations.properties;
 
     for (key, value) in table_value.key_values() {
@@ -1010,15 +1005,10 @@ fn collect_evaluated_properties_from_table_schema<'a>(
     table_schema: &'a tombi_schema_store::TableSchema,
     current_schema: &'a CurrentSchema<'a>,
     schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-    visited_schema_values: &'a mut HashSet<usize>,
 ) -> BoxFuture<'a, crate::Valid> {
     async move {
-        let schema_key = std::sync::Arc::as_ptr(&current_schema.schema_view) as usize;
-        if !visited_schema_values.insert(schema_key) {
-            return crate::Valid::new();
-        }
-
         let mut result = crate::Valid::new();
+        let mut dependent_schema_items = Vec::new();
 
         let property_keys = table_schema
             .properties
@@ -1097,17 +1087,7 @@ fn collect_evaluated_properties_from_table_schema<'a>(
                         }
                     }
                     tombi_schema_store::Dependency::Schema(schema_item) => {
-                        result.merge_from(
-                            collect_evaluated_properties_from_schema_item(
-                                table_value,
-                                accessors,
-                                schema_item,
-                                current_schema,
-                                schema_context,
-                                visited_schema_values,
-                            )
-                            .await,
-                        );
+                        dependent_schema_items.push((dependent_key, schema_item));
                     }
                 }
             }
@@ -1125,17 +1105,68 @@ fn collect_evaluated_properties_from_table_schema<'a>(
         if let Some(dependent_schemas) = &table_schema.dependent_schemas {
             for (dependent_key, schema_item) in dependent_schemas {
                 result.mark_property(dependent_key.clone());
-                result.merge_from(
-                    collect_evaluated_properties_from_schema_item(
-                        table_value,
-                        accessors,
-                        schema_item,
-                        current_schema,
-                        schema_context,
-                        visited_schema_values,
+                dependent_schema_items.push((dependent_key, schema_item));
+            }
+        }
+
+        if !dependent_schema_items.is_empty() {
+            let dependency_schema_context = tombi_schema_store::SchemaContext {
+                toml_version: schema_context.toml_version,
+                root_schema: schema_context.root_schema,
+                sub_schema_link_map: schema_context.sub_schema_link_map,
+                deprecated_lint_level: schema_context.deprecated_lint_level,
+                schema_format_rules: schema_context.schema_format_rules,
+                schema_lint_rules: schema_context.schema_lint_rules,
+                schema_overrides: schema_context.schema_overrides,
+                schema_visits: schema_context.schema_visits.clone(),
+                store: schema_context.store,
+                strict: Some(false.into()),
+            };
+            let comment_directives = table_value
+                .comment_directives()
+                .map(|directives| directives.cloned().collect_vec());
+
+            for (dependent_key, schema_item) in dependent_schema_items {
+                if !table_value.keys().any(|key| key.value() == dependent_key) {
+                    continue;
+                }
+
+                let Ok(Some(schema)) = tombi_schema_store::resolve_schema_item(
+                    schema_item,
+                    current_schema.schema_uri.clone(),
+                    current_schema.definitions.clone(),
+                    current_schema.strict,
+                    schema_context.store,
+                )
+                .await
+                .inspect_err(|err| log::warn!("{err}")) else {
+                    continue;
+                };
+                let schema = schema
+                    .for_instance_type(
+                        tombi_schema_store::SchemaType::Object,
+                        schema_context.string_formats(),
                     )
-                    .await,
-                );
+                    .unwrap_or(schema);
+                let Some(validation_result) = crate::validate::validate_resolved_schema(
+                    table_value,
+                    accessors,
+                    &schema,
+                    &dependency_schema_context,
+                    comment_directives.as_deref(),
+                    None,
+                )
+                .await
+                else {
+                    continue;
+                };
+
+                if is_assertion_success(&validation_result) {
+                    match validation_result {
+                        Ok(evaluated_locations) => result.merge_from(evaluated_locations),
+                        Err(error) => result.merge_from(error.local_evaluated_locations),
+                    }
+                }
             }
         }
 
@@ -1147,7 +1178,6 @@ fn collect_evaluated_properties_from_table_schema<'a>(
                     one_of_schema.as_ref(),
                     current_schema,
                     schema_context,
-                    visited_schema_values,
                 )
                 .await,
             );
@@ -1160,7 +1190,6 @@ fn collect_evaluated_properties_from_table_schema<'a>(
                     any_of_schema.as_ref(),
                     current_schema,
                     schema_context,
-                    visited_schema_values,
                 )
                 .await,
             );
@@ -1173,24 +1202,28 @@ fn collect_evaluated_properties_from_table_schema<'a>(
                     all_of_schema.as_ref(),
                     current_schema,
                     schema_context,
-                    visited_schema_values,
                 )
                 .await,
             );
         }
 
         if let Some(if_then_else_schema) = &table_schema.if_then_else {
-            result.merge_from(
-                collect_evaluated_properties_from_if_then_else_schema(
-                    table_value,
-                    accessors,
-                    if_then_else_schema,
-                    current_schema,
-                    schema_context,
-                    visited_schema_values,
-                )
-                .await,
-            );
+            let validation_result = validate_if_then_else(
+                table_value,
+                accessors,
+                if_then_else_schema,
+                current_schema,
+                schema_context,
+                None,
+            )
+            .await;
+
+            if is_assertion_success(&validation_result) {
+                match validation_result {
+                    Ok(evaluated_locations) => result.merge_from(evaluated_locations),
+                    Err(error) => result.merge_from(error.local_evaluated_locations),
+                }
+            }
         }
 
         // An `unevaluatedProperties: true` subschema succeeds for every
@@ -1209,54 +1242,12 @@ fn collect_evaluated_properties_from_table_schema<'a>(
     .boxed()
 }
 
-fn collect_evaluated_properties_from_schema_item<'a>(
-    table_value: &'a tombi_document_tree_syntax::Table,
-    accessors: &'a [tombi_schema_store::Accessor],
-    schema_item: &'a tombi_schema_store::SchemaItem,
-    current_schema: &'a CurrentSchema<'a>,
-    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-    visited_schema_values: &'a mut HashSet<usize>,
-) -> BoxFuture<'a, crate::Valid> {
-    async move {
-        if let Ok(Some(schema)) = tombi_schema_store::resolve_schema_item(
-            schema_item,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            current_schema.strict,
-            schema_context.store,
-        )
-        .await
-        .inspect_err(|err| log::warn!("{err}"))
-        {
-            let schema = schema
-                .for_instance_type(
-                    tombi_schema_store::SchemaType::Object,
-                    schema_context.string_formats(),
-                )
-                .unwrap_or(schema);
-            collect_evaluated_properties_from_schema_view(
-                table_value,
-                accessors,
-                schema.schema_view.as_ref(),
-                &schema,
-                schema_context,
-                visited_schema_values,
-            )
-            .await
-        } else {
-            crate::Valid::new()
-        }
-    }
-    .boxed()
-}
-
 fn collect_evaluated_properties_from_referable_schemas<'a>(
     table_value: &'a tombi_document_tree_syntax::Table,
     accessors: &'a [tombi_schema_store::Accessor],
     applicator: &'a (impl CompositeSchema + Sync),
     current_schema: &'a CurrentSchema<'a>,
     schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-    _visited_schema_values: &'a mut HashSet<usize>,
 ) -> BoxFuture<'a, crate::Valid> {
     async move {
         let mut result = crate::Valid::new();
@@ -1299,178 +1290,6 @@ fn collect_evaluated_properties_from_referable_schemas<'a>(
             }
         }
         result
-    }
-    .boxed()
-}
-
-fn collect_evaluated_properties_from_schema_view<'a>(
-    table_value: &'a tombi_document_tree_syntax::Table,
-    accessors: &'a [tombi_schema_store::Accessor],
-    schema_view: &'a SchemaView,
-    current_schema: &'a CurrentSchema<'a>,
-    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-    visited_schema_values: &'a mut HashSet<usize>,
-) -> BoxFuture<'a, crate::Valid> {
-    async move {
-        match schema_view {
-            SchemaView::Table(table_schema) => {
-                collect_evaluated_properties_from_table_schema(
-                    table_value,
-                    accessors,
-                    table_schema,
-                    current_schema,
-                    schema_context,
-                    visited_schema_values,
-                )
-                .await
-            }
-            SchemaView::OneOf(one_of_schema) => {
-                collect_evaluated_properties_from_referable_schemas(
-                    table_value,
-                    accessors,
-                    one_of_schema,
-                    current_schema,
-                    schema_context,
-                    visited_schema_values,
-                )
-                .await
-            }
-            SchemaView::AnyOf(any_of_schema) => {
-                collect_evaluated_properties_from_referable_schemas(
-                    table_value,
-                    accessors,
-                    any_of_schema,
-                    current_schema,
-                    schema_context,
-                    visited_schema_values,
-                )
-                .await
-            }
-            SchemaView::AllOf(all_of_schema) => {
-                collect_evaluated_properties_from_referable_schemas(
-                    table_value,
-                    accessors,
-                    all_of_schema,
-                    current_schema,
-                    schema_context,
-                    visited_schema_values,
-                )
-                .await
-            }
-            _ => crate::Valid::new(),
-        }
-    }
-    .boxed()
-}
-
-fn collect_evaluated_properties_from_applied_branch<'a>(
-    table_value: &'a tombi_document_tree_syntax::Table,
-    accessors: &'a [tombi_schema_store::Accessor],
-    schema_item: &'a tombi_schema_store::SchemaItem,
-    current_schema: &'a CurrentSchema<'a>,
-    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-) -> BoxFuture<'a, Option<crate::Valid>> {
-    async move {
-        let Ok(Some(branch_current_schema)) = tombi_schema_store::resolve_schema_item(
-            schema_item,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            current_schema.strict,
-            schema_context.store,
-        )
-        .await
-        .inspect_err(|err| log::warn!("{err}")) else {
-            return Some(crate::Valid::new());
-        };
-        let branch_current_schema = branch_current_schema
-            .for_instance_type(
-                tombi_schema_store::SchemaType::Object,
-                schema_context.string_formats(),
-            )
-            .unwrap_or(branch_current_schema);
-
-        match table_value
-            .validate(accessors, Some(&branch_current_schema), schema_context)
-            .await
-        {
-            Ok(evaluated_locations) => Some(evaluated_locations),
-            Err(error) if !error.assertion_failed => Some(error.local_evaluated_locations),
-            Err(_) => None,
-        }
-    }
-    .boxed()
-}
-
-fn collect_evaluated_properties_from_if_then_else_schema<'a>(
-    table_value: &'a tombi_document_tree_syntax::Table,
-    accessors: &'a [tombi_schema_store::Accessor],
-    if_then_else_schema: &'a tombi_schema_store::IfThenElseSchema,
-    current_schema: &'a CurrentSchema<'a>,
-    schema_context: &'a tombi_schema_store::SchemaContext<'a>,
-    visited_schema_values: &'a mut HashSet<usize>,
-) -> BoxFuture<'a, crate::Valid> {
-    async move {
-        let Ok(Some(if_current_schema)) = tombi_schema_store::resolve_schema_item(
-            &if_then_else_schema.if_schema,
-            current_schema.schema_uri.clone(),
-            current_schema.definitions.clone(),
-            current_schema.strict,
-            schema_context.store,
-        )
-        .await
-        .inspect_err(|err| log::warn!("{err}")) else {
-            return crate::Valid::new();
-        };
-        let if_current_schema = if_current_schema
-            .for_instance_type(
-                tombi_schema_store::SchemaType::Object,
-                schema_context.string_formats(),
-            )
-            .unwrap_or(if_current_schema);
-
-        let if_result = table_value
-            .validate(accessors, Some(&if_current_schema), schema_context)
-            .await;
-
-        if is_assertion_success(&if_result) {
-            let mut result = collect_evaluated_properties_from_schema_view(
-                table_value,
-                accessors,
-                if_current_schema.schema_view.as_ref(),
-                &if_current_schema,
-                schema_context,
-                visited_schema_values,
-            )
-            .await;
-
-            if let Some(then_schema) = &if_then_else_schema.then_schema {
-                let Some(then_evaluated) = collect_evaluated_properties_from_applied_branch(
-                    table_value,
-                    accessors,
-                    then_schema,
-                    current_schema,
-                    schema_context,
-                )
-                .await
-                else {
-                    return crate::Valid::new();
-                };
-                result.merge_from(then_evaluated);
-            }
-            result
-        } else if let Some(else_schema) = &if_then_else_schema.else_schema {
-            collect_evaluated_properties_from_applied_branch(
-                table_value,
-                accessors,
-                else_schema,
-                current_schema,
-                schema_context,
-            )
-            .await
-            .unwrap_or_default()
-        } else {
-            crate::Valid::new()
-        }
     }
     .boxed()
 }

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -296,7 +296,7 @@ async fn validate_table(
             common_rules,
         )
         .await;
-        evaluated_locations.merge_result(result)
+        evaluated_locations.merge_result_keeping_annotations(result)
     } else {
         None
     };

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -1079,32 +1079,14 @@ fn collect_evaluated_properties_from_table_schema<'a>(
 
         if let Some(dependencies) = &table_schema.dependencies {
             for (dependent_key, dependency) in dependencies {
-                result.mark_property(dependent_key.clone());
-                match dependency {
-                    tombi_schema_store::Dependency::Property(required_keys) => {
-                        for key in required_keys {
-                            result.mark_property(key.clone());
-                        }
-                    }
-                    tombi_schema_store::Dependency::Schema(schema_item) => {
-                        dependent_schema_items.push((dependent_key, schema_item));
-                    }
-                }
-            }
-        }
-
-        if let Some(dependent_required) = &table_schema.dependent_required {
-            for (dependent_key, required_keys) in dependent_required {
-                result.mark_property(dependent_key.clone());
-                for key in required_keys {
-                    result.mark_property(key.clone());
+                if let tombi_schema_store::Dependency::Schema(schema_item) = dependency {
+                    dependent_schema_items.push((dependent_key, schema_item));
                 }
             }
         }
 
         if let Some(dependent_schemas) = &table_schema.dependent_schemas {
             for (dependent_key, schema_item) in dependent_schemas {
-                result.mark_property(dependent_key.clone());
                 dependent_schema_items.push((dependent_key, schema_item));
             }
         }

--- a/schemas/unevaluated-properties-if-then-test.schema.json
+++ b/schemas/unevaluated-properties-if-then-test.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UnevaluatedPropertiesIfThenTest",
+  "type": "object",
+  "properties": {
+    "then_branch": {
+      "type": "object",
+      "if": {
+        "properties": { "kind": { "type": "string" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": {
+          "kind": { "type": "string" },
+          "value": { "type": "integer" }
+        },
+        "maxProperties": 2
+      },
+      "unevaluatedProperties": false
+    },
+    "else_branch": {
+      "type": "object",
+      "if": {
+        "properties": { "kind": { "type": "string" } },
+        "required": ["kind"]
+      },
+      "else": {
+        "properties": {
+          "other": { "type": "integer" }
+        },
+        "maxProperties": 1
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- scope `if` / `then` / `else` annotations to successful conditional evaluation
- collect `dependencies` / `dependentSchemas` annotations from successful subschemas without annotating the trigger key itself
- reuse validation results so `unevaluatedProperties` and `unevaluatedItems` see the same evaluation outcome as diagnostics

This PR is stacked on #2154. Until #2154 lands, its commits are included in this PR.

## Testing

- `cargo fmt --all --check`
- `cargo check -p tombi-validator`
- `cargo test -p tombi-validator`
- `cargo test -p tombi-linter --test integration`
- `cargo clippy -p tombi-validator -p tombi-linter --all-targets -- -D warnings`

An earlier exact-head validation also ran `cargo nextest run -p tombi-schema-store -p tombi-validator -p tombi-linter -p tombi-lsp` (1344 passed); the current follow-up was revalidated with the commands above.

## Local review

- independent Codex review-quality subagent: no actionable findings
- reviewed fingerprint: `fa1df8edbe5df2c3cc440b10fb3beb3901bf0d05:74046c4383b7a872ca0762525a2aab52ff53fdf85b43d7cd1c76beb796fcd3fc`
