### PR TITLE
fix(deps): avoid uuid no_std configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,6 +3463,10 @@ name = "uuid"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ tower-lsp = { version = "0.20.0", default-features = false }
 typed-builder = "0.21.0"
 ungrammar.version = "1.16.1"
 unicode-segmentation = "1.12.0"
-uuid = { version = "1.18.0", default-features = false }
+uuid = { version = "1.18.0", default-features = false, features = ["std"] }
 wasi = { version = "0.14.7" }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.50"


### PR DESCRIPTION
Enable the `std` feature for `uuid` to prevent it from being built with `no_std`.