### PR TITLE
fix(lsp): respect ignore files in watcher updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ flate2 = "1.0.35"
 futures = "0.3.31"
 glob = "0.3.2"
 gloo-net = { version = "0.6.0", default-features = false, features = ["http"] }
-ignore = "0.4.20"
+ignore = "0.4.33"
 itertools = "0.14.0"
 js-sys = "0.3.77"
 log = "0.4.22"

--- a/crates/tombi-glob/src/lib.rs
+++ b/crates/tombi-glob/src/lib.rs
@@ -12,7 +12,7 @@ use tombi_config::{FormatOptions, LintOptions, OverrideFilesOptions, config_base
 pub use error::Error;
 pub use file_match::{MatchResult, matches_file_patterns};
 pub use file_search::{FileInputType, FileSearch, FileSearchEntry, search_pattern_matched_paths};
-pub use walk_dir::WalkDir;
+pub use walk_dir::{WalkDir, is_path_ignored};
 
 pub fn get_format_options(
     config: &tombi_config::Config,

--- a/crates/tombi-glob/src/walk_dir.rs
+++ b/crates/tombi-glob/src/walk_dir.rs
@@ -1,5 +1,7 @@
 #[cfg(not(target_family = "wasm"))]
 use ignore::WalkBuilder;
+#[cfg(target_family = "wasm")]
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use std::path::{Path, PathBuf};
 #[cfg(not(target_family = "wasm"))]
 use std::sync::{Arc, Mutex};
@@ -152,6 +154,7 @@ impl WalkDir {
 
         let include_patterns = self.options.include.unwrap_or_default();
         let exclude_patterns = self.options.exclude.unwrap_or_default();
+        let respect_ignore_files = self.options.respect_ignore_files.value();
         let mut directories = vec![root_path.clone()];
         let mut results = Vec::new();
 
@@ -163,10 +166,14 @@ impl WalkDir {
                 })?;
             for entry in entries {
                 let path = entry.path().to_path_buf();
-                if entry.is_dir() {
-                    if !is_vcs_metadata_dir(&path) {
-                        directories.push(path);
-                    }
+                let is_dir = entry.is_dir();
+                if (is_dir && is_vcs_metadata_dir(&path))
+                    || (respect_ignore_files && is_path_ignored(&root_path, &path))
+                {
+                    continue;
+                }
+                if is_dir {
+                    directories.push(path);
                     continue;
                 }
 
@@ -188,6 +195,97 @@ impl WalkDir {
 
         Ok(results)
     }
+}
+
+/// Returns whether an existing path is excluded by repository ignore files.
+#[cfg(not(target_family = "wasm"))]
+pub fn is_path_ignored(root: &Path, path: &Path) -> bool {
+    let mut builder = WalkBuilder::new(root);
+    builder.hidden(false).git_global(false);
+    let Some(mut matcher) = builder.build_matchers().pop() else {
+        return false;
+    };
+    let Some(relative_path) = matcher.normalize(path) else {
+        return false;
+    };
+
+    matcher.matched(relative_path, path.is_dir()).is_ignore()
+}
+
+/// Returns whether an existing path is excluded by repository ignore files.
+#[cfg(target_family = "wasm")]
+pub fn is_path_ignored(root: &Path, path: &Path) -> bool {
+    let root = tombi_fs::normalize(root);
+    let path = tombi_fs::normalize(path);
+    if !path.starts_with(&root) || path == root {
+        return false;
+    }
+
+    let mut parents = path
+        .ancestors()
+        .skip(1)
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
+    parents.reverse();
+
+    let repository = parents.iter().rev().find(|directory| {
+        tombi_fs::is_dir(&directory.join(".git")) || tombi_fs::is_dir(&directory.join(".jj"))
+    });
+
+    let build_matcher = |base: &Path, ignore_path: PathBuf| {
+        let content = tombi_fs::read_to_string(&ignore_path).ok()?;
+        let mut builder = GitignoreBuilder::new(base);
+        for (index, line) in content.lines().enumerate() {
+            let line = if index == 0 {
+                line.trim_start_matches('\u{feff}')
+            } else {
+                line
+            };
+            if let Err(error) = builder.add_line(Some(ignore_path.clone()), line) {
+                log::debug!("failed to parse {}: {error}", ignore_path.display());
+            }
+        }
+        builder.build().ok()
+    };
+
+    // Precedence: .ignore, .gitignore, then .git/info/exclude.
+    let mut matchers: [Vec<Gitignore>; 3] = Default::default();
+
+    for (index, directory) in parents.iter().enumerate() {
+        if let Some(matcher) = build_matcher(directory, directory.join(".ignore")) {
+            matchers[0].push(matcher);
+        }
+        if let Some(git_root) = repository
+            && directory.starts_with(git_root)
+        {
+            if let Some(matcher) = build_matcher(directory, directory.join(".gitignore")) {
+                matchers[1].push(matcher);
+            }
+            if directory == git_root
+                && let Some(matcher) = build_matcher(git_root, git_root.join(".git/info/exclude"))
+            {
+                matchers[2].push(matcher);
+            }
+        }
+
+        let entry_path = parents.get(index + 1).unwrap_or(&path);
+        let is_dir = entry_path != &path || tombi_fs::is_dir(&path);
+        let ignored = matchers.iter().find_map(|category| {
+            category.iter().rev().find_map(|matcher| {
+                let matched = matcher.matched(entry_path, is_dir);
+                matched
+                    .is_ignore()
+                    .then_some(true)
+                    .or_else(|| matched.is_whitelist().then_some(false))
+            })
+        });
+        if ignored.unwrap_or(false) {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -488,12 +586,35 @@ mod tests {
         };
     }
 
+    macro_rules! test_single_path_ignore {
+        ($name:ident, $respect_ignore_files:literal, $expected:literal) => {
+            #[test]
+            fn $name() {
+                let tempdir = tempdir().unwrap();
+                let root = tempdir.path();
+                make_git_root(root);
+                write_file(&root.join(".gitignore"), "**/.terraform/*\n");
+                let path = root.join("module/.terraform/modules/child.toml");
+                write_file(&path, "invalid TOML\n");
+
+                let ignored = $respect_ignore_files && is_path_ignored(root, &path);
+                assert_eq!(ignored, $expected);
+            }
+        };
+    }
+
     test_walkdir_excludes_vcs_metadata_dirs!(
         test_walkdir_excludes_vcs_metadata_dirs_when_respecting_ignore_files,
         true
     );
     test_walkdir_excludes_vcs_metadata_dirs!(
         test_walkdir_excludes_vcs_metadata_dirs_when_ignoring_ignore_files,
+        false
+    );
+    test_single_path_ignore!(test_single_path_respects_gitignore_when_enabled, true, true);
+    test_single_path_ignore!(
+        test_single_path_ignores_gitignore_when_disabled,
+        false,
         false
     );
 

--- a/crates/tombi-lsp/src/handler/did_change_watched_files.rs
+++ b/crates/tombi-lsp/src/handler/did_change_watched_files.rs
@@ -2,7 +2,9 @@ use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType};
 
 use crate::{
     backend::Backend,
-    workspace_config::{WorkspaceConfig, get_workspace_configs, is_workspace_target},
+    workspace_config::{
+        WorkspaceConfig, get_workspace_configs, is_workspace_ignored, is_workspace_target,
+    },
     workspace_diagnostic::upsert_document_source,
 };
 
@@ -23,6 +25,42 @@ pub async fn handle_did_change_watched_files(
         let uri: tombi_uri::Uri = change.uri.clone().into();
 
         log::debug!("detected {:?} via watcher: {}", change.typ, uri);
+
+        if matches!(
+            change.typ,
+            FileChangeType::CREATED | FileChangeType::CHANGED
+        ) {
+            if workspace_configs.is_none() {
+                workspace_configs = Some(get_workspace_configs(backend).await.unwrap_or_default());
+            }
+
+            if is_workspace_ignored(&uri, workspace_configs.as_deref().unwrap_or(&[])) {
+                backend.wait_for_document_open(&uri).await;
+                let mut document_sources = backend.document_sources.write().await;
+                if document_sources
+                    .get(&uri)
+                    .is_none_or(|source| source.version.is_none())
+                {
+                    log::debug!("clear watcher diagnostics for ignored file: {uri}");
+                    document_sources.remove(&uri);
+                    backend
+                        .workspace_diagnostics_cache
+                        .write()
+                        .await
+                        .untrack(&uri);
+
+                    if backend.is_diagnostic_mode_push().await {
+                        backend
+                            .client
+                            .publish_diagnostics(change.uri, Vec::new(), None)
+                            .await;
+                    } else {
+                        should_refresh_pull_diagnostics = true;
+                    }
+                    continue;
+                }
+            }
+        }
 
         match change.typ {
             FileChangeType::DELETED => {

--- a/crates/tombi-lsp/src/workspace_config.rs
+++ b/crates/tombi-lsp/src/workspace_config.rs
@@ -47,6 +47,15 @@ impl WorkspaceConfig {
             &self.config,
         ) == MatchResult::Matched
     }
+
+    #[inline]
+    fn is_ignored(&self, text_document_path: &std::path::Path) -> bool {
+        self.config
+            .files
+            .as_ref()
+            .is_none_or(|files| files.respect_ignore_files.value())
+            && tombi_glob::is_path_ignored(&self.workspace_folder_path, text_document_path)
+    }
 }
 
 pub async fn get_workspace_configs(backend: &Backend) -> Option<Vec<WorkspaceConfig>> {
@@ -99,4 +108,72 @@ pub fn is_workspace_target(
     workspace_configs
         .iter()
         .any(|workspace_config| workspace_config.is_workspace_target(&text_document_path, home_dir))
+}
+
+pub fn is_workspace_ignored(
+    text_document_uri: &tombi_uri::Uri,
+    workspace_configs: &[WorkspaceConfig],
+) -> bool {
+    let Ok(text_document_path) = tombi_uri::Uri::to_file_path(text_document_uri) else {
+        return false;
+    };
+
+    let mut matched_workspace = false;
+    for workspace_config in workspace_configs {
+        if !text_document_path.starts_with(&workspace_config.workspace_folder_path) {
+            continue;
+        }
+
+        matched_workspace = true;
+        if !workspace_config.is_ignored(&text_document_path) {
+            return false;
+        }
+    }
+
+    matched_workspace
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+    use tombi_config::FilesOptions;
+
+    use super::*;
+
+    macro_rules! test_workspace_ignore {
+        ($name:ident, $respect_ignore_files:literal, $expected:literal) => {
+            #[test]
+            fn $name() {
+                let tempdir = tempdir().unwrap();
+                let root = tempdir.path();
+                fs::create_dir(root.join(".git")).unwrap();
+                fs::write(root.join(".gitignore"), "**/.terraform/*\n").unwrap();
+                let path = root.join("module/.terraform/modules/child.toml");
+                fs::create_dir_all(path.parent().unwrap()).unwrap();
+                fs::write(&path, "invalid TOML\n").unwrap();
+
+                let mut config = Config::default();
+                config.files = Some(FilesOptions {
+                    respect_ignore_files: $respect_ignore_files.into(),
+                    ..Default::default()
+                });
+                let workspace_config = WorkspaceConfig {
+                    workspace_folder_path: root.to_path_buf(),
+                    config,
+                    config_path: Some(root.join("tombi.toml")),
+                };
+                let uri = tombi_uri::Uri::from_file_path(&path).unwrap();
+
+                assert_eq!(
+                    is_workspace_ignored(&uri, std::slice::from_ref(&workspace_config)),
+                    $expected
+                );
+            }
+        };
+    }
+
+    test_workspace_ignore!(workspace_ignore_respects_gitignore, true, true);
+    test_workspace_ignore!(workspace_ignore_disabled, false, false);
 }

--- a/rust/tombi-wasm/tests/lsp-smoke.mjs
+++ b/rust/tombi-wasm/tests/lsp-smoke.mjs
@@ -54,8 +54,43 @@ await init({ module_or_path: wasm });
 
 set_workspace_files([
   {
+    uri: "file:///workspace/.git/HEAD",
+    text: "ref: refs/heads/main\n",
+  },
+  {
+    uri: "file:///workspace/.gitignore",
+    text: "**/.terraform/*\nconflict.toml\n",
+  },
+  {
+    uri: "file:///workspace/.git/info/exclude",
+    text: "**/.private/*\n",
+  },
+  {
+    uri: "file:///workspace/.ignore",
+    text: "**/.cache/*\n!conflict.toml\n",
+  },
+  {
+    uri: "file:///workspace/module/.terraform/existing.toml",
+    text: "key =\n",
+  },
+  {
+    uri: "file:///workspace/module/.private/existing.toml",
+    text: "key =\n",
+  },
+  {
+    uri: "file:///workspace/module/.cache/existing.toml",
+    text: "key =\n",
+  },
+  {
+    uri: "file:///workspace/conflict.toml",
+    text: "key = 1\n",
+  },
+  {
     uri: "file:///workspace/tombi.toml",
     text: `toml-version = "v1.1.0"
+
+[files]
+respect-ignore-files = true
 
 [format.rules]
 
@@ -102,6 +137,7 @@ const input = new AsyncByteQueue();
 let outputBuffer = new Uint8Array();
 const messages = [];
 const outputWaiters = [];
+let deferWorkspaceFoldersResponse = false;
 
 function waitForMessages(count) {
   if (messages.length >= count) return Promise.resolve();
@@ -131,7 +167,9 @@ async function waitForMessage(predicate) {
 }
 
 function waitForResponse(id) {
-  return waitForMessage((message) => message.id === id);
+  return waitForMessage(
+    (message) => message.id === id && message.method === undefined,
+  );
 }
 
 const output = new WritableStream({
@@ -151,7 +189,21 @@ const output = new WritableStream({
       const message = JSON.parse(decoder.decode(outputBuffer.slice(bodyStart, bodyStart + length)));
       messages.push(message);
       if (message.id !== undefined && message.method) {
-        input.push(encode({ jsonrpc: "2.0", id: message.id, result: null }));
+        if (
+          message.method !== "workspace/workspaceFolders" ||
+          !deferWorkspaceFoldersResponse
+        ) {
+          input.push(
+            encode({
+              jsonrpc: "2.0",
+              id: message.id,
+              result:
+                message.method === "workspace/workspaceFolders"
+                  ? [{ name: "workspace", uri: "file:///workspace" }]
+                  : null,
+            }),
+          );
+        }
       }
       outputBuffer = outputBuffer.slice(bodyStart + length);
       for (const waiter of outputWaiters.splice(0)) {
@@ -186,12 +238,147 @@ assert.ok(messages[0]?.result?.capabilities?.codeActionProvider);
 assert.ok(messages[0]?.result?.capabilities?.semanticTokensProvider);
 
 input.push(encode({ jsonrpc: "2.0", method: "initialized", params: {} }));
+
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    id: 10,
+    method: "workspace/diagnostic",
+    params: {
+      identifier: null,
+      partialResultToken: null,
+      previousResultIds: [],
+      workDoneToken: null,
+    },
+  }),
+);
+const workspaceDiagnosticResponse = await waitForResponse(10);
+assert.equal(workspaceDiagnosticResponse?.error, undefined);
+for (const ignoredUri of [
+  "file:///workspace/module/.terraform/existing.toml",
+  "file:///workspace/module/.private/existing.toml",
+  "file:///workspace/module/.cache/existing.toml",
+]) {
+  assert.ok(
+    !workspaceDiagnosticResponse?.result?.items?.some(
+      (item) => item.uri === ignoredUri,
+    ),
+    `WASM workspace discovery should exclude ${ignoredUri}: ${JSON.stringify(workspaceDiagnosticResponse)}`,
+  );
+}
+assert.ok(
+  workspaceDiagnosticResponse?.result?.items?.some(
+    (item) => item.uri === "file:///workspace/conflict.toml",
+  ),
+  `.ignore whitelist should override .gitignore: ${JSON.stringify(workspaceDiagnosticResponse)}`,
+);
+
+const watchedIgnoredUri = "file:///workspace/module/.terraform/watched.toml";
+set_workspace_file(watchedIgnoredUri, "key =\n");
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "workspace/didChangeWatchedFiles",
+    params: {
+      changes: [{ type: 1, uri: watchedIgnoredUri }],
+    },
+  }),
+);
+const ignoredWatcherDiagnostics = await waitForMessage(
+  (message) =>
+    message.method === "textDocument/publishDiagnostics" &&
+    message.params?.uri === watchedIgnoredUri,
+);
+assert.deepEqual(ignoredWatcherDiagnostics.params?.diagnostics, []);
+
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "textDocument/didOpen",
+    params: {
+      textDocument: {
+        languageId: "toml",
+        text: "key =\n",
+        uri: watchedIgnoredUri,
+        version: 1,
+      },
+    },
+  }),
+);
+const explicitlyOpenedIgnoredDiagnostics = await waitForMessage(
+  (message) =>
+    message.method === "textDocument/publishDiagnostics" &&
+    message.params?.uri === watchedIgnoredUri &&
+    message.params?.version === 1,
+);
+assert.ok(explicitlyOpenedIgnoredDiagnostics.params?.diagnostics?.length > 0);
+
+const concurrentOpenUri =
+  "file:///workspace/module/.terraform/concurrent-open.toml";
+set_workspace_file(concurrentOpenUri, "key =\n");
+deferWorkspaceFoldersResponse = true;
+const previousWorkspaceFolderRequests = new Set(
+  messages.filter((message) => message.method === "workspace/workspaceFolders"),
+);
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "workspace/didChangeWatchedFiles",
+    params: { changes: [{ type: 1, uri: concurrentOpenUri }] },
+  }),
+);
+const deferredWorkspaceFoldersRequest = await waitForMessage(
+  (message) =>
+    message.method === "workspace/workspaceFolders" &&
+    !previousWorkspaceFolderRequests.has(message),
+);
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "textDocument/didOpen",
+    params: {
+      textDocument: {
+        languageId: "toml",
+        text: "key =\n",
+        uri: concurrentOpenUri,
+        version: 1,
+      },
+    },
+  }),
+);
+await waitForMessage(
+  (message) =>
+    message.method === "textDocument/publishDiagnostics" &&
+    message.params?.uri === concurrentOpenUri &&
+    message.params?.version === 1,
+);
+const messagesBeforeWatcherResume = new Set(messages);
+deferWorkspaceFoldersResponse = false;
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    id: deferredWorkspaceFoldersRequest.id,
+    result: [{ name: "workspace", uri: "file:///workspace" }],
+  }),
+);
+const concurrentWatcherDiagnostics = await waitForMessage(
+  (message) =>
+    !messagesBeforeWatcherResume.has(message) &&
+    message.method === "textDocument/publishDiagnostics" &&
+    message.params?.uri === concurrentOpenUri,
+);
+assert.equal(concurrentWatcherDiagnostics.params?.version, 1);
+assert.ok(concurrentWatcherDiagnostics.params?.diagnostics?.length > 0);
+
 for (const textDocument of [
   {
     languageId: "toml",
     uri: "file:///workspace/tombi.toml",
     version: 1,
     text: `toml-version = "v1.1.0"
+
+[files]
+respect-ignore-files = true
 
 [format.rules]
 
@@ -262,7 +449,10 @@ input.push(
 
 const diagnosticResponse = await waitForResponse(2);
 assert.equal(diagnosticResponse?.error, undefined);
-assert.ok(diagnosticResponse?.result?.items?.length > 0);
+assert.ok(
+  diagnosticResponse?.result?.items?.length > 0,
+  `WASM LSP pull diagnostics should report invalid TOML: ${JSON.stringify(diagnosticResponse)}`,
+);
 
 input.push(
   encode({
@@ -386,7 +576,7 @@ input.push(
     id: 6,
     method: "textDocument/hover",
     params: {
-      position: { line: 2, character: 5 },
+      position: { line: 5, character: 5 },
       textDocument: { uri: "file:///workspace/tombi.toml" },
     },
   }),
@@ -403,7 +593,7 @@ input.push(
     method: "textDocument/completion",
     params: {
       context: { triggerKind: 1 },
-      position: { line: 3, character: 0 },
+      position: { line: 6, character: 0 },
       textDocument: { uri: "file:///workspace/tombi.toml" },
     },
   }),
@@ -417,6 +607,9 @@ assert.ok(
 );
 
 const updatedConfig = `toml-version = "v1.1.0"
+
+[files]
+respect-ignore-files = false
 
 [format.rules]
 group-blank-lines-limit = 5
@@ -448,6 +641,25 @@ input.push(
 const updateConfigResponse = await waitForResponse(8);
 assert.equal(updateConfigResponse?.error, undefined);
 assert.equal(updateConfigResponse?.result, true);
+
+const watchedIncludedUri =
+  "file:///workspace/module/.terraform/watched-when-disabled.toml";
+set_workspace_file(watchedIncludedUri, "key =\n");
+input.push(
+  encode({
+    jsonrpc: "2.0",
+    method: "workspace/didChangeWatchedFiles",
+    params: {
+      changes: [{ type: 1, uri: watchedIncludedUri }],
+    },
+  }),
+);
+const includedWatcherDiagnostics = await waitForMessage(
+  (message) =>
+    message.method === "textDocument/publishDiagnostics" &&
+    message.params?.uri === watchedIncludedUri,
+);
+assert.ok(includedWatcherDiagnostics.params?.diagnostics?.length > 0);
 
 input.push(
   encode({


### PR DESCRIPTION
## Summary

- honor repository ignore files for files received through LSP watcher events
- share path ignore matching with workspace discovery on native and browser-backed filesystems
- keep explicitly opened ignored files diagnosable and preserve them across concurrent watcher events
- update `ignore` to 0.4.33 for incremental native path matching

## Testing

- `cargo test -p tombi-glob --locked`
- `cargo test -p tombi-lsp --locked --quiet`
- `cargo clippy -p tombi-glob -p tombi-lsp --all-targets --locked -- -D warnings`
- `cargo clippy -p tombi-glob -p tombi-lsp --target wasm32-unknown-unknown --locked -- -D warnings`
- `pnpm --dir typescript/@tombi-toml/wasm-lsp test`
- `cargo fmt --all --check`

Closes #2166
