### PR TITLE
fix(lsp): skip workspace diagnostics when lsp.diagnostic is disabled

### DIFF
--- a/crates/tombi-config/src/lib.rs
+++ b/crates/tombi-config/src/lib.rs
@@ -24,7 +24,7 @@ pub use schema::{
     SchemaOverrideItem, SchemaOverrideLintOptions, SchemaOverrideLintRules,
     SchemaOverrideTableKeysOrderRule, SchemaTableKeysOrderRule, SubSchema,
 };
-pub use server::{LspCompletion, LspDiagnostic, LspOptions};
+pub use server::{LspCompletion, LspDiagnostic, LspOptions, LspWorkspaceDiagnostic};
 pub use tombi_severity_level::SeverityLevel;
 pub use tombi_toml_version::TomlVersion;
 pub use tombi_x_keyword::{ArrayValuesOrder, TableKeysOrder};

--- a/crates/tombi-lsp/src/diagnostic.rs
+++ b/crates/tombi-lsp/src/diagnostic.rs
@@ -50,14 +50,7 @@ pub async fn get_diagnostics_result(
         .config_schema_store_for_uri(text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|lsp| lsp.diagnostic.as_ref())
-        .and_then(|diagnostic| diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !crate::workspace_config::is_diagnostic_enabled(&config) {
         log::debug!("`lsp.diagnostic.enabled` is false");
         return None;
     }

--- a/crates/tombi-lsp/src/handler/did_close.rs
+++ b/crates/tombi-lsp/src/handler/did_close.rs
@@ -29,14 +29,7 @@ pub async fn handle_did_close(backend: &Backend, params: DidCloseTextDocumentPar
         .config_schema_store_for_uri(text_document_uri)
         .await;
 
-    if !config
-        .lsp
-        .as_ref()
-        .and_then(|server| server.workspace_diagnostic.as_ref())
-        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
-        .unwrap_or_default()
-        .value()
-    {
+    if !crate::workspace_config::is_workspace_diagnostic_enabled(&config) {
         backend
             .client
             .publish_diagnostics(text_document.uri, Vec::new(), None)

--- a/crates/tombi-lsp/src/workspace_config.rs
+++ b/crates/tombi-lsp/src/workspace_config.rs
@@ -16,13 +16,7 @@ pub struct WorkspaceConfig {
 impl WorkspaceConfig {
     #[inline]
     pub fn is_workspace_diagnostic_enabled(&self) -> bool {
-        self.config
-            .lsp
-            .as_ref()
-            .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
-            .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
-            .unwrap_or_default()
-            .value()
+        is_workspace_diagnostic_enabled(&self.config)
     }
 
     #[inline]
@@ -94,6 +88,39 @@ pub async fn get_workspace_configs(backend: &Backend) -> Option<Vec<WorkspaceCon
     }
 
     Some(configs)
+}
+
+/// Whether the workspace diagnostic feature is enabled for the given config.
+///
+/// Workspace diagnostics are computed through the same pipeline as document diagnostics,
+/// so `lsp.diagnostic.enabled = false` disables them as well.
+/// Without this, the whole workspace would still be crawled and linted only to
+/// throw the results away.
+#[inline]
+pub fn is_workspace_diagnostic_enabled(config: &Config) -> bool {
+    if !is_diagnostic_enabled(config) {
+        return false;
+    }
+
+    config
+        .lsp
+        .as_ref()
+        .and_then(|lsp| lsp.workspace_diagnostic.as_ref())
+        .and_then(|workspace_diagnostic| workspace_diagnostic.enabled)
+        .unwrap_or_default()
+        .value()
+}
+
+/// Whether the document diagnostic feature is enabled for the given config.
+#[inline]
+pub fn is_diagnostic_enabled(config: &Config) -> bool {
+    config
+        .lsp
+        .as_ref()
+        .and_then(|lsp| lsp.diagnostic.as_ref())
+        .and_then(|diagnostic| diagnostic.enabled)
+        .unwrap_or_default()
+        .value()
 }
 
 pub fn is_workspace_target(
@@ -176,4 +203,56 @@ mod tests {
 
     test_workspace_ignore!(workspace_ignore_respects_gitignore, true, true);
     test_workspace_ignore!(workspace_ignore_disabled, false, false);
+
+    macro_rules! test_workspace_diagnostic_enabled {
+        ($name:ident, diagnostic = $diagnostic:expr, workspace_diagnostic = $workspace_diagnostic:expr, $expected:literal) => {
+            #[test]
+            fn $name() {
+                let mut config = Config::default();
+                config.lsp = Some(tombi_config::LspOptions {
+                    diagnostic: $diagnostic.map(|enabled: bool| tombi_config::LspDiagnostic {
+                        enabled: Some(enabled.into()),
+                    }),
+                    workspace_diagnostic: $workspace_diagnostic.map(|enabled: bool| {
+                        tombi_config::LspWorkspaceDiagnostic {
+                            enabled: Some(enabled.into()),
+                        }
+                    }),
+                    ..Default::default()
+                });
+
+                assert_eq!(is_workspace_diagnostic_enabled(&config), $expected);
+            }
+        };
+    }
+
+    test_workspace_diagnostic_enabled!(
+        workspace_diagnostic_enabled_by_default,
+        diagnostic = None,
+        workspace_diagnostic = None,
+        true
+    );
+
+    // `lsp.diagnostic.enabled = false` must also stop workspace diagnostics,
+    // otherwise the whole workspace is crawled and linted only to discard the results.
+    test_workspace_diagnostic_enabled!(
+        workspace_diagnostic_follows_disabled_diagnostic,
+        diagnostic = Some(false),
+        workspace_diagnostic = None,
+        false
+    );
+
+    test_workspace_diagnostic_enabled!(
+        workspace_diagnostic_disabled_even_if_explicitly_enabled,
+        diagnostic = Some(false),
+        workspace_diagnostic = Some(true),
+        false
+    );
+
+    test_workspace_diagnostic_enabled!(
+        workspace_diagnostic_disabled_alone,
+        diagnostic = Some(true),
+        workspace_diagnostic = Some(false),
+        false
+    );
 }

--- a/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/schema.json
+++ b/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "settings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bar": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/target.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/target.toml
@@ -1,0 +1,2 @@
+[settings]
+foo = 123

--- a/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/tombi.toml
+++ b/crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled/tombi.toml
@@ -1,0 +1,6 @@
+[lsp]
+diagnostic.enabled = false
+
+[[schemas]]
+path = "schema.json"
+include = ["target.toml"]

--- a/crates/tombi-lsp/tests/test_diagnostic.rs
+++ b/crates/tombi-lsp/tests/test_diagnostic.rs
@@ -26,6 +26,30 @@ mod diagnostic {
         );
     }
 
+    mod issue_2173_lsp_diagnostic_disabled {
+        use std::path::PathBuf;
+
+        use super::*;
+        use tombi_test_lib::project_root_path;
+
+        fn fixture_path() -> PathBuf {
+            project_root_path()
+                .join("crates/tombi-lsp/tests/fixtures/issue-2173-lsp-diagnostic-disabled")
+        }
+
+        test_diagnostic_file!(
+            #[tokio::test]
+            async fn unknown_key_is_suppressed(
+                r#"
+                [settings]
+                foo = 123
+                "#,
+                SourcePath(fixture_path().join("target.toml")),
+                ConfigPath(fixture_path().join("tombi.toml")),
+            ) -> Ok([]);
+        );
+    }
+
     /// Test for issue #1495: Local schema and subdirectories
     /// https://github.com/tombi-toml/tombi/issues/1495
     mod issue_1495_subdirectory_glob {


### PR DESCRIPTION
## Summary

Even with `lsp.diagnostic.enabled = false`, the workspace diagnostic target collection decided its own enablement independently, so the whole workspace was still crawled (`search_pattern_matched_paths`), document sources were upserted, and every file was linted. The results were discarded in `get_diagnostics_result`, so no diagnostics were shown — the work was simply wasted.

This makes the workspace diagnostic enablement depend on `lsp.diagnostic.enabled` as well, so turning diagnostics off also skips the workspace crawl entirely.

- Add `workspace_config::is_workspace_diagnostic_enabled` / `is_diagnostic_enabled` taking a `Config`; the former now always returns `false` when `lsp.diagnostic.enabled` is `false`
- Collapse the equivalent inline checks scattered across `diagnostic.rs` and `did_close.rs` into these helpers
- Re-export `tombi_config::LspWorkspaceDiagnostic` for use in tests

`did_close` publishes empty diagnostics when a document is not a workspace diagnostic target, so leftover diagnostics are now cleared on close while diagnostics are disabled too.

Related: #2173

## Validation

- `cargo test -p tombi-lsp` (all passing)
- `cargo clippy --workspace --all-targets` (no warnings)
- `cargo fmt -- --check`

Tests added:

- `crates/tombi-lsp/src/workspace_config.rs`: four combinations of `diagnostic` / `workspace-diagnostic` being enabled or disabled
- `crates/tombi-lsp/tests/test_diagnostic.rs`: a `test_diagnostic_file!` case verifying that schema-derived unknown key diagnostics are suppressed when `lsp.diagnostic.enabled = false` (with a new fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)