### PR TITLE
fix(vscode): persist status bar item visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ libcairo.2.dylib
 # node
 node_modules
 /docs/public/wasm/
+.pnpm-store/
 
 # envrc
 .direnv/

--- a/editors/vscode/src/extension/index.ts
+++ b/editors/vscode/src/extension/index.ts
@@ -33,6 +33,7 @@ export const SUPPORT_JSON_LANGUAGES = ["json"];
 export const TOMBI_DEV_VERSION = "0.0.0-dev";
 const OPEN_TOOLTIP_LINK_COMMAND = `${EXTENSION_ID}.openTooltipLink`;
 const MIN_VERSION_FOR_TOMBI_TOOLTIP_LINK = "0.11.2";
+const STATUS_BAR_ITEM_ID = `${EXTENSION_ID}.status`;
 
 export class Extension {
   private statusBarItem: vscode.StatusBarItem;
@@ -43,9 +44,13 @@ export class Extension {
     private client: node.LanguageClient,
     private server: Server,
   ) {
+    // NOTE: The `id` is required for VSCode to persist the user's
+    //       show/hide preference from the status bar context menu.
     this.statusBarItem = vscode.window.createStatusBarItem(
+      STATUS_BAR_ITEM_ID,
       vscode.StatusBarAlignment.Left,
     );
+    this.statusBarItem.name = `${EXTENSION_NAME} Status`;
     this.context.subscriptions.push(this.statusBarItem);
 
     this.registerEvents();


### PR DESCRIPTION
## Summary

The status bar item was created via `vscode.window.createStatusBarItem(alignment)` without an `id`. VSCode only persists the user's show/hide choice for items that were created with an `id`, so hiding "Tombi (Extension)" from the status bar context menu was reset on every editor restart, as reported in #2175.

This passes an `id` and sets `name`, so the preference survives a restart and the context menu shows a proper label.

Note this covers only the "hiding does not stick" half of #2175. A dedicated setting (e.g. `tombi.statusBar.enabled`) for users who want to manage visibility in their settings file is not included here.

`.gitignore` also gains `.pnpm-store/`, since running pnpm at the repository root creates that store in-tree.

## Validation

- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run format:check`
- `pnpm test` (3 files, 9 tests passed)
- `cargo fmt --all -- --check`

No Rust sources are touched, so `cargo clippy` was not re-run; the branch sits directly on top of `origin/main`.

Refs: #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)