### PR TITLE
fix(json-lexer): report lone CR after LF as invalid line break

### DIFF
--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -134,12 +134,7 @@ impl Cursor<'_> {
             } else {
                 return Err(crate::Error::new(InvalidLineBreak, self.pop_span_range()));
             }
-        } else {
-            while self.peek(1) == '\r' {
-                self.eat_n(1);
-            }
         }
-
         Ok(Token::new(SyntaxKind::LINE_BREAK, self.pop_span_range()))
     }
 

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -8,7 +8,7 @@ use tombi_json_syntax::SyntaxKind::*;
 
 macro_rules! test_tokens {
     {#[test]fn $name:ident($source:expr) -> [
-        $(Token($kind:expr, $text:literal),)*
+        $($item:ident($kind:expr, $text:literal),)*
     ];} => {
         #[test]
         fn $name() {
@@ -17,11 +17,11 @@ macro_rules! test_tokens {
             let tokens = tokenize($source).collect_vec();
             let (expected, _) = [
                 $(
-                    ($kind, $text),
+                    test_tokens!(@item $item($kind, $text)),
                 )*
             ]
             .into_iter()
-            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (kind, text)| {
+            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (result, text)| {
                 let text: &str = text;
                 let end_offset = start_offset + (text.len() as u32);
                 let end_position = start_position + tombi_text::RelativePosition::of(text);
@@ -29,16 +29,25 @@ macro_rules! test_tokens {
                     (start_offset, end_offset).into(),
                     (start_position, end_position).into()
                 );
-                let token = if kind == STRING {
-                    Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
-                } else {
-                    Token::new(kind, span_range)
-                };
-                acc.push(Ok(token));
+                acc.push(match result {
+                    Ok(kind) => Ok(if kind == STRING {
+                        Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
+                    } else {
+                        Token::new(kind, span_range)
+                    }),
+                    Err(kind) => Err(tombi_json_lexer::Error::new(kind, span_range)),
+                });
                 (acc, (end_offset, end_position))
             });
             pretty_assertions::assert_eq!(tokens, expected);
         }
+    };
+
+    (@item Token($kind:expr, $text:literal)) => {
+        (Ok::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
+    };
+    (@item Error($kind:expr, $text:literal)) => {
+        (Err::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
     };
 }
 
@@ -414,10 +423,42 @@ test_token! {
 // Tests for whitespace handling
 test_tokens! {
     #[test]
-    fn whitespace_between_tokens("{ \t\n\r }") -> [
+    fn whitespace_between_tokens("{ \t\n }") -> [
         Token(BRACE_START, "{"),
         Token(WHITESPACE, " \t"),
-        Token(LINE_BREAK, "\n\r"),
+        Token(LINE_BREAK, "\n"),
+        Token(WHITESPACE, " "),
+        Token(BRACE_END, "}"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn crlf_line_break("[1,\r\n2]") -> [
+        Token(BRACKET_START, "["),
+        Token(NUMBER, "1"),
+        Token(COMMA, ","),
+        Token(LINE_BREAK, "\r\n"),
+        Token(NUMBER, "2"),
+        Token(BRACKET_END, "]"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn lf_followed_by_crlf_are_two_line_breaks("\n\r\n") -> [
+        Token(LINE_BREAK, "\n"),
+        Token(LINE_BREAK, "\r\n"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn lone_cr_after_lf_is_invalid("{ \t\n\r }") -> [
+        Token(BRACE_START, "{"),
+        Token(WHITESPACE, " \t"),
+        Token(LINE_BREAK, "\n"),
+        Error(ErrorKind::InvalidLineBreak, "\r"),
         Token(WHITESPACE, " "),
         Token(BRACE_END, "}"),
     ];


### PR DESCRIPTION
`Cursor::line_break`'s LF branch swallowed a following `\r` into the `LINE_BREAK` token, so `"\n\r"` lexed as one valid line break with no error, while a bare `\r` reports `InvalidLineBreak`. Behavior depended on the preceding character and diverged from `tombi-lexer`.

Remove the CR-absorption loop:

- `"\n\r\n"` → `LINE_BREAK "\n"` + `LINE_BREAK "\r\n"`
- lone `\r` after LF → `InvalidLineBreak`, same as a bare `\r`

Tests: extend `test_tokens!` to assert `Error(...)` tokens (like commit 0f086fc04c66f650e8be8592adcb6cc39e7d396c did)