### PR TITLE
fix(json-lexer): accept standalone CR as whitespace

### DIFF
--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -134,12 +134,7 @@ impl Cursor<'_> {
             } else {
                 return Err(crate::Error::new(InvalidLineBreak, self.pop_span_range()));
             }
-        } else {
-            while self.peek(1) == '\r' {
-                self.eat_n(1);
-            }
         }
-
         Ok(Token::new(SyntaxKind::LINE_BREAK, self.pop_span_range()))
     }
 

--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -128,8 +128,12 @@ impl Cursor<'_> {
     fn line_break(&mut self) -> Result<Token, crate::Error> {
         let c = self.current();
         debug_assert!(matches!(c, '\r' | '\n'));
-        if c == '\r' && self.peek(1) == '\n' {
-            self.eat_n(1);
+        if c == '\r' {
+            if self.peek(1) == '\n' {
+                self.eat_n(1);
+            } else {
+                return Ok(Token::new(SyntaxKind::WHITESPACE, self.pop_span_range()));
+            }
         }
         Ok(Token::new(SyntaxKind::LINE_BREAK, self.pop_span_range()))
     }

--- a/crates/tombi-json-lexer/src/lib.rs
+++ b/crates/tombi-json-lexer/src/lib.rs
@@ -128,12 +128,8 @@ impl Cursor<'_> {
     fn line_break(&mut self) -> Result<Token, crate::Error> {
         let c = self.current();
         debug_assert!(matches!(c, '\r' | '\n'));
-        if c == '\r' {
-            if self.peek(1) == '\n' {
-                self.eat_n(1);
-            } else {
-                return Err(crate::Error::new(InvalidLineBreak, self.pop_span_range()));
-            }
+        if c == '\r' && self.peek(1) == '\n' {
+            self.eat_n(1);
         }
         Ok(Token::new(SyntaxKind::LINE_BREAK, self.pop_span_range()))
     }

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -8,7 +8,7 @@ use tombi_json_syntax::SyntaxKind::*;
 
 macro_rules! test_tokens {
     {#[test]fn $name:ident($source:expr) -> [
-        $($item:ident($kind:expr, $text:literal),)*
+        $(Token($kind:expr, $text:literal),)*
     ];} => {
         #[test]
         fn $name() {
@@ -17,11 +17,11 @@ macro_rules! test_tokens {
             let tokens = tokenize($source).collect_vec();
             let (expected, _) = [
                 $(
-                    test_tokens!(@item $item($kind, $text)),
+                    ($kind, $text),
                 )*
             ]
             .into_iter()
-            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (result, text)| {
+            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (kind, text)| {
                 let text: &str = text;
                 let end_offset = start_offset + (text.len() as u32);
                 let end_position = start_position + tombi_text::RelativePosition::of(text);
@@ -29,25 +29,16 @@ macro_rules! test_tokens {
                     (start_offset, end_offset).into(),
                     (start_position, end_position).into()
                 );
-                acc.push(match result {
-                    Ok(kind) => Ok(if kind == STRING {
-                        Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
-                    } else {
-                        Token::new(kind, span_range)
-                    }),
-                    Err(kind) => Err(tombi_json_lexer::Error::new(kind, span_range)),
-                });
+                let token = if kind == STRING {
+                    Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
+                } else {
+                    Token::new(kind, span_range)
+                };
+                acc.push(Ok(token));
                 (acc, (end_offset, end_position))
             });
             pretty_assertions::assert_eq!(tokens, expected);
         }
-    };
-
-    (@item Token($kind:expr, $text:literal)) => {
-        (Ok::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
-    };
-    (@item Error($kind:expr, $text:literal)) => {
-        (Err::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
     };
 }
 
@@ -454,13 +445,28 @@ test_tokens! {
 
 test_tokens! {
     #[test]
-    fn lone_cr_after_lf_is_invalid("{ \t\n\r }") -> [
+    fn lone_cr_line_break("\r") -> [
+        Token(LINE_BREAK, "\r"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn lone_cr_after_lf_is_valid("{ \t\n\r }") -> [
         Token(BRACE_START, "{"),
         Token(WHITESPACE, " \t"),
         Token(LINE_BREAK, "\n"),
-        Error(ErrorKind::InvalidLineBreak, "\r"),
+        Token(LINE_BREAK, "\r"),
         Token(WHITESPACE, " "),
         Token(BRACE_END, "}"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn consecutive_cr_and_crlf_are_separate_line_breaks("\r\r\n") -> [
+        Token(LINE_BREAK, "\r"),
+        Token(LINE_BREAK, "\r\n"),
     ];
 }
 

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -445,8 +445,8 @@ test_tokens! {
 
 test_tokens! {
     #[test]
-    fn lone_cr_line_break("\r") -> [
-        Token(LINE_BREAK, "\r"),
+    fn lone_cr_whitespace("\r") -> [
+        Token(WHITESPACE, "\r"),
     ];
 }
 
@@ -456,7 +456,7 @@ test_tokens! {
         Token(BRACE_START, "{"),
         Token(WHITESPACE, " \t"),
         Token(LINE_BREAK, "\n"),
-        Token(LINE_BREAK, "\r"),
+        Token(WHITESPACE, "\r"),
         Token(WHITESPACE, " "),
         Token(BRACE_END, "}"),
     ];
@@ -464,8 +464,8 @@ test_tokens! {
 
 test_tokens! {
     #[test]
-    fn consecutive_cr_and_crlf_are_separate_line_breaks("\r\r\n") -> [
-        Token(LINE_BREAK, "\r"),
+    fn consecutive_cr_and_crlf_are_separate_trivia("\r\r\n") -> [
+        Token(WHITESPACE, "\r"),
         Token(LINE_BREAK, "\r\n"),
     ];
 }

--- a/crates/tombi-json-lexer/tests/test_lexer.rs
+++ b/crates/tombi-json-lexer/tests/test_lexer.rs
@@ -8,7 +8,7 @@ use tombi_json_syntax::SyntaxKind::*;
 
 macro_rules! test_tokens {
     {#[test]fn $name:ident($source:expr) -> [
-        $(Token($kind:expr, $text:literal),)*
+        $($item:ident($kind:expr, $text:literal),)*
     ];} => {
         #[test]
         fn $name() {
@@ -17,11 +17,11 @@ macro_rules! test_tokens {
             let tokens = tokenize($source).collect_vec();
             let (expected, _) = [
                 $(
-                    ($kind, $text),
+                    test_tokens!(@item $item($kind, $text)),
                 )*
             ]
             .into_iter()
-            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (kind, text)| {
+            .fold((vec![], (0, tombi_text::Position::MIN)), |(mut acc, (start_offset, start_position)), (result, text)| {
                 let text: &str = text;
                 let end_offset = start_offset + (text.len() as u32);
                 let end_position = start_position + tombi_text::RelativePosition::of(text);
@@ -29,16 +29,25 @@ macro_rules! test_tokens {
                     (start_offset, end_offset).into(),
                     (start_position, end_position).into()
                 );
-                let token = if kind == STRING {
-                    Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
-                } else {
-                    Token::new(kind, span_range)
-                };
-                acc.push(Ok(token));
+                acc.push(match result {
+                    Ok(kind) => Ok(if kind == STRING {
+                        Token::new_string(text.as_bytes().contains(&b'\\'), span_range)
+                    } else {
+                        Token::new(kind, span_range)
+                    }),
+                    Err(kind) => Err(tombi_json_lexer::Error::new(kind, span_range)),
+                });
                 (acc, (end_offset, end_position))
             });
             pretty_assertions::assert_eq!(tokens, expected);
         }
+    };
+
+    (@item Token($kind:expr, $text:literal)) => {
+        (Ok::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
+    };
+    (@item Error($kind:expr, $text:literal)) => {
+        (Err::<tombi_json_syntax::SyntaxKind, tombi_json_lexer::ErrorKind>($kind), $text)
     };
 }
 
@@ -414,10 +423,42 @@ test_token! {
 // Tests for whitespace handling
 test_tokens! {
     #[test]
-    fn whitespace_between_tokens("{ \t\n\r }") -> [
+    fn whitespace_between_tokens("{ \t\n }") -> [
         Token(BRACE_START, "{"),
         Token(WHITESPACE, " \t"),
-        Token(LINE_BREAK, "\n\r"),
+        Token(LINE_BREAK, "\n"),
+        Token(WHITESPACE, " "),
+        Token(BRACE_END, "}"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn crlf_line_break("[1,\r\n2]") -> [
+        Token(BRACKET_START, "["),
+        Token(NUMBER, "1"),
+        Token(COMMA, ","),
+        Token(LINE_BREAK, "\r\n"),
+        Token(NUMBER, "2"),
+        Token(BRACKET_END, "]"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn lf_followed_by_crlf_are_two_line_breaks("\n\r\n") -> [
+        Token(LINE_BREAK, "\n"),
+        Token(LINE_BREAK, "\r\n"),
+    ];
+}
+
+test_tokens! {
+    #[test]
+    fn lone_cr_after_lf_is_invalid("{ \t\n\r }") -> [
+        Token(BRACE_START, "{"),
+        Token(WHITESPACE, " \t"),
+        Token(LINE_BREAK, "\n"),
+        Error(ErrorKind::InvalidLineBreak, "\r"),
         Token(WHITESPACE, " "),
         Token(BRACE_END, "}"),
     ];

--- a/crates/tombi-json/src/parser.rs
+++ b/crates/tombi-json/src/parser.rs
@@ -522,6 +522,12 @@ mod tests {
         }
     );
 
+    test_json_parser!(
+        accepts_all_json_whitespace_characters,
+        " \t\n\r[1,\n\r2]\r\n",
+        |result| { result.is_ok() }
+    );
+
     #[test]
     fn test_parse_array() {
         let source = "[1, 2, 3]";


### PR DESCRIPTION
## Summary

This is an alternative to #2160 and includes its commit.

#2160 correctly removes the loop that absorbs carriage returns following an LF into the same `LINE_BREAK` token. However, it then reports the standalone CR as `InvalidLineBreak`.

RFC 8259 defines JSON whitespace as:

```text
ws = *(%x20 / %x09 / %x0A / %x0D)
```

CR (`0x0D`) is therefore valid JSON whitespace independently of LF, and `"\n\r"` is a valid whitespace sequence. The TOML lexer behavior is not applicable here because TOML restricts newlines to LF or CRLF.

## Changes

- keep LF and a following CR as separate tokens
- accept a standalone CR as a `WHITESPACE` trivia token, matching the existing position model
- preserve CRLF as a single `LINE_BREAK` token
- add lexer coverage for CR, LF followed by CR, and consecutive CR/CRLF
- add a parser test covering all four JSON whitespace characters

Reference: https://www.rfc-editor.org/rfc/rfc8259.html#section-2

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p tombi-json-lexer -p tombi-json --locked`
- `cargo clippy -p tombi-json-lexer -p tombi-json --all-targets --locked -- -D warnings`
- `git diff --check`
