### PR TITLE
ci: submit WinGet updates from organization fork

### DIFF
--- a/.github/actions/generate-winget-manifest/action.yml
+++ b/.github/actions/generate-winget-manifest/action.yml
@@ -45,7 +45,7 @@ runs:
         $releaseDate = ([DateTimeOffset]$release.published_at).ToString("yyyy-MM-dd")
 
         $manifestDir = Join-Path $PWD $env:OUTPUT_DIR
-        & $env:WINGETCREATE_PATH update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --release-date $releaseDate --release-notes-url $release.html_url --out $manifestDir
+        & $env:WINGETCREATE_PATH update tombi-toml.tombi --urls "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -v $env:VERSION --release-date $releaseDate --release-notes-url $release.html_url --out $manifestDir -t $env:GITHUB_TOKEN
 
         $installerManifest = Get-ChildItem -Path $manifestDir -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
         if (-not $installerManifest) {

--- a/.github/actions/submit-winget-manifest/action.yml
+++ b/.github/actions/submit-winget-manifest/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Submit manifest from organization fork
       id: submit
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         MANIFEST_ROOT: ${{ inputs.manifest-root }}
         FORK_OWNER: ${{ inputs.fork-owner }}

--- a/.github/actions/submit-winget-manifest/action.yml
+++ b/.github/actions/submit-winget-manifest/action.yml
@@ -1,0 +1,218 @@
+name: Submit winget manifest
+description: Submit a generated winget manifest from the tombi-toml organization fork.
+
+inputs:
+  github-token:
+    description: GitHub token with write access to the fork and permission to create the upstream pull request.
+    required: true
+  manifest-root:
+    description: Directory containing the generated manifests tree.
+    required: false
+    default: winget-manifests
+  fork-owner:
+    description: Owner of the organization-managed winget-pkgs fork.
+    required: false
+    default: tombi-toml
+  upstream-owner:
+    description: Owner of the upstream winget-pkgs repository.
+    required: false
+    default: microsoft
+  repository:
+    description: Name of the upstream and fork repositories.
+    required: false
+    default: winget-pkgs
+  dry-run:
+    description: Validate the manifest and fork without syncing or submitting.
+    required: false
+    default: "false"
+
+outputs:
+  pull-request-url:
+    description: URL of the created or existing pull request.
+    value: ${{ steps.submit.outputs.pull-request-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Submit manifest from organization fork
+      id: submit
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      env:
+        MANIFEST_ROOT: ${{ inputs.manifest-root }}
+        FORK_OWNER: ${{ inputs.fork-owner }}
+        UPSTREAM_OWNER: ${{ inputs.upstream-owner }}
+        REPOSITORY: ${{ inputs.repository }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require("fs");
+          const path = require("path");
+
+          const manifestRoot = path.resolve(process.env.MANIFEST_ROOT);
+          const forkOwner = process.env.FORK_OWNER;
+          const upstreamOwner = process.env.UPSTREAM_OWNER;
+          const repo = process.env.REPOSITORY;
+          const dryRun = process.env.DRY_RUN === "true";
+
+          function collectFiles(directory) {
+            return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+              const entryPath = path.join(directory, entry.name);
+              return entry.isDirectory() ? collectFiles(entryPath) : [entryPath];
+            });
+          }
+
+          if (!fs.existsSync(manifestRoot)) {
+            core.setFailed(`Winget manifest root does not exist: ${manifestRoot}`);
+            return;
+          }
+
+          const files = collectFiles(manifestRoot);
+          const installerManifest = files.find((file) => file.endsWith(".installer.yaml"));
+          if (!installerManifest) {
+            core.setFailed("Winget installer manifest was not downloaded.");
+            return;
+          }
+
+          const installerContent = fs.readFileSync(installerManifest, "utf8");
+          const identifier = installerContent.match(/^PackageIdentifier:\s*(\S+)\s*$/m)?.[1];
+          const version = installerContent.match(/^PackageVersion:\s*(\S+)\s*$/m)?.[1];
+          if (!identifier || !version) {
+            core.setFailed("Winget installer manifest is missing PackageIdentifier or PackageVersion.");
+            return;
+          }
+
+          const treeEntries = files.map((file) => ({
+            fullPath: file,
+            path: path.relative(manifestRoot, file).split(path.sep).join("/"),
+          }));
+          if (treeEntries.some((entry) => !entry.path.startsWith("manifests/") || !entry.path.endsWith(".yaml"))) {
+            core.setFailed("Winget artifact must contain only YAML files below the manifests directory.");
+            return;
+          }
+
+          const [{ data: fork }, { data: upstream }] = await Promise.all([
+            github.rest.repos.get({ owner: forkOwner, repo }),
+            github.rest.repos.get({ owner: upstreamOwner, repo }),
+          ]);
+          if (!fork.fork || fork.parent?.full_name !== `${upstreamOwner}/${repo}`) {
+            core.setFailed(`${forkOwner}/${repo} is not a fork of ${upstreamOwner}/${repo}.`);
+            return;
+          }
+
+          if (dryRun) {
+            core.info(`Validated ${treeEntries.length} manifest files for ${identifier} ${version}.`);
+            core.info(`Would submit from ${forkOwner}/${repo} to ${upstreamOwner}/${repo}.`);
+            return;
+          }
+
+          await github.request("POST /repos/{owner}/{repo}/merge-upstream", {
+            owner: forkOwner,
+            repo,
+            branch: fork.default_branch,
+          });
+
+          const { data: baseRef } = await github.rest.git.getRef({
+            owner: forkOwner,
+            repo,
+            ref: `heads/${fork.default_branch}`,
+          });
+          const baseSha = baseRef.object.sha;
+          const branch = `${identifier}-${version}`;
+
+          let branchExists = true;
+          try {
+            await github.rest.git.getRef({ owner: forkOwner, repo, ref: `heads/${branch}` });
+          } catch (error) {
+            if (error.status !== 404) {
+              throw error;
+            }
+            branchExists = false;
+          }
+
+          if (branchExists) {
+            const { data: existingPulls } = await github.rest.pulls.list({
+              owner: upstreamOwner,
+              repo,
+              state: "open",
+              head: `${forkOwner}:${branch}`,
+            });
+            if (existingPulls.length > 0) {
+              core.info(`Pull request already exists: ${existingPulls[0].html_url}`);
+              core.setOutput("pull-request-url", existingPulls[0].html_url);
+              return;
+            }
+          }
+
+          const { data: baseCommit } = await github.rest.git.getCommit({
+            owner: forkOwner,
+            repo,
+            commit_sha: baseSha,
+          });
+          const blobs = await Promise.all(treeEntries.map(async (entry) => {
+            const { data: blob } = await github.rest.git.createBlob({
+              owner: forkOwner,
+              repo,
+              content: fs.readFileSync(entry.fullPath).toString("base64"),
+              encoding: "base64",
+            });
+            return {
+              path: entry.path,
+              mode: "100644",
+              type: "blob",
+              sha: blob.sha,
+            };
+          }));
+          const { data: tree } = await github.rest.git.createTree({
+            owner: forkOwner,
+            repo,
+            base_tree: baseCommit.tree.sha,
+            tree: blobs,
+          });
+          const title = `${identifier} version ${version}`;
+          const { data: commit } = await github.rest.git.createCommit({
+            owner: forkOwner,
+            repo,
+            message: title,
+            tree: tree.sha,
+            parents: [baseSha],
+          });
+
+          if (branchExists) {
+            await github.rest.git.updateRef({
+              owner: forkOwner,
+              repo,
+              ref: `heads/${branch}`,
+              sha: commit.sha,
+              force: true,
+            });
+          } else {
+            await github.rest.git.createRef({
+              owner: forkOwner,
+              repo,
+              ref: `refs/heads/${branch}`,
+              sha: commit.sha,
+            });
+          }
+
+          const { data: template } = await github.rest.repos.getContent({
+            owner: upstreamOwner,
+            repo,
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            ref: upstream.default_branch,
+          });
+          if (Array.isArray(template) || template.type !== "file" || !template.content) {
+            throw new Error("Upstream pull request template is not a file.");
+          }
+          const body = Buffer.from(template.content, "base64").toString("utf8");
+          const { data: pullRequest } = await github.rest.pulls.create({
+            owner: upstreamOwner,
+            repo,
+            title,
+            head: `${forkOwner}:${branch}`,
+            base: upstream.default_branch,
+            body,
+          });
+
+          core.info(`Created pull request: ${pullRequest.html_url}`);
+          core.setOutput("pull-request-url", pullRequest.html_url);

--- a/.github/actions/submit-winget-manifest/action.yml
+++ b/.github/actions/submit-winget-manifest/action.yml
@@ -49,28 +49,53 @@ runs:
           const fs = require("fs");
           const path = require("path");
 
-          const manifestRoot = path.resolve(process.env.MANIFEST_ROOT);
+          const requestedManifestRoot = path.resolve(process.env.MANIFEST_ROOT);
           const forkOwner = process.env.FORK_OWNER;
           const upstreamOwner = process.env.UPSTREAM_OWNER;
           const repo = process.env.REPOSITORY;
           const dryRun = process.env.DRY_RUN === "true";
 
-          function collectFiles(directory) {
+          function collectFiles(directory, root) {
             return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
               const entryPath = path.join(directory, entry.name);
-              return entry.isDirectory() ? collectFiles(entryPath) : [entryPath];
+              const stats = fs.lstatSync(entryPath);
+              if (stats.isSymbolicLink()) {
+                throw new Error(`Winget artifact must not contain symbolic links: ${entryPath}`);
+              }
+              if (stats.isDirectory()) {
+                return collectFiles(entryPath, root);
+              }
+              if (!stats.isFile()) {
+                throw new Error(`Winget artifact contains an unsupported entry: ${entryPath}`);
+              }
+
+              const realPath = fs.realpathSync(entryPath);
+              const relativeRealPath = path.relative(root, realPath);
+              if (
+                relativeRealPath === ".." ||
+                relativeRealPath.startsWith(`..${path.sep}`) ||
+                path.isAbsolute(relativeRealPath)
+              ) {
+                throw new Error(`Winget artifact entry is outside the manifest root: ${entryPath}`);
+              }
+              return [realPath];
             });
           }
 
-          if (!fs.existsSync(manifestRoot)) {
-            core.setFailed(`Winget manifest root does not exist: ${manifestRoot}`);
+          if (!fs.existsSync(requestedManifestRoot)) {
+            core.setFailed(`Winget manifest root does not exist: ${requestedManifestRoot}`);
             return;
           }
+          if (fs.lstatSync(requestedManifestRoot).isSymbolicLink()) {
+            core.setFailed(`Winget manifest root must not be a symbolic link: ${requestedManifestRoot}`);
+            return;
+          }
+          const manifestRoot = fs.realpathSync(requestedManifestRoot);
 
-          const files = collectFiles(manifestRoot);
+          const files = collectFiles(manifestRoot, manifestRoot);
           const installerManifest = files.find((file) => file.endsWith(".installer.yaml"));
           if (!installerManifest) {
-            core.setFailed("Winget installer manifest was not downloaded.");
+            core.setFailed("Winget installer manifest was not found.");
             return;
           }
 

--- a/.github/workflows/ci_winget_manifest.yml
+++ b/.github/workflows/ci_winget_manifest.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/actions/generate-winget-manifest/**
       - .github/actions/setup-wingetcreate/**
+      - .github/actions/submit-winget-manifest/**
       - .github/workflows/ci_winget_manifest.yml
       - .github/workflows/release_cli_vscode.yml
   workflow_dispatch:
@@ -62,3 +63,10 @@ jobs:
           version: ${{ steps.release.outputs.version }}
           wingetcreate-path: ${{ steps.wingetcreate.outputs.path }}
           github-token: ${{ github.token }}
+
+      - name: Test winget manifest submission
+        uses: ./.github/actions/submit-winget-manifest
+        with:
+          github-token: ${{ github.token }}
+          fork-owner: tombi-toml
+          dry-run: true

--- a/.github/workflows/release_cli_vscode.yml
+++ b/.github/workflows/release_cli_vscode.yml
@@ -50,6 +50,7 @@ jobs:
             .github/actions/generate-winget-manifest/**
             .github/actions/relevant-changes/**
             .github/actions/set-version/**
+            .github/actions/submit-winget-manifest/**
             .github/scripts/install-cross.sh
             .node-version
             .npmrc
@@ -701,25 +702,9 @@ jobs:
           name: winget-manifests
           path: winget-manifests
 
-      - name: Setup wingetcreate
-        id: wingetcreate
-        if: steps.token.outputs.configured == 'true'
-        uses: ./.github/actions/setup-wingetcreate
-        with:
-          version: ${{ env.WINGETCREATE_VERSION }}
-
       - name: Submit winget manifest update
         if: steps.token.outputs.configured == 'true'
-        shell: pwsh
-        env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-          WINGETCREATE_PATH: ${{ steps.wingetcreate.outputs.path }}
-        run: |
-          $manifestRoot = Join-Path $PWD "winget-manifests"
-          $installerManifest = Get-ChildItem -Path $manifestRoot -Recurse -Filter "*.installer.yaml" | Select-Object -First 1
-          if (-not $installerManifest) {
-            throw "winget installer manifest was not downloaded."
-          }
-
-          $manifestVersionDir = Split-Path -Parent $installerManifest.FullName
-          & $env:WINGETCREATE_PATH submit $manifestVersionDir -t $env:WINGET_TOKEN
+        uses: ./.github/actions/submit-winget-manifest
+        with:
+          github-token: ${{ secrets.WINGET_TOKEN }}
+          fork-owner: tombi-toml


### PR DESCRIPTION
## Summary

- submit WinGet manifest updates from the `tombi-toml/winget-pkgs` organization fork
- preserve WingetCreate generation, validation, and install/invoke coverage
- add a dry-run submission check to the WinGet CI workflow
- authenticate `wingetcreate update` to avoid unauthenticated API rate limits
- use the Node 24 version of `actions/github-script`

## Verification

- `mise x actionlint@1.7.12 -- actionlint .github/workflows/ci_winget_manifest.yml .github/workflows/release_cli_vscode.yml`
- `git diff --check`
- parsed the changed workflow/action YAML files
- syntax-checked the embedded GitHub Script
- exercised dry-run locally with the v1.5.2 `winget-manifests` artifact
- workflow dispatch: https://github.com/tombi-toml/tombi/actions/runs/33997009361
- pull request WinGet CI: https://github.com/tombi-toml/tombi/actions/runs/33997183318
- pull request installer CI: https://github.com/tombi-toml/tombi/actions/runs/33997183411

## External setup

- created `tombi-toml/winget-pkgs` as a default-branch-only fork of `microsoft/winget-pkgs`
- verified the fork can be fast-forwarded to the upstream `master` branch
- the submission action synchronizes the fork immediately before creating each release branch