### PR TITLE
test(parser): preserve key after escaped multiline string

### DIFF
--- a/crates/tombi-parser/src/parse/root.rs
+++ b/crates/tombi-parser/src/parse/root.rs
@@ -176,7 +176,37 @@ mod test {
             windows_path = """C:\\Users\\"""
             after = 1
             "#
-        ) -> Ok(|root| -> root.key_values().count() == 2)
+        ) -> Ok(|root| -> {
+            use tombi_ast::{KeyNode as _, ValueNode as _};
+            use tombi_toml_version::TomlVersion;
+
+            let mut key_values = root.key_values();
+            match (key_values.next(), key_values.next()) {
+                (Some(windows_path), Some(after)) => {
+                    windows_path.keys().is_some_and(|keys| {
+                        keys.keys().next().is_some_and(|key| {
+                            key.content(TomlVersion::V1_0_0).as_deref()
+                                == Some("windows_path")
+                        })
+                    }) && windows_path.value().is_some_and(|value| {
+                        matches!(
+                            value.value(TomlVersion::V1_0_0),
+                            Some(tombi_ast::Value::String(value)) if value == "C:\\Users\\"
+                        )
+                    }) && after.keys().is_some_and(|keys| {
+                        keys.keys().next().is_some_and(|key| {
+                            key.content(TomlVersion::V1_0_0).as_deref() == Some("after")
+                        })
+                    }) && after.value().is_some_and(|value| {
+                        matches!(
+                            value.value(TomlVersion::V1_0_0),
+                            Some(tombi_ast::Value::Integer(1))
+                        )
+                    }) && key_values.next().is_none()
+                }
+                _ => false,
+            }
+        })
     }
 
     test_parser! {

--- a/crates/tombi-parser/src/parse/root.rs
+++ b/crates/tombi-parser/src/parse/root.rs
@@ -171,6 +171,16 @@ mod test {
 
     test_parser! {
         #[test]
+        fn multiline_basic_string_ending_in_escaped_backslash_preserves_following_key(
+            r#"
+            windows_path = """C:\\Users\\"""
+            after = 1
+            "#
+        ) -> Ok(|root| -> root.key_values().count() == 2)
+    }
+
+    test_parser! {
+        #[test]
         fn resolves_ascii_eof_after_standalone_carriage_return(
             "a\r"
         ) -> RawAssert(|parsed| {


### PR DESCRIPTION
## Summary

- add a parser regression test for the user-visible failure fixed by #2167
- verify a multi-line basic string ending in an escaped backslash does not consume the following key-value
- reuse the existing `test_parser!` macro

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy -p tombi-parser --all-targets -- -D warnings`
- `cargo test -p tombi-parser` (95 passed)
- `git diff --check`

Follow-up to #2167.
