### PR TITLE
fix(lexer): close multi-line string after escaped backslash

### DIFF
--- a/crates/tombi-lexer/src/lib.rs
+++ b/crates/tombi-lexer/src/lib.rs
@@ -438,8 +438,10 @@ impl Cursor<'_> {
                         self.pop_span_range(),
                     ));
                 }
+                // A backslash escapes the next character only when it is not
+                // itself escaped, so a run of backslashes toggles the flag.
                 '\\' => {
-                    was_quote = true;
+                    was_quote = !was_quote;
                 }
                 _ => {
                     was_quote = false;

--- a/crates/tombi-lexer/tests/test_lex.rs
+++ b/crates/tombi-lexer/tests/test_lex.rs
@@ -470,6 +470,16 @@ test_lex_token! {
 
 test_lex_token! {
     #[test]
+    fn multi_line_basic_string6(r#""""C:\\""""#) -> Ok(Token(MULTI_LINE_BASIC_STRING, (0, 10)));
+}
+
+test_lex_token! {
+    #[test]
+    fn multi_line_basic_string7(r#""""a\\\\""""#) -> Ok(Token(MULTI_LINE_BASIC_STRING, (0, 11)));
+}
+
+test_lex_token! {
+    #[test]
     fn invalid_multi_line_basic_string  (r#"""""""""""#) -> Err(
         Token(InvalidMultilineBasicString, (0, 9))
     );


### PR DESCRIPTION
## Summary

A multi-line basic string whose content ends with an escaped backslash does not lex. `"""C:\\"""` is rejected as `InvalidMultilineBasicString`, and since the lexer keeps looking for a terminator it can no longer find, the error runs to the end of the input and takes the following lines with it. On this document:

```toml
windows_path = """C:\\Users\\"""
after = 1
```

`tombi_parser::parse` returns `InvalidMultilineBasicString` and `ExpectedValue`, both spanning from the opening `"""` to the end of the file, so `after` is lost as well.

## Cause

`Cursor::multi_line_basic_string` in `crates/tombi-lexer/src/lib.rs:441` keeps a `was_quote` flag that suppresses the closing-delimiter check for a character preceded by a backslash. The flag was set to `true` on every backslash, including one that had itself been escaped. After `\\` it therefore stayed set, the next `"` was treated as escaped, and the check was skipped at the one position where all three closing quotes are still in view. By the following quote `peek(2)` is already past the delimiter, so the string never closes.

`Cursor::basic_string` does not have this problem, because it consumes both characters of `\\` in a single match arm and so never treats the character after them as escaped.

## Fix

Toggle the flag on a backslash rather than setting it, so an even run of backslashes leaves the next character unescaped.

## Tests

Two cases in `crates/tombi-lexer/tests/test_lex.rs` using the existing `test_lex_token!` macro: `"""C:\\"""` with two backslashes before the delimiter, and `"""a\\\\"""` with four. Both fail on `main` and pass with this change. Odd-length runs were already correct and stay correct, which `multi_line_basic_string3` covers.

Verified with the stable toolchain (rustc 1.98.0):

```
cargo fmt --all -- --check                                 clean
cargo clippy -p tombi-lexer --all-targets -- -D warnings   clean
cargo test -p tombi-lexer                                  104 passed, 0 failed
cargo test -p tombi-parser                                  94 passed, 0 failed
cargo test -p tombi-document                                43 passed, 0 failed
```

No fixture or snapshot changes. The flag only behaves differently when an even run of backslashes is immediately followed by `"""`, and `git grep -F '\\"""'` matches nothing in the repository outside the two new tests.
