### PR TITLE
fix(lsp): stop logging empty workspace diagnostics

### DIFF
--- a/crates/tombi-lsp/src/handler/code_action.rs
+++ b/crates/tombi-lsp/src/handler/code_action.rs
@@ -14,7 +14,6 @@ pub async fn handle_code_action(
     backend: &Backend,
     params: CodeActionParams,
 ) -> Result<Option<Vec<CodeActionOrCommand>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_code_action");
     log::trace!("{:?}", params);
 
     let CodeActionParams {
@@ -45,6 +44,8 @@ pub async fn handle_code_action(
         log::debug!("`server.code_action.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_code_action");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -50,8 +50,6 @@ pub async fn handle_completion(
         return Ok(None);
     }
 
-    log::info!("handle_completion");
-
     if !config
         .schema
         .as_ref()
@@ -62,6 +60,8 @@ pub async fn handle_completion(
         log::debug!("`schema.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_completion");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/completion.rs
+++ b/crates/tombi-lsp/src/handler/completion.rs
@@ -16,7 +16,6 @@ pub async fn handle_completion(
     backend: &backend::Backend,
     params: CompletionParams,
 ) -> Result<Option<Vec<CompletionContent>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_completion");
     log::trace!("{:?}", params);
 
     let CompletionParams {
@@ -50,6 +49,8 @@ pub async fn handle_completion(
         log::debug!("`server.completion.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_completion");
 
     if !config
         .schema

--- a/crates/tombi-lsp/src/handler/document_link.rs
+++ b/crates/tombi-lsp/src/handler/document_link.rs
@@ -9,7 +9,6 @@ pub async fn handle_document_link(
     backend: &Backend,
     params: DocumentLinkParams,
 ) -> Result<Option<Vec<DocumentLink>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_document_link");
     log::trace!("{:?}", params);
 
     let DocumentLinkParams { text_document, .. } = params;
@@ -31,6 +30,8 @@ pub async fn handle_document_link(
         log::debug!("`server.document_link.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_document_link");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/formatting.rs
+++ b/crates/tombi-lsp/src/handler/formatting.rs
@@ -12,7 +12,6 @@ pub async fn handle_formatting(
     backend: &Backend,
     params: DocumentFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_formatting");
     log::trace!("{:?}", params);
 
     let DocumentFormattingParams {
@@ -42,6 +41,8 @@ pub async fn handle_formatting(
         log::debug!("`server.formatting.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_formatting");
 
     if let Ok(text_document_path) = text_document_uri.to_file_path() {
         match matches_file_patterns(&text_document_path, config_path.as_deref(), &config) {

--- a/crates/tombi-lsp/src/handler/goto_declaration.rs
+++ b/crates/tombi-lsp/src/handler/goto_declaration.rs
@@ -10,7 +10,6 @@ pub async fn handle_goto_declaration(
     backend: &Backend,
     params: GotoDeclarationParams,
 ) -> Result<Option<Vec<tombi_extension::Location>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_goto_declaration");
     log::trace!("{:?}", params);
 
     let GotoDeclarationParams {
@@ -39,6 +38,8 @@ pub async fn handle_goto_declaration(
         log::debug!("`server.goto_declaration.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_goto_declaration");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/goto_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_definition.rs
@@ -9,7 +9,6 @@ pub async fn handle_goto_definition(
     backend: &Backend,
     params: GotoDefinitionParams,
 ) -> Result<Option<Vec<tombi_extension::Location>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_goto_definition");
     log::trace!("{:?}", params);
 
     let GotoDefinitionParams {
@@ -38,6 +37,8 @@ pub async fn handle_goto_definition(
         log::debug!("`server.goto_definition.enabled` is false");
         return Ok(Default::default());
     }
+
+    log::info!("handle_goto_definition");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(Default::default());

--- a/crates/tombi-lsp/src/handler/goto_type_definition.rs
+++ b/crates/tombi-lsp/src/handler/goto_type_definition.rs
@@ -39,7 +39,6 @@ pub async fn handle_goto_type_definition(
     backend: &Backend,
     params: GotoTypeDefinitionParams,
 ) -> Result<Option<Vec<tombi_extension::Location>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_goto_type_definition");
     log::trace!("{:?}", params);
 
     let GotoTypeDefinitionParams {
@@ -73,6 +72,8 @@ pub async fn handle_goto_type_definition(
         log::debug!("`server.goto_type_definition.enabled` is false");
         return Ok(Default::default());
     }
+
+    log::info!("handle_goto_type_definition");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(Default::default());

--- a/crates/tombi-lsp/src/handler/hover.rs
+++ b/crates/tombi-lsp/src/handler/hover.rs
@@ -16,7 +16,6 @@ pub async fn handle_hover(
     backend: &backend::Backend,
     params: HoverParams,
 ) -> Result<Option<HoverContent>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_hover");
     log::trace!("{:?}", params);
 
     let HoverParams {
@@ -49,6 +48,8 @@ pub async fn handle_hover(
         log::debug!("`server.hover.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_hover");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/references.rs
+++ b/crates/tombi-lsp/src/handler/references.rs
@@ -10,7 +10,6 @@ pub async fn handle_references(
     backend: &Backend,
     params: ReferenceParams,
 ) -> Result<Option<Vec<tombi_extension::Location>>, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_references");
     log::trace!("{:?}", params);
 
     let ReferenceParams {
@@ -40,6 +39,8 @@ pub async fn handle_references(
         log::debug!("`server.references.enabled` is false");
         return Ok(None);
     }
+
+    log::info!("handle_references");
 
     let Ok(document_sources) = backend.document_sources.try_read() else {
         return Ok(None);

--- a/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/handler/workspace_diagnostic.rs
@@ -19,9 +19,6 @@ pub async fn handle_workspace_diagnostic(
     backend: &Backend,
     params: WorkspaceDiagnosticParams,
 ) -> Result<WorkspaceDiagnosticReportResult, tower_lsp::jsonrpc::Error> {
-    log::info!("handle_workspace_diagnostic");
-    log::trace!("{:?}", params);
-
     let previous_result_ids = params
         .previous_result_ids
         .into_iter()
@@ -29,6 +26,16 @@ pub async fn handle_workspace_diagnostic(
         .collect::<tombi_hashmap::HashMap<_, _>>();
 
     let targets = collect_workspace_diagnostic_targets(backend).await;
+
+    if targets.is_empty() && previous_result_ids.is_empty() {
+        return Ok(WorkspaceDiagnosticReportResult::Report(
+            WorkspaceDiagnosticReport { items: Vec::new() },
+        ));
+    }
+
+    log::info!("handle_workspace_diagnostic");
+    log::trace!("previous_result_ids: {previous_result_ids:?}");
+
     let target_set = targets
         .iter()
         .cloned()

--- a/crates/tombi-lsp/src/workspace_diagnostic.rs
+++ b/crates/tombi-lsp/src/workspace_diagnostic.rs
@@ -19,10 +19,16 @@ pub async fn push_workspace_diagnostics(
     backend: &Backend,
     options: &WorkspaceDiagnosticOptions,
 ) -> Result<(), tower_lsp::jsonrpc::Error> {
+    let targets = collect_workspace_diagnostic_targets(backend).await;
+
+    if targets.is_empty() {
+        return Ok(());
+    }
+
     log::info!("push_workspace_diagnostics");
     log::trace!("{:?}", options);
 
-    for text_document_uri in collect_workspace_diagnostic_targets(backend).await {
+    for text_document_uri in targets {
         publish_workspace_diagnostics(backend, text_document_uri, options).await;
     }
 


### PR DESCRIPTION
## Problem
The Tombi language server logged what looked like repeated workspace diagnostic runs even when there was no file to process. From a user's point of view, `handle_workspace_diagnostic` kept showing up roughly every 2 seconds while nothing was happening, which reads as wasted work or a performance problem.

## Solution
Return early, without doing anything, when there is nothing to diagnose. Empty workspace diagnostics no longer emit a log; a diagnostic log is recorded only when there is something to actually process.

Along with that, the code action, completion, hover, formatting, and definition LSP handlers no longer emit an `info` log when they return early for an out-of-scope file or configuration.

Fixes #2176