### PR TITLE
feat(schema-store): support compound JSON Schema resources

### DIFF
--- a/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
+++ b/crates/tombi-linter/tests/integration/json_schema_test_suite.rs
@@ -18,43 +18,6 @@ fn normalize_toml_text(input: &str) -> String {
     toml_text
 }
 
-async fn validate_test_suite(
-    schema: JsonValue,
-    toml_text: &str,
-) -> Result<(), Vec<tombi_diagnostic::Diagnostic>> {
-    let temp = tempdir().expect("failed to create temp directory");
-    let schema_path = temp.path().join("schema.json");
-    let source_path = temp.path().join("test.toml");
-
-    fs::write(&schema_path, serde_json::to_vec_pretty(&schema).unwrap()).unwrap();
-    fs::write(&source_path, toml_text).unwrap();
-
-    let schema_store = SchemaStore::new_with_options(SchemaStoreOptions {
-        strict: Some(false.into()),
-        offline: Some(true),
-        cache: None,
-    });
-    let schema_uri = SchemaUri::from_file_path(&schema_path)
-        .expect("failed to convert suite schema path to schema uri");
-    schema_store
-        .associate_schema(
-            schema_uri,
-            vec!["*.toml".to_string()],
-            &AssociateSchemaOptions::default(),
-        )
-        .await;
-
-    let lint_options = LintOptions::default();
-    let linter = Linter::new(
-        TomlVersion::default(),
-        &lint_options,
-        Some(Either::Right(source_path.as_path())),
-        &schema_store,
-    );
-
-    linter.lint(toml_text).await
-}
-
 macro_rules! suite_test {
     (#[tokio::test] async fn $name:ident(
         $data:expr,
@@ -97,6 +60,473 @@ macro_rules! suite_test {
             }
         }
     };
+}
+
+// =============================================================================
+// Draft 2020-12: compound schema documents
+// =============================================================================
+mod draft2020_12_compound_schema {
+    use super::*;
+
+    fn absolute_id_schema() -> JsonValue {
+        serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "shoko://python/pyproject",
+            "type": "object",
+            "properties": {
+                "tool": {
+                    "type": "object",
+                    "properties": {
+                        "tombi": { "$ref": "shoko://tombi-toml/tombi" }
+                    }
+                }
+            },
+            "$defs": {
+                "tombi": {
+                    "$id": "shoko://tombi-toml/tombi",
+                    "type": "object",
+                    "properties": { "strict": { "type": "boolean" } },
+                    "required": ["strict"]
+                }
+            }
+        })
+    }
+
+    suite_test!(
+        #[tokio::test] async fn resolves_absolute_embedded_resource_offline(
+            r#"
+            [tool.tombi]
+            "#,
+            JsonSchema(absolute_id_schema()),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TableKeyRequired {
+                    key: "strict".to_string(),
+                },
+                ((0, 0), (1, 0)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn resolves_relative_sibling_resources(
+            r#"
+            value = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "$ref": "resources/consumer",
+                "$defs": {
+                    "consumer": {
+                        "$id": "resources/consumer",
+                        "$ref": "value"
+                    },
+                    "value": {
+                        "$id": "resources/value",
+                        "type": "object",
+                        "properties": { "value": { "type": "string" } }
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::String,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((0, 8), (0, 10)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn resolves_versionless_alias_to_versioned_resources_offline(
+            r#"
+            [tool.tombi]
+            strict = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$ref": "shoko://python/pyproject",
+                "$defs": {
+                    "python-pyproject-alias": {
+                        "$id": "shoko://python/pyproject",
+                        "$ref": "shoko://python/pyproject/versions/1.0.0/schema.json"
+                    },
+                    "python-pyproject-1.0.0": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "$id": "shoko://python/pyproject/versions/1.0.0/schema.json",
+                        "type": "object",
+                        "properties": {
+                            "tool": {
+                                "type": "object",
+                                "properties": {
+                                    "tombi": { "$ref": "shoko://tombi-toml/tombi" }
+                                },
+                                "required": ["tombi"]
+                            }
+                        },
+                        "required": ["tool"]
+                    },
+                    "tombi-alias": {
+                        "$id": "shoko://tombi-toml/tombi",
+                        "$ref": "shoko://tombi-toml/tombi/versions/1.2.3/schema.json"
+                    },
+                    "tombi-1.2.3": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "$id": "shoko://tombi-toml/tombi/versions/1.2.3/schema.json",
+                        "type": "object",
+                        "properties": {
+                            "strict": { "type": "boolean" }
+                        },
+                        "required": ["strict"],
+                        "additionalProperties": false
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::Boolean,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((1, 9), (1, 11)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn resolves_nested_embedded_resource_with_enclosing_base(
+            r#"
+            value = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "$ref": "resources/outer",
+                "$defs": {
+                    "outer": {
+                        "$id": "resources/outer",
+                        "$ref": "nested/child",
+                        "$defs": {
+                            "child": {
+                                "$id": "nested/child",
+                                "type": "object",
+                                "properties": { "value": { "type": "string" } }
+                            }
+                        }
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::String,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((0, 8), (0, 10)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn resolves_static_anchor_inside_embedded_resource(
+            r#"
+            value = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "$ref": "resources/model#valueModel",
+                "$defs": {
+                    "model": {
+                        "$id": "resources/model",
+                        "$defs": {
+                            "value-model": {
+                                "$anchor": "valueModel",
+                                "type": "object",
+                                "properties": { "value": { "type": "string" } }
+                            }
+                        }
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::String,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((0, 8), (0, 10)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn embedded_resource_uses_its_explicit_dialect(
+            r#"
+            values = ["ok", "wrong"]
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "type": "object",
+                "properties": { "values": { "$ref": "resources/tuple" } },
+                "$defs": {
+                    "tuple": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$id": "resources/tuple",
+                        "type": "array",
+                        "items": [
+                            { "type": "string" },
+                            { "type": "integer" }
+                        ],
+                        "additionalItems": false
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::Integer,
+                    actual: tombi_document_tree_syntax::ValueType::String,
+                },
+                ((0, 16), (0, 23)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn json_pointer_reference_still_works(
+            r#"
+            [tool.tombi]
+            "#,
+            JsonSchema({
+                let mut schema = absolute_id_schema();
+                schema["properties"]["tool"]["properties"]["tombi"]["$ref"] =
+                    serde_json::json!("#/$defs/tombi");
+                schema
+            }),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TableKeyRequired {
+                    key: "strict".to_string(),
+                },
+                ((0, 0), (1, 0)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn relative_dynamic_ref_uses_outer_dynamic_anchor(
+            r#"
+            strict = true
+            [child]
+            strict = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "$ref": "resources/strict",
+                "$defs": {
+                    "strict": {
+                        "$id": "resources/strict",
+                        "$dynamicAnchor": "node",
+                        "type": "object",
+                        "properties": {
+                            "strict": { "type": "boolean" },
+                            "child": { "$dynamicRef": "tree#node" }
+                        },
+                        "required": ["strict"]
+                    },
+                    "tree": {
+                        "$id": "resources/tree",
+                        "$dynamicAnchor": "node",
+                        "type": "object"
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::Boolean,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((2, 9), (2, 11)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn dynamic_ref_does_not_override_static_anchor_target(
+            r#"
+            strict = true
+            [child]
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "$ref": "resources/strict",
+                "$defs": {
+                    "strict": {
+                        "$id": "resources/strict",
+                        "$dynamicAnchor": "node",
+                        "type": "object",
+                        "properties": {
+                            "strict": { "type": "boolean" },
+                            "child": { "$dynamicRef": "plain#node" }
+                        },
+                        "required": ["strict"]
+                    },
+                    "plain": {
+                        "$id": "resources/plain",
+                        "$anchor": "node",
+                        "type": "object"
+                    }
+                }
+            })),
+        ) -> Ok(_);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn shared_dynamic_ref_uses_each_outer_scope(
+            r#"
+            [one.nested.recurse]
+            marker = 42
+            [two.nested.recurse]
+            marker = "wrong"
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle/root.json",
+                "type": "object",
+                "properties": {
+                    "one": { "$ref": "resources/one" },
+                    "two": { "$ref": "resources/two" }
+                },
+                "$defs": {
+                    "one": {
+                        "$id": "resources/one",
+                        "$dynamicAnchor": "node",
+                        "type": "object",
+                        "properties": {
+                            "marker": { "type": "string" },
+                            "nested": { "$ref": "shared" }
+                        }
+                    },
+                    "two": {
+                        "$id": "resources/two",
+                        "$dynamicAnchor": "node",
+                        "type": "object",
+                        "properties": {
+                            "marker": { "type": "integer" },
+                            "nested": { "$ref": "shared" }
+                        }
+                    },
+                    "shared": {
+                        "$id": "resources/shared",
+                        "type": "object",
+                        "properties": {
+                            "recurse": { "$dynamicRef": "fallback#node" }
+                        }
+                    },
+                    "fallback": {
+                        "$id": "resources/fallback",
+                        "$dynamicAnchor": "node",
+                        "type": "object"
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::String,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((1, 9), (1, 11)),
+            ),
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::Integer,
+                    actual: tombi_document_tree_syntax::ValueType::String,
+                },
+                ((3, 9), (3, 16)),
+            ),
+        ]);
+    );
+
+    suite_test!(
+        #[tokio::test] async fn cyclic_embedded_resources_terminate(
+            r#"
+            value = 42
+            "#,
+            JsonSchema(serde_json::json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "shoko://cycle/root",
+                "$ref": "shoko://cycle/a",
+                "$defs": {
+                    "a": {
+                        "$id": "shoko://cycle/a",
+                        "$ref": "shoko://cycle/b",
+                        "type": "object",
+                        "properties": {
+                            "value": { "type": "string" }
+                        }
+                    },
+                    "b": {
+                        "$id": "shoko://cycle/b",
+                        "$ref": "shoko://cycle/a"
+                    }
+                }
+            })),
+        ) -> Err([
+            tombi_validator::Diagnostic::new(
+                tombi_validator::DiagnosticKind::TypeMismatch {
+                    expected: tombi_schema_store::ValueType::String,
+                    actual: tombi_document_tree_syntax::ValueType::Integer,
+                },
+                ((0, 8), (0, 10)),
+            ),
+        ]);
+    );
+}
+
+async fn validate_test_suite(
+    schema: JsonValue,
+    toml_text: &str,
+) -> Result<(), Vec<tombi_diagnostic::Diagnostic>> {
+    let temp = tempdir().expect("failed to create temp directory");
+    let schema_path = temp.path().join("schema.json");
+    let source_path = temp.path().join("test.toml");
+
+    fs::write(&schema_path, serde_json::to_vec_pretty(&schema).unwrap()).unwrap();
+    fs::write(&source_path, toml_text).unwrap();
+
+    let schema_store = SchemaStore::new_with_options(SchemaStoreOptions {
+        strict: Some(false.into()),
+        offline: Some(true),
+        cache: None,
+    });
+    let schema_uri = SchemaUri::from_file_path(&schema_path)
+        .expect("failed to convert suite schema path to schema uri");
+    schema_store
+        .associate_schema(
+            schema_uri,
+            vec!["*.toml".to_string()],
+            &AssociateSchemaOptions::default(),
+        )
+        .await;
+
+    let lint_options = LintOptions::default();
+    let linter = Linter::new(
+        TomlVersion::default(),
+        &lint_options,
+        Some(Either::Right(source_path.as_path())),
+        &schema_store,
+    );
+
+    linter.lint(toml_text).await
 }
 
 // =============================================================================

--- a/crates/tombi-lsp/src/completion.rs
+++ b/crates/tombi-lsp/src/completion.rs
@@ -360,7 +360,7 @@ pub(super) fn take_completion_schema_tooltip(
     if item.schema_uri.as_ref() == Some(current_schema.schema_uri.as_ref()) {
         item.schema_uri = Some(
             tombi_extension::get_schema_link_uri(
-                current_schema.schema_uri.as_ref(),
+                current_schema.source_schema_uri().as_ref(),
                 current_schema.schema_view.range().start,
             )
             .into(),

--- a/crates/tombi-lsp/src/goto_type_definition/all_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/all_of.rs
@@ -81,7 +81,7 @@ impl GetTypeDefinition for tombi_schema_store::AllOfSchema {
             };
 
             vec![schema_type_definition(
-                current_schema.schema_uri.as_ref(),
+                current_schema.source_schema_uri().as_ref(),
                 accessors,
                 self.range,
             )]

--- a/crates/tombi-lsp/src/goto_type_definition/any_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/any_of.rs
@@ -113,7 +113,7 @@ impl GetTypeDefinition for tombi_schema_store::AnyOfSchema {
             };
 
             vec![schema_type_definition(
-                current_schema.schema_uri.as_ref(),
+                current_schema.source_schema_uri().as_ref(),
                 accessors,
                 self.range,
             )]

--- a/crates/tombi-lsp/src/goto_type_definition/one_of.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/one_of.rs
@@ -113,7 +113,7 @@ impl GetTypeDefinition for tombi_schema_store::OneOfSchema {
             };
 
             vec![schema_type_definition(
-                current_schema.schema_uri.as_ref(),
+                current_schema.source_schema_uri().as_ref(),
                 accessors,
                 self.range,
             )]

--- a/crates/tombi-lsp/src/goto_type_definition/value.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value.rs
@@ -371,7 +371,7 @@ impl GetTypeDefinition for tombi_schema_store::SchemaView {
                 }
                 Self::Anything(schema) => current_schema.map_or_else(Vec::new, |current_schema| {
                     vec![schema_type_definition(
-                        current_schema.schema_uri.as_ref(),
+                        current_schema.source_schema_uri().as_ref(),
                         accessors,
                         schema.range,
                     )]

--- a/crates/tombi-lsp/src/goto_type_definition/value/array.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/array.rs
@@ -233,7 +233,7 @@ impl GetTypeDefinition for ArraySchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/boolean.rs
@@ -136,7 +136,7 @@ impl GetTypeDefinition for tombi_schema_store::BooleanSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/float.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/float.rs
@@ -136,7 +136,7 @@ impl GetTypeDefinition for tombi_schema_store::FloatSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/integer.rs
@@ -142,7 +142,7 @@ impl GetTypeDefinition for tombi_schema_store::IntegerSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date.rs
@@ -136,7 +136,7 @@ impl GetTypeDefinition for tombi_schema_store::LocalDateSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_date_time.rs
@@ -138,7 +138,7 @@ impl GetTypeDefinition for tombi_schema_store::LocalDateTimeSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/local_time.rs
@@ -136,7 +136,7 @@ impl GetTypeDefinition for tombi_schema_store::LocalTimeSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/offset_date_time.rs
@@ -138,7 +138,7 @@ impl GetTypeDefinition for tombi_schema_store::OffsetDateTimeSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/string.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/string.rs
@@ -274,7 +274,7 @@ impl GetTypeDefinition for tombi_schema_store::StringSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/goto_type_definition/value/table.rs
+++ b/crates/tombi-lsp/src/goto_type_definition/value/table.rs
@@ -304,7 +304,8 @@ impl GetTypeDefinition for tombi_document_tree_syntax::Table {
                                     )
                                     .await
                             } else {
-                                let mut schema_uri = current_schema.schema_uri.as_ref().clone();
+                                let mut schema_uri =
+                                    current_schema.source_schema_uri().into_owned();
                                 schema_uri.set_fragment(Some(&format!(
                                     "L{}",
                                     key.range().start.line + 1
@@ -432,7 +433,7 @@ impl GetTypeDefinition for tombi_document_tree_syntax::Table {
                         .await
                     }
                     _ => vec![TypeDefinition {
-                        schema_uri: current_schema.schema_uri.as_ref().clone(),
+                        schema_uri: current_schema.source_schema_uri().into_owned(),
                         schema_accessors: accessors.iter().map(Into::into).collect_vec(),
                         range: tombi_text::Range::default(),
                     }],
@@ -475,7 +476,7 @@ impl GetTypeDefinition for TableSchema {
     ) -> tombi_future::BoxFuture<'b, Vec<TypeDefinition>> {
         async move {
             current_schema.map_or_else(Vec::new, |schema| {
-                let mut schema_uri = schema.schema_uri.as_ref().clone();
+                let mut schema_uri = schema.source_schema_uri().into_owned();
                 schema_uri.set_fragment(Some(&format!("L{}", self.range.start.line + 1)));
 
                 vec![TypeDefinition {

--- a/crates/tombi-lsp/src/hover.rs
+++ b/crates/tombi-lsp/src/hover.rs
@@ -79,8 +79,12 @@ pub(super) fn schema_link_uri(
 pub(super) fn current_schema_link_uri(
     current_schema: Option<&CurrentSchema<'_>>,
 ) -> Option<SchemaUri> {
-    current_schema
-        .map(|schema| schema_link_uri(schema.schema_uri.as_ref(), schema.schema_view.range()))
+    current_schema.map(|schema| {
+        schema_link_uri(
+            schema.source_schema_uri().as_ref(),
+            schema.schema_view.range(),
+        )
+    })
 }
 
 fn merge_optional_vec<T: PartialEq>(

--- a/crates/tombi-lsp/tests/fixtures/compound-schema.schema.json
+++ b/crates/tombi-lsp/tests/fixtures/compound-schema.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/compound/bundle",
+  "$defs": {
+    "settings": {
+      "$id": "shoko://tombi.dev/settings",
+      "type": "object",
+      "properties": {
+        "strict": {
+          "description": "Strict mode from an embedded schema resource.",
+          "type": "boolean"
+        }
+      },
+      "required": ["strict"],
+      "additionalProperties": false
+    }
+  },
+  "$ref": "shoko://tombi.dev/settings"
+}

--- a/crates/tombi-lsp/tests/test_completion_labels.rs
+++ b/crates/tombi-lsp/tests/test_completion_labels.rs
@@ -8,8 +8,20 @@ use tombi_test_lib::{
     today_local_date_time, today_local_time, today_offset_date_time,
 };
 
+fn compound_schema_path() -> std::path::PathBuf {
+    project_root_path().join("crates/tombi-lsp/tests/fixtures/compound-schema.schema.json")
+}
+
 mod completion_labels {
     use super::*;
+
+    test_completion_labels! {
+        #[tokio::test]
+        async fn embedded_resource_with_absolute_id(
+            "█",
+            SchemaPath(compound_schema_path()),
+        ) -> Ok(["strict"]);
+    }
 
     test_completion_labels! {
         #[tokio::test]

--- a/crates/tombi-lsp/tests/test_document_link.rs
+++ b/crates/tombi-lsp/tests/test_document_link.rs
@@ -17,6 +17,28 @@ fn tombi_document_link_all_enabled_config_path() -> std::path::PathBuf {
 mod document_link_tests {
     use super::*;
 
+    mod compound_schema {
+        use super::*;
+
+        test_document_link!(
+            #[tokio::test]
+            async fn embedded_resource_schema_links_to_physical_bundle(
+                "#:schema crates/tombi-lsp/tests/fixtures/compound-schema.schema.json\nstrict = true",
+                SourcePath(project_root_path().join("compound-schema.toml")),
+                SchemaPath(project_root_path().join(
+                    "crates/tombi-lsp/tests/fixtures/compound-schema.schema.json"
+                )),
+            ) -> Ok(Some(vec![
+                {
+                    path: project_root_path().join(
+                        "crates/tombi-lsp/tests/fixtures/compound-schema.schema.json"
+                    ),
+                    range: 0:9..0:68
+                }
+            ]));
+        );
+    }
+
     mod cargo_schema {
         use super::*;
 

--- a/crates/tombi-lsp/tests/test_goto_type_definition.rs
+++ b/crates/tombi-lsp/tests/test_goto_type_definition.rs
@@ -9,6 +9,19 @@ mod goto_type_definition_tests {
     struct ExpectedRange(tombi_text::Range);
     struct ExpectedRanges(Vec<tombi_text::Range>);
 
+    fn compound_schema_path() -> std::path::PathBuf {
+        tombi_test_lib::project_root_path()
+            .join("crates/tombi-lsp/tests/fixtures/compound-schema.schema.json")
+    }
+
+    test_goto_type_definition!(
+        #[tokio::test]
+        async fn embedded_resource_uses_physical_schema_uri(
+            "strict█ = true",
+            SchemaPath(compound_schema_path()),
+        ) -> Ok(compound_schema_path());
+    );
+
     mod strict_priority {
         use super::*;
 
@@ -160,7 +173,7 @@ mod goto_type_definition_tests {
                 "#,
                 SourcePath(tombi_test_lib::project_root_path().join("pyproject.toml")),
                 SchemaPath(pyproject_schema_path()),
-            ) -> Ok("https://json.schemastore.org/partial-taskipy.json");
+            ) -> Ok("https://www.schemastore.org/partial-taskipy.json");
         );
 
         test_goto_type_definition!(

--- a/crates/tombi-lsp/tests/test_hover.rs
+++ b/crates/tombi-lsp/tests/test_hover.rs
@@ -19,6 +19,11 @@ fn nested_table_keys_order_schema_path() -> PathBuf {
         .join("crates/tombi-lsp/tests/fixtures/nested-table-keys-order.schema.json")
 }
 
+fn compound_schema_path() -> PathBuf {
+    tombi_test_lib::project_root_path()
+        .join("crates/tombi-lsp/tests/fixtures/compound-schema.schema.json")
+}
+
 fn array_values_order_schema_path() -> PathBuf {
     tombi_test_lib::project_root_path()
         .join("crates/tombi-lsp/tests/fixtures/array-values-order.schema.json")
@@ -83,6 +88,21 @@ async fn write_cached_response(url: &str, body: &str) {
 
 mod hover_keys_value {
     use super::*;
+
+    test_hover_keys_value!(
+        #[tokio::test]
+        async fn embedded_resource_uses_physical_schema_link(
+            "strict = █true",
+            SchemaPath(compound_schema_path()),
+        ) -> Ok({
+            "Keys": "strict",
+            "Value": "Boolean",
+            "Hover Contains": [
+                "Strict mode from an embedded schema resource.",
+                "compound-schema.schema.json"
+            ]
+        });
+    );
 
     test_hover_keys_value!(
         #[tokio::test]

--- a/crates/tombi-schema-store/src/error.rs
+++ b/crates/tombi-schema-store/src/error.rs
@@ -93,6 +93,9 @@ pub enum Error {
         schema_uri: SchemaUri,
     },
 
+    #[error("cyclic schema resource reference: {schema_uri}")]
+    CyclicSchemaReference { schema_uri: SchemaUri },
+
     #[error("unsupported reference: {reference}, schema_uri: {schema_uri}")]
     UnsupportedReference {
         reference: String,
@@ -104,6 +107,12 @@ pub enum Error {
 
     #[error("schema must be an object or boolean: {schema_uri}")]
     SchemaMustBeObjectOrBoolean { schema_uri: SchemaUri },
+
+    #[error("invalid schema resources in {schema_uri}: {reason}")]
+    InvalidSchemaResources {
+        schema_uri: SchemaUri,
+        reason: String,
+    },
 
     #[error(transparent)]
     CacheError(#[from] tombi_cache::Error),

--- a/crates/tombi-schema-store/src/schema.rs
+++ b/crates/tombi-schema-store/src/schema.rs
@@ -15,6 +15,7 @@ mod not_schema;
 mod offset_date_time_schema;
 mod one_of_schema;
 mod referable_schema;
+mod resource_index;
 mod schema_context;
 mod schema_cycle_guard;
 mod schema_view;
@@ -42,10 +43,12 @@ pub use local_time_schema::LocalTimeSchema;
 pub use not_schema::NotSchema;
 pub use offset_date_time_schema::OffsetDateTimeSchema;
 pub use one_of_schema::OneOfSchema;
+pub(crate) use referable_schema::resolve_json_pointer_node;
 pub use referable_schema::{
     CurrentSchema, Referable, ReferenceKind, is_online_url, resolve_and_collect_schemas,
     resolve_and_collect_schemas_with_errors, resolve_json_pointer, resolve_schema_item,
 };
+pub(crate) use resource_index::{ResourceIndex, ResourceMetadata, ResourceTarget};
 pub use schema_context::{ResolvedFormatOrder, SchemaContext};
 pub use schema_cycle_guard::{SchemaCycleGuard, SchemaVisits};
 pub use schema_view::*;
@@ -139,7 +142,111 @@ pub type SchemaPatternProperties =
     Arc<tokio::sync::RwLock<tombi_hashmap::HashMap<String, PropertySchema>>>;
 pub type SchemaItem = Arc<tokio::sync::RwLock<Referable<SchemaView>>>;
 pub type SchemaMap = tombi_hashmap::HashMap<String, Referable<SchemaView>>;
-pub type SchemaDefinitions = Arc<tokio::sync::RwLock<SchemaMap>>;
+
+/// Definitions together with the immutable, evaluation-specific dynamic scope.
+///
+/// Keeping the scope in the existing resolution environment lets every schema
+/// consumer preserve `$dynamicRef` state without enlarging `CurrentSchema` with
+/// duplicated URIs or introducing mutable global state.
+#[derive(Debug, Clone)]
+pub struct SchemaDefinitions {
+    values: Arc<tokio::sync::RwLock<SchemaMap>>,
+    context: Arc<SchemaResolutionContext>,
+}
+
+#[derive(Debug, Default)]
+struct SchemaResolutionContext {
+    dynamic_scope: Arc<Vec<DynamicScopeEntry>>,
+    source_schema_uri: Option<Arc<SchemaUri>>,
+    generation: Option<Arc<crate::store::SchemaGeneration>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DynamicScopeEntry {
+    pub(crate) schema_uri: SchemaUri,
+    pub(crate) generation: Option<Arc<crate::store::SchemaGeneration>>,
+}
+
+impl SchemaDefinitions {
+    pub fn new(values: tokio::sync::RwLock<SchemaMap>) -> Self {
+        Self {
+            values: Arc::new(values),
+            context: Arc::new(SchemaResolutionContext::default()),
+        }
+    }
+
+    pub(crate) fn with_dynamic_scope(&self, dynamic_scope: Vec<DynamicScopeEntry>) -> Self {
+        Self {
+            values: self.values.clone(),
+            context: Arc::new(SchemaResolutionContext {
+                dynamic_scope: Arc::new(dynamic_scope),
+                source_schema_uri: self.context.source_schema_uri.clone(),
+                generation: self.context.generation.clone(),
+            }),
+        }
+    }
+
+    pub(crate) fn dynamic_scope(&self) -> &[DynamicScopeEntry] {
+        &self.context.dynamic_scope
+    }
+
+    pub(crate) fn with_source_schema_uri(&self, source_schema_uri: SchemaUri) -> Self {
+        Self {
+            values: self.values.clone(),
+            context: Arc::new(SchemaResolutionContext {
+                dynamic_scope: self.context.dynamic_scope.clone(),
+                source_schema_uri: Some(Arc::new(source_schema_uri)),
+                generation: self.context.generation.clone(),
+            }),
+        }
+    }
+
+    pub(crate) fn source_schema_uri(&self) -> Option<&SchemaUri> {
+        self.context.source_schema_uri.as_deref()
+    }
+
+    pub(crate) fn with_generation(&self, generation: Arc<crate::store::SchemaGeneration>) -> Self {
+        Self {
+            values: self.values.clone(),
+            context: Arc::new(SchemaResolutionContext {
+                dynamic_scope: self.context.dynamic_scope.clone(),
+                source_schema_uri: self.context.source_schema_uri.clone(),
+                generation: Some(generation),
+            }),
+        }
+    }
+
+    pub(crate) fn generation(&self) -> Option<&Arc<crate::store::SchemaGeneration>> {
+        self.context.generation.as_ref()
+    }
+
+    /// Removes evaluation-local state before storing a compiled schema in its
+    /// generation. In particular, this prevents a strong-reference cycle from
+    /// `SchemaGeneration` back to itself.
+    pub(crate) fn without_runtime_context(&self) -> Self {
+        Self {
+            values: self.values.clone(),
+            context: Arc::new(SchemaResolutionContext {
+                dynamic_scope: Arc::new(Vec::new()),
+                source_schema_uri: self.context.source_schema_uri.clone(),
+                generation: None,
+            }),
+        }
+    }
+
+    pub(crate) fn effective_base(&self, position: tombi_text::Position) -> Option<&SchemaUri> {
+        self.generation()?.resource_index.effective_base(position)
+    }
+}
+
+impl std::ops::Deref for SchemaDefinitions {
+    type Target = tokio::sync::RwLock<SchemaMap>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
 pub type SchemaAnchors = Arc<tokio::sync::RwLock<SchemaMap>>;
 pub type SchemaDynamicAnchors = Arc<tokio::sync::RwLock<SchemaMap>>;
 pub type AnchorCollector = SchemaMap;

--- a/crates/tombi-schema-store/src/schema/document_schema.rs
+++ b/crates/tombi-schema-store/src/schema/document_schema.rs
@@ -28,6 +28,10 @@ pub struct DocumentSchema {
     pub definitions: SchemaDefinitions,
     pub anchors: SchemaAnchors,
     pub dynamic_anchors: SchemaDynamicAnchors,
+    /// Generation that owns this physical document. This intentionally differs
+    /// from `definitions.generation()` when a root `$ref` evaluates in another
+    /// document's context.
+    pub(crate) owner_generation: Option<Arc<crate::store::SchemaGeneration>>,
 }
 
 impl DocumentSchema {
@@ -37,57 +41,121 @@ impl DocumentSchema {
         strict: Option<BoolDefaultTrue>,
         schema_store: &SchemaStore,
     ) -> Self {
-        match node {
-            tombi_json::ValueNode::Object(object) => {
-                Self::new_from_object(object, schema_uri, strict, schema_store).await
-            }
-            tombi_json::ValueNode::Bool(bool) => Self {
-                id: None,
-                schema_uri,
-                strict,
-                dialect: None,
-                toml_version: None,
-                string_formats: None,
-                format_assertion: true,
-                schema_view: Some(Arc::new(super::bool_schema_view(bool.value, bool.range))),
-                semantic_schema: SemanticSchema::from_value_node(
-                    &tombi_json::ValueNode::Bool(bool),
-                    None,
-                )
-                .map(Arc::new),
-                definitions: SchemaDefinitions::new(Default::default()),
-                anchors: SchemaAnchors::new(Default::default()),
-                dynamic_anchors: SchemaDynamicAnchors::new(Default::default()),
-            },
-            _ => Self {
-                id: None,
-                schema_uri,
-                strict,
-                dialect: None,
-                toml_version: None,
-                string_formats: None,
-                format_assertion: true,
-                schema_view: None,
-                semantic_schema: None,
-                definitions: SchemaDefinitions::new(Default::default()),
-                anchors: SchemaAnchors::new(Default::default()),
-                dynamic_anchors: SchemaDynamicAnchors::new(Default::default()),
-            },
-        }
+        Self::new_indexed(&node, schema_uri, None, None, None, strict, schema_store).await
     }
 
-    async fn new_from_object(
-        object: tombi_json::ObjectNode,
+    pub(crate) async fn new_indexed(
+        node: &tombi_json::ValueNode,
         schema_uri: SchemaUri,
+        resolved_id: Option<SchemaUri>,
+        inherited_dialect: Option<JsonSchemaDialect>,
+        generation: Option<Arc<crate::store::SchemaGeneration>>,
         strict: Option<BoolDefaultTrue>,
         schema_store: &SchemaStore,
     ) -> Self {
-        let id = resolve_schema_id(&object, &schema_uri);
+        match node {
+            tombi_json::ValueNode::Object(object) => {
+                Self::new_from_object(
+                    object,
+                    schema_uri,
+                    resolved_id,
+                    inherited_dialect,
+                    generation,
+                    strict,
+                    schema_store,
+                )
+                .await
+            }
+            tombi_json::ValueNode::Bool(bool) => {
+                let owner_generation = generation.clone();
+                let definitions = SchemaDefinitions::new(Default::default())
+                    .with_source_schema_uri(schema_uri.clone());
+                let definitions = generation.map_or(definitions.clone(), |generation| {
+                    definitions.with_generation(generation)
+                });
+                Self {
+                    id: resolved_id,
+                    schema_uri: schema_uri.clone(),
+                    strict,
+                    dialect: None,
+                    toml_version: None,
+                    string_formats: None,
+                    format_assertion: true,
+                    schema_view: Some(Arc::new(super::bool_schema_view(bool.value, bool.range))),
+                    semantic_schema: SemanticSchema::from_value_node(node, None).map(Arc::new),
+                    definitions,
+                    anchors: SchemaAnchors::new(Default::default()),
+                    dynamic_anchors: SchemaDynamicAnchors::new(Default::default()),
+                    owner_generation,
+                }
+            }
+            _ => {
+                let owner_generation = generation.clone();
+                let definitions = SchemaDefinitions::new(Default::default())
+                    .with_source_schema_uri(schema_uri.clone());
+                let definitions = generation.map_or(definitions.clone(), |generation| {
+                    definitions.with_generation(generation)
+                });
+                Self {
+                    id: resolved_id,
+                    schema_uri: schema_uri.clone(),
+                    strict,
+                    dialect: None,
+                    toml_version: None,
+                    string_formats: None,
+                    format_assertion: true,
+                    schema_view: None,
+                    semantic_schema: None,
+                    definitions,
+                    anchors: SchemaAnchors::new(Default::default()),
+                    dynamic_anchors: SchemaDynamicAnchors::new(Default::default()),
+                    owner_generation,
+                }
+            }
+        }
+    }
 
-        let dialect = object.get("$schema").and_then(|value| match value {
-            tombi_json::ValueNode::String(s) => JsonSchemaDialect::try_from(s.value.as_str()).ok(),
-            _ => None,
-        });
+    pub(crate) async fn new_embedded(
+        node: &tombi_json::ValueNode,
+        source_schema_uri: SchemaUri,
+        canonical_uri: SchemaUri,
+        inherited_dialect: Option<JsonSchemaDialect>,
+        generation: Arc<crate::store::SchemaGeneration>,
+        strict: Option<BoolDefaultTrue>,
+        schema_store: &SchemaStore,
+    ) -> Self {
+        Self::new_indexed(
+            node,
+            source_schema_uri,
+            Some(canonical_uri),
+            inherited_dialect,
+            Some(generation),
+            strict,
+            schema_store,
+        )
+        .await
+    }
+
+    async fn new_from_object(
+        object: &tombi_json::ObjectNode,
+        schema_uri: SchemaUri,
+        resolved_id: Option<SchemaUri>,
+        inherited_dialect: Option<JsonSchemaDialect>,
+        generation: Option<Arc<crate::store::SchemaGeneration>>,
+        strict: Option<BoolDefaultTrue>,
+        schema_store: &SchemaStore,
+    ) -> Self {
+        let id = resolved_id.or_else(|| resolve_schema_id(object, &schema_uri));
+
+        let dialect = object
+            .get("$schema")
+            .and_then(|value| match value {
+                tombi_json::ValueNode::String(s) => {
+                    JsonSchemaDialect::try_from(s.value.as_str()).ok()
+                }
+                _ => None,
+            })
+            .or(inherited_dialect);
 
         let toml_version = object.get(X_TOMBI_TOML_VERSION).and_then(|obj| match obj {
             tombi_json::ValueNode::String(version) => TomlVersion::from_str(&version.value).ok(),
@@ -119,10 +187,10 @@ impl DocumentSchema {
         let format_assertion = match dialect {
             Some(JsonSchemaDialect::Draft07) | None => true,
             Some(JsonSchemaDialect::Draft2019_09) => {
-                has_enabled_vocabulary(&object, FORMAT_2019_VOCAB)
+                has_enabled_vocabulary(object, FORMAT_2019_VOCAB)
             }
             Some(JsonSchemaDialect::Draft2020_12) => {
-                has_enabled_vocabulary(&object, FORMAT_ASSERTION_2020_VOCAB)
+                has_enabled_vocabulary(object, FORMAT_ASSERTION_2020_VOCAB)
             }
         };
 
@@ -134,7 +202,7 @@ impl DocumentSchema {
         // The root value schema may itself be a `$ref`. A direct schema resolves to an
         // `Arc` immediately; a root `$ref` is resolved below once the definitions are built.
         let (mut schema_view, semantic_schema, root_ref) = match Referable::new(
-            &object,
+            object,
             string_formats.as_deref(),
             dialect,
             collect_anchor.then_some(&mut anchors),
@@ -147,7 +215,7 @@ impl DocumentSchema {
             }) => (Some(value), semantic_schema, None),
             Some(root_ref @ Referable::Ref { .. }) => (
                 None,
-                Some(Arc::new(SemanticSchema::from_object_node(&object, dialect))),
+                Some(Arc::new(SemanticSchema::from_object_node(object, dialect))),
                 Some(root_ref),
             ),
             None => (None, None, None),
@@ -191,6 +259,13 @@ impl DocumentSchema {
             }
         }
 
+        let source_schema_uri = schema_uri.clone();
+        let definitions =
+            SchemaDefinitions::new(definitions.into()).with_source_schema_uri(source_schema_uri);
+        let owner_generation = generation.clone();
+        let definitions = generation.map_or(definitions.clone(), |generation| {
+            definitions.with_generation(generation)
+        });
         let mut document_schema = Self {
             id,
             schema_uri,
@@ -201,9 +276,10 @@ impl DocumentSchema {
             format_assertion,
             schema_view,
             semantic_schema,
-            definitions: SchemaDefinitions::new(definitions.into()),
+            definitions,
             anchors: SchemaAnchors::new(anchors.into()),
             dynamic_anchors: SchemaDynamicAnchors::new(dynamic_anchors.into()),
+            owner_generation,
         };
 
         // Resolve a root-level `$ref` once at load time so the document exposes a usable
@@ -222,11 +298,22 @@ impl DocumentSchema {
                 Ok(resolved) => {
                     if let Some(current_schema) = resolved {
                         document_schema.semantic_schema = current_schema.semantic_schema;
+                        document_schema.definitions = current_schema.definitions.into_owned();
                         Some(current_schema.schema_view)
                     } else {
                         None
                     }
                 }
+                Err(crate::Error::CyclicSchemaReference { .. }) => document_schema
+                    .semantic_schema
+                    .as_deref()
+                    .and_then(|schema| {
+                        schema.schema_view_for_type(
+                            super::SchemaType::Object,
+                            document_schema.string_formats.as_deref(),
+                        )
+                    })
+                    .map(Arc::new),
                 Err(error) => {
                     log::warn!(
                         "failed to resolve root $ref for {}: {error}",

--- a/crates/tombi-schema-store/src/schema/referable_schema.rs
+++ b/crates/tombi-schema-store/src/schema/referable_schema.rs
@@ -7,9 +7,31 @@ use tombi_x_keyword::StringFormat;
 use crate::x_taplo::XTaplo;
 
 use super::{
-    AnchorCollector, Deprecation, DynamicAnchorCollector, SchemaDefinitions, SchemaMap, SchemaUri,
-    SchemaView, bool_schema_view,
+    AnchorCollector, Deprecation, DynamicAnchorCollector, DynamicScopeEntry, SchemaDefinitions,
+    SchemaMap, SchemaUri, SchemaView, bool_schema_view,
 };
+
+fn push_dynamic_scope(
+    scope: &mut Vec<DynamicScopeEntry>,
+    schema_uri: SchemaUri,
+    generation: Option<&Arc<crate::store::SchemaGeneration>>,
+) {
+    if !scope.iter().any(|entry| entry.schema_uri == schema_uri) {
+        scope.push(DynamicScopeEntry {
+            schema_uri,
+            generation: generation.cloned(),
+        });
+    }
+}
+
+fn schema_value_in_generation<'a>(
+    schema_uri: &SchemaUri,
+    generation: Option<&'a Arc<crate::store::SchemaGeneration>>,
+) -> Option<&'a tombi_json::ValueNode> {
+    let generation = generation?;
+    let metadata = generation.resource_index.resource(schema_uri)?;
+    crate::resolve_json_pointer_node(&generation.source_node, &metadata.root_pointer)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReferenceKind {
@@ -28,6 +50,7 @@ pub enum Referable<T> {
     Ref {
         reference: String,
         kind: ReferenceKind,
+        source_position: tombi_text::Position,
         semantic_schema: Option<Arc<super::SemanticSchema>>,
         title: Option<String>,
         description: Option<String>,
@@ -58,6 +81,43 @@ impl<'a> CurrentSchema<'a> {
             definitions: Cow::Owned(self.definitions.into_owned()),
             strict: self.strict,
         }
+    }
+
+    /// Physical document URI used for editor locations.
+    pub fn source_schema_uri(&self) -> Cow<'_, SchemaUri> {
+        if let Some(source_schema_uri) = self.definitions.source_schema_uri() {
+            return Cow::Borrowed(source_schema_uri);
+        }
+
+        if self.schema_uri.fragment().is_none() {
+            return Cow::Borrowed(self.schema_uri.as_ref());
+        }
+
+        let mut source_schema_uri = self.schema_uri.as_ref().clone();
+        source_schema_uri.set_fragment(None);
+        Cow::Owned(source_schema_uri)
+    }
+
+    /// Physical document URI with the logical schema fragment, used in diagnostics.
+    pub fn diagnostic_schema_uri(&self) -> Cow<'_, SchemaUri> {
+        let source_schema_uri = self.source_schema_uri();
+        let Some(fragment) = self.schema_uri.fragment() else {
+            return source_schema_uri;
+        };
+
+        let physical_fragment = self.definitions.generation().and_then(|generation| {
+            generation
+                .resource_index
+                .physical_fragment(self.schema_uri.as_ref(), fragment)
+        });
+
+        if self.definitions.generation().is_some() && physical_fragment.is_none() {
+            return Cow::Borrowed(self.schema_uri.as_ref());
+        }
+
+        let mut diagnostic_schema_uri = source_schema_uri.into_owned();
+        diagnostic_schema_uri.set_fragment(Some(physical_fragment.as_deref().unwrap_or(fragment)));
+        Cow::Owned(diagnostic_schema_uri)
     }
 
     /// Rebuilds this schema around a projected view, keeping the semantic
@@ -197,6 +257,7 @@ impl Referable<SchemaView> {
             Some(Referable::Ref {
                 reference: reference.to_string(),
                 kind,
+                source_position: object.range.start,
                 semantic_schema,
                 // Keep annotation siblings for compatibility with existing Draft 7
                 // schemas. They do not affect validation, unlike assertion and
@@ -329,7 +390,7 @@ impl Referable<SchemaView> {
         strict: Option<BoolDefaultTrue>,
         schema_store: &'a crate::SchemaStore,
     ) -> tombi_future::BoxFuture<'b, Result<Option<CurrentSchema<'a>>, crate::Error>> {
-        let dynamic_scope = vec![schema_uri.as_ref().clone()];
+        let dynamic_scope = definitions.dynamic_scope().to_vec();
         self.resolve_with_dynamic_scope(
             schema_uri,
             definitions,
@@ -345,13 +406,14 @@ impl Referable<SchemaView> {
         definitions: Cow<'a, SchemaDefinitions>,
         strict: Option<BoolDefaultTrue>,
         schema_store: &'a crate::SchemaStore,
-        dynamic_scope: Vec<SchemaUri>,
+        dynamic_scope: Vec<DynamicScopeEntry>,
     ) -> tombi_future::BoxFuture<'b, Result<Option<CurrentSchema<'a>>, crate::Error>> {
         Box::pin(async move {
             match self {
                 Referable::Ref {
                     reference,
                     kind,
+                    source_position,
                     semantic_schema: ref_semantic_schema,
                     title,
                     description,
@@ -359,16 +421,40 @@ impl Referable<SchemaView> {
                     examples,
                     deprecation,
                 } => {
-                    let dynamic_target = match kind {
-                        ReferenceKind::DynamicRef => parse_dynamic_anchor_reference(reference),
-                        ReferenceKind::RecursiveRef => parse_recursive_anchor_reference(reference),
+                    let effective_base = {
+                        match definitions.effective_base(*source_position) {
+                            Some(base) => Some(base.clone()),
+                            None => {
+                                schema_store
+                                    .effective_base_uri(schema_uri.as_ref(), *source_position)
+                                    .await
+                            }
+                        }
+                    };
+                    let schema_uri = effective_base.map_or(schema_uri, Cow::Owned);
+                    let mut dynamic_scope = dynamic_scope;
+                    push_dynamic_scope(
+                        &mut dynamic_scope,
+                        schema_uri.as_ref().clone(),
+                        definitions.generation(),
+                    );
+                    let dynamic_anchor_ref = match kind {
+                        ReferenceKind::DynamicRef => {
+                            resolve_static_dynamic_anchor_reference(
+                                reference,
+                                schema_uri.as_ref(),
+                                definitions.generation(),
+                                schema_store,
+                            )
+                            .await?
+                        }
+                        ReferenceKind::RecursiveRef => {
+                            parse_recursive_anchor_reference(reference).map(|(_, anchor)| anchor)
+                        }
                         ReferenceKind::Ref => None,
                     };
-                    if let Some((base_schema_uri, dynamic_anchor_ref)) = dynamic_target {
-                        let mut scope_for_dynamic_ref = dynamic_scope.clone();
-                        if let Some(base_schema_uri) = base_schema_uri {
-                            scope_for_dynamic_ref.insert(0, base_schema_uri);
-                        }
+                    if let Some(dynamic_anchor_ref) = dynamic_anchor_ref {
+                        let scope_for_dynamic_ref = dynamic_scope.clone();
                         if let Some((mut referable_schema, owner_schema_uri, owner_definitions)) =
                             resolve_dynamic_anchor_from_scope(
                                 &dynamic_anchor_ref,
@@ -386,8 +472,7 @@ impl Referable<SchemaView> {
                                 examples.as_ref(),
                                 deprecation.clone(),
                             );
-                            *self = referable_schema;
-                            return self
+                            let resolved = referable_schema
                                 .resolve_with_dynamic_scope(
                                     Cow::Owned(owner_schema_uri),
                                     Cow::Owned(owner_definitions),
@@ -395,14 +480,21 @@ impl Referable<SchemaView> {
                                     schema_store,
                                     scope_for_dynamic_ref,
                                 )
-                                .await;
+                                .await?;
+                            return Ok(resolved.map(CurrentSchema::into_owned));
                         }
                     }
 
                     let definition_schema =
                         { resolve_from_schema_map(&definitions, reference).await };
                     let anchor_schema = if definition_schema.is_none() {
-                        resolve_anchor_reference(reference, &schema_uri, schema_store).await?
+                        resolve_anchor_reference(
+                            reference,
+                            &schema_uri,
+                            definitions.generation(),
+                            schema_store,
+                        )
+                        .await?
                     } else {
                         None
                     };
@@ -424,9 +516,17 @@ impl Referable<SchemaView> {
                         // Exceptional handling for schemas that do not use `#/definitions/*`.
                         // Therefore, schema_value is not cached in memory, but read from file cache.
                         // Execution speed decreases, but memory usage can be reduced.
-                        if let Some(schema_value) =
-                            schema_store.fetch_schema_value(&schema_uri).await?
+                        let schema_value = if let Some(schema_value) =
+                            schema_value_in_generation(&schema_uri, definitions.generation())
                         {
+                            Some(Cow::Borrowed(schema_value))
+                        } else {
+                            schema_store
+                                .fetch_external_schema_value(&schema_uri)
+                                .await?
+                                .map(Cow::Owned)
+                        };
+                        if let Some(schema_value) = schema_value {
                             let dialect = schema_value
                                 .as_object()
                                 .and_then(|object| object.get("$schema"))
@@ -435,7 +535,7 @@ impl Referable<SchemaView> {
                                     crate::JsonSchemaDialect::try_from(dialect_uri).ok()
                                 });
                             if let Some(mut resolved_schema) =
-                                resolve_json_pointer(&schema_value, pointer, None, dialect)?
+                                resolve_json_pointer(schema_value.as_ref(), pointer, None, dialect)?
                             {
                                 if title.is_some() || description.is_some() {
                                     resolved_schema.set_title(title.to_owned());
@@ -454,7 +554,7 @@ impl Referable<SchemaView> {
                                 return Ok(Some(CurrentSchema {
                                     schema_view: Arc::new(resolved_schema),
                                     semantic_schema: resolve_json_pointer_node(
-                                        &schema_value,
+                                        schema_value.as_ref(),
                                         pointer,
                                     )
                                     .and_then(|value| {
@@ -486,10 +586,20 @@ impl Referable<SchemaView> {
                         reference,
                         schema_uri.as_ref(),
                         strict,
+                        definitions.generation(),
                         schema_store,
                     )
                     .await?
                     {
+                        let Some(mut resolved_resource_uri) = schema_uri
+                            .join(reference)
+                            .ok()
+                            .map(SchemaUri::from)
+                            .or_else(|| SchemaUri::from_str(reference).ok())
+                        else {
+                            unreachable!("external reference was resolved above")
+                        };
+                        resolved_resource_uri.set_fragment(None);
                         if ref_semantic_schema
                             .as_deref()
                             .is_some_and(has_reference_projection_siblings)
@@ -511,9 +621,7 @@ impl Referable<SchemaView> {
                                     semantic_schema: Some(local_semantic),
                                 },
                                 Referable::Resolved {
-                                    schema_uri: Some(
-                                        resolved_reference.schema_uri.as_ref().clone(),
-                                    ),
+                                    schema_uri: Some(resolved_resource_uri.clone()),
                                     value: resolved_reference.schema_view.clone(),
                                     semantic_schema: resolved_reference.semantic_schema.clone(),
                                 },
@@ -564,26 +672,33 @@ impl Referable<SchemaView> {
                             schema_view.set_deprecation(deprecation.clone());
                         }
 
+                        let resolved_semantic_schema = combine_ref_semantics(
+                            ref_semantic_schema.clone(),
+                            resolved_reference.semantic_schema.clone(),
+                        );
                         *self = Referable::Resolved {
-                            schema_uri: Some(resolved_reference.schema_uri.as_ref().clone()),
-                            value: resolved_value,
-                            semantic_schema: combine_ref_semantics(
-                                ref_semantic_schema.clone(),
-                                resolved_reference.semantic_schema.clone(),
-                            ),
+                            schema_uri: Some(resolved_resource_uri.clone()),
+                            value: resolved_value.clone(),
+                            semantic_schema: resolved_semantic_schema.clone(),
                         };
                         let mut dynamic_scope = dynamic_scope.clone();
-                        dynamic_scope.insert(0, resolved_reference.schema_uri.as_ref().clone());
-
-                        return self
-                            .resolve_with_dynamic_scope(
-                                Cow::Owned(resolved_reference.schema_uri.into_owned()),
-                                Cow::Owned(resolved_reference.definitions.into_owned()),
-                                resolved_reference.strict,
-                                schema_store,
-                                dynamic_scope,
-                            )
-                            .await;
+                        push_dynamic_scope(
+                            &mut dynamic_scope,
+                            resolved_resource_uri,
+                            resolved_reference.definitions.generation(),
+                        );
+                        return Ok(Some(CurrentSchema {
+                            schema_view: resolved_value,
+                            semantic_schema: resolved_semantic_schema,
+                            schema_uri: Cow::Owned(resolved_reference.schema_uri.into_owned()),
+                            definitions: Cow::Owned(
+                                resolved_reference
+                                    .definitions
+                                    .into_owned()
+                                    .with_dynamic_scope(dynamic_scope),
+                            ),
+                            strict: resolved_reference.strict,
+                        }));
                     } else {
                         return Err(crate::Error::UnsupportedReference {
                             reference: reference.to_owned(),
@@ -608,18 +723,48 @@ impl Referable<SchemaView> {
                     let (schema_uri, definitions) = {
                         match reference_url {
                             Some(reference_url) => {
-                                if let Some(document_schema) =
-                                    schema_store.try_get_document_schema(reference_url).await?
+                                if let Some(document_schema) = schema_store
+                                    .try_get_document_schema_in_generation(
+                                        reference_url,
+                                        definitions.generation(),
+                                    )
+                                    .await?
                                 {
+                                    let mut dynamic_scope = dynamic_scope;
+                                    let resource_uri = document_schema.base_uri().clone();
+                                    push_dynamic_scope(
+                                        &mut dynamic_scope,
+                                        resource_uri.clone(),
+                                        document_schema.definitions.generation(),
+                                    );
+                                    let source_schema_uri =
+                                        document_source_schema_uri(&document_schema);
                                     (
-                                        Cow::Owned(document_base_uri(&document_schema)),
-                                        Cow::Owned(document_schema.definitions.clone()),
+                                        Cow::Owned(resource_uri),
+                                        Cow::Owned(
+                                            document_schema
+                                                .definitions
+                                                .with_source_schema_uri(source_schema_uri)
+                                                .with_dynamic_scope(dynamic_scope),
+                                        ),
                                     )
                                 } else {
-                                    (schema_uri, definitions)
+                                    (
+                                        schema_uri,
+                                        Cow::Owned(
+                                            definitions
+                                                .into_owned()
+                                                .with_dynamic_scope(dynamic_scope),
+                                        ),
+                                    )
                                 }
                             }
-                            None => (schema_uri, definitions),
+                            None => (
+                                schema_uri,
+                                Cow::Owned(
+                                    definitions.into_owned().with_dynamic_scope(dynamic_scope),
+                                ),
+                            ),
                         }
                     };
 
@@ -656,12 +801,29 @@ impl Referable<SchemaView> {
             } => {
                 let (schema_uri, definitions) = match reference_url {
                     Some(reference_url) => {
-                        if let Some(document_schema) =
-                            schema_store.try_get_document_schema(reference_url).await?
+                        if let Some(document_schema) = schema_store
+                            .try_get_document_schema_in_generation(
+                                reference_url,
+                                definitions.generation(),
+                            )
+                            .await?
                         {
+                            let mut dynamic_scope = definitions.dynamic_scope().to_vec();
+                            let resource_uri = document_schema.base_uri().clone();
+                            push_dynamic_scope(
+                                &mut dynamic_scope,
+                                resource_uri.clone(),
+                                document_schema.definitions.generation(),
+                            );
+                            let source_schema_uri = document_source_schema_uri(&document_schema);
                             (
-                                Cow::Owned(document_base_uri(&document_schema)),
-                                Cow::Owned(document_schema.definitions.clone()),
+                                Cow::Owned(resource_uri),
+                                Cow::Owned(
+                                    document_schema
+                                        .definitions
+                                        .with_source_schema_uri(source_schema_uri)
+                                        .with_dynamic_scope(dynamic_scope),
+                                ),
                             )
                         } else {
                             (schema_uri, definitions)
@@ -786,7 +948,7 @@ fn apply_ref_semantics(
 }
 
 async fn resolve_from_schema_map(
-    map: &std::sync::Arc<tokio::sync::RwLock<SchemaMap>>,
+    map: &tokio::sync::RwLock<SchemaMap>,
     reference: &str,
 ) -> Option<Referable<SchemaView>> {
     let map_guard = map.read().await;
@@ -796,12 +958,16 @@ async fn resolve_from_schema_map(
 async fn resolve_anchor_reference(
     reference: &str,
     schema_uri: &SchemaUri,
+    generation: Option<&Arc<crate::store::SchemaGeneration>>,
     schema_store: &crate::SchemaStore,
 ) -> Result<Option<Referable<SchemaView>>, crate::Error> {
     if !is_plain_name_anchor_reference(reference) {
         return Ok(None);
     }
-    let Some(document_schema) = schema_store.try_get_document_schema(schema_uri).await? else {
+    let Some(document_schema) = schema_store
+        .try_get_document_schema_in_generation(schema_uri, generation)
+        .await?
+    else {
         return Ok(None);
     };
     Ok(resolve_from_schema_map(&document_schema.anchors, reference).await)
@@ -809,12 +975,12 @@ async fn resolve_anchor_reference(
 
 async fn resolve_dynamic_anchor_from_scope(
     reference: &str,
-    dynamic_scope: &[SchemaUri],
+    dynamic_scope: &[DynamicScopeEntry],
     schema_store: &crate::SchemaStore,
 ) -> Result<Option<(Referable<SchemaView>, SchemaUri, SchemaDefinitions)>, crate::Error> {
-    for scope_schema_uri in dynamic_scope {
+    for scope in dynamic_scope {
         let Some(document_schema) = schema_store
-            .try_get_document_schema(scope_schema_uri)
+            .try_get_document_schema_in_generation(&scope.schema_uri, scope.generation.as_ref())
             .await?
         else {
             continue;
@@ -840,6 +1006,7 @@ async fn resolve_external_reference(
     reference: &str,
     base_schema_uri: &SchemaUri,
     strict: Option<BoolDefaultTrue>,
+    generation: Option<&Arc<crate::store::SchemaGeneration>>,
     schema_store: &crate::SchemaStore,
 ) -> Result<Option<CurrentSchema<'static>>, crate::Error> {
     let joined = if let Ok(url) = base_schema_uri.join(reference) {
@@ -858,11 +1025,15 @@ async fn resolve_external_reference(
     resolved_schema_uri.set_fragment(None);
 
     let Some(document_schema) = schema_store
-        .try_get_document_schema(&resolved_schema_uri)
+        .try_get_document_schema_in_generation(&resolved_schema_uri, generation)
         .await?
     else {
         return Ok(None);
     };
+    let source_schema_uri = document_source_schema_uri(&document_schema);
+    let target_definitions = document_schema
+        .definitions
+        .with_source_schema_uri(source_schema_uri);
 
     let Some(fragment) = fragment else {
         let Some(schema_view) = document_schema.schema_view.as_ref() else {
@@ -874,21 +1045,26 @@ async fn resolve_external_reference(
         return Ok(Some(CurrentSchema {
             schema_view: schema_view.clone(),
             semantic_schema: document_schema.semantic_schema.clone(),
-            schema_uri: Cow::Owned(document_base_uri(&document_schema)),
-            definitions: Cow::Owned(document_schema.definitions.clone()),
+            schema_uri: Cow::Owned(document_schema.schema_uri.clone()),
+            definitions: Cow::Owned(target_definitions),
             strict,
         }));
     };
 
     let reference_with_fragment = format!("#{fragment}");
     if is_plain_name_anchor_reference(&reference_with_fragment) {
-        if let Some(mut referable) =
-            resolve_from_schema_map(&document_schema.anchors, &reference_with_fragment).await
-        {
+        let mut referable =
+            resolve_from_schema_map(&document_schema.anchors, &reference_with_fragment).await;
+        if referable.is_none() {
+            referable =
+                resolve_from_schema_map(&document_schema.dynamic_anchors, &reference_with_fragment)
+                    .await;
+        }
+        if let Some(mut referable) = referable {
             return referable
                 .resolve(
                     Cow::Owned(document_base_uri(&document_schema)),
-                    Cow::Owned(document_schema.definitions.clone()),
+                    Cow::Owned(target_definitions),
                     strict,
                     schema_store,
                 )
@@ -902,28 +1078,39 @@ async fn resolve_external_reference(
     }
 
     if is_json_pointer(&reference_with_fragment) {
-        if let Some(schema_value) = schema_store
-            .fetch_schema_value(&resolved_schema_uri)
-            .await?
+        let target_generation = document_schema.definitions.generation();
+        let schema_value = if let Some(schema_value) =
+            schema_value_in_generation(&resolved_schema_uri, target_generation)
         {
+            Some(Cow::Borrowed(schema_value))
+        } else {
+            schema_store
+                .fetch_external_schema_value(&resolved_schema_uri)
+                .await?
+                .map(Cow::Owned)
+        };
+        if let Some(schema_value) = schema_value {
             let dialect = schema_value
                 .as_object()
                 .and_then(|object| object.get("$schema"))
                 .and_then(|value| value.as_str())
                 .and_then(|dialect_uri| crate::JsonSchemaDialect::try_from(dialect_uri).ok());
-            if let Some(schema_view) =
-                resolve_json_pointer(&schema_value, &reference_with_fragment, None, dialect)?
-            {
+            if let Some(schema_view) = resolve_json_pointer(
+                schema_value.as_ref(),
+                &reference_with_fragment,
+                None,
+                dialect,
+            )? {
                 return Ok(Some(CurrentSchema {
                     schema_view: Arc::new(schema_view),
                     semantic_schema: resolve_json_pointer_node(
-                        &schema_value,
+                        schema_value.as_ref(),
                         &reference_with_fragment,
                     )
                     .and_then(|value| super::SemanticSchema::from_value_node(value, dialect))
                     .map(Arc::new),
-                    schema_uri: Cow::Owned(document_base_uri(&document_schema)),
-                    definitions: Cow::Owned(document_schema.definitions.clone()),
+                    schema_uri: Cow::Owned(document_schema.schema_uri.clone()),
+                    definitions: Cow::Owned(target_definitions),
                     strict,
                 }));
             }
@@ -944,21 +1131,46 @@ fn document_base_uri(document_schema: &crate::DocumentSchema) -> SchemaUri {
     document_schema.base_uri().clone()
 }
 
-fn parse_dynamic_anchor_reference(reference: &str) -> Option<(Option<SchemaUri>, String)> {
-    if let Some(fragment) = reference.strip_prefix('#') {
-        if !is_plain_name_fragment(fragment) {
-            return None;
-        }
-        return Some((None, format!("#{fragment}")));
-    }
+fn document_source_schema_uri(document_schema: &crate::DocumentSchema) -> SchemaUri {
+    document_schema
+        .definitions
+        .source_schema_uri()
+        .unwrap_or(&document_schema.schema_uri)
+        .clone()
+}
 
-    let (base_uri, fragment) = reference.split_once('#')?;
+async fn resolve_static_dynamic_anchor_reference(
+    reference: &str,
+    base_schema_uri: &SchemaUri,
+    generation: Option<&Arc<crate::store::SchemaGeneration>>,
+    schema_store: &crate::SchemaStore,
+) -> Result<Option<String>, crate::Error> {
+    let Some((_, fragment)) = reference.rsplit_once('#') else {
+        return Ok(None);
+    };
     if !is_plain_name_fragment(fragment) {
-        return None;
+        return Ok(None);
     }
 
-    let base_schema_uri = SchemaUri::from_str(base_uri).ok()?;
-    Some((Some(base_schema_uri), format!("#{fragment}")))
+    let Ok(mut target_schema_uri) = base_schema_uri.join(reference) else {
+        return Ok(None);
+    };
+    target_schema_uri.set_fragment(None);
+    let target_schema_uri = SchemaUri::from(target_schema_uri);
+    let Some(document_schema) = schema_store
+        .try_get_document_schema_in_generation(&target_schema_uri, generation)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    let anchor = format!("#{fragment}");
+    let is_dynamic_anchor = document_schema
+        .dynamic_anchors
+        .read()
+        .await
+        .contains_key(&anchor);
+    Ok(is_dynamic_anchor.then_some(anchor))
 }
 
 fn parse_recursive_anchor_reference(reference: &str) -> Option<(Option<SchemaUri>, String)> {
@@ -1081,13 +1293,29 @@ pub async fn resolve_and_collect_schemas_with_errors(
             let (current_schema_uri, current_definitions) =
                 if let Some(resolved_schema_uri) = resolved_schema_uri {
                     match schema_store
-                        .try_get_document_schema(&resolved_schema_uri)
+                        .try_get_document_schema_in_generation(
+                            &resolved_schema_uri,
+                            definitions.generation(),
+                        )
                         .await
                     {
-                        Ok(Some(document_schema)) => (
-                            document_base_uri(&document_schema),
-                            document_schema.definitions.clone(),
-                        ),
+                        Ok(Some(document_schema)) => {
+                            let mut dynamic_scope = definitions.dynamic_scope().to_vec();
+                            let resource_uri = document_schema.base_uri().clone();
+                            push_dynamic_scope(
+                                &mut dynamic_scope,
+                                resource_uri,
+                                document_schema.definitions.generation(),
+                            );
+                            let source_schema_uri = document_source_schema_uri(&document_schema);
+                            (
+                                document_schema.schema_uri.clone(),
+                                document_schema
+                                    .definitions
+                                    .with_source_schema_uri(source_schema_uri)
+                                    .with_dynamic_scope(dynamic_scope),
+                            )
+                        }
                         Ok(None) => (default_schema_uri.clone(), default_definitions.clone()),
                         Err(err) => {
                             errors.push(err);
@@ -1242,7 +1470,7 @@ pub fn resolve_json_pointer(
     }
 }
 
-fn resolve_json_pointer_node<'a>(
+pub(crate) fn resolve_json_pointer_node<'a>(
     schema_node: &'a tombi_json::ValueNode,
     pointer: &str,
 ) -> Option<&'a tombi_json::ValueNode> {
@@ -1321,12 +1549,55 @@ fn percent_decode(input: &str) -> String {
 
 #[cfg(test)]
 mod test {
-    use std::{borrow::Cow, str::FromStr};
+    use std::{borrow::Cow, str::FromStr, sync::Arc};
 
     use crate::{
-        Referable, SchemaStore, SchemaView,
-        schema::referable_schema::{parse_dynamic_anchor_reference, resolve_json_pointer},
+        AnythingSchema, CurrentSchema, Referable, SchemaDefinitions, SchemaStore, SchemaView,
+        schema::referable_schema::resolve_json_pointer,
     };
+
+    #[test]
+    fn source_schema_uri_uses_physical_document_for_reference_fragments() {
+        let physical_uri = crate::SchemaUri::from_str("file:///tmp/schema.json").unwrap();
+        let definitions =
+            SchemaDefinitions::new(Default::default()).with_source_schema_uri(physical_uri.clone());
+
+        for fragment in ["#/properties/value", "#value"] {
+            let current = CurrentSchema {
+                schema_view: Arc::new(SchemaView::Anything(AnythingSchema {
+                    title: None,
+                    description: None,
+                    range: tombi_text::Range::default(),
+                })),
+                semantic_schema: None,
+                schema_uri: Cow::Owned(
+                    crate::SchemaUri::from_str(&format!("file:///tmp/schema.json{fragment}"))
+                        .unwrap(),
+                ),
+                definitions: Cow::Borrowed(&definitions),
+                strict: None,
+            };
+
+            assert_eq!(current.source_schema_uri().as_ref(), &physical_uri);
+            assert_eq!(
+                current.diagnostic_schema_uri().as_ref(),
+                current.schema_uri.as_ref()
+            );
+
+            let current_without_source = CurrentSchema {
+                definitions: Cow::Owned(SchemaDefinitions::new(Default::default())),
+                ..current
+            };
+            assert_eq!(
+                current_without_source.source_schema_uri().as_ref(),
+                &physical_uri
+            );
+            assert_eq!(
+                current_without_source.diagnostic_schema_uri().as_ref(),
+                current_without_source.schema_uri.as_ref()
+            );
+        }
+    }
 
     #[test]
     fn ref_assertion_siblings_follow_dialect() {
@@ -1478,6 +1749,7 @@ mod test {
         let referable = Referable::Ref {
             reference: "#/definitions/foo".to_string(),
             kind: super::ReferenceKind::Ref,
+            source_position: tombi_text::Position::default(),
             semantic_schema: None,
             title: None,
             description: None,
@@ -1770,19 +2042,5 @@ mod test {
         );
         drop(branches);
         std::fs::remove_dir_all(temp_dir).unwrap();
-    }
-
-    #[test]
-    fn test_parse_dynamic_anchor_reference() {
-        let local = parse_dynamic_anchor_reference("#rootDyn");
-        assert_eq!(local, Some((None, "#rootDyn".to_string())));
-
-        let remote = parse_dynamic_anchor_reference("https://example.com/schema.json#rootDyn");
-        std::assert_matches!(
-            remote,
-            Some((Some(_), anchor)) if anchor == "#rootDyn"
-        );
-
-        assert!(parse_dynamic_anchor_reference("#/defs/x").is_none());
     }
 }

--- a/crates/tombi-schema-store/src/schema/resource_index.rs
+++ b/crates/tombi-schema-store/src/schema/resource_index.rs
@@ -1,0 +1,710 @@
+use std::str::FromStr;
+
+use tombi_hashmap::HashMap;
+use tombi_json::{ObjectNode, ValueNode};
+use tombi_text::Range;
+
+use crate::{JsonSchemaDialect, SchemaUri};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BuildError {
+    InvalidId {
+        id: String,
+        base_uri: SchemaUri,
+        range: Range,
+    },
+    IdWithNonEmptyFragment {
+        id: String,
+        range: Range,
+    },
+    DuplicateResource {
+        uri: SchemaUri,
+        first_range: Range,
+        duplicate_range: Range,
+    },
+    InvalidAnchor {
+        keyword: &'static str,
+        anchor: String,
+        range: Range,
+    },
+    DuplicateAnchor {
+        resource_uri: SchemaUri,
+        anchor: String,
+        first_range: Range,
+        duplicate_range: Range,
+    },
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidId {
+                id,
+                base_uri,
+                range,
+            } => write!(f, "invalid $id {id:?} relative to {base_uri} at {range}"),
+            Self::IdWithNonEmptyFragment { id, range } => {
+                write!(
+                    f,
+                    "$id must not contain a non-empty fragment: {id:?} at {range}"
+                )
+            }
+            Self::DuplicateResource {
+                uri,
+                first_range,
+                duplicate_range,
+            } => write!(
+                f,
+                "duplicate schema resource URI {uri}: first at {first_range}, duplicate at {duplicate_range}"
+            ),
+            Self::InvalidAnchor {
+                keyword,
+                anchor,
+                range,
+            } => write!(f, "invalid {keyword} name {anchor:?} at {range}"),
+            Self::DuplicateAnchor {
+                resource_uri,
+                anchor,
+                first_range,
+                duplicate_range,
+            } => write!(
+                f,
+                "duplicate anchor {anchor:?} in schema resource {resource_uri}: first at {first_range}, duplicate at {duplicate_range}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BuildError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResourceTarget {
+    /// JSON Pointer from the root of the physical schema document.
+    pub pointer: String,
+    pub range: Range,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResourceMetadata {
+    /// JSON Pointer from the root of the physical schema document.
+    pub root_pointer: String,
+    pub root_range: Range,
+    pub dialect: Option<JsonSchemaDialect>,
+    pub anchors: HashMap<String, ResourceTarget>,
+    pub dynamic_anchors: HashMap<String, ResourceTarget>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResourceIndex {
+    retrieval_uri: SchemaUri,
+    root_resource_uri: SchemaUri,
+    resources: HashMap<SchemaUri, ResourceMetadata>,
+    effective_base_by_position: HashMap<tombi_text::Position, SchemaUri>,
+}
+
+impl ResourceIndex {
+    pub fn build(
+        root: &ValueNode,
+        retrieval_uri: &SchemaUri,
+        default_dialect: Option<JsonSchemaDialect>,
+    ) -> Result<Self, BuildError> {
+        let retrieval_uri = without_fragment(retrieval_uri.clone());
+        let mut index = Self {
+            root_resource_uri: retrieval_uri.clone(),
+            retrieval_uri: retrieval_uri.clone(),
+            resources: HashMap::default(),
+            effective_base_by_position: HashMap::default(),
+        };
+
+        let ValueNode::Object(root_object) = root else {
+            index.resources.insert(
+                retrieval_uri.clone(),
+                ResourceMetadata {
+                    root_pointer: "#".to_owned(),
+                    root_range: root.range(),
+                    dialect: default_dialect,
+                    anchors: HashMap::default(),
+                    dynamic_anchors: HashMap::default(),
+                },
+            );
+            return Ok(index);
+        };
+
+        let mut stack = vec![Frame {
+            object: root_object,
+            pointer: "#".to_owned(),
+            incoming_base: retrieval_uri.clone(),
+            resource_uri: retrieval_uri,
+            dialect: default_dialect,
+            is_root: true,
+        }];
+
+        while let Some(frame) = stack.pop() {
+            let dialect = schema_dialect(frame.object).or(frame.dialect);
+            let mut effective_base = frame.incoming_base;
+            let mut resource_uri = frame.resource_uri;
+            let mut starts_resource = frame.is_root;
+
+            if let Some(id_node) = frame.object.get("$id")
+                && let Some(id) = id_node.as_str()
+            {
+                effective_base = resolve_id(id, &effective_base, id_node.range())?;
+                let has_non_empty_fragment =
+                    effective_base.fragment().is_some_and(|f| !f.is_empty());
+                if has_non_empty_fragment
+                    && dialect.is_some_and(|dialect| dialect >= JsonSchemaDialect::Draft2019_09)
+                {
+                    return Err(BuildError::IdWithNonEmptyFragment {
+                        id: id.to_owned(),
+                        range: id_node.range(),
+                    });
+                }
+
+                // Draft 7 permits legacy fragment-bearing identifiers. They change
+                // the base URI but do not start an independently addressable resource.
+                if !has_non_empty_fragment {
+                    effective_base = without_fragment(effective_base);
+                    resource_uri = effective_base.clone();
+                    starts_resource = true;
+                }
+            }
+
+            // ReferableSchema only asks for the base of an object containing a
+            // reference. Keeping entries for every schema object made the
+            // index proportional to the entire document for no benefit.
+            if ["$ref", "$dynamicRef", "$recursiveRef"]
+                .iter()
+                .any(|keyword| frame.object.get(keyword).is_some())
+            {
+                index
+                    .effective_base_by_position
+                    .insert(frame.object.range.start, effective_base.clone());
+            }
+
+            if starts_resource {
+                if !frame.is_root && resource_uri == index.retrieval_uri {
+                    let first_range = index
+                        .resources
+                        .get(&index.root_resource_uri)
+                        .expect("the root resource is indexed before its children")
+                        .root_range;
+                    return Err(BuildError::DuplicateResource {
+                        uri: resource_uri,
+                        first_range,
+                        duplicate_range: frame.object.range,
+                    });
+                }
+                let metadata = ResourceMetadata {
+                    root_pointer: frame.pointer.clone(),
+                    root_range: frame.object.range,
+                    dialect,
+                    anchors: HashMap::default(),
+                    dynamic_anchors: HashMap::default(),
+                };
+                if let Some(previous) = index.resources.insert(resource_uri.clone(), metadata) {
+                    return Err(BuildError::DuplicateResource {
+                        uri: resource_uri,
+                        first_range: previous.root_range,
+                        duplicate_range: frame.object.range,
+                    });
+                }
+                if frame.is_root {
+                    index.root_resource_uri = resource_uri.clone();
+                }
+            }
+
+            index.collect_anchors(frame.object, &frame.pointer, &resource_uri, dialect)?;
+
+            let mut children = Vec::new();
+            collect_schema_children(frame.object, dialect, &frame.pointer, &mut children);
+            for (object, pointer) in children.into_iter().rev() {
+                stack.push(Frame {
+                    object,
+                    pointer,
+                    incoming_base: effective_base.clone(),
+                    resource_uri: resource_uri.clone(),
+                    dialect,
+                    is_root: false,
+                });
+            }
+        }
+
+        Ok(index)
+    }
+
+    pub fn root_resource_uri(&self) -> &SchemaUri {
+        &self.root_resource_uri
+    }
+
+    pub fn resources(&self) -> &HashMap<SchemaUri, ResourceMetadata> {
+        &self.resources
+    }
+
+    pub fn resource(&self, uri: &SchemaUri) -> Option<&ResourceMetadata> {
+        let uri = without_fragment(uri.clone());
+        if uri == self.retrieval_uri {
+            self.resources.get(&self.root_resource_uri)
+        } else {
+            self.resources.get(&uri)
+        }
+    }
+
+    pub fn physical_fragment(&self, uri: &SchemaUri, fragment: &str) -> Option<String> {
+        let resource = self.resource(uri)?;
+        if fragment.starts_with('/') {
+            return Some(format!(
+                "{}{}",
+                resource.root_pointer.strip_prefix('#').unwrap_or(""),
+                fragment
+            ));
+        }
+
+        let anchor = format!("#{fragment}");
+        resource
+            .anchors
+            .get(&anchor)
+            .or_else(|| resource.dynamic_anchors.get(&anchor))
+            .map(|target| {
+                target
+                    .pointer
+                    .strip_prefix('#')
+                    .unwrap_or(&target.pointer)
+                    .to_owned()
+            })
+    }
+
+    pub fn effective_base(&self, position: tombi_text::Position) -> Option<&SchemaUri> {
+        self.effective_base_by_position.get(&position)
+    }
+
+    fn collect_anchors(
+        &mut self,
+        object: &ObjectNode,
+        pointer: &str,
+        resource_uri: &SchemaUri,
+        dialect: Option<JsonSchemaDialect>,
+    ) -> Result<(), BuildError> {
+        if crate::supports_keyword(dialect, "$anchor")
+            && let Some(node) = object.get("$anchor")
+            && let Some(anchor) = node.as_str()
+        {
+            self.insert_anchor(
+                resource_uri,
+                "$anchor",
+                anchor,
+                pointer,
+                node.range(),
+                false,
+            )?;
+        }
+
+        if crate::supports_keyword(dialect, "$dynamicAnchor")
+            && let Some(node) = object.get("$dynamicAnchor")
+            && let Some(anchor) = node.as_str()
+        {
+            self.insert_anchor(
+                resource_uri,
+                "$dynamicAnchor",
+                anchor,
+                pointer,
+                node.range(),
+                true,
+            )?;
+        }
+
+        if crate::supports_keyword(dialect, "$recursiveAnchor")
+            && object.get("$recursiveAnchor").and_then(ValueNode::as_bool) == Some(true)
+        {
+            let range = object
+                .get("$recursiveAnchor")
+                .map(ValueNode::range)
+                .unwrap_or(object.range);
+            self.insert_named_target(resource_uri, "#", pointer, range, true)?;
+        }
+
+        Ok(())
+    }
+
+    fn insert_anchor(
+        &mut self,
+        resource_uri: &SchemaUri,
+        keyword: &'static str,
+        anchor: &str,
+        pointer: &str,
+        range: Range,
+        dynamic: bool,
+    ) -> Result<(), BuildError> {
+        if !is_plain_name(anchor) {
+            return Err(BuildError::InvalidAnchor {
+                keyword,
+                anchor: anchor.to_owned(),
+                range,
+            });
+        }
+        self.insert_named_target(resource_uri, &format!("#{anchor}"), pointer, range, dynamic)
+    }
+
+    fn insert_named_target(
+        &mut self,
+        resource_uri: &SchemaUri,
+        name: &str,
+        pointer: &str,
+        range: Range,
+        dynamic: bool,
+    ) -> Result<(), BuildError> {
+        let resource = self
+            .resources
+            .get_mut(resource_uri)
+            .expect("the owning resource is inserted before its anchors");
+        let previous = resource
+            .anchors
+            .get(name)
+            .or_else(|| resource.dynamic_anchors.get(name));
+        if let Some(previous) = previous {
+            return Err(BuildError::DuplicateAnchor {
+                resource_uri: resource_uri.clone(),
+                anchor: name.to_owned(),
+                first_range: previous.range,
+                duplicate_range: range,
+            });
+        }
+
+        let target = ResourceTarget {
+            pointer: pointer.to_owned(),
+            range,
+        };
+        if dynamic {
+            resource.dynamic_anchors.insert(name.to_owned(), target);
+        } else {
+            resource.anchors.insert(name.to_owned(), target);
+        }
+        Ok(())
+    }
+}
+
+struct Frame<'a> {
+    object: &'a ObjectNode,
+    pointer: String,
+    incoming_base: SchemaUri,
+    resource_uri: SchemaUri,
+    dialect: Option<JsonSchemaDialect>,
+    is_root: bool,
+}
+
+fn resolve_id(id: &str, base_uri: &SchemaUri, range: Range) -> Result<SchemaUri, BuildError> {
+    base_uri
+        .join(id)
+        .map(SchemaUri::from)
+        .or_else(|_| SchemaUri::from_str(id))
+        .map_err(|_| BuildError::InvalidId {
+            id: id.to_owned(),
+            base_uri: base_uri.clone(),
+            range,
+        })
+}
+
+fn without_fragment(mut uri: SchemaUri) -> SchemaUri {
+    uri.set_fragment(None);
+    uri
+}
+
+fn schema_dialect(object: &ObjectNode) -> Option<JsonSchemaDialect> {
+    object
+        .get("$schema")
+        .and_then(ValueNode::as_str)
+        .and_then(|uri| JsonSchemaDialect::try_from(uri).ok())
+}
+
+fn is_plain_name(anchor: &str) -> bool {
+    let mut chars = anchor.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+fn collect_schema_children<'a>(
+    object: &'a ObjectNode,
+    dialect: Option<JsonSchemaDialect>,
+    pointer: &str,
+    output: &mut Vec<(&'a ObjectNode, String)>,
+) {
+    const SINGLE_SCHEMA_KEYWORDS: &[&str] = &[
+        "additionalProperties",
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "propertyNames",
+        "contains",
+        "not",
+        "if",
+        "then",
+        "else",
+        "contentSchema",
+        "additionalItems",
+    ];
+    const ARRAY_SCHEMA_KEYWORDS: &[&str] = &["allOf", "anyOf", "oneOf", "prefixItems"];
+    const MAP_SCHEMA_KEYWORDS: &[&str] = &[
+        "$defs",
+        "definitions",
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+    ];
+
+    for keyword in SINGLE_SCHEMA_KEYWORDS {
+        if crate::supports_keyword(dialect, keyword)
+            && let Some(child) = object.get(keyword).and_then(ValueNode::as_object)
+        {
+            output.push((child, child_pointer(pointer, keyword)));
+        }
+    }
+
+    for keyword in ARRAY_SCHEMA_KEYWORDS {
+        if crate::supports_keyword(dialect, keyword)
+            && let Some(array) = object.get(keyword).and_then(ValueNode::as_array)
+        {
+            let base = child_pointer(pointer, keyword);
+            for (index, child) in array.items.iter().enumerate() {
+                if let Some(child) = child.as_object() {
+                    output.push((child, format!("{base}/{index}")));
+                }
+            }
+        }
+    }
+
+    for keyword in MAP_SCHEMA_KEYWORDS {
+        if crate::supports_keyword(dialect, keyword)
+            && let Some(map) = object.get(keyword).and_then(ValueNode::as_object)
+        {
+            let base = child_pointer(pointer, keyword);
+            for (name, child) in &map.properties {
+                if let Some(child) = child.as_object() {
+                    output.push((
+                        child,
+                        format!("{base}/{}", escape_json_pointer_token(&name.value)),
+                    ));
+                }
+            }
+        }
+    }
+
+    if crate::supports_keyword(dialect, "items")
+        && let Some(items) = object.get("items")
+    {
+        let base = child_pointer(pointer, "items");
+        match items {
+            ValueNode::Object(child) => output.push((child, base)),
+            ValueNode::Array(array)
+                if dialect.is_none_or(|dialect| dialect < JsonSchemaDialect::Draft2020_12) =>
+            {
+                for (index, child) in array.items.iter().enumerate() {
+                    if let Some(child) = child.as_object() {
+                        output.push((child, format!("{base}/{index}")));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if crate::supports_keyword(dialect, "dependencies")
+        && let Some(map) = object.get("dependencies").and_then(ValueNode::as_object)
+    {
+        let base = child_pointer(pointer, "dependencies");
+        for (name, child) in &map.properties {
+            if let Some(child) = child.as_object() {
+                output.push((
+                    child,
+                    format!("{base}/{}", escape_json_pointer_token(&name.value)),
+                ));
+            }
+        }
+    }
+}
+
+fn child_pointer(parent: &str, token: &str) -> String {
+    format!("{parent}/{}", escape_json_pointer_token(token))
+}
+
+fn escape_json_pointer_token(token: &str) -> String {
+    token.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(value: &str) -> SchemaUri {
+        SchemaUri::from_str(value).expect("valid test URI")
+    }
+
+    fn schema(value: &str) -> ValueNode {
+        ValueNode::from_str(value).expect("valid test schema")
+    }
+
+    #[test]
+    fn indexes_relative_compound_resources_and_effective_bases() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/root/bundle.json",
+                "$defs": {
+                    "first": {
+                        "$id": "models/first",
+                        "$defs": {
+                            "nested": { "$id": "../nested", "type": "string" }
+                        }
+                    }
+                }
+            }"#,
+        );
+        let index = ResourceIndex::build(&root, &uri("file:///tmp/bundle.json"), None).unwrap();
+
+        assert_eq!(
+            index.root_resource_uri().as_str(),
+            "https://example.com/root/bundle.json"
+        );
+        assert!(
+            index
+                .resource(&uri("https://example.com/root/models/first"))
+                .is_some()
+        );
+        let nested = index
+            .resource(&uri("https://example.com/root/nested"))
+            .unwrap();
+        assert_eq!(nested.root_pointer, "#/$defs/first/$defs/nested");
+        assert_eq!(
+            index.physical_fragment(&uri("https://example.com/root/nested"), "/type"),
+            Some("/$defs/first/$defs/nested/type".to_owned())
+        );
+        assert_eq!(
+            index
+                .resource(&uri("file:///tmp/bundle.json"))
+                .unwrap()
+                .root_pointer,
+            "#"
+        );
+    }
+
+    #[test]
+    fn scopes_equal_anchor_names_to_their_resources() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/bundle",
+                "$anchor": "same",
+                "$defs": {
+                    "child": {
+                        "$id": "child",
+                        "$anchor": "same",
+                        "$dynamicAnchor": "dynamic"
+                    }
+                }
+            }"#,
+        );
+        let index = ResourceIndex::build(&root, &uri("file:///bundle.json"), None).unwrap();
+
+        let root_resource = index.resource(index.root_resource_uri()).unwrap();
+        let child = index.resource(&uri("https://example.com/child")).unwrap();
+        assert_eq!(root_resource.anchors["#same"].pointer, "#");
+        assert_eq!(child.anchors["#same"].pointer, "#/$defs/child");
+        assert_eq!(child.dynamic_anchors["#dynamic"].pointer, "#/$defs/child");
+        assert_eq!(
+            index.physical_fragment(&uri("https://example.com/child"), "same"),
+            Some("/$defs/child".to_owned())
+        );
+        assert_eq!(
+            index.physical_fragment(&uri("https://example.com/child"), "dynamic"),
+            Some("/$defs/child".to_owned())
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_canonical_resource_uri_after_normalization() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://EXAMPLE.com/a/bundle",
+                "$defs": {
+                    "a": { "$id": "../resource" },
+                    "b": { "$id": "https://example.com/resource" }
+                }
+            }"#,
+        );
+        let error = ResourceIndex::build(&root, &uri("file:///bundle.json"), None).unwrap_err();
+        assert!(matches!(error, BuildError::DuplicateResource { .. }));
+    }
+
+    #[test]
+    fn reserves_retrieval_uri_for_the_root_resource() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/root",
+                "$defs": {
+                    "shadow": { "$id": "file:///tmp/bundle.json" }
+                }
+            }"#,
+        );
+        let root_range = root.range();
+        let error = ResourceIndex::build(&root, &uri("file:///tmp/bundle.json"), None).unwrap_err();
+
+        assert!(matches!(
+            error,
+            BuildError::DuplicateResource {
+                uri: duplicate_uri,
+                first_range,
+                duplicate_range,
+            } if duplicate_uri == uri("file:///tmp/bundle.json")
+                && first_range == root_range
+                && duplicate_range != root_range
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_static_and_dynamic_anchor_names_in_one_resource() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$anchor": "same",
+                "$defs": {
+                    "nested": { "$dynamicAnchor": "same" }
+                }
+            }"#,
+        );
+        let error = ResourceIndex::build(&root, &uri("file:///bundle.json"), None).unwrap_err();
+        assert!(matches!(error, BuildError::DuplicateAnchor { .. }));
+
+        let invalid = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$anchor": "invalid:name"
+            }"#,
+        );
+        let error = ResourceIndex::build(&invalid, &uri("file:///bundle.json"), None).unwrap_err();
+        assert!(matches!(error, BuildError::InvalidAnchor { .. }));
+    }
+
+    #[test]
+    fn ignores_id_lookalikes_in_instance_values() {
+        let root = schema(
+            r#"{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "const": { "$id": "https://example.com/not-a-schema" },
+                "default": { "$id": "https://example.com/not-a-schema-either" },
+                "properties": {
+                    "actual": { "$id": "https://example.com/schema" }
+                }
+            }"#,
+        );
+        let index = ResourceIndex::build(&root, &uri("file:///bundle.json"), None).unwrap();
+
+        assert_eq!(index.resources().len(), 2);
+        assert!(index.resource(&uri("https://example.com/schema")).is_some());
+        assert!(
+            index
+                .resource(&uri("https://example.com/not-a-schema"))
+                .is_none()
+        );
+    }
+}

--- a/crates/tombi-schema-store/src/store.rs
+++ b/crates/tombi-schema-store/src/store.rs
@@ -1,10 +1,19 @@
-use std::{borrow::Cow, ops::Deref, str::FromStr, sync::Arc};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    ops::Deref,
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use crate::resolve_json_pointer;
 use crate::{
     AllOfSchema, AnyOfSchema, CatalogUri, DocumentSchema, OneOfSchema, PatternAccessor,
-    PatternAccessors, SchemaView, SourceSchema, SubSchemaLink, SubSchemaLinkMap,
-    get_tombi_schemastore_content,
+    PatternAccessors, ResourceIndex, SchemaAnchors, SchemaDynamicAnchors, SchemaMap, SchemaView,
+    SourceSchema, SubSchemaLink, SubSchemaLinkMap, get_tombi_schemastore_content,
     http_client::{DefaultHttpClient, HttpClient},
     json::JsonCatalog,
 };
@@ -17,7 +26,115 @@ use tombi_config::{SchemaItem, SchemaOverviewOptions, TomlVersion, config_base_d
 use tombi_future::{BoxFuture, Boxable};
 use tombi_uri::SchemaUri;
 
-type DocumentSchemas = Arc<RwLock<tombi_hashmap::HashMap<SchemaUri, CachedDocumentSchema>>>;
+type SchemaCache = Arc<RwLock<CacheState>>;
+
+#[derive(Debug, Default)]
+struct CacheState {
+    documents: tombi_hashmap::HashMap<SchemaUri, CachedDocumentSchema>,
+    resources: ResourceRegistry,
+}
+
+#[derive(Debug, Default)]
+struct ResourceRegistry {
+    by_uri: tombi_hashmap::HashMap<SchemaUri, EmbeddedResource>,
+    by_source: tombi_hashmap::HashMap<SchemaUri, Arc<SchemaGeneration>>,
+}
+
+tokio::task_local! {
+    static RESOLUTION_STACK: RefCell<Vec<SchemaUri>>;
+}
+
+struct ResolutionGuard(SchemaUri);
+
+impl ResolutionGuard {
+    fn enter(schema_uri: &SchemaUri) -> Option<Self> {
+        RESOLUTION_STACK
+            .try_with(|stack| {
+                let mut stack = stack.borrow_mut();
+                if stack.contains(schema_uri) {
+                    None
+                } else {
+                    stack.push(schema_uri.clone());
+                    Some(Self(schema_uri.clone()))
+                }
+            })
+            .ok()
+            .flatten()
+    }
+}
+
+impl Drop for ResolutionGuard {
+    fn drop(&mut self) {
+        let _ = RESOLUTION_STACK.try_with(|stack| {
+            let mut stack = stack.borrow_mut();
+            if let Some(position) = stack.iter().rposition(|uri| uri == &self.0) {
+                stack.remove(position);
+            }
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EmbeddedResource {
+    generation: Arc<SchemaGeneration>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SchemaGeneration {
+    revision: u64,
+    pub(crate) source_schema_uri: Arc<SchemaUri>,
+    pub(crate) source_node: Arc<tombi_json::ValueNode>,
+    pub(crate) resource_index: Arc<ResourceIndex>,
+    /// Completed resource schemas with all generation-local strong references
+    /// removed. Misses may compile concurrently; insertion is idempotent.
+    compiled_resources: std::sync::RwLock<tombi_hashmap::HashMap<SchemaUri, Arc<DocumentSchema>>>,
+}
+
+fn build_schema_map(
+    schema_value: &tombi_json::ValueNode,
+    targets: &tombi_hashmap::HashMap<String, crate::ResourceTarget>,
+    string_formats: Option<&[tombi_x_keyword::StringFormat]>,
+    dialect: Option<crate::JsonSchemaDialect>,
+) -> SchemaMap {
+    targets
+        .iter()
+        .filter_map(|(name, target)| {
+            crate::resolve_json_pointer_node(schema_value, &target.pointer)
+                .and_then(|node| {
+                    crate::schema::referable_from_schema_value(
+                        node,
+                        string_formats,
+                        dialect,
+                        None,
+                        None,
+                    )
+                })
+                .map(|schema| (name.clone(), schema))
+        })
+        .collect()
+}
+
+fn build_anchor_maps(
+    schema_value: &tombi_json::ValueNode,
+    metadata: &crate::ResourceMetadata,
+    string_formats: Option<&[tombi_x_keyword::StringFormat]>,
+    dialect: Option<crate::JsonSchemaDialect>,
+) -> (SchemaAnchors, SchemaDynamicAnchors) {
+    (
+        SchemaAnchors::new(RwLock::new(build_schema_map(
+            schema_value,
+            &metadata.anchors,
+            string_formats,
+            dialect,
+        ))),
+        SchemaDynamicAnchors::new(RwLock::new(build_schema_map(
+            schema_value,
+            &metadata.dynamic_anchors,
+            string_formats,
+            dialect,
+        ))),
+    )
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SchemaCacheVersion {
@@ -28,6 +145,7 @@ struct SchemaCacheVersion {
 #[derive(Debug, Clone)]
 struct CachedDocumentSchema {
     version: Option<SchemaCacheVersion>,
+    source_schema_uri: SchemaUri,
     document_schema: Result<Arc<DocumentSchema>, crate::Error>,
 }
 
@@ -105,7 +223,8 @@ pub struct AssociateSchemaOptions {
 #[derive(Debug, Clone)]
 pub struct SchemaStore {
     http_client: Arc<dyn HttpClient>,
-    document_schemas: DocumentSchemas,
+    cache: SchemaCache,
+    next_generation: Arc<AtomicU64>,
     schemas: Arc<RwLock<Vec<StoredSchema>>>,
     options: crate::Options,
     base_dir_path: Arc<RwLock<Option<std::path::PathBuf>>>,
@@ -127,7 +246,7 @@ impl SchemaStore {
     }
 
     pub async fn is_empty(&self) -> bool {
-        self.document_schemas.read().await.is_empty() && self.schemas.read().await.is_empty()
+        self.cache.read().await.documents.is_empty() && self.schemas.read().await.is_empty()
     }
 
     /// New with options
@@ -145,7 +264,8 @@ impl SchemaStore {
     ) -> Self {
         Self {
             http_client,
-            document_schemas: Arc::new(RwLock::default()),
+            cache: Arc::new(RwLock::default()),
+            next_generation: Arc::new(AtomicU64::new(0)),
             schemas: Arc::new(RwLock::new(Vec::new())),
             options,
             base_dir_path: Arc::new(RwLock::new(None)),
@@ -185,7 +305,7 @@ impl SchemaStore {
         config: &tombi_config::Config,
         config_path: Option<&std::path::Path>,
     ) -> Result<(), crate::Error> {
-        self.document_schemas.write().await.clear();
+        *self.cache.write().await = CacheState::default();
         self.schemas.write().await.clear();
         self.load_config(config, config_path).await?;
         Ok(())
@@ -458,18 +578,17 @@ impl SchemaStore {
             schema_uri.set_fragment(None);
         }
 
-        let has_key = { self.document_schemas.read().await.contains_key(&schema_uri) };
+        let has_key = { self.cache.read().await.documents.contains_key(&schema_uri) };
         if has_key
-            && let Some(document_schema) = self.fetch_document_schema(&schema_uri).await.transpose()
+            && let Some((document_schema, version)) = RESOLUTION_STACK
+                .scope(
+                    RefCell::new(Vec::new()),
+                    self.fetch_stable_document_schema(&schema_uri),
+                )
+                .await?
         {
-            let version = schema_cache_version(&schema_uri).await;
-            self.document_schemas.write().await.insert(
-                schema_uri.clone(),
-                CachedDocumentSchema {
-                    version,
-                    document_schema,
-                },
-            );
+            self.replace_cached_source_document(schema_uri.clone(), version, document_schema)
+                .await?;
             log::debug!("update schema: {}", schema_uri);
             return Ok(true);
         }
@@ -481,6 +600,46 @@ impl SchemaStore {
         &self,
         schema_uri: &SchemaUri,
     ) -> Result<Option<tombi_json::ValueNode>, crate::Error> {
+        self.fetch_schema_value_with_registry(schema_uri, true)
+            .await
+    }
+
+    async fn fetch_schema_value_with_registry(
+        &self,
+        schema_uri: &SchemaUri,
+        consult_embedded_registry: bool,
+    ) -> Result<Option<tombi_json::ValueNode>, crate::Error> {
+        if consult_embedded_registry
+            && let Some(resource) = self
+                .cache
+                .read()
+                .await
+                .resources
+                .by_uri
+                .get(schema_uri)
+                .cloned()
+        {
+            let Some(metadata) = resource.generation.resource_index.resource(schema_uri) else {
+                return Ok(None);
+            };
+            return Ok(crate::resolve_json_pointer_node(
+                &resource.generation.source_node,
+                &metadata.root_pointer,
+            )
+            .cloned());
+        }
+        let aliased_source = if consult_embedded_registry {
+            self.cache
+                .read()
+                .await
+                .documents
+                .get(schema_uri)
+                .map(|cached| cached.source_schema_uri.clone())
+                .filter(|source| source != schema_uri)
+        } else {
+            None
+        };
+        let schema_uri = aliased_source.as_ref().unwrap_or(schema_uri);
         match schema_uri.scheme() {
             "file" => {
                 let schema_path = tombi_uri::Uri::to_file_path(schema_uri).map_err(|_| {
@@ -591,24 +750,143 @@ impl SchemaStore {
         }
     }
 
+    pub(crate) async fn fetch_external_schema_value(
+        &self,
+        schema_uri: &SchemaUri,
+    ) -> Result<Option<tombi_json::ValueNode>, crate::Error> {
+        self.fetch_schema_value_with_registry(schema_uri, false)
+            .await
+    }
+
     async fn fetch_document_schema(
         &self,
         schema_uri: &SchemaUri,
     ) -> Result<Option<Arc<DocumentSchema>>, crate::Error> {
-        let schema_value = match self.fetch_schema_value(schema_uri).await? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
+        self.fetch_document_schema_with_registry(schema_uri, true, true)
+            .await
+    }
+
+    async fn fetch_stable_document_schema(
+        &self,
+        schema_uri: &SchemaUri,
+    ) -> Result<Option<(Arc<DocumentSchema>, Option<SchemaCacheVersion>)>, crate::Error> {
+        self.fetch_stable_document_schema_with_registry(schema_uri, true, true)
+            .await
+    }
+
+    async fn fetch_stable_document_schema_with_registry(
+        &self,
+        schema_uri: &SchemaUri,
+        consult_embedded_registry: bool,
+        publish_embedded_resources: bool,
+    ) -> Result<Option<(Arc<DocumentSchema>, Option<SchemaCacheVersion>)>, crate::Error> {
+        for _ in 0..3 {
+            let before = schema_cache_version(schema_uri).await;
+            let document_schema = self
+                .fetch_document_schema_with_registry(
+                    schema_uri,
+                    consult_embedded_registry,
+                    publish_embedded_resources,
+                )
+                .await?;
+            let after = schema_cache_version(schema_uri).await;
+            if before == after {
+                return Ok(document_schema.map(|document| (document, after)));
+            }
+        }
+
+        // Do not bless a racing read with a version it may not represent. A
+        // missing version forces the next lookup to retry once the source is stable.
+        Ok(self
+            .fetch_document_schema_with_registry(
+                schema_uri,
+                consult_embedded_registry,
+                publish_embedded_resources,
+            )
+            .await?
+            .map(|document| (document, None)))
+    }
+
+    async fn fetch_document_schema_with_registry(
+        &self,
+        schema_uri: &SchemaUri,
+        consult_embedded_registry: bool,
+        publish_embedded_resources: bool,
+    ) -> Result<Option<Arc<DocumentSchema>>, crate::Error> {
+        if consult_embedded_registry
+            && let Some(resource) = self
+                .cache
+                .read()
+                .await
+                .resources
+                .by_uri
+                .get(schema_uri)
+                .cloned()
+        {
+            return self
+                .document_schema_from_generation(schema_uri, resource.generation)
+                .await;
+        }
+
+        let revision = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let schema_value = Arc::new(
+            match self
+                .fetch_schema_value_with_registry(schema_uri, consult_embedded_registry)
+                .await?
+            {
+                Some(value) => value,
+                None => return Ok(None),
+            },
+        );
         if !matches!(
-            schema_value,
+            schema_value.as_ref(),
             tombi_json::ValueNode::Object(_) | tombi_json::ValueNode::Bool(_)
         ) {
             return Err(crate::Error::SchemaMustBeObjectOrBoolean {
                 schema_uri: schema_uri.clone(),
             });
         }
-        let document_schema =
-            DocumentSchema::new(schema_value, schema_uri.clone(), None, self).await;
+        let resource_index = Arc::new(
+            ResourceIndex::build(&schema_value, schema_uri, None).map_err(|error| {
+                crate::Error::InvalidSchemaResources {
+                    schema_uri: schema_uri.clone(),
+                    reason: error.to_string(),
+                }
+            })?,
+        );
+        let generation = Arc::new(SchemaGeneration {
+            revision,
+            source_schema_uri: Arc::new(schema_uri.clone()),
+            source_node: schema_value.clone(),
+            resource_index: resource_index.clone(),
+            compiled_resources: std::sync::RwLock::new(Default::default()),
+        });
+        let root_resource_uri = resource_index.root_resource_uri().clone();
+        let Some(_resolution_guard) = ResolutionGuard::enter(&root_resource_uri) else {
+            return Err(crate::Error::CyclicSchemaReference {
+                schema_uri: root_resource_uri,
+            });
+        };
+        let mut document_schema = DocumentSchema::new_indexed(
+            &schema_value,
+            schema_uri.clone(),
+            Some(root_resource_uri.clone()),
+            None,
+            Some(generation.clone()),
+            None,
+            self,
+        )
+        .await;
+        if let Some(metadata) = resource_index.resource(&root_resource_uri) {
+            let (anchors, dynamic_anchors) = build_anchor_maps(
+                &schema_value,
+                metadata,
+                document_schema.string_formats(),
+                document_schema.dialect(),
+            );
+            document_schema.anchors = anchors;
+            document_schema.dynamic_anchors = dynamic_anchors;
+        }
         if let Some(
             SchemaView::AllOf(AllOfSchema { schemas, .. })
             | SchemaView::AnyOf(AnyOfSchema { schemas, .. })
@@ -630,7 +908,397 @@ impl SchemaStore {
             }
         }
 
+        if publish_embedded_resources {
+            self.register_embedded_resources(generation).await?;
+        }
+
         Ok(Some(Arc::new(document_schema)))
+    }
+
+    pub(crate) async fn try_get_document_schema_in_generation(
+        &self,
+        schema_uri: &SchemaUri,
+        generation: Option<&Arc<SchemaGeneration>>,
+    ) -> Result<Option<Arc<DocumentSchema>>, crate::Error> {
+        if let Some(generation) = generation {
+            if generation.resource_index.resource(schema_uri).is_some() {
+                if RESOLUTION_STACK.try_with(|_| ()).is_err() {
+                    return RESOLUTION_STACK
+                        .scope(
+                            RefCell::new(Vec::new()),
+                            self.document_schema_from_generation(schema_uri, generation.clone()),
+                        )
+                        .await;
+                }
+                return self
+                    .document_schema_from_generation(schema_uri, generation.clone())
+                    .await;
+            }
+            let registered = self
+                .cache
+                .read()
+                .await
+                .resources
+                .by_uri
+                .get(schema_uri)
+                .filter(|resource| {
+                    resource.generation.source_schema_uri != generation.source_schema_uri
+                })
+                .cloned();
+            if let Some(resource) = registered {
+                if RESOLUTION_STACK.try_with(|_| ()).is_err() {
+                    return RESOLUTION_STACK
+                        .scope(
+                            RefCell::new(Vec::new()),
+                            self.document_schema_from_generation(schema_uri, resource.generation),
+                        )
+                        .await;
+                }
+                return self
+                    .document_schema_from_generation(schema_uri, resource.generation)
+                    .await;
+            }
+            let cached_source = self
+                .cache
+                .read()
+                .await
+                .documents
+                .get(schema_uri)
+                .map(|cached| cached.source_schema_uri.clone());
+            if cached_source
+                .as_ref()
+                .is_some_and(|source| source != generation.source_schema_uri.as_ref())
+                && let Some(document_schema) = self.try_get_document_schema(schema_uri).await?
+                && document_schema
+                    .definitions
+                    .generation()
+                    .is_none_or(|resolved_generation| {
+                        resolved_generation.source_schema_uri != generation.source_schema_uri
+                    })
+            {
+                return Ok(Some(document_schema));
+            }
+            if RESOLUTION_STACK.try_with(|_| ()).is_err() {
+                return RESOLUTION_STACK
+                    .scope(
+                        RefCell::new(Vec::new()),
+                        self.fetch_and_cache_external_document_schema(schema_uri, generation),
+                    )
+                    .await;
+            }
+            self.fetch_and_cache_external_document_schema(schema_uri, generation)
+                .await
+        } else {
+            self.try_get_document_schema(schema_uri).await
+        }
+    }
+
+    async fn fetch_and_cache_external_document_schema(
+        &self,
+        schema_uri: &SchemaUri,
+        pinned_generation: &Arc<SchemaGeneration>,
+    ) -> Result<Option<Arc<DocumentSchema>>, crate::Error> {
+        let Some((document_schema, version)) = self
+            .fetch_stable_document_schema_with_registry(schema_uri, false, false)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if self
+            .try_publish_external_candidate(schema_uri, version, document_schema.clone())
+            .await
+        {
+            return Ok(Some(document_schema));
+        }
+
+        let registered = self
+            .cache
+            .read()
+            .await
+            .resources
+            .by_uri
+            .get(schema_uri)
+            .filter(|resource| {
+                resource.generation.source_schema_uri != pinned_generation.source_schema_uri
+            })
+            .cloned();
+        if let Some(resource) = registered {
+            return self
+                .document_schema_from_generation(schema_uri, resource.generation)
+                .await;
+        }
+        let cached_source = self
+            .cache
+            .read()
+            .await
+            .documents
+            .get(schema_uri)
+            .map(|cached| cached.source_schema_uri.clone());
+        if cached_source
+            .as_ref()
+            .is_some_and(|source| source != pinned_generation.source_schema_uri.as_ref())
+            && let Some(document_schema) = self.try_get_document_schema(schema_uri).await?
+            && document_schema
+                .definitions
+                .generation()
+                .is_none_or(|resolved_generation| {
+                    resolved_generation.source_schema_uri != pinned_generation.source_schema_uri
+                })
+        {
+            return Ok(Some(document_schema));
+        }
+        // A pinned generation may legitimately need a private external fallback
+        // whose URI is owned globally by a newer same-source generation.
+        log::debug!("keep external schema private: {schema_uri}");
+        Ok(Some(document_schema))
+    }
+
+    /// Publishes a separately-built external candidate as one transaction.
+    /// Returning `false` leaves both registries unchanged.
+    async fn try_publish_external_candidate(
+        &self,
+        key: &SchemaUri,
+        version: Option<SchemaCacheVersion>,
+        document_schema: Arc<DocumentSchema>,
+    ) -> bool {
+        let Some(generation) = document_schema.owner_generation.clone() else {
+            return false;
+        };
+        let source_schema_uri = generation.source_schema_uri.as_ref().clone();
+        let resource_uris = generation
+            .resource_index
+            .resources()
+            .keys()
+            .filter(|uri| {
+                *uri != generation.resource_index.root_resource_uri() && *uri != &source_schema_uri
+            })
+            .cloned()
+            .collect_vec();
+        let aliases = std::iter::once(key)
+            .chain(document_schema.id.as_ref())
+            .collect_vec();
+
+        let mut cache = self.cache.write().await;
+        if cache
+            .resources
+            .by_source
+            .get(&source_schema_uri)
+            .is_some_and(|installed| installed.revision > generation.revision)
+        {
+            return false;
+        }
+        if resource_uris.iter().any(|uri| {
+            cache
+                .documents
+                .get(uri)
+                .is_some_and(|existing| existing.source_schema_uri != source_schema_uri)
+                || cache.resources.by_uri.get(uri).is_some_and(|existing| {
+                    existing.generation.source_schema_uri.as_ref() != &source_schema_uri
+                })
+        }) || aliases.iter().any(|uri| {
+            cache
+                .documents
+                .get(*uri)
+                .is_some_and(|existing| existing.source_schema_uri != source_schema_uri)
+                || cache.resources.by_uri.get(*uri).is_some_and(|existing| {
+                    existing.generation.source_schema_uri.as_ref() != &source_schema_uri
+                })
+        }) {
+            return false;
+        }
+
+        cache.resources.by_uri.retain(|_, resource| {
+            resource.generation.source_schema_uri.as_ref() != &source_schema_uri
+        });
+        cache
+            .resources
+            .by_uri
+            .extend(resource_uris.into_iter().map(|uri| {
+                (
+                    uri,
+                    EmbeddedResource {
+                        generation: generation.clone(),
+                    },
+                )
+            }));
+        cache
+            .resources
+            .by_source
+            .insert(source_schema_uri.clone(), generation);
+
+        cache
+            .documents
+            .retain(|_, existing| existing.source_schema_uri != source_schema_uri);
+        let id = document_schema.id.clone();
+        let cached = CachedDocumentSchema {
+            version,
+            source_schema_uri: source_schema_uri.clone(),
+            document_schema: Ok(document_schema),
+        };
+        cache.documents.insert(key.clone(), cached.clone());
+        if let Some(id) = id {
+            cache.documents.insert(id, cached);
+        }
+        true
+    }
+
+    async fn document_schema_from_generation(
+        &self,
+        schema_uri: &SchemaUri,
+        generation: Arc<SchemaGeneration>,
+    ) -> Result<Option<Arc<DocumentSchema>>, crate::Error> {
+        let compiled = {
+            generation
+                .compiled_resources
+                .read()
+                .expect("compiled resource cache poisoned")
+                .get(schema_uri)
+                .cloned()
+        };
+        if let Some(template) = compiled {
+            let mut document_schema = template.as_ref().clone();
+            document_schema.definitions = document_schema
+                .definitions
+                .with_generation(generation.clone());
+            document_schema.owner_generation = Some(generation);
+            return Ok(Some(Arc::new(document_schema)));
+        }
+        let Some(_resolution_guard) = ResolutionGuard::enter(schema_uri) else {
+            return Err(crate::Error::CyclicSchemaReference {
+                schema_uri: schema_uri.clone(),
+            });
+        };
+        let Some(metadata) = generation.resource_index.resource(schema_uri) else {
+            return Ok(None);
+        };
+        let Some(node) =
+            crate::resolve_json_pointer_node(&generation.source_node, &metadata.root_pointer)
+        else {
+            return Ok(None);
+        };
+        let mut document_schema = DocumentSchema::new_embedded(
+            node,
+            generation.source_schema_uri.as_ref().clone(),
+            schema_uri.clone(),
+            metadata.dialect,
+            generation.clone(),
+            None,
+            self,
+        )
+        .await;
+        let (anchors, dynamic_anchors) = build_anchor_maps(
+            &generation.source_node,
+            metadata,
+            document_schema.string_formats(),
+            document_schema.dialect(),
+        );
+        document_schema.anchors = anchors;
+        document_schema.dynamic_anchors = dynamic_anchors;
+        if document_schema.definitions.dynamic_scope().is_empty()
+            && document_schema
+                .definitions
+                .generation()
+                .is_some_and(|resolved_generation| Arc::ptr_eq(resolved_generation, &generation))
+        {
+            let mut template = document_schema.clone();
+            template.definitions = template.definitions.without_runtime_context();
+            template.owner_generation = None;
+            generation
+                .compiled_resources
+                .write()
+                .expect("compiled resource cache poisoned")
+                .entry(schema_uri.clone())
+                .or_insert_with(|| Arc::new(template));
+        }
+        Ok(Some(Arc::new(document_schema)))
+    }
+
+    async fn register_embedded_resources(
+        &self,
+        generation: Arc<SchemaGeneration>,
+    ) -> Result<bool, crate::Error> {
+        let mut discovered = Vec::new();
+        let source_schema_uri = &generation.source_schema_uri;
+        for canonical_uri in generation.resource_index.resources().keys() {
+            if canonical_uri == generation.resource_index.root_resource_uri()
+                && canonical_uri == source_schema_uri.as_ref()
+            {
+                continue;
+            }
+            discovered.push((
+                canonical_uri.clone(),
+                EmbeddedResource {
+                    generation: generation.clone(),
+                },
+            ));
+        }
+
+        let mut cache = self.cache.write().await;
+        for (canonical_uri, _) in &discovered {
+            if let Some(existing) = cache
+                .documents
+                .get(canonical_uri)
+                .filter(|existing| &existing.source_schema_uri != source_schema_uri.as_ref())
+            {
+                return Err(crate::Error::InvalidSchemaResources {
+                    schema_uri: source_schema_uri.as_ref().clone(),
+                    reason: format!(
+                        "duplicate schema resource URI {canonical_uri}; already loaded from {}",
+                        existing.source_schema_uri
+                    ),
+                });
+            }
+        }
+        let registry = &mut cache.resources;
+        if registry
+            .by_source
+            .get(source_schema_uri.as_ref())
+            .is_some_and(|installed| installed.revision > generation.revision)
+        {
+            return Ok(false);
+        }
+        for (canonical_uri, _) in &discovered {
+            if let Some(existing) = registry.by_uri.get(canonical_uri).filter(|existing| {
+                existing.generation.source_schema_uri.as_ref() != source_schema_uri.as_ref()
+            }) {
+                return Err(crate::Error::InvalidSchemaResources {
+                    schema_uri: source_schema_uri.as_ref().clone(),
+                    reason: format!(
+                        "duplicate schema resource URI {canonical_uri}; already loaded from {}",
+                        existing.generation.source_schema_uri
+                    ),
+                });
+            }
+        }
+        registry.by_uri.retain(|_, resource| {
+            resource.generation.source_schema_uri.as_ref() != source_schema_uri.as_ref()
+        });
+        registry.by_uri.extend(discovered);
+        registry
+            .by_source
+            .insert(source_schema_uri.as_ref().clone(), generation.clone());
+        Ok(true)
+    }
+
+    pub(crate) async fn effective_base_uri(
+        &self,
+        schema_uri: &SchemaUri,
+        position: tombi_text::Position,
+    ) -> Option<SchemaUri> {
+        let cache = self.cache.read().await;
+        let registry = &cache.resources;
+        registry
+            .by_uri
+            .get(schema_uri)
+            .map(|resource| &resource.generation.resource_index)
+            .or_else(|| {
+                registry
+                    .by_source
+                    .get(schema_uri)
+                    .map(|generation| &generation.resource_index)
+            })
+            .and_then(|index| index.effective_base(position))
+            .cloned()
     }
 
     pub fn try_get_document_schema<'a: 'b, 'b>(
@@ -638,8 +1306,15 @@ impl SchemaStore {
         schema_uri: &'a SchemaUri,
     ) -> BoxFuture<'b, Result<Option<Arc<DocumentSchema>>, crate::Error>> {
         async move {
+            if RESOLUTION_STACK.try_with(|_| ()).is_err() {
+                return RESOLUTION_STACK
+                    .scope(
+                        RefCell::new(Vec::new()),
+                        self.try_get_document_schema(schema_uri),
+                    )
+                    .await;
+            }
             let requested_schema_uri = schema_uri.clone();
-
             let (schema_uri, fragment) = {
                 let mut uri = schema_uri.clone();
                 let fragment = uri.fragment().map(ToOwned::to_owned);
@@ -647,43 +1322,78 @@ impl SchemaStore {
                 (uri, fragment)
             };
 
-            let cached_document_schema =
-                self.document_schemas.read().await.get(&schema_uri).cloned();
-            let document_schema = if let Some(cached_document_schema) = cached_document_schema {
-                let cache_version = schema_cache_version(&schema_uri).await;
+            let (embedded_resource, cached_document_schema) = {
+                let cache = self.cache.read().await;
+                (
+                    cache.resources.by_uri.get(&schema_uri).cloned(),
+                    cache.documents.get(&schema_uri).cloned(),
+                )
+            };
+            let document_schema = if let Some(resource) = embedded_resource {
+                self.document_schema_from_generation(&schema_uri, resource.generation)
+                    .await?
+            } else if let Some(cached_document_schema) = cached_document_schema {
+                let cache_version =
+                    schema_cache_version(&cached_document_schema.source_schema_uri).await;
                 if cached_document_schema.version == cache_version {
                     match cached_document_schema.document_schema {
                         Ok(document_schema) => Some(document_schema),
                         Err(err) => return Err(err),
                     }
                 } else {
-                    match self.fetch_document_schema(&schema_uri).await.transpose() {
-                        Some(document_schema) => {
-                            let cache_version = schema_cache_version(&schema_uri).await;
-                            self.document_schemas.write().await.insert(
+                    let source_schema_uri = cached_document_schema.source_schema_uri;
+                    match self
+                        .fetch_stable_document_schema(&source_schema_uri)
+                        .await
+                        .transpose()
+                    {
+                        Some(source_document_schema) => {
+                            let (source_document_schema, cache_version) = source_document_schema?;
+                            self.replace_cached_source_document(
+                                source_schema_uri.clone(),
+                                cache_version,
+                                source_document_schema.clone(),
+                            )
+                            .await?;
+                            let document_schema = if schema_uri == source_schema_uri {
+                                source_document_schema
+                            } else {
+                                let Some(document_schema) =
+                                    self.fetch_document_schema(&schema_uri).await?
+                                else {
+                                    return Ok(None);
+                                };
+                                document_schema
+                            };
+                            self.cache_document_schema(
                                 schema_uri.clone(),
-                                CachedDocumentSchema {
-                                    version: cache_version,
-                                    document_schema: document_schema.clone(),
-                                },
-                            );
-                            Some(document_schema?)
+                                source_schema_uri,
+                                cache_version,
+                                document_schema.clone(),
+                            )
+                            .await?;
+                            Some(document_schema)
                         }
                         None => None,
                     }
                 }
             } else {
-                match self.fetch_document_schema(&schema_uri).await.transpose() {
+                match self
+                    .fetch_stable_document_schema(&schema_uri)
+                    .await
+                    .transpose()
+                {
                     Some(document_schema) => {
-                        let cache_version = schema_cache_version(&schema_uri).await;
-                        self.document_schemas.write().await.insert(
+                        let (document_schema, cache_version) = document_schema?;
+                        let source_schema_uri = document_schema.schema_uri.clone();
+                        self.cache_document_schema(
                             schema_uri.clone(),
-                            CachedDocumentSchema {
-                                version: cache_version,
-                                document_schema: document_schema.clone(),
-                            },
-                        );
-                        Some(document_schema?)
+                            source_schema_uri,
+                            cache_version,
+                            document_schema.clone(),
+                        )
+                        .await?;
+                        Some(document_schema)
                     }
                     None => None,
                 }
@@ -719,9 +1429,8 @@ impl SchemaStore {
                     });
                 };
 
-                // Create a new document schema with the fragment-referenced schema_uri in the return value
                 let mut fragment_document_schema = document_schema.as_ref().clone();
-                fragment_document_schema.schema_uri = requested_schema_uri; // Use fragment-full URI for return value
+                fragment_document_schema.schema_uri = requested_schema_uri;
                 fragment_document_schema.schema_view = Some(Arc::new(fragment_schema_view));
                 return Ok(Some(Arc::new(fragment_document_schema)));
             }
@@ -748,9 +1457,8 @@ impl SchemaStore {
                     )
                     .await?
             {
-                // Create a new document schema with the fragment-referenced schema_uri in the return value
                 let mut fragment_document_schema = document_schema.as_ref().clone();
-                fragment_document_schema.schema_uri = requested_schema_uri; // Use fragment-full URI for return value
+                fragment_document_schema.schema_uri = requested_schema_uri;
                 fragment_document_schema.schema_view = Some(current_schema.schema_view);
                 return Ok(Some(Arc::new(fragment_document_schema)));
             }
@@ -761,6 +1469,94 @@ impl SchemaStore {
             })
         }
         .boxed()
+    }
+
+    async fn cache_document_schema(
+        &self,
+        key: SchemaUri,
+        source_schema_uri: SchemaUri,
+        version: Option<SchemaCacheVersion>,
+        document_schema: Arc<DocumentSchema>,
+    ) -> Result<(), crate::Error> {
+        let cached = CachedDocumentSchema {
+            version,
+            source_schema_uri: source_schema_uri.clone(),
+            document_schema: Ok(document_schema.clone()),
+        };
+        let mut cache = self.cache.write().await;
+        if let Some(generation) = document_schema.owner_generation.as_ref()
+            && !cache
+                .resources
+                .by_source
+                .get(&source_schema_uri)
+                .is_some_and(|installed| Arc::ptr_eq(installed, generation))
+        {
+            return Ok(());
+        }
+        for uri in std::iter::once(&key).chain(document_schema.id.as_ref()) {
+            if let Some(resource) = cache.resources.by_uri.get(uri).filter(|resource| {
+                resource.generation.source_schema_uri.as_ref() != &source_schema_uri
+            }) {
+                return Err(crate::Error::InvalidSchemaResources {
+                    schema_uri: source_schema_uri.clone(),
+                    reason: format!(
+                        "duplicate schema resource URI {uri}; already loaded from {}",
+                        resource.generation.source_schema_uri
+                    ),
+                });
+            }
+        }
+        let schemas = &mut cache.documents;
+        schemas.insert(key, cached.clone());
+        if let Some(id) = &document_schema.id {
+            schemas.insert(id.clone(), cached);
+        }
+        Ok(())
+    }
+
+    /// Atomically replaces every alias belonging to one physical document.
+    /// This prevents removed `$id` values from surviving a successful reload.
+    async fn replace_cached_source_document(
+        &self,
+        source_schema_uri: SchemaUri,
+        version: Option<SchemaCacheVersion>,
+        document_schema: Arc<DocumentSchema>,
+    ) -> Result<(), crate::Error> {
+        let cached = CachedDocumentSchema {
+            version,
+            source_schema_uri: source_schema_uri.clone(),
+            document_schema: Ok(document_schema.clone()),
+        };
+        let mut cache = self.cache.write().await;
+        if let Some(generation) = document_schema.owner_generation.as_ref()
+            && !cache
+                .resources
+                .by_source
+                .get(&source_schema_uri)
+                .is_some_and(|installed| Arc::ptr_eq(installed, generation))
+        {
+            return Ok(());
+        }
+        for uri in std::iter::once(&source_schema_uri).chain(document_schema.id.as_ref()) {
+            if let Some(resource) = cache.resources.by_uri.get(uri).filter(|resource| {
+                resource.generation.source_schema_uri.as_ref() != &source_schema_uri
+            }) {
+                return Err(crate::Error::InvalidSchemaResources {
+                    schema_uri: source_schema_uri.clone(),
+                    reason: format!(
+                        "duplicate schema resource URI {uri}; already loaded from {}",
+                        resource.generation.source_schema_uri
+                    ),
+                });
+            }
+        }
+        let schemas = &mut cache.documents;
+        schemas.retain(|_, existing| existing.source_schema_uri != source_schema_uri);
+        schemas.insert(source_schema_uri, cached.clone());
+        if let Some(id) = &document_schema.id {
+            schemas.insert(id.clone(), cached);
+        }
+        Ok(())
     }
 
     #[inline]
@@ -1440,6 +2236,11 @@ fn parse_override_target(target: &str) -> Option<Vec<PatternAccessor>> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -1448,10 +2249,11 @@ mod tests {
     };
 
     use super::{
-        SchemaStore, load_catalog_from_cache_ignoring_ttl,
+        SchemaGeneration, SchemaStore, load_catalog_from_cache_ignoring_ttl,
         load_json_schema_from_cache_ignoring_ttl, matches_schema_patterns,
     };
-    use crate::{CatalogUri, SchemaView};
+    use crate::{CatalogUri, ResourceIndex, SchemaAccessor, SchemaView};
+    use tombi_future::Boxable;
     use tombi_uri::SchemaUri;
 
     fn temp_cache_path(test_name: &str) -> PathBuf {
@@ -1466,6 +2268,23 @@ mod tests {
         let file = fs::File::options().write(true).open(path).unwrap();
         let modified = file.metadata().unwrap().modified().unwrap() + Duration::from_secs(1);
         file.set_modified(modified).unwrap();
+    }
+
+    #[derive(Debug)]
+    struct CountingHttpClient {
+        requests: AtomicUsize,
+        response: &'static str,
+    }
+
+    impl crate::http_client::HttpClient for CountingHttpClient {
+        fn get_bytes<'a>(
+            &'a self,
+            _url: &'a str,
+        ) -> crate::http_client::HttpFuture<'a, Result<bytes::Bytes, crate::http_client::FetchError>>
+        {
+            self.requests.fetch_add(1, Ordering::Relaxed);
+            async move { Ok(bytes::Bytes::from_static(self.response.as_bytes())) }.boxed()
+        }
     }
 
     #[test]
@@ -1652,6 +2471,469 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(schema_path);
+    }
+
+    #[tokio::test]
+    async fn retained_document_resolves_with_its_original_generation() {
+        let schema_path = std::env::temp_dir().join(format!(
+            "tombi_reload_compound_schema_{}_{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let schema_uri = SchemaUri::from_file_path(&schema_path).unwrap();
+        let schema_store = SchemaStore::new();
+        let schema = |value_type: &str| {
+            format!(
+                r#"{{
+                    "$schema":"https://json-schema.org/draft/2020-12/schema",
+                    "$id":"https://example.com/root",
+                    "type":"object",
+                    "properties":{{"value":{{"$ref":"child"}}}},
+                    "$defs":{{"child":{{"$id":"https://example.com/child","type":"{value_type}"}}}}
+                }}"#
+            )
+        };
+
+        std::fs::write(&schema_path, schema("string")).unwrap();
+        let old_document = schema_store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        std::fs::write(&schema_path, schema("integer")).unwrap();
+        bump_modified(&schema_path);
+        let new_document = schema_store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        async fn value_schema(
+            document: &crate::DocumentSchema,
+            store: &SchemaStore,
+        ) -> crate::CurrentSchema<'static> {
+            let SchemaView::Table(table) = document.schema_view.as_deref().unwrap() else {
+                panic!("root schema must be an object")
+            };
+            table
+                .resolve_property_schema(
+                    &SchemaAccessor::Key("value".to_owned()),
+                    Cow::Borrowed(&document.schema_uri),
+                    Cow::Borrowed(&document.definitions),
+                    document.strict,
+                    store,
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }
+
+        let old_value = value_schema(&old_document, &schema_store).await;
+        let new_value = value_schema(&new_document, &schema_store).await;
+        assert!(matches!(
+            old_value.schema_view.as_ref(),
+            SchemaView::String(_)
+        ));
+        assert!(matches!(
+            new_value.schema_view.as_ref(),
+            SchemaView::Integer(_)
+        ));
+
+        let _ = std::fs::remove_file(schema_path);
+    }
+
+    #[tokio::test]
+    async fn retained_generation_miss_does_not_see_new_embedded_resource() {
+        let schema_path = temp_cache_path("generation-negative-lookup");
+        let external_path = schema_path.with_extension("child.json");
+        let external_name = external_path.file_name().unwrap().to_string_lossy();
+        let schema_uri = SchemaUri::from_file_path(&schema_path).unwrap();
+        let schema = |embedded_type: Option<&str>| {
+            let defs = embedded_type.map_or_else(String::new, |value_type| {
+                format!(
+                    r#", "$defs":{{"child":{{"$id":"{external_name}","type":"{value_type}","$defs":{{"nested":{{"$id":"nested","type":"{value_type}"}}}}}}}}"#
+                )
+            });
+            format!(
+                r#"{{
+                    "$schema":"https://json-schema.org/draft/2020-12/schema",
+                    "type":"object",
+                    "properties":{{"value":{{"$ref":"{external_name}"}}}}
+                    {defs}
+                }}"#
+            )
+        };
+        std::fs::write(
+            &external_path,
+            r#"{"type":"string","$defs":{"nested":{"$id":"nested","type":"string"}}}"#,
+        )
+        .unwrap();
+        std::fs::write(&schema_path, schema(None)).unwrap();
+        let store = SchemaStore::new();
+        let old_document = store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        std::fs::write(&schema_path, schema(Some("integer"))).unwrap();
+        bump_modified(&schema_path);
+        let new_document = store
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        async fn value_schema(
+            document: &crate::DocumentSchema,
+            store: &SchemaStore,
+        ) -> crate::CurrentSchema<'static> {
+            let SchemaView::Table(table) = document.schema_view.as_deref().unwrap() else {
+                panic!("root schema must be an object")
+            };
+            table
+                .resolve_property_schema(
+                    &SchemaAccessor::Key("value".to_owned()),
+                    Cow::Borrowed(&document.schema_uri),
+                    Cow::Borrowed(&document.definitions),
+                    document.strict,
+                    store,
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }
+
+        assert!(matches!(
+            value_schema(&old_document, &store)
+                .await
+                .schema_view
+                .as_ref(),
+            SchemaView::String(_)
+        ));
+        assert!(matches!(
+            value_schema(&new_document, &store)
+                .await
+                .schema_view
+                .as_ref(),
+            SchemaView::Integer(_)
+        ));
+        let nested_uri =
+            SchemaUri::from_file_path(external_path.parent().unwrap().join("nested")).unwrap();
+        let new_generation = new_document.definitions.generation().unwrap();
+        let cache = store.cache.read().await;
+        let external_uri = SchemaUri::from_file_path(&external_path).unwrap();
+        assert!(!cache.resources.by_source.contains_key(&external_uri));
+        assert!(
+            cache
+                .resources
+                .by_uri
+                .get(&nested_uri)
+                .is_some_and(|resource| { Arc::ptr_eq(&resource.generation, new_generation) })
+        );
+        drop(cache);
+
+        let _ = std::fs::remove_file(schema_path);
+        let _ = std::fs::remove_file(external_path);
+    }
+
+    #[tokio::test]
+    async fn embedded_resource_falls_back_to_external_file() {
+        let schema_path = temp_cache_path("compound-external-fallback");
+        let external_path = schema_path.with_extension("external.json");
+        let external_name = external_path.file_name().unwrap().to_string_lossy();
+        let schema_uri = SchemaUri::from_file_path(&schema_path).unwrap();
+        std::fs::write(&external_path, r#"{"type":"string"}"#).unwrap();
+        std::fs::write(
+            &schema_path,
+            format!(
+                r#"{{
+                    "$schema":"https://json-schema.org/draft/2020-12/schema",
+                    "$ref":"embedded",
+                    "$defs":{{"embedded":{{"$id":"embedded","$ref":"{external_name}"}}}}
+                }}"#
+            ),
+        )
+        .unwrap();
+
+        let document_schema = SchemaStore::new()
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            document_schema.schema_view.as_deref(),
+            Some(SchemaView::String(_))
+        ));
+
+        let _ = std::fs::remove_file(schema_path);
+        let _ = std::fs::remove_file(external_path);
+    }
+
+    #[tokio::test]
+    async fn duplicate_embedded_resource_ids_are_rejected_by_store() {
+        let schema_path = temp_cache_path("duplicate-compound-resource");
+        let schema_uri = SchemaUri::from_file_path(&schema_path).unwrap();
+        std::fs::write(
+            &schema_path,
+            r#"{
+                "$schema":"https://json-schema.org/draft/2020-12/schema",
+                "$defs":{
+                    "one":{"$id":"duplicate","type":"string"},
+                    "two":{"$id":"duplicate","type":"integer"}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let error = SchemaStore::new()
+            .try_get_document_schema(&schema_uri)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, crate::Error::InvalidSchemaResources { .. }));
+        assert!(error.to_string().contains("duplicate schema resource URI"));
+
+        let _ = std::fs::remove_file(schema_path);
+    }
+
+    #[tokio::test]
+    async fn preloaded_canonical_resource_resolves_across_documents() {
+        let target_path = temp_cache_path("preloaded-canonical-target");
+        let source_path = temp_cache_path("preloaded-canonical-source");
+        let target_uri = SchemaUri::from_file_path(&target_path).unwrap();
+        let source_uri = SchemaUri::from_file_path(&source_path).unwrap();
+        std::fs::write(
+            &target_path,
+            r#"{"$id":"shoko://example/B","type":"string"}"#,
+        )
+        .unwrap();
+        std::fs::write(&source_path, r#"{"$ref":"shoko://example/B"}"#).unwrap();
+
+        let store = SchemaStore::new();
+        let target = store
+            .try_get_document_schema(&target_uri)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            target
+                .as_current_schema()
+                .unwrap()
+                .source_schema_uri()
+                .as_ref(),
+            &target_uri
+        );
+        let source = store
+            .try_get_document_schema(&source_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            source.schema_view.as_deref(),
+            Some(SchemaView::String(_))
+        ));
+        assert_eq!(
+            source
+                .as_current_schema()
+                .unwrap()
+                .source_schema_uri()
+                .as_ref(),
+            &target_uri
+        );
+
+        let _ = std::fs::remove_file(target_path);
+        let _ = std::fs::remove_file(source_path);
+    }
+
+    #[tokio::test]
+    async fn external_json_pointer_reuses_the_fetched_generation() {
+        let source_path = temp_cache_path("external-pointer-generation");
+        let source_uri = SchemaUri::from_file_path(&source_path).unwrap();
+        let external_url = format!(
+            "https://example.invalid/{}.json#/$defs/value",
+            source_path.file_stem().unwrap().to_string_lossy()
+        );
+        std::fs::write(
+            &source_path,
+            format!(
+                r#"{{
+                    "$defs":{{
+                        "useExternal":{{"$ref":"{external_url}"}}
+                    }}
+                }}"#
+            ),
+        )
+        .unwrap();
+        let client = Arc::new(CountingHttpClient {
+            requests: AtomicUsize::new(0),
+            response: r#"{
+                "$defs": {
+                    "value": {"type":"string"}
+                }
+            }"#,
+        });
+        let store = SchemaStore::new_with_options_and_http_client(
+            crate::Options::default(),
+            client.clone(),
+        );
+
+        let source = store
+            .try_get_document_schema(&source_uri)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let definitions = source.definitions.clone();
+        let mut referable = {
+            let definitions = definitions.read().await;
+            definitions.get("#/$defs/useExternal").cloned().unwrap()
+        };
+        let item = referable
+            .resolve(
+                Cow::Owned(source.schema_uri.clone()),
+                Cow::Owned(definitions.clone()),
+                None,
+                &store,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            item.schema_view.as_ref(),
+            SchemaView::String(_) | SchemaView::AnyOf(_)
+        ));
+        let mut external_schema_uri = SchemaUri::from_str(&external_url).unwrap();
+        external_schema_uri.set_fragment(None);
+        {
+            let cache = store.cache.read().await;
+            assert!(cache.documents.contains_key(&external_schema_uri));
+            assert!(cache.resources.by_source.contains_key(&external_schema_uri));
+            assert!(!cache.resources.by_uri.contains_key(&external_schema_uri));
+        }
+        referable
+            .resolve(
+                Cow::Owned(source.schema_uri.clone()),
+                Cow::Owned(definitions),
+                None,
+                &store,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(client.requests.load(Ordering::Relaxed), 1);
+
+        let _ = std::fs::remove_file(source_path);
+    }
+
+    #[tokio::test]
+    async fn standalone_and_embedded_resource_ownership_never_split() {
+        let standalone_path = temp_cache_path("standalone-owner");
+        let bundle_path = temp_cache_path("embedded-owner");
+        let standalone_uri = SchemaUri::from_file_path(&standalone_path).unwrap();
+        let bundle_uri = SchemaUri::from_file_path(&bundle_path).unwrap();
+        let canonical_uri = "https://example.com/shared-resource";
+        std::fs::write(
+            &standalone_path,
+            format!(r#"{{"$id":"{canonical_uri}","type":"string"}}"#),
+        )
+        .unwrap();
+        std::fs::write(
+            &bundle_path,
+            format!(r#"{{"$defs":{{"shared":{{"$id":"{canonical_uri}","type":"integer"}}}}}}"#),
+        )
+        .unwrap();
+
+        let standalone_first = SchemaStore::new();
+        standalone_first
+            .try_get_document_schema(&standalone_uri)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            standalone_first.try_get_document_schema(&bundle_uri).await,
+            Err(crate::Error::InvalidSchemaResources { .. })
+        ));
+
+        let embedded_first = SchemaStore::new();
+        embedded_first
+            .try_get_document_schema(&bundle_uri)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            embedded_first
+                .try_get_document_schema(&standalone_uri)
+                .await,
+            Err(crate::Error::InvalidSchemaResources { .. })
+        ));
+
+        for _ in 0..16 {
+            let concurrent = SchemaStore::new();
+            let (standalone, embedded) = tokio::join!(
+                concurrent.try_get_document_schema(&standalone_uri),
+                concurrent.try_get_document_schema(&bundle_uri),
+            );
+            assert_ne!(
+                standalone.is_ok(),
+                embedded.is_ok(),
+                "exactly one source must acquire the canonical URI"
+            );
+        }
+
+        let _ = std::fs::remove_file(standalone_path);
+        let _ = std::fs::remove_file(bundle_path);
+    }
+
+    #[tokio::test]
+    async fn older_generation_cannot_replace_newer_publication() {
+        fn generation(
+            source: &SchemaUri,
+            revision: u64,
+            value_type: &str,
+        ) -> Arc<SchemaGeneration> {
+            let node = Arc::new(
+                tombi_json::ValueNode::from_str(&format!(
+                    r#"{{"$id":"https://example.com/root","$defs":{{"child":{{"$id":"child","type":"{value_type}"}}}}}}"#
+                ))
+                .unwrap(),
+            );
+            Arc::new(SchemaGeneration {
+                revision,
+                source_schema_uri: Arc::new(source.clone()),
+                resource_index: Arc::new(ResourceIndex::build(&node, source, None).unwrap()),
+                source_node: node,
+                compiled_resources: std::sync::RwLock::new(Default::default()),
+            })
+        }
+
+        let source = SchemaUri::from_str("file:///tmp/tombi-generation-order.json").unwrap();
+        let older = generation(&source, 1, "string");
+        let newer = generation(&source, 2, "integer");
+        let store = SchemaStore::new();
+
+        assert!(
+            store
+                .register_embedded_resources(newer.clone())
+                .await
+                .unwrap()
+        );
+        assert!(!store.register_embedded_resources(older).await.unwrap());
+
+        let cache = store.cache.read().await;
+        assert!(
+            cache
+                .resources
+                .by_source
+                .get(&source)
+                .is_some_and(|installed| Arc::ptr_eq(installed, &newer))
+        );
     }
 
     #[tokio::test]

--- a/crates/tombi-validator/src/validate/table.rs
+++ b/crates/tombi-validator/src/validate/table.rs
@@ -630,7 +630,7 @@ async fn validate_table(
                 crate::Diagnostic {
                     kind: Box::new(crate::DiagnosticKind::TableStrictAdditionalKeys {
                         accessors: MarkdownSchemaAccessors::from(accessors),
-                        schema_uri: current_schema.schema_uri.as_ref().clone(),
+                        schema_uri: current_schema.diagnostic_schema_uri().into_owned(),
                         key: key.to_string(),
                     }),
                     range: key.range() + value.range(),


### PR DESCRIPTION
Closes #2164

## Summary

- index embedded JSON Schema resources by effective `$id`, dialect, `$anchor`, and `$dynamicAnchor`
- pin schema generations and publish external documents/resources atomically, with generation-local compiled-template caching
- preserve physical source locations for embedded resources across completion, hover, goto definition, and document links
- reserve the retrieval URI for the root resource so embedded resources cannot shadow its root alias
- cover nested/sibling resources, mixed dialects, anchors, cycles, reload isolation, external pointers, duplicates, and the reported shoko schema chain

## Verification

- `cargo fmt --all --check`
- `cargo nextest run --workspace`: 2433 passed
- WASM `lib` and `lsp` Clippy with `-D warnings`
- independent correctness review: APPROVED, no actionable findings
- independent performance/memory/simplicity review: APPROVED, no blocking findings

## Performance

Release benchmarks use alternating runs and medians.

- cold retained workload (100 documents × 64 resources): 68,153 → 96,095 µs (+41.0%); peak RSS 97,927,168 → 118,505,472 bytes (+21.0%)
- warm canonical-resource lookup (25,600 lookups over 256 resources), compared with the pre-redesign implementation: 3,230,195 → 25,992 µs (~124× faster, -99.2%); peak RSS 23,298,048 → 16,318,464 bytes (-30.0%)

The cold cost is the retained AST/resource index required for correct compound-schema generations; the redesigned hot path is O(1) and avoids per-lookup recompilation and ownership cycles. `CurrentSchema` remains 128 bytes; the final URI contract adds no persistent field.
